### PR TITLE
chore(docker): dockerize backend and postgresql for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Optional: copy to `.env` in the repository root when using `docker compose` from this directory.
+# Docker Compose substitutes these into docker-compose.yml (see Compose variable substitution).
+# Do not commit `.env` — it is gitignored.
+
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=sem
+JWT_SECRET=dev-only-change-for-production

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Local env (see backend/.env.example)
 .env
+
+# Optional Compose merge for local Postgres port (see docker-compose.override.example.yml)
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
-# bounswe2026group11
-CMPE354 Group 11 repository
+# CMPE354 Group 11 Repository - Social Event Mapper
 
 ## Backend
-
-Go module: [`github.com/bounswe/bounswe2026group11/backend`](https://github.com/bounswe/bounswe2026group11) (directory `backend/`; [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) layout: `internal/domain`, `internal/application`, `internal/adapter`, `infrastructure`, `pkg`).
 
 Run the API server:
 
 ```bash
 cd backend
-cp .env.example .env   # then edit required values (e.g. JWT_SECRET)
+cp .env.example .env   # optional: override secrets for local dev
 go run ./cmd/server
 ```
 
-Configuration is loaded with [viper](https://github.com/spf13/viper): optional `backend/.env` plus environment variables (CI/CD). Env vars override the file. Required keys are listed in [`backend/.env.example`](backend/.env.example).
+### Docker (API + PostGIS)
 
-- Health check: `GET /health` → `200 OK` (listen port from `APP_PORT`, default `8080` if unset).
+Requires [Docker Compose](https://docs.docker.com/compose/). From the repository root:
+
+```bash
+docker compose up --build
+```
+
+- **API:** `http://localhost:8080` — `GET /health` should return `200` (port: `APP_PORT`, default `8080`).
+- **Database:** Postgres stays on the Docker network only (not on the host). To reach it from your machine at `localhost:5432` (GUI, `psql`, local `go run`), copy [`docker-compose.override.example.yml`](docker-compose.override.example.yml) to `docker-compose.override.yml`.
+- **Env overrides:** Optionally copy [`.env.example`](.env.example) to `.env` at the repo root for DB credentials, `JWT_SECRET`, etc. (gitignored).
+
+PostGIS runs with a persistent volume; migrations apply on API startup. Full options: [`backend/.env.example`](backend/.env.example).
 
 ## Database
 

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+.env
+*.md
+.git
+.gitignore

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,8 @@
+# For `docker compose` from repo root, you can copy the same keys to `../.env` (see root `.env.example`).
 APP_PORT=8080
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=sem
 DB_USER=postgres
-DB_PASSWORD=
-JWT_SECRET=
+DB_PASSWORD=postgres
+JWT_SECRET=dev-only-change-for-production

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build: the final image only contains the compiled server, SQL migrations,
+# and the migrate tool — not the full Go SDK. That keeps the image small and deploys faster.
+
+# --- Build the API binary (full Go SDK on Debian; output is still static / CGO-disabled). ---
+FROM golang:1.24-bookworm AS builder
+
+WORKDIR /src
+
+# Copy module files first so `go mod download` is cached until dependencies change.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# CGO_ENABLED=0 produces a static binary that runs on Alpine (musl) without linking glibc.
+# -trimpath strips local paths from the binary; -s -w strip debug info to shrink size.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
+
+# --- Borrow only the official `migrate` binary; same version the entrypoint expects. ---
+FROM migrate/migrate:v4.18.2 AS migrate
+
+# --- Runtime: Alpine + TLS roots (for HTTPS clients) + app + migrations + entrypoint. ---
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=migrate /migrate /usr/local/bin/migrate
+RUN chmod +x /usr/local/bin/migrate
+
+WORKDIR /app
+
+COPY --from=builder /out/server /app/server
+COPY migrations /migrations
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# Document the port; compose maps this to the host.
+EXPOSE 8080
+
+# Entrypoint applies pending migrations, then execs the HTTP server.
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+: "${DB_HOST:?DB_HOST is required}"
+: "${DB_USER:?DB_USER is required}"
+: "${DB_NAME:?DB_NAME is required}"
+
+db_port="${DB_PORT:-5432}"
+if [ -n "${DB_PASSWORD:-}" ]; then
+	db_url="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${db_port}/${DB_NAME}?sslmode=disable"
+else
+	db_url="postgres://${DB_USER}@${DB_HOST}:${db_port}/${DB_NAME}?sslmode=disable"
+fi
+
+migrate -path /migrations -database "$db_url" up
+
+exec /app/server

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,11 @@
+# Optional local-development overlay. Copy this file to `docker-compose.override.yml`
+# (that filename is gitignored). Docker Compose automatically merges `docker-compose.yml`
+# with `docker-compose.override.yml`, so you do not need extra `-f` arguments.
+#
+# This example publishes Postgres to the host so GUI clients or `psql` on your machine
+# can connect. Binding to 127.0.0.1 limits access to your machine, not the whole LAN.
+
+services:
+  postgres:
+    ports:
+      - "127.0.0.1:5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+# Application stack: PostgreSQL with PostGIS plus the Go backend API.
+# Variables like DB_NAME, DB_USER, DB_PASSWORD, JWT_SECRET come from a `.env` file
+# next to this compose file (copy from `.env.example`). Compose injects them here.
+
+services:
+  postgres:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    # We do not map 5432 to the host by default: only other services on this network
+    # can reach Postgres (the backend uses hostname `postgres`). Safer on a VPS.
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    # Wait until Postgres accepts connections before the backend starts, so the API
+    # does not crash on startup while the database is still initializing.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # Built from ./backend; publishes HTTP on host port 8080. `depends_on` with
+  # `service_healthy` delays this container until Postgres passes its healthcheck.
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      APP_PORT: "8080"
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+
+# Database files live in a named volume so they persist across container restarts.
+# `docker compose down` keeps this data; add `-v` only when you intend to wipe the DB.
+volumes:
+  pgdata:


### PR DESCRIPTION
## 📋 Summary

Adds a Docker Compose stack so developers can run the Go API and a PostGIS-backed PostgreSQL database locally with one command. The backend image is built with a multi-stage Dockerfile, runs migrations on startup, and the README documents how to use root `.env`, optional host port exposure for Postgres, and non-Docker `go run` workflows.

## 🔄 Changes

- **`docker-compose.yml`** — New stack: `postgis/postgis:16-3.4` with healthcheck, named volume `pgdata`, and `backend` service built from `./backend`, depending on healthy Postgres; wires `APP_PORT`, `DB_*`, and `JWT_SECRET` from Compose env substitution.
- **`backend/Dockerfile`** — Multi-stage build (Go 1.24 → static binary), embeds `migrate` v4.18.2, copies migrations and `docker-entrypoint.sh`, Alpine runtime with CA certs, exposes 8080.
- **`backend/docker-entrypoint.sh`** — Validates required DB env vars, builds Postgres URL (with or without password), runs `migrate up`, then execs the API server.
- **`docker-compose.override.example.yml`** — Example merge file to publish Postgres on `127.0.0.1:5432` for local tools; actual override filename gitignored.
- **`.env.example` (repo root)** — Template for `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `JWT_SECRET` when using Compose from the repo root.
- **`backend/.env.example`** — Default dev values for `DB_PASSWORD` and `JWT_SECRET`, note about mirroring keys to root `.env` for Compose.
- **`backend/.dockerignore`** — Excludes `.env`, markdown, git metadata from build context.
- **`.gitignore`** — Ignores `docker-compose.override.yml` in addition to existing `.env`.
- **`README.md`** — Retitles project, documents `docker compose up --build`, health check URL, DB networking, override and `.env` usage; trims redundant backend module link text.

## 🧪 Testing

1. From the repository root, optionally copy `.env.example` to `.env` and adjust secrets if needed.
2. Run `docker compose up --build`.
3. Confirm `GET http://localhost:8080/health` returns **200**.
4. Optionally copy `docker-compose.override.example.yml` to `docker-compose.override.yml`, restart Compose, and verify you can connect to Postgres on `localhost:5432` with the configured user/database.
5. Non-Docker path still works: `cd backend && cp .env.example .env && go run ./cmd/server` (point `DB_HOST` at `localhost` when DB is exposed or run outside Docker as before).

## 🔗 Related

Closes #119 