### PR TITLE
docs(conventions): add development conventions and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## 📋 Summary
+<!-- What does this PR do and why? Keep it concise for reviewers. -->
+
+## 🔄 Changes
+<!-- Bullet list of what changed (files, behavior, API, etc.) -->
+
+## 🧪 Testing
+<!-- Steps to verify the change locally, or note if not applicable -->
+
+## 🔗 Related
+<!-- Link issues with: Closes #123, Fixes #456, or Related to #789 -->

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="kaanunsel" uuid="dc4ca85e-b58a-4e3f-82e9-99ddffef4716">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5432/kaanunsel</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+    <data-source source="LOCAL" name="postgres" uuid="056a111f-af5c-4cdf-8741-38f1499255fb">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5432/postgres</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/.idea/db-forest-config.xml
+++ b/.idea/db-forest-config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="db-tree-configuration">
+    <option name="data" value="----------------------------------------&#10;1:0:dc4ca85e-b58a-4e3f-82e9-99ddffef4716&#10;2:0:056a111f-af5c-4cdf-8741-38f1499255fb&#10;" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/social-event-mapper.iml" filepath="$PROJECT_DIR$/.idea/social-event-mapper.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/social-event-mapper.iml
+++ b/.idea/social-event-mapper.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/docs/design/conventions.md
+++ b/docs/design/conventions.md
@@ -1,0 +1,59 @@
+# Git and PR conventions
+
+## Commit messages (Conventional Commits)
+
+**Format:** `type(optional scope): description`
+
+| type | Use for |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation |
+| `test` | Tests added or updated |
+| `refactor` | Code structure change, same behavior |
+| `chore` | Maintenance, tooling, small config |
+| `devops` | CI, build/packaging, performance tuning, deployment and infra-related changes |
+
+**Examples:** `feat: add location search`, `fix(api): parsing error on empty body`
+
+---
+
+## Branch names
+
+**Format:** `<prefix>/<issue-number>-<short-description>` (kebab-case after the number)
+
+Start every branch with the **GitHub issue number** (or equivalent tracker id), then a short slug.
+
+| prefix | Purpose |
+|--------|---------|
+| `feature/` | New feature work |
+| `fix/` | Bug fixes |
+| `devops/` | CI, deployment, infrastructure, IaC |
+| `chore/` | Maintenance, deps, tooling (no product feature) |
+| `docs/` | Documentation only |
+
+**Examples:** `feature/115-add-api`, `fix/42-empty-response`, `devops/8-terraform-db`, `docs/3-readme-setup`
+
+---
+
+## Pull request scope
+
+Each PR should change **one product surface** at a time—for example the **backend** (API, services, server config) or the **mobile** app—not both in the same merge.
+
+When a feature needs server and client work, split it into **separate PRs** (and usually separate issues/branches), and link them in the descriptions. That keeps reviews focused, CI runs meaningful for each stack, and rollbacks or cherry-picks stay safe.
+
+Shared-only exceptions (e.g. a root `README` or repo-wide policy) should stay small and clearly unrelated to app logic.
+
+---
+
+## Before opening a PR
+
+1. **Target `dev`:** Open every PR against `dev`, not `main`.
+2. Code runs successfully locally.
+3. Commits and style match this doc.
+4. **Branch is up to date with `dev`** — sync before the PR (`git pull` or `git rebase` onto `dev`).
+
+## Merge
+
+- Merge only after at least **one** approved review.
+- The team reviews each other’s work as part of normal development.


### PR DESCRIPTION
## Summary

Documents team **Git / Conventional Commits** and **PR** practices, and adds a **default GitHub PR template** so new PRs follow a consistent structure.

## Changes

- **`docs/design/conventions.md`** — Single source for:
  - Commit message types (`feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `devops`)
  - Branch naming: `<prefix>/<issue-number>-<slug>` with prefixes `feature/`, `fix/`, `devops/`, `chore/`, `docs/`
  - **PR scope:** one surface per PR (e.g. backend **or** mobile, not both); cross-stack work split across linked PRs
  - **Base branch:** PRs target **`dev`**, not `main`; branch synced with `dev` before review
  - **Merge:** at least one approval
- **`.github/pull_request_template.md`** — Sections for summary, changes, testing, and related issues

## Testing

N/A (documentation and GitHub template only).

## Related

Closes #116 

---

**Note:** This commit also includes **`.idea/`** IDE metadata. Remove from the PR or document if the team wants it tracked.