### PR TITLE
docs: add generic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/generic-issue-template.md
@@ -1,0 +1,19 @@
+---
+name: Generic issue template
+about: A general-purpose template for tracking tasks, bugs, and improvements.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## 📋 Description
+<!-- Provide a clear explanation of the issue, task, or goal -->
+
+## ✅ Acceptance Criteria
+- [ ] Goals and expectations are well-defined
+- [ ] Work follows applicable conventions and standards
+- [ ] Results can be reviewed and validated
+
+## 🔗 References
+<!-- Include links to related issues, documentation, or external sources -->


### PR DESCRIPTION
Added a generic issue template to standardize how issues are created in the repository.

This template helps ensure that all issues have a consistent structure and include the necessary information for tracking and review.