### PR TITLE
feat(mobile): add full forgot-password flow to mobile (request OTP, verify, reset)

### DIFF
--- a/mobile/src/app/forgot-password.tsx
+++ b/mobile/src/app/forgot-password.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/views/auth/ForgotPasswordView';

--- a/mobile/src/models/auth.ts
+++ b/mobile/src/models/auth.ts
@@ -20,6 +20,38 @@ export interface RequestOtpResponse {
   message: string;
 }
 
+/** Matches OpenAPI `ForgotPasswordRequestResponse`. */
+export interface ForgotPasswordRequestResponse {
+  status: 'ok';
+  message: string;
+}
+
+/** Matches OpenAPI `VerifyPasswordResetRequest`. */
+export interface VerifyPasswordResetRequest {
+  email: string;
+  otp: string;
+}
+
+/** Matches OpenAPI `PasswordResetGrantResponse`. */
+export interface PasswordResetGrantResponse {
+  status: 'ok';
+  reset_token: string;
+  expires_in_seconds: number;
+}
+
+/** Matches OpenAPI `ResetPasswordRequest`. */
+export interface ResetPasswordRequest {
+  email: string;
+  reset_token: string;
+  new_password: string;
+}
+
+/** Matches OpenAPI `PasswordResetSuccessResponse`. */
+export interface PasswordResetSuccessResponse {
+  status: 'ok';
+  message: string;
+}
+
 export interface LoginRequest {
   username: string;
   password: string;

--- a/mobile/src/services/authService.ts
+++ b/mobile/src/services/authService.ts
@@ -5,6 +5,11 @@ import {
   LoginRequest,
   RequestOtpRequest,
   RequestOtpResponse,
+  ForgotPasswordRequestResponse,
+  VerifyPasswordResetRequest,
+  PasswordResetGrantResponse,
+  ResetPasswordRequest,
+  PasswordResetSuccessResponse,
   VerifyRegistrationRequest,
   AuthSessionResponse,
 } from '@/models/auth';
@@ -35,4 +40,31 @@ export function verifyRegistration(
 
 export function login(data: LoginRequest): Promise<AuthSessionResponse> {
   return apiPost<AuthSessionResponse>('/auth/login', data);
+}
+
+export function requestPasswordResetOtp(
+  data: RequestOtpRequest,
+): Promise<ForgotPasswordRequestResponse> {
+  return apiPost<ForgotPasswordRequestResponse>(
+    '/auth/forgot-password/request-otp',
+    data,
+  );
+}
+
+export function verifyPasswordResetOtp(
+  data: VerifyPasswordResetRequest,
+): Promise<PasswordResetGrantResponse> {
+  return apiPost<PasswordResetGrantResponse>(
+    '/auth/forgot-password/verify-otp',
+    data,
+  );
+}
+
+export function resetPassword(
+  data: ResetPasswordRequest,
+): Promise<PasswordResetSuccessResponse> {
+  return apiPost<PasswordResetSuccessResponse>(
+    '/auth/forgot-password/reset-password',
+    data,
+  );
 }

--- a/mobile/src/viewmodels/auth/useForgotPasswordViewModel.test.tsx
+++ b/mobile/src/viewmodels/auth/useForgotPasswordViewModel.test.tsx
@@ -1,0 +1,369 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act, type RenderHookResult } from '@testing-library/react';
+import * as authService from '@/services/authService';
+import { ApiError } from '@/services/api';
+import {
+  useForgotPasswordViewModel,
+  type ForgotPasswordViewModel,
+} from './useForgotPasswordViewModel';
+
+jest.mock('@/services/authService');
+
+const mockRequestPasswordResetOtp = jest.mocked(
+  authService.requestPasswordResetOtp,
+);
+const mockVerifyPasswordResetOtp = jest.mocked(
+  authService.verifyPasswordResetOtp,
+);
+const mockResetPassword = jest.mocked(authService.resetPassword);
+
+const genericOtpSuccess = {
+  status: 'ok' as const,
+  message:
+    'If an account with that email exists, a password-reset OTP has been sent.',
+};
+
+const verifySuccess = {
+  status: 'ok' as const,
+  reset_token: 'test-reset-token-abc123',
+  expires_in_seconds: 600,
+};
+
+const resetSuccess = {
+  status: 'ok' as const,
+  message: 'Password has been reset.',
+};
+
+type HookResult = RenderHookResult<ForgotPasswordViewModel, unknown>;
+
+async function advanceToOtpStep(hook: HookResult) {
+  await act(async () => {
+    hook.result.current.updateField('email', 'user@example.com');
+  });
+  await act(async () => {
+    await hook.result.current.handleRequestOtp();
+  });
+}
+
+async function advanceToResetStep(hook: HookResult) {
+  await advanceToOtpStep(hook);
+  await act(async () => {
+    hook.result.current.updateField('otp', '123456');
+  });
+  await act(async () => {
+    await hook.result.current.handleVerifyOtp();
+  });
+}
+
+describe('useForgotPasswordViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequestPasswordResetOtp.mockResolvedValue(genericOtpSuccess);
+    mockVerifyPasswordResetOtp.mockResolvedValue(verifySuccess);
+    mockResetPassword.mockResolvedValue(resetSuccess);
+  });
+
+  // --- Step 1: Email / Request OTP ---
+
+  it('starts on the email step with empty form', () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    expect(hook.result.current.step).toBe('email');
+    expect(hook.result.current.formData.email).toBe('');
+    expect(hook.result.current.isLoading).toBe(false);
+    expect(hook.result.current.apiError).toBeNull();
+    expect(hook.result.current.successMessage).toBeNull();
+  });
+
+  it('does not call API when email validation fails', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+
+    await act(async () => {
+      await hook.result.current.handleRequestOtp();
+    });
+
+    expect(mockRequestPasswordResetOtp).not.toHaveBeenCalled();
+    expect(hook.result.current.errors.email).toBeTruthy();
+    expect(hook.result.current.step).toBe('email');
+  });
+
+  it('advances to otp step after successful OTP request', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToOtpStep(hook);
+
+    expect(mockRequestPasswordResetOtp).toHaveBeenCalledWith({
+      email: 'user@example.com',
+    });
+    expect(hook.result.current.step).toBe('otp');
+    expect(hook.result.current.apiError).toBeNull();
+  });
+
+  it('trims email before sending', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+
+    await act(async () => {
+      hook.result.current.updateField('email', '  user@example.com  ');
+    });
+    await act(async () => {
+      await hook.result.current.handleRequestOtp();
+    });
+
+    expect(mockRequestPasswordResetOtp).toHaveBeenCalledWith({
+      email: 'user@example.com',
+    });
+  });
+
+  it('shows apiError on OTP request failure', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+
+    mockRequestPasswordResetOtp.mockRejectedValueOnce(
+      new ApiError(500, {
+        error: {
+          code: 'internal_server_error',
+          message: 'An unexpected error occurred.',
+        },
+      }),
+    );
+
+    await act(async () => {
+      hook.result.current.updateField('email', 'user@example.com');
+    });
+    await act(async () => {
+      await hook.result.current.handleRequestOtp();
+    });
+
+    expect(hook.result.current.apiError).toBe('An unexpected error occurred.');
+    expect(hook.result.current.step).toBe('email');
+  });
+
+  it('handles unexpected error on OTP request', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+
+    mockRequestPasswordResetOtp.mockRejectedValueOnce(new Error('Network'));
+
+    await act(async () => {
+      hook.result.current.updateField('email', 'user@example.com');
+    });
+    await act(async () => {
+      await hook.result.current.handleRequestOtp();
+    });
+
+    expect(hook.result.current.apiError).toBe(
+      'An unexpected error occurred. Please try again.',
+    );
+  });
+
+  it('clears field error when email is updated', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+
+    await act(async () => {
+      await hook.result.current.handleRequestOtp();
+    });
+    expect(hook.result.current.errors.email).toBeTruthy();
+
+    await act(async () => {
+      hook.result.current.updateField('email', 'a@b.co');
+    });
+    expect(hook.result.current.errors.email).toBeNull();
+    expect(hook.result.current.apiError).toBeNull();
+  });
+
+  // --- Step 2: OTP Verification ---
+
+  it('does not call verify API when OTP validation fails', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToOtpStep(hook);
+
+    await act(async () => {
+      await hook.result.current.handleVerifyOtp();
+    });
+
+    expect(mockVerifyPasswordResetOtp).not.toHaveBeenCalled();
+    expect(hook.result.current.errors.otp).toBeTruthy();
+    expect(hook.result.current.step).toBe('otp');
+  });
+
+  it('advances to reset step after successful OTP verification', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToResetStep(hook);
+
+    expect(mockVerifyPasswordResetOtp).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      otp: '123456',
+    });
+    expect(hook.result.current.step).toBe('reset');
+    expect(hook.result.current.apiError).toBeNull();
+  });
+
+  it('shows OTP field error on invalid_otp and clears the input', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToOtpStep(hook);
+
+    mockVerifyPasswordResetOtp.mockRejectedValueOnce(
+      new ApiError(401, {
+        error: {
+          code: 'invalid_otp',
+          message: 'The OTP is invalid or has expired.',
+        },
+      }),
+    );
+
+    await act(async () => {
+      hook.result.current.updateField('otp', '999999');
+    });
+    await act(async () => {
+      await hook.result.current.handleVerifyOtp();
+    });
+
+    expect(hook.result.current.errors.otp).toBe(
+      'The OTP is invalid or has expired.',
+    );
+    expect(hook.result.current.formData.otp).toBe('');
+    expect(hook.result.current.step).toBe('otp');
+  });
+
+  it('shows apiError on OTP verify server error', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToOtpStep(hook);
+
+    mockVerifyPasswordResetOtp.mockRejectedValueOnce(
+      new ApiError(500, {
+        error: {
+          code: 'internal_server_error',
+          message: 'An unexpected error occurred.',
+        },
+      }),
+    );
+
+    await act(async () => {
+      hook.result.current.updateField('otp', '123456');
+    });
+    await act(async () => {
+      await hook.result.current.handleVerifyOtp();
+    });
+
+    expect(hook.result.current.apiError).toBe('An unexpected error occurred.');
+    expect(hook.result.current.step).toBe('otp');
+  });
+
+  // --- Step 3: Reset Password ---
+
+  it('does not call reset API when password validation fails', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToResetStep(hook);
+
+    await act(async () => {
+      hook.result.current.updateField('newPassword', 'short');
+    });
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await hook.result.current.handleResetPassword();
+    });
+
+    expect(mockResetPassword).not.toHaveBeenCalled();
+    expect(hook.result.current.errors.newPassword).toBeTruthy();
+    expect(success).toBe(false);
+  });
+
+  it('calls reset API and returns true on success', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToResetStep(hook);
+
+    await act(async () => {
+      hook.result.current.updateField('newPassword', 'StrongPassword123');
+    });
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await hook.result.current.handleResetPassword();
+    });
+
+    expect(mockResetPassword).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      reset_token: 'test-reset-token-abc123',
+      new_password: 'StrongPassword123',
+    });
+    expect(success).toBe(true);
+    expect(hook.result.current.successMessage).toBe('Password has been reset.');
+  });
+
+  it('shows apiError on invalid reset token', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToResetStep(hook);
+
+    mockResetPassword.mockRejectedValueOnce(
+      new ApiError(401, {
+        error: {
+          code: 'invalid_password_reset_token',
+          message: 'The password reset session is invalid or has expired.',
+        },
+      }),
+    );
+
+    await act(async () => {
+      hook.result.current.updateField('newPassword', 'StrongPassword123');
+    });
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await hook.result.current.handleResetPassword();
+    });
+
+    expect(success).toBe(false);
+    expect(hook.result.current.apiError).toBe(
+      'The password reset session is invalid or has expired.',
+    );
+  });
+
+  it('handles unexpected error on reset', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToResetStep(hook);
+
+    mockResetPassword.mockRejectedValueOnce(new Error('Network'));
+
+    await act(async () => {
+      hook.result.current.updateField('newPassword', 'StrongPassword123');
+    });
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await hook.result.current.handleResetPassword();
+    });
+
+    expect(success).toBe(false);
+    expect(hook.result.current.apiError).toBe(
+      'An unexpected error occurred. Please try again.',
+    );
+  });
+
+  // --- Navigation: goBack ---
+
+  it('goes back from otp to email step', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToOtpStep(hook);
+    expect(hook.result.current.step).toBe('otp');
+
+    await act(async () => {
+      hook.result.current.goBack();
+    });
+
+    expect(hook.result.current.step).toBe('email');
+    expect(hook.result.current.formData.otp).toBe('');
+    expect(hook.result.current.apiError).toBeNull();
+  });
+
+  it('goes back from reset to otp step', async () => {
+    const hook = renderHook(() => useForgotPasswordViewModel());
+    await advanceToResetStep(hook);
+    expect(hook.result.current.step).toBe('reset');
+
+    await act(async () => {
+      hook.result.current.goBack();
+    });
+
+    expect(hook.result.current.step).toBe('otp');
+    expect(hook.result.current.formData.newPassword).toBe('');
+  });
+});

--- a/mobile/src/viewmodels/auth/useForgotPasswordViewModel.ts
+++ b/mobile/src/viewmodels/auth/useForgotPasswordViewModel.ts
@@ -1,0 +1,187 @@
+import { useState, useCallback } from 'react';
+import {
+  requestPasswordResetOtp,
+  verifyPasswordResetOtp,
+  resetPassword,
+} from '@/services/authService';
+import { ApiError } from '@/services/api';
+import { validateEmail, validateOtp, validatePassword } from '@/utils/validators';
+
+export type ForgotPasswordStep = 'email' | 'otp' | 'reset';
+
+export interface ForgotPasswordFormData {
+  email: string;
+  otp: string;
+  newPassword: string;
+}
+
+export interface ForgotPasswordFormErrors {
+  email?: string | null;
+  otp?: string | null;
+  newPassword?: string | null;
+}
+
+export interface ForgotPasswordViewModel {
+  step: ForgotPasswordStep;
+  formData: ForgotPasswordFormData;
+  errors: ForgotPasswordFormErrors;
+  isLoading: boolean;
+  apiError: string | null;
+  successMessage: string | null;
+  handleRequestOtp: () => Promise<void>;
+  handleVerifyOtp: () => Promise<void>;
+  handleResetPassword: () => Promise<boolean>;
+  updateField: <K extends keyof ForgotPasswordFormData>(
+    field: K,
+    value: ForgotPasswordFormData[K],
+  ) => void;
+  goBack: () => void;
+}
+
+const INITIAL_FORM_DATA: ForgotPasswordFormData = {
+  email: '',
+  otp: '',
+  newPassword: '',
+};
+
+const OTP_ERROR_CODES = new Set(['invalid_otp', 'otp_attempts_exceeded']);
+
+export function useForgotPasswordViewModel(): ForgotPasswordViewModel {
+  const [step, setStep] = useState<ForgotPasswordStep>('email');
+  const [formData, setFormData] =
+    useState<ForgotPasswordFormData>(INITIAL_FORM_DATA);
+  const [errors, setErrors] = useState<ForgotPasswordFormErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [resetToken, setResetToken] = useState<string | null>(null);
+
+  const updateField = useCallback(
+    <K extends keyof ForgotPasswordFormData>(
+      field: K,
+      value: ForgotPasswordFormData[K],
+    ) => {
+      setFormData((prev) => ({ ...prev, [field]: value }));
+      setErrors((prev) => ({ ...prev, [field]: null }));
+      setApiError(null);
+    },
+    [],
+  );
+
+  const handleRequestOtp = useCallback(async () => {
+    const trimmedEmail = formData.email.trim();
+    const emailError = validateEmail(trimmedEmail);
+    if (emailError) {
+      setErrors({ email: emailError });
+      return;
+    }
+
+    setIsLoading(true);
+    setApiError(null);
+    try {
+      await requestPasswordResetOtp({ email: trimmedEmail });
+      setFormData((prev) => ({ ...prev, email: trimmedEmail }));
+      setStep('otp');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setApiError(err.message);
+      } else {
+        setApiError('An unexpected error occurred. Please try again.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [formData.email]);
+
+  const handleVerifyOtp = useCallback(async () => {
+    const otpError = validateOtp(formData.otp);
+    if (otpError) {
+      setErrors((prev) => ({ ...prev, otp: otpError }));
+      return;
+    }
+
+    setIsLoading(true);
+    setApiError(null);
+    try {
+      const grant = await verifyPasswordResetOtp({
+        email: formData.email,
+        otp: formData.otp,
+      });
+      setResetToken(grant.reset_token);
+      setStep('reset');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (OTP_ERROR_CODES.has(err.code)) {
+          setFormData((prev) => ({ ...prev, otp: '' }));
+          setErrors({ otp: err.message });
+        }
+        setApiError(err.message);
+      } else {
+        setApiError('An unexpected error occurred. Please try again.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [formData.email, formData.otp]);
+
+  const handleResetPassword = useCallback(async (): Promise<boolean> => {
+    const passwordError = validatePassword(formData.newPassword);
+    if (passwordError) {
+      setErrors((prev) => ({ ...prev, newPassword: passwordError }));
+      return false;
+    }
+
+    if (!resetToken) {
+      setApiError('Reset session expired. Please start over.');
+      return false;
+    }
+
+    setIsLoading(true);
+    setApiError(null);
+    try {
+      const result = await resetPassword({
+        email: formData.email,
+        reset_token: resetToken,
+        new_password: formData.newPassword,
+      });
+      setSuccessMessage(result.message);
+      return true;
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setApiError(err.message);
+      } else {
+        setApiError('An unexpected error occurred. Please try again.');
+      }
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [formData.email, formData.newPassword, resetToken]);
+
+  const goBack = useCallback(() => {
+    setApiError(null);
+    setErrors({});
+    if (step === 'otp') {
+      setFormData((prev) => ({ ...prev, otp: '' }));
+      setStep('email');
+    } else if (step === 'reset') {
+      setFormData((prev) => ({ ...prev, otp: '', newPassword: '' }));
+      setResetToken(null);
+      setStep('otp');
+    }
+  }, [step]);
+
+  return {
+    step,
+    formData,
+    errors,
+    isLoading,
+    apiError,
+    successMessage,
+    handleRequestOtp,
+    handleVerifyOtp,
+    handleResetPassword,
+    updateField,
+    goBack,
+  };
+}

--- a/mobile/src/views/auth/ForgotPasswordView.tsx
+++ b/mobile/src/views/auth/ForgotPasswordView.tsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { router } from 'expo-router';
+import {
+  useForgotPasswordViewModel,
+  ForgotPasswordStep,
+} from '@/viewmodels/auth/useForgotPasswordViewModel';
+
+const STEPS: ForgotPasswordStep[] = ['email', 'otp', 'reset'];
+
+const STEP_SUBTITLES: Record<ForgotPasswordStep, string> = {
+  email: 'Enter your email address to request a password reset.',
+  otp: 'Enter the verification code sent to your email.',
+  reset: 'Choose a new password for your account.',
+};
+
+const BUTTON_LABELS: Record<ForgotPasswordStep, string> = {
+  email: 'Send reset code',
+  otp: 'Verify code',
+  reset: 'Reset password',
+};
+
+export default function ForgotPasswordView() {
+  const vm = useForgotPasswordViewModel();
+
+  const handleNext = async () => {
+    if (vm.step === 'email') {
+      await vm.handleRequestOtp();
+    } else if (vm.step === 'otp') {
+      await vm.handleVerifyOtp();
+    } else {
+      const success = await vm.handleResetPassword();
+      if (success) {
+        router.replace('/');
+      }
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={styles.title}>Forgot password</Text>
+        <Text style={styles.subtitle}>{STEP_SUBTITLES[vm.step]}</Text>
+
+        <View style={styles.stepIndicator}>
+          {STEPS.map((s, i) => (
+            <View
+              key={s}
+              style={[
+                styles.stepDot,
+                STEPS.indexOf(vm.step) >= i && styles.stepDotActive,
+              ]}
+            />
+          ))}
+        </View>
+
+        {vm.successMessage && (
+          <View style={styles.successBanner}>
+            <Text style={styles.successBannerText}>{vm.successMessage}</Text>
+          </View>
+        )}
+
+        {vm.apiError && (
+          <View style={styles.errorBanner}>
+            <Text style={styles.errorBannerText}>{vm.apiError}</Text>
+          </View>
+        )}
+
+        {vm.step === 'email' && (
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Email</Text>
+            <TextInput
+              style={[styles.input, vm.errors.email && styles.inputError]}
+              placeholder="you@example.com"
+              placeholderTextColor="#9CA3AF"
+              value={vm.formData.email}
+              onChangeText={(v) => vm.updateField('email', v)}
+              autoCapitalize="none"
+              autoComplete="email"
+              keyboardType="email-address"
+              editable={!vm.isLoading}
+            />
+            {vm.errors.email && (
+              <Text style={styles.fieldError}>{vm.errors.email}</Text>
+            )}
+          </View>
+        )}
+
+        {vm.step === 'otp' && (
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Verification Code</Text>
+            <TextInput
+              style={[styles.input, vm.errors.otp && styles.inputError]}
+              placeholder="123456"
+              placeholderTextColor="#9CA3AF"
+              value={vm.formData.otp}
+              onChangeText={(v) => vm.updateField('otp', v)}
+              keyboardType="number-pad"
+              maxLength={6}
+              editable={!vm.isLoading}
+            />
+            {vm.errors.otp && (
+              <Text style={styles.fieldError}>{vm.errors.otp}</Text>
+            )}
+          </View>
+        )}
+
+        {vm.step === 'reset' && (
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>New Password</Text>
+            <TextInput
+              style={[
+                styles.input,
+                vm.errors.newPassword && styles.inputError,
+              ]}
+              placeholder="At least 8 characters"
+              placeholderTextColor="#9CA3AF"
+              value={vm.formData.newPassword}
+              onChangeText={(v) => vm.updateField('newPassword', v)}
+              secureTextEntry
+              autoComplete="new-password"
+              editable={!vm.isLoading}
+            />
+            {vm.errors.newPassword && (
+              <Text style={styles.fieldError}>{vm.errors.newPassword}</Text>
+            )}
+          </View>
+        )}
+
+        <TouchableOpacity
+          style={[styles.button, vm.isLoading && styles.buttonDisabled]}
+          onPress={handleNext}
+          disabled={vm.isLoading}
+          activeOpacity={0.8}
+        >
+          {vm.isLoading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.buttonText}>{BUTTON_LABELS[vm.step]}</Text>
+          )}
+        </TouchableOpacity>
+
+        {vm.step !== 'email' && (
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={vm.goBack}
+            disabled={vm.isLoading}
+          >
+            <Text style={styles.backButtonText}>Go Back</Text>
+          </TouchableOpacity>
+        )}
+
+        {vm.step === 'email' && (
+          <View style={styles.footer}>
+            <TouchableOpacity
+              onPress={() => router.back()}
+              disabled={vm.isLoading}
+            >
+              <Text style={styles.footerLink}>Back to Sign In</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  scrollContent: {
+    flexGrow: 1,
+    padding: 24,
+    paddingTop: 60,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 15,
+    color: '#6B7280',
+    marginBottom: 24,
+  },
+  stepIndicator: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 32,
+  },
+  stepDot: {
+    flex: 1,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '#E5E7EB',
+  },
+  stepDotActive: {
+    backgroundColor: '#2563EB',
+  },
+  successBanner: {
+    backgroundColor: '#ECFDF5',
+    borderWidth: 1,
+    borderColor: '#A7F3D0',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  successBannerText: {
+    color: '#047857',
+    fontSize: 14,
+  },
+  errorBanner: {
+    backgroundColor: '#FEF2F2',
+    borderWidth: 1,
+    borderColor: '#FECACA',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  errorBannerText: {
+    color: '#DC2626',
+    fontSize: 14,
+  },
+  fieldGroup: {
+    marginBottom: 20,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: '#111827',
+    backgroundColor: '#F9FAFB',
+  },
+  inputError: {
+    borderColor: '#EF4444',
+    backgroundColor: '#FEF2F2',
+  },
+  fieldError: {
+    color: '#EF4444',
+    fontSize: 13,
+    marginTop: 4,
+  },
+  button: {
+    backgroundColor: '#2563EB',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  backButton: {
+    alignItems: 'center',
+    marginTop: 16,
+    paddingVertical: 8,
+  },
+  backButtonText: {
+    color: '#6B7280',
+    fontSize: 15,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 24,
+  },
+  footerLink: {
+    fontSize: 15,
+    color: '#2563EB',
+    fontWeight: '600',
+  },
+});

--- a/mobile/src/views/auth/LoginView.tsx
+++ b/mobile/src/views/auth/LoginView.tsx
@@ -10,7 +10,7 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
-import { router } from 'expo-router';
+import { router, type Href } from 'expo-router';
 import { useLoginViewModel } from '@/viewmodels/auth/useLoginViewModel';
 
 export default function LoginView() {
@@ -76,6 +76,14 @@ export default function LoginView() {
             <Text style={styles.fieldError}>{vm.errors.password}</Text>
           )}
         </View>
+
+        <TouchableOpacity
+          style={styles.forgotPasswordLink}
+          onPress={() => router.push('/forgot-password' as Href)}
+          disabled={vm.isLoading}
+        >
+          <Text style={styles.footerLink}>Forgot password?</Text>
+        </TouchableOpacity>
 
         <TouchableOpacity
           style={[styles.button, vm.isLoading && styles.buttonDisabled]}
@@ -164,6 +172,10 @@ const styles = StyleSheet.create({
     color: '#EF4444',
     fontSize: 13,
     marginTop: 4,
+  },
+  forgotPasswordLink: {
+    alignSelf: 'flex-end',
+    marginBottom: 8,
   },
   button: {
     backgroundColor: '#2563EB',


### PR DESCRIPTION
## 📋 Summary

Adds a mobile **forgot password** flow (email → OTP → new password) wired to the backend forgot-password endpoints, following MVVM (`useForgotPasswordViewModel` + `ForgotPasswordView`, `authService`). The login screen links to `/forgot-password`; after a successful reset, the user can return to login.

## 🔄 Changes

- **Model:** `ForgotPasswordRequestResponse`, `VerifyPasswordResetRequest`, `PasswordResetGrantResponse`, `ResetPasswordRequest`, `PasswordResetSuccessResponse` in `mobile/src/models/auth.ts`
- **Service:** `requestPasswordResetOtp`, `verifyPasswordResetOtp`, `resetPassword` in `mobile/src/services/authService.ts` calling `POST /auth/forgot-password/request-otp`, `POST /auth/forgot-password/verify-otp`, and `POST /auth/forgot-password/reset-password`
- **ViewModel:** `mobile/src/viewmodels/auth/useForgotPasswordViewModel.ts` — multi-step state (`email` | `otp` | `reset`), validation via existing validators, loading and `ApiError` handling (including OTP error codes such as `invalid_otp` / `otp_attempts_exceeded`)
- **View:** `mobile/src/views/auth/ForgotPasswordView.tsx` — step UI, error banner, loading/success, back navigation between steps
- **Routing:** `mobile/src/app/forgot-password.tsx` → `ForgotPasswordView` at `/forgot-password`
- **Login UX:** “Forgot password?” on `mobile/src/views/auth/LoginView.tsx` → `/forgot-password`
- **Tests:** `mobile/src/viewmodels/auth/useForgotPasswordViewModel.test.tsx`

## 🧪 Testing

**Automated**

```bash
cd mobile
npm test -- useForgotPasswordViewModel # tests only the changes with this feature
npm test # tests everything implemented until now 
```

**Manual**
1. Run the backend (or use a deployed API) so the forgot-password routes are reachable.
2. If needed, set `EXPO_PUBLIC_API_BASE_URL` in `mobile` so the emulator/device can reach the API (see `mobile/src/config/apiBaseUrl.ts`).
3. From the repo: `cd mobile && npx expo start`, then open the app.
4. On login page, tap **Forgot password?** → `/forgot-password`.
5. **Email step:** submit empty/invalid email → validation; submit valid email → OTP requested.
6. **OTP step:** wrong OTP → API error where applicable; valid OTP → reset step.
7. **Reset step:** set new password (validation errors as appropriate) → success; confirm navigation back to login works.
8. **Regression:** `/` login and `/register` still behave as before.

## 🔗 Related
Closes #157 