### PR TITLE
feat(mobile): add login screen and login flow

### DIFF
--- a/mobile/src/app/index.tsx
+++ b/mobile/src/app/index.tsx
@@ -1,1 +1,1 @@
-export { default } from '@/views/auth/RegisterView';
+export { default } from '@/views/auth/LoginView';

--- a/mobile/src/app/register.tsx
+++ b/mobile/src/app/register.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/views/auth/RegisterView';

--- a/mobile/src/models/auth.ts
+++ b/mobile/src/models/auth.ts
@@ -20,6 +20,11 @@ export interface RequestOtpResponse {
   message: string;
 }
 
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
 export interface VerifyRegistrationRequest {
   email: string;
   otp: string;

--- a/mobile/src/services/authService.ts
+++ b/mobile/src/services/authService.ts
@@ -2,6 +2,7 @@ import { apiPost } from './api';
 import {
   CheckAvailabilityRequest,
   CheckAvailabilityResponse,
+  LoginRequest,
   RequestOtpRequest,
   RequestOtpResponse,
   VerifyRegistrationRequest,
@@ -30,4 +31,8 @@ export function verifyRegistration(
   data: VerifyRegistrationRequest,
 ): Promise<AuthSessionResponse> {
   return apiPost<AuthSessionResponse>('/auth/register/email/verify', data);
+}
+
+export function login(data: LoginRequest): Promise<AuthSessionResponse> {
+  return apiPost<AuthSessionResponse>('/auth/login', data);
 }

--- a/mobile/src/viewmodels/auth/useLoginViewModel.test.tsx
+++ b/mobile/src/viewmodels/auth/useLoginViewModel.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import * as authService from '@/services/authService';
+import { ApiError } from '@/services/api';
+import type { AuthSessionResponse } from '@/models/auth';
+import {
+  useLoginViewModel,
+  type LoginViewModel,
+} from './useLoginViewModel';
+
+jest.mock('@/services/authService');
+
+const mockLogin = jest.mocked(authService.login);
+
+const validCredentials = {
+  username: 'maplover',
+  password: 'StrongPassword123',
+};
+
+async function fillForm(vm: LoginViewModel) {
+  await act(async () => {
+    vm.updateField('username', validCredentials.username);
+    vm.updateField('password', validCredentials.password);
+  });
+}
+
+const sessionFixture: AuthSessionResponse = {
+  access_token: 'access',
+  refresh_token: 'refresh',
+  token_type: 'Bearer',
+  expires_in_seconds: 900,
+  user: {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    username: 'maplover',
+    email: 'user@example.com',
+    phone_number: null,
+    email_verified: true,
+    status: 'active',
+  },
+};
+
+describe('useLoginViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLogin.mockResolvedValue(sessionFixture);
+  });
+
+  it('starts with empty form and no errors', () => {
+    const { result } = renderHook(() => useLoginViewModel());
+    expect(result.current.formData.username).toBe('');
+    expect(result.current.formData.password).toBe('');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.apiError).toBeNull();
+  });
+
+  it('does not call API when validation fails', async () => {
+    const { result } = renderHook(() => useLoginViewModel());
+
+    await act(async () => {
+      await result.current.handleLogin();
+    });
+
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(result.current.errors.username).toBeTruthy();
+    expect(result.current.errors.password).toBeTruthy();
+  });
+
+  it('clears field error and apiError when a field is updated', async () => {
+    const { result } = renderHook(() => useLoginViewModel());
+
+    await act(async () => {
+      await result.current.handleLogin();
+    });
+    expect(result.current.errors.username).toBeTruthy();
+
+    await act(async () => {
+      result.current.updateField('username', 'a');
+    });
+    expect(result.current.errors.username).toBeNull();
+  });
+
+  it('returns session on successful login', async () => {
+    const { result } = renderHook(() => useLoginViewModel());
+
+    await fillForm(result.current);
+
+    let session: AuthSessionResponse | null = null;
+    await act(async () => {
+      session = await result.current.handleLogin();
+    });
+
+    expect(mockLogin).toHaveBeenCalledWith({
+      username: validCredentials.username,
+      password: validCredentials.password,
+    });
+    expect(session).toEqual(sessionFixture);
+    expect(result.current.apiError).toBeNull();
+  });
+
+  it('sets apiError on invalid credentials (401)', async () => {
+    const { result } = renderHook(() => useLoginViewModel());
+
+    mockLogin.mockRejectedValueOnce(
+      new ApiError(401, {
+        error: {
+          code: 'invalid_credentials',
+          message: 'Invalid username or password.',
+        },
+      }),
+    );
+
+    await fillForm(result.current);
+    await act(async () => {
+      await result.current.handleLogin();
+    });
+
+    expect(result.current.apiError).toBe('Invalid username or password.');
+  });
+
+  it('sets apiError on rate limit (429)', async () => {
+    const { result } = renderHook(() => useLoginViewModel());
+
+    mockLogin.mockRejectedValueOnce(
+      new ApiError(429, {
+        error: {
+          code: 'rate_limited',
+          message: 'Too many requests. Try again later.',
+        },
+      }),
+    );
+
+    await fillForm(result.current);
+    await act(async () => {
+      await result.current.handleLogin();
+    });
+
+    expect(result.current.apiError).toBe('Too many requests. Try again later.');
+  });
+
+  it('sets generic apiError on unexpected errors', async () => {
+    const { result } = renderHook(() => useLoginViewModel());
+
+    mockLogin.mockRejectedValueOnce(new Error('Network failure'));
+
+    await fillForm(result.current);
+    await act(async () => {
+      await result.current.handleLogin();
+    });
+
+    expect(result.current.apiError).toBe(
+      'An unexpected error occurred. Please try again.',
+    );
+  });
+
+  it('returns null when login fails', async () => {
+    const { result } = renderHook(() => useLoginViewModel());
+
+    mockLogin.mockRejectedValueOnce(
+      new ApiError(401, {
+        error: {
+          code: 'invalid_credentials',
+          message: 'Invalid username or password.',
+        },
+      }),
+    );
+
+    await fillForm(result.current);
+
+    let session: AuthSessionResponse | null = null;
+    await act(async () => {
+      session = await result.current.handleLogin();
+    });
+
+    expect(session).toBeNull();
+  });
+});

--- a/mobile/src/viewmodels/auth/useLoginViewModel.ts
+++ b/mobile/src/viewmodels/auth/useLoginViewModel.ts
@@ -1,0 +1,88 @@
+import { useState, useCallback } from 'react';
+import { login } from '@/services/authService';
+import { AuthSessionResponse } from '@/models/auth';
+import { ApiError } from '@/services/api';
+import { validateUsername, validatePassword } from '@/utils/validators';
+
+export interface LoginFormData {
+  username: string;
+  password: string;
+}
+
+export interface LoginFormErrors {
+  username?: string | null;
+  password?: string | null;
+}
+
+export interface LoginViewModel {
+  formData: LoginFormData;
+  errors: LoginFormErrors;
+  isLoading: boolean;
+  apiError: string | null;
+  updateField: <K extends keyof LoginFormData>(
+    field: K,
+    value: LoginFormData[K],
+  ) => void;
+  handleLogin: () => Promise<AuthSessionResponse | null>;
+}
+
+const INITIAL_FORM_DATA: LoginFormData = {
+  username: '',
+  password: '',
+};
+
+export function useLoginViewModel(): LoginViewModel {
+  const [formData, setFormData] = useState<LoginFormData>(INITIAL_FORM_DATA);
+  const [errors, setErrors] = useState<LoginFormErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const updateField = useCallback(
+    <K extends keyof LoginFormData>(field: K, value: LoginFormData[K]) => {
+      setFormData((prev) => ({ ...prev, [field]: value }));
+      setErrors((prev) => ({ ...prev, [field]: null }));
+      setApiError(null);
+    },
+    [],
+  );
+
+  const handleLogin = useCallback(async (): Promise<AuthSessionResponse | null> => {
+    const newErrors: LoginFormErrors = {
+      username: validateUsername(formData.username),
+      password: validatePassword(formData.password),
+    };
+
+    const hasErrors = Object.values(newErrors).some((e) => e != null);
+    if (hasErrors) {
+      setErrors(newErrors);
+      return null;
+    }
+
+    setIsLoading(true);
+    setApiError(null);
+    try {
+      return await login({
+        username: formData.username,
+        password: formData.password,
+      });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setApiError(err.message);
+      } else {
+        setApiError('An unexpected error occurred. Please try again.');
+      }
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [formData]);
+
+  return {
+    formData,
+    errors,
+    isLoading,
+    apiError,
+    updateField,
+    handleLogin,
+  };
+}

--- a/mobile/src/views/auth/LoginView.tsx
+++ b/mobile/src/views/auth/LoginView.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { router } from 'expo-router';
+import { useLoginViewModel } from '@/viewmodels/auth/useLoginViewModel';
+
+export default function LoginView() {
+  const vm = useLoginViewModel();
+
+  const handleSubmit = async () => {
+    const session = await vm.handleLogin();
+    if (session) {
+      router.replace('/');
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={styles.title}>Welcome Back</Text>
+        <Text style={styles.subtitle}>
+          Sign in to continue to your account
+        </Text>
+
+        {vm.apiError && (
+          <View style={styles.errorBanner}>
+            <Text style={styles.errorBannerText}>{vm.apiError}</Text>
+          </View>
+        )}
+
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Username</Text>
+          <TextInput
+            style={[styles.input, vm.errors.username && styles.inputError]}
+            placeholder="maplover"
+            placeholderTextColor="#9CA3AF"
+            value={vm.formData.username}
+            onChangeText={(v) => vm.updateField('username', v)}
+            autoCapitalize="none"
+            autoComplete="username"
+            editable={!vm.isLoading}
+          />
+          {vm.errors.username && (
+            <Text style={styles.fieldError}>{vm.errors.username}</Text>
+          )}
+        </View>
+
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Password</Text>
+          <TextInput
+            style={[styles.input, vm.errors.password && styles.inputError]}
+            placeholder="Your password"
+            placeholderTextColor="#9CA3AF"
+            value={vm.formData.password}
+            onChangeText={(v) => vm.updateField('password', v)}
+            secureTextEntry
+            autoComplete="current-password"
+            editable={!vm.isLoading}
+          />
+          {vm.errors.password && (
+            <Text style={styles.fieldError}>{vm.errors.password}</Text>
+          )}
+        </View>
+
+        <TouchableOpacity
+          style={[styles.button, vm.isLoading && styles.buttonDisabled]}
+          onPress={handleSubmit}
+          disabled={vm.isLoading}
+          activeOpacity={0.8}
+        >
+          {vm.isLoading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.buttonText}>Sign In</Text>
+          )}
+        </TouchableOpacity>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>Don&apos;t have an account? </Text>
+          <TouchableOpacity
+            onPress={() => router.push('/register')}
+            disabled={vm.isLoading}
+          >
+            <Text style={styles.footerLink}>Sign Up</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  scrollContent: {
+    flexGrow: 1,
+    padding: 24,
+    paddingTop: 60,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 15,
+    color: '#6B7280',
+    marginBottom: 32,
+  },
+  errorBanner: {
+    backgroundColor: '#FEF2F2',
+    borderWidth: 1,
+    borderColor: '#FECACA',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  errorBannerText: {
+    color: '#DC2626',
+    fontSize: 14,
+  },
+  fieldGroup: {
+    marginBottom: 20,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: '#111827',
+    backgroundColor: '#F9FAFB',
+  },
+  inputError: {
+    borderColor: '#EF4444',
+    backgroundColor: '#FEF2F2',
+  },
+  fieldError: {
+    color: '#EF4444',
+    fontSize: 13,
+    marginTop: 4,
+  },
+  button: {
+    backgroundColor: '#2563EB',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 24,
+  },
+  footerText: {
+    fontSize: 15,
+    color: '#6B7280',
+  },
+  footerLink: {
+    fontSize: 15,
+    color: '#2563EB',
+    fontWeight: '600',
+  },
+});

--- a/mobile/src/views/auth/RegisterView.tsx
+++ b/mobile/src/views/auth/RegisterView.tsx
@@ -253,6 +253,18 @@ export default function RegisterView() {
             <Text style={styles.backButtonText}>Go Back</Text>
           </TouchableOpacity>
         )}
+
+        {vm.step === 'details' && (
+          <View style={styles.footer}>
+            <Text style={styles.footerText}>Already have an account? </Text>
+            <TouchableOpacity
+              onPress={() => router.push('/')}
+              disabled={vm.isLoading}
+            >
+              <Text style={styles.footerLink}>Sign In</Text>
+            </TouchableOpacity>
+          </View>
+        )}
       </ScrollView>
     </KeyboardAvoidingView>
   );
@@ -384,5 +396,19 @@ const styles = StyleSheet.create({
   backButtonText: {
     color: '#6B7280',
     fontSize: 15,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 24,
+  },
+  footerText: {
+    fontSize: 15,
+    color: '#6B7280',
+  },
+  footerLink: {
+    fontSize: 15,
+    color: '#2563EB',
+    fontWeight: '600',
   },
 });


### PR DESCRIPTION
## 📋 Summary

Adds a mobile login screen and connects it to `POST /auth/login`, following the MVVM pattern (`useLoginViewModel` + `LoginView`, `authService.login`). The app entry route shows login; registration remains available at `/register`, with navigation links between the two flows.

## 🔄 Changes

- **Model:** `LoginRequest` in `mobile/src/models/auth.ts`
- **Service:** `login()` in `mobile/src/services/authService.ts` calling `POST /auth/login`
- **ViewModel:** `mobile/src/viewmodels/auth/useLoginViewModel.ts` — username/password validation via existing validators, loading and `ApiError` handling (including invalid credentials)
- **View:** `mobile/src/views/auth/LoginView.tsx` — form, error banner, loading state, link to register
- **Routing:** `mobile/src/app/index.tsx` → `LoginView`; `mobile/src/app/register.tsx` → `RegisterView`
- **Register UX:** footer on the details step linking back to login (`mobile/src/views/auth/RegisterView.tsx`)
- **Tests:** `mobile/src/viewmodels/auth/useLoginViewModel.test.tsx`

## 🧪 Testing

**Automated**

```bash
cd mobile
npm test
npm test -- useLoginViewModel
```

**Manual**

1. Run the backend (or use a deployed API) so `POST /auth/login` is reachable.
2. If needed, set `EXPO_PUBLIC_API_BASE_URL` in `mobile` so the emulator/device can reach the API (see `mobile/src/config/apiBaseUrl.ts`).
3. From the repo: `cd mobile && npx expo start`, then open the app.
4. On `/`:
   - Submit an empty form → field validation errors.
   - Submit wrong credentials → API error message in the banner.
   - Submit valid credentials → successful login.
5. Tap **Sign Up** → `/register`; on the register details step, tap **Sign In** → `/`.
6. Regression: complete the registration flow on `/register`.

## 🔗 Related
Closes #142 