### PR TITLE
feat(backend): add event discovery endpoint with filters

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -222,6 +222,265 @@ func buildRouteWKT(points []domain.GeoPoint) string {
 	return "SRID=4326;LINESTRING(" + strings.Join(segments, ", ") + ")"
 }
 
+// ListDiscoverableEvents returns nearby ACTIVE PUBLIC/PROTECTED events using
+// combined full-text search, structured filters, and keyset pagination.
+func (r *EventRepository) ListDiscoverableEvents(
+	ctx context.Context,
+	userID uuid.UUID,
+	params eventapp.DiscoverEventsParams,
+) ([]eventapp.DiscoverableEventRecord, error) {
+	args := make([]any, 0, 12)
+	addArg := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	lonPlaceholder := addArg(params.Origin.Lon)
+	latPlaceholder := addArg(params.Origin.Lat)
+	userPlaceholder := addArg(userID)
+	statusPlaceholder := addArg(string(domain.EventStatusActive))
+	privacyPlaceholder := addArg(toPrivacyLevelStringSlice(params.PrivacyLevels))
+	radiusPlaceholder := addArg(params.RadiusMeters)
+
+	originExpr := fmt.Sprintf("ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography", lonPlaceholder, latPlaceholder)
+	searchVectorExpr := "COALESCE(e.search_vector, ''::tsvector)"
+	routeAnchorExpr := "ST_StartPoint(el.geom::geometry)::geography"
+	distanceSourceExpr := fmt.Sprintf(
+		"CASE WHEN e.location_type = '%s' THEN %s ELSE el.geom END",
+		domain.LocationRoute,
+		routeAnchorExpr,
+	)
+	distanceExpr := fmt.Sprintf("ST_Distance(%s, %s)", distanceSourceExpr, originExpr)
+	routeRadiusExpr := fmt.Sprintf(
+		`EXISTS (
+			SELECT 1
+			FROM ST_DumpPoints(el.geom::geometry) AS route_point
+			WHERE ST_DWithin(route_point.geom::geography, %s, %s)
+		)`,
+		originExpr,
+		radiusPlaceholder,
+	)
+	relevanceExpr := "NULL::double precision"
+
+	filters := []string{
+		fmt.Sprintf("e.status = %s", statusPlaceholder),
+		fmt.Sprintf("e.privacy_level = ANY(%s::text[])", privacyPlaceholder),
+		fmt.Sprintf(
+			"((e.location_type = '%s' AND %s) OR (e.location_type <> '%s' AND ST_DWithin(el.geom, %s, %s)))",
+			domain.LocationRoute,
+			routeRadiusExpr,
+			domain.LocationRoute,
+			originExpr,
+			radiusPlaceholder,
+		),
+	}
+
+	if params.SearchTSQuery != "" {
+		queryPlaceholder := addArg(params.SearchTSQuery)
+		filters = append(filters, fmt.Sprintf("%s @@ to_tsquery('simple', %s)", searchVectorExpr, queryPlaceholder))
+		relevanceExpr = fmt.Sprintf("ts_rank_cd(%s, to_tsquery('simple', %s))::double precision", searchVectorExpr, queryPlaceholder)
+	}
+
+	if len(params.CategoryIDs) > 0 {
+		filters = append(filters, fmt.Sprintf(
+			"e.category_id::bigint = ANY(%s::bigint[])",
+			addArg(toInt64Slice(params.CategoryIDs)),
+		))
+	}
+
+	if params.StartFrom != nil {
+		filters = append(filters, fmt.Sprintf("e.start_time >= %s", addArg(*params.StartFrom)))
+	}
+
+	if params.StartTo != nil {
+		filters = append(filters, fmt.Sprintf("e.start_time <= %s", addArg(*params.StartTo)))
+	}
+
+	if len(params.TagNames) > 0 {
+		filters = append(filters, fmt.Sprintf(
+			`EXISTS (
+				SELECT 1
+				FROM event_tag et
+				WHERE et.event_id = e.id
+				  AND LOWER(et.name) = ANY(%s::text[])
+			)`,
+			addArg(params.TagNames),
+		))
+	}
+
+	if params.OnlyFavorited {
+		filters = append(filters, "fav.event_id IS NOT NULL")
+	}
+
+	paginationClause, orderByClause := buildDiscoverEventsPagination(params, addArg)
+	limitPlaceholder := addArg(params.RepositoryFetchLimit)
+
+	query := fmt.Sprintf(`
+		WITH base AS (
+			SELECT
+				e.id,
+				e.title,
+				COALESCE(ec.name, '') AS category_name,
+				e.image_url,
+				e.start_time,
+				el.address AS location_address,
+				e.privacy_level,
+				e.approved_participant_count,
+				(fav.event_id IS NOT NULL) AS is_favorited,
+				%s AS distance_meters,
+				%s AS relevance_score
+			FROM event e
+			JOIN event_location el ON el.event_id = e.id
+			LEFT JOIN event_category ec ON ec.id = e.category_id
+			LEFT JOIN favorite_event fav ON fav.event_id = e.id AND fav.user_id = %s
+			WHERE %s
+		)
+		SELECT
+			id,
+			title,
+			category_name,
+			image_url,
+			start_time,
+			location_address,
+			privacy_level,
+			approved_participant_count,
+			is_favorited,
+			distance_meters,
+			relevance_score
+		FROM base
+		%s
+		ORDER BY %s
+		LIMIT %s
+	`, distanceExpr, relevanceExpr, userPlaceholder, strings.Join(filters, "\n			AND "), paginationClause, orderByClause, limitPlaceholder)
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list discoverable events: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]eventapp.DiscoverableEventRecord, 0, params.RepositoryFetchLimit)
+	for rows.Next() {
+		var (
+			id                       uuid.UUID
+			title                    string
+			categoryName             string
+			imageURL                 pgtype.Text
+			startTime                time.Time
+			locationAddress          pgtype.Text
+			privacyLevel             string
+			approvedParticipantCount int
+			isFavorited              bool
+			distanceMeters           float64
+			relevanceScore           pgtype.Float8
+		)
+
+		if err := rows.Scan(
+			&id,
+			&title,
+			&categoryName,
+			&imageURL,
+			&startTime,
+			&locationAddress,
+			&privacyLevel,
+			&approvedParticipantCount,
+			&isFavorited,
+			&distanceMeters,
+			&relevanceScore,
+		); err != nil {
+			return nil, fmt.Errorf("scan discoverable event: %w", err)
+		}
+
+		record := eventapp.DiscoverableEventRecord{
+			ID:                       id,
+			Title:                    title,
+			CategoryName:             categoryName,
+			StartTime:                startTime,
+			PrivacyLevel:             domain.EventPrivacyLevel(privacyLevel),
+			ApprovedParticipantCount: approvedParticipantCount,
+			IsFavorited:              isFavorited,
+			DistanceMeters:           distanceMeters,
+		}
+		if imageURL.Valid {
+			record.ImageURL = &imageURL.String
+		}
+		if locationAddress.Valid {
+			record.LocationAddress = &locationAddress.String
+		}
+		if relevanceScore.Valid {
+			record.RelevanceScore = &relevanceScore.Float64
+		}
+
+		records = append(records, record)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate discoverable events: %w", err)
+	}
+
+	return records, nil
+}
+
+func buildDiscoverEventsPagination(
+	params eventapp.DiscoverEventsParams,
+	addArg func(value any) string,
+) (string, string) {
+	switch params.SortBy {
+	case domain.EventDiscoverySortDistance:
+		if params.DecodedCursor == nil {
+			return "", "base.distance_meters ASC, base.start_time ASC, base.id ASC"
+		}
+
+		return fmt.Sprintf(
+				"WHERE (base.distance_meters, base.start_time, base.id) > (%s, %s, %s)",
+				addArg(*params.DecodedCursor.DistanceMeters),
+				addArg(params.DecodedCursor.StartTime),
+				addArg(params.DecodedCursor.EventID),
+			),
+			"base.distance_meters ASC, base.start_time ASC, base.id ASC"
+	case domain.EventDiscoverySortRelevance:
+		if params.DecodedCursor == nil {
+			return "", "base.relevance_score DESC, base.distance_meters ASC, base.start_time ASC, base.id ASC"
+		}
+
+		return fmt.Sprintf(
+				"WHERE ((base.relevance_score * -1), base.distance_meters, base.start_time, base.id) > (%s, %s, %s, %s)",
+				addArg(-*params.DecodedCursor.RelevanceScore),
+				addArg(*params.DecodedCursor.DistanceMeters),
+				addArg(params.DecodedCursor.StartTime),
+				addArg(params.DecodedCursor.EventID),
+			),
+			"base.relevance_score DESC, base.distance_meters ASC, base.start_time ASC, base.id ASC"
+	default:
+		if params.DecodedCursor == nil {
+			return "", "base.start_time ASC, base.id ASC"
+		}
+
+		return fmt.Sprintf(
+				"WHERE (base.start_time, base.id) > (%s, %s)",
+				addArg(params.DecodedCursor.StartTime),
+				addArg(params.DecodedCursor.EventID),
+			),
+			"base.start_time ASC, base.id ASC"
+	}
+}
+
+func toInt64Slice(values []int) []int64 {
+	converted := make([]int64, len(values))
+	for i, value := range values {
+		converted[i] = int64(value)
+	}
+	return converted
+}
+
+func toPrivacyLevelStringSlice(values []domain.EventPrivacyLevel) []string {
+	converted := make([]string, len(values))
+	for i, value := range values {
+		converted[i] = string(value)
+	}
+	return converted
+}
+
 // GetEventByID fetches a single event row by its primary key.
 // Returns domain.ErrNotFound when no matching row exists.
 func (r *EventRepository) GetEventByID(ctx context.Context, eventID uuid.UUID) (*domain.Event, error) {

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
@@ -1,6 +1,9 @@
 package event_handler
 
 import (
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
@@ -25,9 +28,26 @@ func NewEventHandler(service event.UseCase) *EventHandler {
 // decisions remain outside the handler.
 func RegisterEventRoutes(router fiber.Router, handler *EventHandler, auth fiber.Handler) {
 	group := router.Group("/events")
+	group.Get("/", auth, handler.DiscoverEvents)
 	group.Post("/", auth, handler.CreateEvent)
 	group.Post("/:id/join", auth, handler.JoinEvent)
 	group.Post("/:id/join-request", auth, handler.RequestJoin)
+}
+
+// DiscoverEvents handles GET /events.
+func (h *EventHandler) DiscoverEvents(c *fiber.Ctx) error {
+	input, errs := parseDiscoverEventsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.DiscoverEvents(c.UserContext(), claims.UserID, input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.JSON(result)
 }
 
 // CreateEvent handles POST /events.
@@ -186,4 +206,197 @@ func parseEventIDParam(c *fiber.Ctx) (uuid.UUID, error) {
 		return uuid.Nil, domain.ValidationError(map[string]string{"id": "must be a valid UUID"})
 	}
 	return eventID, nil
+}
+
+func parseDiscoverEventsInput(c *fiber.Ctx) (event.DiscoverEventsInput, map[string]string) {
+	values, err := url.ParseQuery(string(c.Context().URI().QueryString()))
+	if err != nil {
+		return event.DiscoverEventsInput{}, map[string]string{"query": "query string must be valid"}
+	}
+
+	input := event.DiscoverEventsInput{}
+	errs := make(map[string]string)
+
+	if lat, ok, msg := parseOptionalFloatQuery(c, "lat"); msg != "" {
+		errs["lat"] = msg
+	} else if ok {
+		input.Lat = &lat
+	}
+
+	if lon, ok, msg := parseOptionalFloatQuery(c, "lon"); msg != "" {
+		errs["lon"] = msg
+	} else if ok {
+		input.Lon = &lon
+	}
+
+	if radius, ok, msg := parseOptionalIntQuery(c, "radius_meters"); msg != "" {
+		errs["radius_meters"] = msg
+	} else if ok {
+		input.RadiusMeters = &radius
+	}
+
+	if limit, ok, msg := parseOptionalIntQuery(c, "limit"); msg != "" {
+		errs["limit"] = msg
+	} else if ok {
+		input.Limit = &limit
+	}
+
+	if rawQuery := strings.TrimSpace(c.Query("q")); rawQuery != "" {
+		input.Query = &rawQuery
+	}
+
+	if privacyLevels, msg := parsePrivacyLevels(values, "privacy_levels"); msg != "" {
+		errs["privacy_levels"] = msg
+	} else {
+		input.PrivacyLevels = privacyLevels
+	}
+
+	if categoryIDs, msg := parseCategoryIDs(values, "category_ids"); msg != "" {
+		errs["category_ids"] = msg
+	} else {
+		input.CategoryIDs = categoryIDs
+	}
+
+	tagNames := parseListQueryValues(values, "tag_names")
+	if len(tagNames) > 0 {
+		input.TagNames = tagNames
+	}
+
+	if startFrom, ok, msg := parseOptionalTimeQuery(c, "start_from"); msg != "" {
+		errs["start_from"] = msg
+	} else if ok {
+		input.StartFrom = &startFrom
+	}
+
+	if startTo, ok, msg := parseOptionalTimeQuery(c, "start_to"); msg != "" {
+		errs["start_to"] = msg
+	} else if ok {
+		input.StartTo = &startTo
+	}
+
+	if rawOnlyFavorited := strings.TrimSpace(c.Query("only_favorited")); rawOnlyFavorited != "" {
+		parsed, err := strconv.ParseBool(rawOnlyFavorited)
+		if err != nil {
+			errs["only_favorited"] = "only_favorited must be a boolean"
+		} else {
+			input.OnlyFavorited = parsed
+		}
+	}
+
+	if rawSortBy := strings.TrimSpace(c.Query("sort_by")); rawSortBy != "" {
+		sortBy, ok := domain.ParseEventDiscoverySort(rawSortBy)
+		if !ok {
+			errs["sort_by"] = "must be one of: START_TIME, DISTANCE, RELEVANCE"
+		} else {
+			input.SortBy = &sortBy
+		}
+	}
+
+	if rawCursor := strings.TrimSpace(c.Query("cursor")); rawCursor != "" {
+		input.Cursor = &rawCursor
+	}
+
+	return input, errs
+}
+
+func parseOptionalFloatQuery(c *fiber.Ctx, key string) (float64, bool, string) {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return 0, false, ""
+	}
+
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, false, key + " must be a valid number"
+	}
+
+	return value, true, ""
+}
+
+func parseOptionalIntQuery(c *fiber.Ctx, key string) (int, bool, string) {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return 0, false, ""
+	}
+
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false, key + " must be a valid integer"
+	}
+
+	return value, true, ""
+}
+
+func parseOptionalTimeQuery(c *fiber.Ctx, key string) (time.Time, bool, string) {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return time.Time{}, false, ""
+	}
+
+	value, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false, key + " must be a valid RFC3339 date-time with timezone"
+	}
+
+	return value, true, ""
+}
+
+func parseCategoryIDs(values url.Values, key string) ([]int, string) {
+	rawValues := parseListQueryValues(values, key)
+	if len(rawValues) == 0 {
+		return nil, ""
+	}
+
+	categoryIDs := make([]int, 0, len(rawValues))
+	for _, raw := range rawValues {
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			return nil, "category_ids must contain only integers"
+		}
+		categoryIDs = append(categoryIDs, value)
+	}
+
+	return categoryIDs, ""
+}
+
+func parsePrivacyLevels(values url.Values, key string) ([]domain.EventPrivacyLevel, string) {
+	rawValues := parseListQueryValues(values, key)
+	if len(rawValues) == 0 {
+		return nil, ""
+	}
+
+	levels := make([]domain.EventPrivacyLevel, 0, len(rawValues))
+	for _, raw := range rawValues {
+		switch raw {
+		case string(domain.PrivacyPublic):
+			levels = append(levels, domain.PrivacyPublic)
+		case string(domain.PrivacyProtected):
+			levels = append(levels, domain.PrivacyProtected)
+		default:
+			return nil, "privacy_levels must contain only: PUBLIC, PROTECTED"
+		}
+	}
+
+	return levels, ""
+}
+
+func parseListQueryValues(values url.Values, key string) []string {
+	rawValues := values[key]
+	if len(rawValues) == 0 {
+		return nil
+	}
+
+	items := make([]string, 0, len(rawValues))
+	for _, rawValue := range rawValues {
+		parts := strings.Split(rawValue, ",")
+		for _, part := range parts {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			items = append(items, trimmed)
+		}
+	}
+
+	return items
 }

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -17,10 +18,13 @@ import (
 
 type stubEventService struct {
 	result               *event.CreateEventResult
+	discoverResult       *event.DiscoverEventsResult
 	err                  error
 	callCount            int
+	discoverCallCount    int
 	requestJoinCallCount int
 	lastInput            event.CreateEventInput
+	lastDiscoverInput    event.DiscoverEventsInput
 	lastRequestJoinInput event.RequestJoinInput
 }
 
@@ -41,6 +45,23 @@ func (s *stubEventService) CreateEvent(_ context.Context, _ uuid.UUID, input eve
 		Status:       string(domain.EventStatusActive),
 		StartTime:    now.Add(time.Hour),
 		CreatedAt:    now,
+	}, nil
+}
+
+func (s *stubEventService) DiscoverEvents(_ context.Context, _ uuid.UUID, input event.DiscoverEventsInput) (*event.DiscoverEventsResult, error) {
+	s.discoverCallCount++
+	s.lastDiscoverInput = input
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.discoverResult != nil {
+		return s.discoverResult, nil
+	}
+	return &event.DiscoverEventsResult{
+		Items: []event.DiscoverableEventItem{},
+		PageInfo: event.DiscoverEventsPageInfo{
+			HasNext: false,
+		},
 	}, nil
 }
 
@@ -99,6 +120,159 @@ func authedVerifier() *fakeVerifier {
 			Username: "testuser",
 			Email:    "test@example.com",
 		},
+	}
+}
+
+func TestDiscoverEventsParsesQueryParamsBeforeCallingService(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+	startFrom := url.QueryEscape("2030-01-01T10:00:00+03:00")
+	startTo := url.QueryEscape("2030-01-02T10:00:00+03:00")
+
+	req := httptest.NewRequest(
+		fiber.MethodGet,
+		"/events/?lat=41.01&lon=29.02&radius_meters=9000&q=trail&privacy_levels=PUBLIC,PROTECTED&category_ids=1,3&tag_names=hiking,outdoor&start_from="+startFrom+"&start_to="+startTo+"&only_favorited=true&sort_by=DISTANCE&limit=15&cursor=test-cursor",
+		nil,
+	)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.discoverCallCount != 1 {
+		t.Fatalf("expected discover service to be called once, got %d", svc.discoverCallCount)
+	}
+	if svc.lastDiscoverInput.Lat == nil || *svc.lastDiscoverInput.Lat != 41.01 {
+		t.Fatalf("expected parsed lat 41.01, got %v", svc.lastDiscoverInput.Lat)
+	}
+	if svc.lastDiscoverInput.Lon == nil || *svc.lastDiscoverInput.Lon != 29.02 {
+		t.Fatalf("expected parsed lon 29.02, got %v", svc.lastDiscoverInput.Lon)
+	}
+	if svc.lastDiscoverInput.RadiusMeters == nil || *svc.lastDiscoverInput.RadiusMeters != 9000 {
+		t.Fatalf("expected parsed radius 9000, got %v", svc.lastDiscoverInput.RadiusMeters)
+	}
+	if svc.lastDiscoverInput.Query == nil || *svc.lastDiscoverInput.Query != "trail" {
+		t.Fatalf("expected parsed q %q, got %v", "trail", svc.lastDiscoverInput.Query)
+	}
+	if len(svc.lastDiscoverInput.PrivacyLevels) != 2 ||
+		svc.lastDiscoverInput.PrivacyLevels[0] != domain.PrivacyPublic ||
+		svc.lastDiscoverInput.PrivacyLevels[1] != domain.PrivacyProtected {
+		t.Fatalf("expected parsed privacy_levels [PUBLIC PROTECTED], got %v", svc.lastDiscoverInput.PrivacyLevels)
+	}
+	if len(svc.lastDiscoverInput.CategoryIDs) != 2 || svc.lastDiscoverInput.CategoryIDs[0] != 1 || svc.lastDiscoverInput.CategoryIDs[1] != 3 {
+		t.Fatalf("expected parsed category_ids [1 3], got %v", svc.lastDiscoverInput.CategoryIDs)
+	}
+	if len(svc.lastDiscoverInput.TagNames) != 2 || svc.lastDiscoverInput.TagNames[0] != "hiking" || svc.lastDiscoverInput.TagNames[1] != "outdoor" {
+		t.Fatalf("expected parsed tag_names [hiking outdoor], got %v", svc.lastDiscoverInput.TagNames)
+	}
+	if svc.lastDiscoverInput.StartFrom == nil || svc.lastDiscoverInput.StartTo == nil {
+		t.Fatal("expected parsed start_from and start_to")
+	}
+	if !svc.lastDiscoverInput.OnlyFavorited {
+		t.Fatal("expected only_favorited to be true")
+	}
+	if svc.lastDiscoverInput.SortBy == nil || *svc.lastDiscoverInput.SortBy != domain.EventDiscoverySortDistance {
+		t.Fatalf("expected parsed sort_by %q, got %v", domain.EventDiscoverySortDistance, svc.lastDiscoverInput.SortBy)
+	}
+	if svc.lastDiscoverInput.Limit == nil || *svc.lastDiscoverInput.Limit != 15 {
+		t.Fatalf("expected parsed limit 15, got %v", svc.lastDiscoverInput.Limit)
+	}
+	if svc.lastDiscoverInput.Cursor == nil || *svc.lastDiscoverInput.Cursor != "test-cursor" {
+		t.Fatalf("expected parsed cursor %q, got %v", "test-cursor", svc.lastDiscoverInput.Cursor)
+	}
+}
+
+func TestDiscoverEventsInvalidLatitudeReturns400(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/?lat=not-a-number&lon=29.02", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+	if svc.discoverCallCount != 0 {
+		t.Fatalf("expected discover service not to be called, got %d", svc.discoverCallCount)
+	}
+}
+
+func TestDiscoverEventsInvalidSortReturns400(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/?lat=41.01&lon=29.02&sort_by=POPULAR", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+	if svc.discoverCallCount != 0 {
+		t.Fatalf("expected discover service not to be called, got %d", svc.discoverCallCount)
+	}
+}
+
+func TestDiscoverEventsIgnoresEmptyOptionalListParams(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(
+		fiber.MethodGet,
+		"/events/?lat=41.01&lon=29.02&privacy_levels=&category_ids=&tag_names=",
+		nil,
+	)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.discoverCallCount != 1 {
+		t.Fatalf("expected discover service to be called once, got %d", svc.discoverCallCount)
+	}
+	if len(svc.lastDiscoverInput.PrivacyLevels) != 0 {
+		t.Fatalf("expected empty privacy_levels, got %v", svc.lastDiscoverInput.PrivacyLevels)
+	}
+	if len(svc.lastDiscoverInput.CategoryIDs) != 0 {
+		t.Fatalf("expected empty category_ids, got %v", svc.lastDiscoverInput.CategoryIDs)
+	}
+	if len(svc.lastDiscoverInput.TagNames) != 0 {
+		t.Fatalf("expected empty tag_names, got %v", svc.lastDiscoverInput.TagNames)
 	}
 }
 

--- a/backend/internal/application/event/discovery_cursor.go
+++ b/backend/internal/application/event/discovery_cursor.go
@@ -1,0 +1,138 @@
+package event
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+type discoverEventsFingerprintPayload struct {
+	Lat           float64  `json:"lat"`
+	Lon           float64  `json:"lon"`
+	RadiusMeters  int      `json:"radius_meters"`
+	Query         string   `json:"query"`
+	PrivacyLevels []string `json:"privacy_levels,omitempty"`
+	CategoryIDs   []int    `json:"category_ids,omitempty"`
+	StartFrom     *string  `json:"start_from,omitempty"`
+	StartTo       *string  `json:"start_to,omitempty"`
+	TagNames      []string `json:"tag_names,omitempty"`
+	OnlyFavorited bool     `json:"only_favorited"`
+}
+
+// buildDiscoverEventsFilterFingerprint hashes the normalized filter set so a
+// cursor cannot be reused with a different filter combination.
+func buildDiscoverEventsFilterFingerprint(params DiscoverEventsParams) (string, error) {
+	payload := discoverEventsFingerprintPayload{
+		Lat:           params.Origin.Lat,
+		Lon:           params.Origin.Lon,
+		RadiusMeters:  params.RadiusMeters,
+		Query:         params.Query,
+		PrivacyLevels: toPrivacyLevelStrings(params.PrivacyLevels),
+		CategoryIDs:   params.CategoryIDs,
+		TagNames:      params.TagNames,
+		OnlyFavorited: params.OnlyFavorited,
+	}
+	if params.StartFrom != nil {
+		value := params.StartFrom.UTC().Format(timeLayoutCursor)
+		payload.StartFrom = &value
+	}
+	if params.StartTo != nil {
+		value := params.StartTo.UTC().Format(timeLayoutCursor)
+		payload.StartTo = &value
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal discovery fingerprint: %w", err)
+	}
+
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+const timeLayoutCursor = "2006-01-02T15:04:05.999999999Z07:00"
+
+func encodeDiscoverEventsCursor(cursor DiscoverEventsCursor) (string, error) {
+	raw, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("marshal discovery cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func decodeDiscoverEventsCursor(token string) (*DiscoverEventsCursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return nil, fmt.Errorf("decode discovery cursor: %w", err)
+	}
+
+	var cursor DiscoverEventsCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil {
+		return nil, fmt.Errorf("unmarshal discovery cursor: %w", err)
+	}
+
+	if _, ok := domain.ParseEventDiscoverySort(string(cursor.SortBy)); !ok {
+		return nil, fmt.Errorf("cursor contains unsupported sort mode")
+	}
+	if cursor.FilterFingerprint == "" {
+		return nil, fmt.Errorf("cursor is missing filter fingerprint")
+	}
+	if cursor.StartTime.IsZero() {
+		return nil, fmt.Errorf("cursor is missing start_time")
+	}
+	if cursor.EventID == uuid.Nil {
+		return nil, fmt.Errorf("cursor is missing event_id")
+	}
+	if cursor.SortBy == domain.EventDiscoverySortDistance && cursor.DistanceMeters == nil {
+		return nil, fmt.Errorf("cursor is missing distance_meters")
+	}
+	if cursor.SortBy == domain.EventDiscoverySortRelevance {
+		if cursor.DistanceMeters == nil {
+			return nil, fmt.Errorf("cursor is missing distance_meters")
+		}
+		if cursor.RelevanceScore == nil {
+			return nil, fmt.Errorf("cursor is missing relevance_score")
+		}
+	}
+
+	return &cursor, nil
+}
+
+func buildNextDiscoverEventsCursor(params DiscoverEventsParams, record DiscoverableEventRecord) (DiscoverEventsCursor, error) {
+	cursor := DiscoverEventsCursor{
+		SortBy:            params.SortBy,
+		FilterFingerprint: params.FilterFingerprint,
+		StartTime:         record.StartTime.UTC(),
+		EventID:           record.ID,
+	}
+
+	switch params.SortBy {
+	case domain.EventDiscoverySortDistance:
+		cursor.DistanceMeters = &record.DistanceMeters
+	case domain.EventDiscoverySortRelevance:
+		if record.RelevanceScore == nil {
+			return DiscoverEventsCursor{}, fmt.Errorf("relevance cursor requires relevance score")
+		}
+		cursor.DistanceMeters = &record.DistanceMeters
+		cursor.RelevanceScore = record.RelevanceScore
+	}
+
+	return cursor, nil
+}
+
+func toPrivacyLevelStrings(levels []domain.EventPrivacyLevel) []string {
+	if len(levels) == 0 {
+		return nil
+	}
+
+	values := make([]string, len(levels))
+	for i, level := range levels {
+		values[i] = string(level)
+	}
+	return values
+}

--- a/backend/internal/application/event/discovery_validator.go
+++ b/backend/internal/application/event/discovery_validator.go
@@ -1,0 +1,218 @@
+package event
+
+import (
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+)
+
+const (
+	defaultDiscoverRadiusMeters = 10000
+	maxDiscoverRadiusMeters     = 50000
+	defaultDiscoverLimit        = 20
+	maxDiscoverLimit            = 50
+)
+
+// normalizeAndValidateDiscoverEventsInput applies defaults, normalizes filters,
+// and validates discovery-specific invariants before the repository is called.
+func normalizeAndValidateDiscoverEventsInput(input DiscoverEventsInput) (DiscoverEventsParams, map[string]string) {
+	errs := make(map[string]string)
+	params := DiscoverEventsParams{
+		OnlyFavorited: input.OnlyFavorited,
+	}
+
+	if input.Lat == nil {
+		errs["lat"] = "lat is required"
+	} else if *input.Lat < -90 || *input.Lat > 90 {
+		errs["lat"] = "lat must be between -90 and 90"
+	} else {
+		params.Origin.Lat = *input.Lat
+	}
+
+	if input.Lon == nil {
+		errs["lon"] = "lon is required"
+	} else if *input.Lon < -180 || *input.Lon > 180 {
+		errs["lon"] = "lon must be between -180 and 180"
+	} else {
+		params.Origin.Lon = *input.Lon
+	}
+
+	params.RadiusMeters = defaultDiscoverRadiusMeters
+	if input.RadiusMeters != nil {
+		params.RadiusMeters = *input.RadiusMeters
+	}
+	if params.RadiusMeters <= 0 || params.RadiusMeters > maxDiscoverRadiusMeters {
+		errs["radius_meters"] = "radius_meters must be between 1 and 50000"
+	}
+
+	params.Limit = defaultDiscoverLimit
+	if input.Limit != nil {
+		params.Limit = *input.Limit
+	}
+	if params.Limit <= 0 || params.Limit > maxDiscoverLimit {
+		errs["limit"] = "limit must be between 1 and 50"
+	}
+
+	if input.Query != nil {
+		params.Query = strings.TrimSpace(*input.Query)
+	}
+	if params.Query != "" {
+		params.SearchTSQuery = buildPrefixTSQuery(params.Query)
+		if params.SearchTSQuery == "" {
+			errs["q"] = "q must contain at least one letter or number"
+		}
+	}
+
+	privacyLevels, privacyErr := normalizePrivacyLevels(input.PrivacyLevels)
+	if privacyErr != "" {
+		errs["privacy_levels"] = privacyErr
+	} else {
+		params.PrivacyLevels = privacyLevels
+	}
+
+	categoryIDs, categoryErr := normalizeCategoryIDs(input.CategoryIDs)
+	if categoryErr != "" {
+		errs["category_ids"] = categoryErr
+	} else {
+		params.CategoryIDs = categoryIDs
+	}
+
+	tagNames, tagErr := normalizeTagNames(input.TagNames)
+	if tagErr != "" {
+		errs["tag_names"] = tagErr
+	} else {
+		params.TagNames = tagNames
+	}
+
+	params.StartFrom = normalizeTime(input.StartFrom)
+	params.StartTo = normalizeTime(input.StartTo)
+	if params.StartFrom != nil && params.StartTo != nil && params.StartFrom.After(*params.StartTo) {
+		errs["start_from"] = "start_from must be before or equal to start_to"
+	}
+
+	if input.SortBy != nil {
+		params.SortBy = *input.SortBy
+	} else if params.Query != "" {
+		params.SortBy = domain.EventDiscoverySortRelevance
+	} else {
+		params.SortBy = domain.EventDiscoverySortStartTime
+	}
+	if _, ok := domain.ParseEventDiscoverySort(string(params.SortBy)); !ok {
+		errs["sort_by"] = "must be one of: START_TIME, DISTANCE, RELEVANCE"
+	}
+	if params.SortBy == domain.EventDiscoverySortRelevance && params.Query == "" {
+		errs["sort_by"] = "sort_by=RELEVANCE requires q"
+	}
+
+	if input.Cursor != nil {
+		params.CursorToken = strings.TrimSpace(*input.Cursor)
+	}
+
+	return params, errs
+}
+
+func normalizePrivacyLevels(levels []domain.EventPrivacyLevel) ([]domain.EventPrivacyLevel, string) {
+	if len(levels) == 0 {
+		return []domain.EventPrivacyLevel{
+			domain.PrivacyPublic,
+			domain.PrivacyProtected,
+		}, ""
+	}
+
+	seen := make(map[domain.EventPrivacyLevel]struct{}, len(levels))
+	normalized := make([]domain.EventPrivacyLevel, 0, len(levels))
+	for _, level := range levels {
+		if level != domain.PrivacyPublic && level != domain.PrivacyProtected {
+			return nil, "privacy_levels may only include PUBLIC or PROTECTED"
+		}
+		if _, ok := seen[level]; ok {
+			continue
+		}
+		seen[level] = struct{}{}
+		normalized = append(normalized, level)
+	}
+
+	sort.Slice(normalized, func(i, j int) bool {
+		return normalized[i] < normalized[j]
+	})
+
+	return normalized, ""
+}
+
+func normalizeCategoryIDs(categoryIDs []int) ([]int, string) {
+	if len(categoryIDs) == 0 {
+		return nil, ""
+	}
+
+	seen := make(map[int]struct{}, len(categoryIDs))
+	normalized := make([]int, 0, len(categoryIDs))
+	for _, categoryID := range categoryIDs {
+		if categoryID <= 0 {
+			return nil, "category_ids must contain only positive integers"
+		}
+		if _, ok := seen[categoryID]; ok {
+			continue
+		}
+		seen[categoryID] = struct{}{}
+		normalized = append(normalized, categoryID)
+	}
+
+	sort.Ints(normalized)
+	return normalized, ""
+}
+
+func normalizeTagNames(tagNames []string) ([]string, string) {
+	if len(tagNames) == 0 {
+		return nil, ""
+	}
+
+	seen := make(map[string]struct{}, len(tagNames))
+	normalized := make([]string, 0, len(tagNames))
+	for _, tagName := range tagNames {
+		trimmed := strings.TrimSpace(tagName)
+		if trimmed == "" {
+			return nil, "tag_names must not contain empty values"
+		}
+
+		lower := strings.ToLower(trimmed)
+		if _, ok := seen[lower]; ok {
+			continue
+		}
+		seen[lower] = struct{}{}
+		normalized = append(normalized, lower)
+	}
+
+	sort.Strings(normalized)
+	return normalized, ""
+}
+
+func normalizeTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+
+	utc := value.UTC()
+	return &utc
+}
+
+func buildPrefixTSQuery(query string) string {
+	tokens := strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+	})
+	if len(tokens) == 0 {
+		return ""
+	}
+
+	prefixed := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
+		prefixed = append(prefixed, token+":*")
+	}
+
+	return strings.Join(prefixed, " & ")
+}

--- a/backend/internal/application/event/helpers.go
+++ b/backend/internal/application/event/helpers.go
@@ -63,6 +63,20 @@ func toCreateEventParams(hostID uuid.UUID, input CreateEventInput) CreateEventPa
 	return params
 }
 
+func toDiscoverableEventItem(record DiscoverableEventRecord) DiscoverableEventItem {
+	return DiscoverableEventItem{
+		ID:                       record.ID.String(),
+		Title:                    record.Title,
+		CategoryName:             record.CategoryName,
+		ImageURL:                 record.ImageURL,
+		StartTime:                record.StartTime,
+		LocationAddress:          record.LocationAddress,
+		PrivacyLevel:             string(record.PrivacyLevel),
+		ApprovedParticipantCount: record.ApprovedParticipantCount,
+		IsFavorited:              record.IsFavorited,
+	}
+}
+
 func toDomainRoutePoints(points []RoutePointInput) []domain.GeoPoint {
 	domainPoints := make([]domain.GeoPoint, len(points))
 	for i, point := range points {

--- a/backend/internal/application/event/repository.go
+++ b/backend/internal/application/event/repository.go
@@ -10,5 +10,6 @@ import (
 // Repository is the application-layer persistence port for event flows.
 type Repository interface {
 	CreateEvent(ctx context.Context, params CreateEventParams) (*domain.Event, error)
+	ListDiscoverableEvents(ctx context.Context, userID uuid.UUID, params DiscoverEventsParams) ([]DiscoverableEventRecord, error)
 	GetEventByID(ctx context.Context, eventID uuid.UUID) (*domain.Event, error)
 }

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -34,3 +34,48 @@ type EventConstraintParams struct {
 	Type string
 	Info string
 }
+
+// DiscoverEventsParams carries the normalized discovery filters and pagination state.
+type DiscoverEventsParams struct {
+	Origin               domain.GeoPoint
+	RadiusMeters         int
+	Query                string
+	SearchTSQuery        string
+	PrivacyLevels        []domain.EventPrivacyLevel
+	CategoryIDs          []int
+	StartFrom            *time.Time
+	StartTo              *time.Time
+	TagNames             []string
+	OnlyFavorited        bool
+	SortBy               domain.EventDiscoverySort
+	Limit                int
+	CursorToken          string
+	FilterFingerprint    string
+	DecodedCursor        *DiscoverEventsCursor
+	RepositoryFetchLimit int
+}
+
+// DiscoverableEventRecord is the repository-level projection used for discovery responses.
+type DiscoverableEventRecord struct {
+	ID                       uuid.UUID
+	Title                    string
+	CategoryName             string
+	ImageURL                 *string
+	StartTime                time.Time
+	LocationAddress          *string
+	PrivacyLevel             domain.EventPrivacyLevel
+	ApprovedParticipantCount int
+	IsFavorited              bool
+	DistanceMeters           float64
+	RelevanceScore           *float64
+}
+
+// DiscoverEventsCursor is the opaque keyset cursor payload used by discovery pagination.
+type DiscoverEventsCursor struct {
+	SortBy            domain.EventDiscoverySort `json:"sort_by"`
+	FilterFingerprint string                    `json:"filter_fingerprint"`
+	StartTime         time.Time                 `json:"start_time"`
+	EventID           uuid.UUID                 `json:"event_id"`
+	DistanceMeters    *float64                  `json:"distance_meters,omitempty"`
+	RelevanceScore    *float64                  `json:"relevance_score,omitempty"`
+}

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -51,6 +51,73 @@ func (s *Service) CreateEvent(ctx context.Context, hostID uuid.UUID, input Creat
 	return toCreateEventResult(created), nil
 }
 
+// DiscoverEvents returns nearby discoverable events using combined full-text,
+// structured filters, and keyset pagination.
+func (s *Service) DiscoverEvents(ctx context.Context, userID uuid.UUID, input DiscoverEventsInput) (*DiscoverEventsResult, error) {
+	params, errs := normalizeAndValidateDiscoverEventsInput(input)
+	if len(errs) > 0 {
+		return nil, domain.ValidationError(errs)
+	}
+
+	fingerprint, err := buildDiscoverEventsFilterFingerprint(params)
+	if err != nil {
+		return nil, err
+	}
+	params.FilterFingerprint = fingerprint
+	params.RepositoryFetchLimit = params.Limit + 1
+
+	if params.CursorToken != "" {
+		cursor, err := decodeDiscoverEventsCursor(params.CursorToken)
+		if err != nil {
+			return nil, domain.ValidationError(map[string]string{
+				"cursor": "cursor is invalid",
+			})
+		}
+		if cursor.SortBy != params.SortBy || cursor.FilterFingerprint != params.FilterFingerprint {
+			return nil, domain.ValidationError(map[string]string{
+				"cursor": "cursor does not match the active filters or sort order",
+			})
+		}
+		params.DecodedCursor = cursor
+	}
+
+	records, err := s.eventRepo.ListDiscoverableEvents(ctx, userID, params)
+	if err != nil {
+		return nil, err
+	}
+
+	hasNext := len(records) > params.Limit
+	if hasNext {
+		records = records[:params.Limit]
+	}
+
+	items := make([]DiscoverableEventItem, len(records))
+	for i, record := range records {
+		items[i] = toDiscoverableEventItem(record)
+	}
+
+	var nextCursor *string
+	if hasNext && len(records) > 0 {
+		cursor, err := buildNextDiscoverEventsCursor(params, records[len(records)-1])
+		if err != nil {
+			return nil, err
+		}
+		encoded, err := encodeDiscoverEventsCursor(cursor)
+		if err != nil {
+			return nil, err
+		}
+		nextCursor = &encoded
+	}
+
+	return &DiscoverEventsResult{
+		Items: items,
+		PageInfo: DiscoverEventsPageInfo{
+			NextCursor: nextCursor,
+			HasNext:    hasNext,
+		},
+	}, nil
+}
+
 // JoinEvent allows a user to join a PUBLIC event directly. The resulting
 // participation record has status APPROVED.
 //

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -50,6 +50,48 @@ type CreateEventResult struct {
 	CreatedAt    time.Time  `json:"created_at"`
 }
 
+// DiscoverEventsInput is the validated input for event discovery and search.
+type DiscoverEventsInput struct {
+	Lat           *float64
+	Lon           *float64
+	RadiusMeters  *int
+	Query         *string
+	PrivacyLevels []domain.EventPrivacyLevel
+	CategoryIDs   []int
+	StartFrom     *time.Time
+	StartTo       *time.Time
+	TagNames      []string
+	OnlyFavorited bool
+	SortBy        *domain.EventDiscoverySort
+	Limit         *int
+	Cursor        *string
+}
+
+// DiscoverEventsResult is returned after a successful event discovery query.
+type DiscoverEventsResult struct {
+	Items    []DiscoverableEventItem `json:"items"`
+	PageInfo DiscoverEventsPageInfo  `json:"page_info"`
+}
+
+// DiscoverableEventItem is the compact event-card payload returned by discovery.
+type DiscoverableEventItem struct {
+	ID                       string    `json:"id"`
+	Title                    string    `json:"title"`
+	CategoryName             string    `json:"category_name"`
+	ImageURL                 *string   `json:"image_url"`
+	StartTime                time.Time `json:"start_time"`
+	LocationAddress          *string   `json:"location_address"`
+	PrivacyLevel             string    `json:"privacy_level"`
+	ApprovedParticipantCount int       `json:"approved_participant_count"`
+	IsFavorited              bool      `json:"is_favorited"`
+}
+
+// DiscoverEventsPageInfo contains cursor pagination metadata.
+type DiscoverEventsPageInfo struct {
+	NextCursor *string `json:"next_cursor"`
+	HasNext    bool    `json:"has_next"`
+}
+
 // JoinEventResult is returned after a user successfully joins a public event.
 type JoinEventResult struct {
 	ParticipationID string    `json:"participation_id"`

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -13,8 +13,13 @@ import (
 
 // fakeEventRepo is an in-memory implementation of Repository.
 type fakeEventRepo struct {
-	err    error
-	events map[uuid.UUID]*domain.Event
+	err                error
+	discoverErr        error
+	events             map[uuid.UUID]*domain.Event
+	discoverRecords    []DiscoverableEventRecord
+	discoverCallCount  int
+	lastDiscoverUserID uuid.UUID
+	lastDiscoverParams DiscoverEventsParams
 }
 
 func (r *fakeEventRepo) CreateEvent(_ context.Context, params CreateEventParams) (*domain.Event, error) {
@@ -41,6 +46,18 @@ func (r *fakeEventRepo) GetEventByID(_ context.Context, id uuid.UUID) (*domain.E
 		return e, nil
 	}
 	return nil, domain.ErrNotFound
+}
+
+func (r *fakeEventRepo) ListDiscoverableEvents(_ context.Context, userID uuid.UUID, params DiscoverEventsParams) ([]DiscoverableEventRecord, error) {
+	r.discoverCallCount++
+	r.lastDiscoverUserID = userID
+	r.lastDiscoverParams = params
+
+	if r.discoverErr != nil {
+		return nil, r.discoverErr
+	}
+
+	return r.discoverRecords, nil
 }
 
 // fakeParticipationService is an in-memory implementation of ParticipationService.
@@ -486,6 +503,266 @@ func TestCreateEventRepoErrorPropagates(t *testing.T) {
 	// then
 	if err == nil {
 		t.Fatal("expected error from repo, got nil")
+	}
+}
+
+func TestDiscoverEventsAppliesDefaultsAndMapsResults(t *testing.T) {
+	// given
+	svc, eventRepo, _, _ := newTestEventService()
+	userID := uuid.New()
+	lat := 41.0082
+	lon := 28.9784
+	startTime := time.Date(2030, time.January, 1, 18, 0, 0, 0, time.UTC)
+	imageURL := "https://example.com/event.jpg"
+	address := "Bebek, Istanbul"
+
+	eventRepo.discoverRecords = []DiscoverableEventRecord{
+		{
+			ID:                       uuid.New(),
+			Title:                    "Nearby Event",
+			CategoryName:             "Sports",
+			ImageURL:                 &imageURL,
+			StartTime:                startTime,
+			LocationAddress:          &address,
+			PrivacyLevel:             domain.PrivacyPublic,
+			ApprovedParticipantCount: 7,
+			IsFavorited:              true,
+			DistanceMeters:           1200,
+		},
+	}
+
+	// when
+	result, err := svc.DiscoverEvents(context.Background(), userID, DiscoverEventsInput{
+		Lat: &lat,
+		Lon: &lon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	if eventRepo.discoverCallCount != 1 {
+		t.Fatalf("expected repository to be called once, got %d", eventRepo.discoverCallCount)
+	}
+	if eventRepo.lastDiscoverUserID != userID {
+		t.Fatalf("expected repository to receive user %s, got %s", userID, eventRepo.lastDiscoverUserID)
+	}
+	if eventRepo.lastDiscoverParams.RadiusMeters != defaultDiscoverRadiusMeters {
+		t.Fatalf("expected default radius %d, got %d", defaultDiscoverRadiusMeters, eventRepo.lastDiscoverParams.RadiusMeters)
+	}
+	if eventRepo.lastDiscoverParams.Limit != defaultDiscoverLimit {
+		t.Fatalf("expected default limit %d, got %d", defaultDiscoverLimit, eventRepo.lastDiscoverParams.Limit)
+	}
+	if eventRepo.lastDiscoverParams.RepositoryFetchLimit != defaultDiscoverLimit+1 {
+		t.Fatalf("expected fetch limit %d, got %d", defaultDiscoverLimit+1, eventRepo.lastDiscoverParams.RepositoryFetchLimit)
+	}
+	if eventRepo.lastDiscoverParams.SortBy != domain.EventDiscoverySortStartTime {
+		t.Fatalf("expected default sort %q, got %q", domain.EventDiscoverySortStartTime, eventRepo.lastDiscoverParams.SortBy)
+	}
+	if len(eventRepo.lastDiscoverParams.PrivacyLevels) != 2 ||
+		eventRepo.lastDiscoverParams.PrivacyLevels[0] != domain.PrivacyPublic ||
+		eventRepo.lastDiscoverParams.PrivacyLevels[1] != domain.PrivacyProtected {
+		t.Fatalf("expected default privacy levels [PUBLIC PROTECTED], got %v", eventRepo.lastDiscoverParams.PrivacyLevels)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result.Items))
+	}
+	if result.Items[0].Title != "Nearby Event" {
+		t.Fatalf("expected title %q, got %q", "Nearby Event", result.Items[0].Title)
+	}
+	if result.Items[0].CategoryName != "Sports" {
+		t.Fatalf("expected category name %q, got %q", "Sports", result.Items[0].CategoryName)
+	}
+	if !result.Items[0].IsFavorited {
+		t.Fatal("expected event to be favorited")
+	}
+	if result.PageInfo.HasNext {
+		t.Fatal("expected has_next to be false")
+	}
+	if result.PageInfo.NextCursor != nil {
+		t.Fatalf("expected nil next_cursor, got %v", result.PageInfo.NextCursor)
+	}
+}
+
+func TestDiscoverEventsDefaultsToRelevanceWhenQueryProvided(t *testing.T) {
+	// given
+	svc, eventRepo, _, _ := newTestEventService()
+	lat := 41.0082
+	lon := 28.9784
+	query := "live music"
+
+	// when
+	_, err := svc.DiscoverEvents(context.Background(), uuid.New(), DiscoverEventsInput{
+		Lat:   &lat,
+		Lon:   &lon,
+		Query: &query,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	if eventRepo.lastDiscoverParams.SortBy != domain.EventDiscoverySortRelevance {
+		t.Fatalf("expected default sort %q, got %q", domain.EventDiscoverySortRelevance, eventRepo.lastDiscoverParams.SortBy)
+	}
+	if eventRepo.lastDiscoverParams.Query != query {
+		t.Fatalf("expected query %q, got %q", query, eventRepo.lastDiscoverParams.Query)
+	}
+}
+
+func TestDiscoverEventsRejectsRelevanceWithoutQuery(t *testing.T) {
+	// given
+	svc, _, _, _ := newTestEventService()
+	lat := 41.0082
+	lon := 28.9784
+	sortBy := domain.EventDiscoverySortRelevance
+
+	// when
+	_, err := svc.DiscoverEvents(context.Background(), uuid.New(), DiscoverEventsInput{
+		Lat:    &lat,
+		Lon:    &lon,
+		SortBy: &sortBy,
+	})
+
+	// then
+	assertValidationDetail(t, err, "sort_by")
+}
+
+func TestDiscoverEventsRejectsInvalidCursor(t *testing.T) {
+	// given
+	svc, _, _, _ := newTestEventService()
+	lat := 41.0082
+	lon := 28.9784
+	cursor := "%%%invalid%%%"
+
+	// when
+	_, err := svc.DiscoverEvents(context.Background(), uuid.New(), DiscoverEventsInput{
+		Lat:    &lat,
+		Lon:    &lon,
+		Cursor: &cursor,
+	})
+
+	// then
+	assertValidationDetail(t, err, "cursor")
+}
+
+func TestDiscoverEventsRejectsCursorMismatch(t *testing.T) {
+	// given
+	svc, _, _, _ := newTestEventService()
+	lat := 41.0082
+	lon := 28.9784
+	cursorValue, err := encodeDiscoverEventsCursor(DiscoverEventsCursor{
+		SortBy:            domain.EventDiscoverySortStartTime,
+		FilterFingerprint: "different-filter",
+		StartTime:         time.Now().UTC(),
+		EventID:           uuid.New(),
+	})
+	if err != nil {
+		t.Fatalf("encodeDiscoverEventsCursor() error = %v", err)
+	}
+
+	// when
+	_, err = svc.DiscoverEvents(context.Background(), uuid.New(), DiscoverEventsInput{
+		Lat:    &lat,
+		Lon:    &lon,
+		Cursor: &cursorValue,
+	})
+
+	// then
+	assertValidationDetail(t, err, "cursor")
+}
+
+func TestDiscoverEventsRejectsOutOfRangeRadiusAndLimit(t *testing.T) {
+	// given
+	svc, _, _, _ := newTestEventService()
+	lat := 41.0082
+	lon := 28.9784
+	radius := 50001
+	limit := 0
+
+	// when
+	_, err := svc.DiscoverEvents(context.Background(), uuid.New(), DiscoverEventsInput{
+		Lat:          &lat,
+		Lon:          &lon,
+		RadiusMeters: &radius,
+		Limit:        &limit,
+	})
+
+	// then
+	assertValidationDetail(t, err, "radius_meters")
+	assertValidationDetail(t, err, "limit")
+}
+
+func TestDiscoverEventsRejectsPrivateVisibilityFilter(t *testing.T) {
+	// given
+	svc, _, _, _ := newTestEventService()
+	lat := 41.0082
+	lon := 28.9784
+
+	// when
+	_, err := svc.DiscoverEvents(context.Background(), uuid.New(), DiscoverEventsInput{
+		Lat:           &lat,
+		Lon:           &lon,
+		PrivacyLevels: []domain.EventPrivacyLevel{domain.PrivacyPrivate},
+	})
+
+	// then
+	assertValidationDetail(t, err, "privacy_levels")
+}
+
+func TestDiscoverEventsBuildsNextCursorFromLastReturnedItem(t *testing.T) {
+	// given
+	svc, eventRepo, _, _ := newTestEventService()
+	lat := 41.0082
+	lon := 28.9784
+	limit := 1
+	first := DiscoverableEventRecord{
+		ID:                       uuid.New(),
+		Title:                    "First Event",
+		CategoryName:             "Sports",
+		StartTime:                time.Date(2030, time.January, 1, 18, 0, 0, 0, time.UTC),
+		PrivacyLevel:             domain.PrivacyPublic,
+		ApprovedParticipantCount: 5,
+		DistanceMeters:           100,
+	}
+	second := DiscoverableEventRecord{
+		ID:                       uuid.New(),
+		Title:                    "Second Event",
+		CategoryName:             "Sports",
+		StartTime:                time.Date(2030, time.January, 2, 18, 0, 0, 0, time.UTC),
+		PrivacyLevel:             domain.PrivacyPublic,
+		ApprovedParticipantCount: 6,
+		DistanceMeters:           200,
+	}
+	eventRepo.discoverRecords = []DiscoverableEventRecord{first, second}
+
+	// when
+	result, err := svc.DiscoverEvents(context.Background(), uuid.New(), DiscoverEventsInput{
+		Lat:   &lat,
+		Lon:   &lon,
+		Limit: &limit,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	if !result.PageInfo.HasNext {
+		t.Fatal("expected has_next to be true")
+	}
+	if result.PageInfo.NextCursor == nil {
+		t.Fatal("expected next_cursor to be present")
+	}
+
+	cursor, err := decodeDiscoverEventsCursor(*result.PageInfo.NextCursor)
+	if err != nil {
+		t.Fatalf("decodeDiscoverEventsCursor() error = %v", err)
+	}
+	if cursor.EventID != first.ID {
+		t.Fatalf("expected cursor event_id %s, got %s", first.ID, cursor.EventID)
+	}
+	if cursor.StartTime != first.StartTime {
+		t.Fatalf("expected cursor start_time %v, got %v", first.StartTime, cursor.StartTime)
 	}
 }
 

--- a/backend/internal/application/event/usecase.go
+++ b/backend/internal/application/event/usecase.go
@@ -7,6 +7,7 @@ import "github.com/google/uuid"
 // UseCase is the inbound application port for event flows.
 type UseCase interface {
 	CreateEvent(ctx context.Context, hostID uuid.UUID, input CreateEventInput) (*CreateEventResult, error)
+	DiscoverEvents(ctx context.Context, userID uuid.UUID, input DiscoverEventsInput) (*DiscoverEventsResult, error)
 	JoinEvent(ctx context.Context, userID, eventID uuid.UUID) (*JoinEventResult, error)
 	RequestJoin(ctx context.Context, userID, eventID uuid.UUID, input RequestJoinInput) (*RequestJoinResult, error)
 }

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -18,6 +18,9 @@ type EventParticipantGender string
 // EventStatus defines the lifecycle state of an event.
 type EventStatus string
 
+// EventDiscoverySort defines the supported event discovery ordering modes.
+type EventDiscoverySort string
+
 // Accepted values for event fields.
 const (
 	PrivacyPublic    EventPrivacyLevel = "PUBLIC"
@@ -32,6 +35,10 @@ const (
 	GenderOther  EventParticipantGender = "OTHER"
 
 	EventStatusActive EventStatus = "ACTIVE"
+
+	EventDiscoverySortStartTime EventDiscoverySort = "START_TIME"
+	EventDiscoverySortDistance  EventDiscoverySort = "DISTANCE"
+	EventDiscoverySortRelevance EventDiscoverySort = "RELEVANCE"
 
 	MaxEventTags        = 5
 	MaxEventConstraints = 5
@@ -56,6 +63,12 @@ var eventParticipantGenders = map[string]EventParticipantGender{
 	string(GenderOther):  GenderOther,
 }
 
+var eventDiscoverySorts = map[string]EventDiscoverySort{
+	string(EventDiscoverySortStartTime): EventDiscoverySortStartTime,
+	string(EventDiscoverySortDistance):  EventDiscoverySortDistance,
+	string(EventDiscoverySortRelevance): EventDiscoverySortRelevance,
+}
+
 // ParseEventPrivacyLevel converts a wire string to an EventPrivacyLevel.
 func ParseEventPrivacyLevel(value string) (EventPrivacyLevel, bool) {
 	level, ok := eventPrivacyLevels[value]
@@ -72,6 +85,12 @@ func ParseEventLocationType(value string) (EventLocationType, bool) {
 func ParseEventParticipantGender(value string) (EventParticipantGender, bool) {
 	gender, ok := eventParticipantGenders[value]
 	return gender, ok
+}
+
+// ParseEventDiscoverySort converts a wire string to an EventDiscoverySort.
+func ParseEventDiscoverySort(value string) (EventDiscoverySort, bool) {
+	sort, ok := eventDiscoverySorts[value]
+	return sort, ok
 }
 
 // GeoPoint is a single WGS84 coordinate used for event locations.

--- a/backend/migrations/000013_event_discovery_index.down.sql
+++ b/backend/migrations/000013_event_discovery_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_event_discovery_start_time_active_visible;

--- a/backend/migrations/000013_event_discovery_index.up.sql
+++ b/backend/migrations/000013_event_discovery_index.up.sql
@@ -1,0 +1,4 @@
+CREATE INDEX idx_event_discovery_start_time_active_visible
+    ON event (start_time, id)
+    WHERE status = 'ACTIVE'
+      AND privacy_level IN ('PUBLIC', 'PROTECTED');

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -320,6 +320,589 @@ func TestCreateRouteEventSuccessPath(t *testing.T) {
 	}
 }
 
+func TestDiscoverEventsReturnsOnlyNearbyActivePublicAndProtectedEvents(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 39.9208
+	originLon := 32.8541
+	baseStart := time.Now().UTC().Add(24 * time.Hour)
+
+	nearPublic := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Near Public",
+		Description:  "close by",
+		CategoryID:   categoryID,
+		Lat:          39.9212,
+		Lon:          32.8548,
+		StartTime:    baseStart,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	nearProtected := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Near Protected",
+		Description:  "also close by",
+		CategoryID:   categoryID,
+		Lat:          39.9240,
+		Lon:          32.8580,
+		StartTime:    baseStart.Add(time.Hour),
+		PrivacyLevel: domain.PrivacyProtected,
+	})
+	_ = createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Far Public",
+		Description:  "too far away",
+		CategoryID:   categoryID,
+		Lat:          40.0400,
+		Lon:          32.9800,
+		StartTime:    baseStart.Add(2 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	_ = createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Near Private",
+		Description:  "should stay hidden",
+		CategoryID:   categoryID,
+		Lat:          39.9215,
+		Lon:          32.8552,
+		StartTime:    baseStart.Add(3 * time.Hour),
+		PrivacyLevel: domain.PrivacyPrivate,
+	})
+	inactiveID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Near Inactive",
+		Description:  "should be excluded",
+		CategoryID:   categoryID,
+		Lat:          39.9220,
+		Lon:          32.8558,
+		StartTime:    baseStart.Add(4 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	updateEventStatus(t, inactiveID, "ARCHIVED")
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat: &originLat,
+		Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	assertDiscoverEventIDsInOrder(t, result.Items, nearPublic, nearProtected)
+}
+
+func TestDiscoverEventsIncludesRouteWhenAnyRoutePointFallsWithinRadius(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 35.1856
+	originLon := 33.3823
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+
+	routeID := createRouteDiscoveryEvent(t, harness, routeDiscoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Route Event",
+		Description:  "passes near the viewer",
+		CategoryID:   categoryID,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyProtected,
+		RoutePoints: []eventapp.RoutePointInput{
+			{Lat: common.Float64Ptr(35.3000), Lon: common.Float64Ptr(33.5000)},
+			{Lat: common.Float64Ptr(35.1860), Lon: common.Float64Ptr(33.3830)},
+			{Lat: common.Float64Ptr(35.1700), Lon: common.Float64Ptr(33.3600)},
+		},
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat: &originLat,
+		Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	assertDiscoverEventIDsInOrder(t, result.Items, routeID)
+}
+
+func TestDiscoverEventsSortsRouteByFirstPointWhenUsingDistance(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 34.6793
+	originLon := 33.0413
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	sortBy := domain.EventDiscoverySortDistance
+
+	pointID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Point Event",
+		Description:  "nearby point",
+		CategoryID:   categoryID,
+		Lat:          34.6850,
+		Lon:          33.0450,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	routeID := createRouteDiscoveryEvent(t, harness, routeDiscoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Route Event",
+		Description:  "first point is farther away",
+		CategoryID:   categoryID,
+		StartTime:    startTime.Add(time.Hour),
+		PrivacyLevel: domain.PrivacyProtected,
+		RoutePoints: []eventapp.RoutePointInput{
+			{Lat: common.Float64Ptr(34.7000), Lon: common.Float64Ptr(33.0700)},
+			{Lat: common.Float64Ptr(34.6795), Lon: common.Float64Ptr(33.0415)},
+			{Lat: common.Float64Ptr(34.6780), Lon: common.Float64Ptr(33.0400)},
+		},
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:    &originLat,
+		Lon:    &originLon,
+		SortBy: &sortBy,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	assertDiscoverEventIDsInOrder(t, result.Items, pointID, routeID)
+}
+
+func TestDiscoverEventsSearchMatchesTitleDescriptionAndTags(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 38.4237
+	originLon := 27.1428
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+
+	titleID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Istanbul Run",
+		Description:  "group cardio",
+		CategoryID:   categoryID,
+		Lat:          38.4242,
+		Lon:          27.1432,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	descriptionID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Board Game Night",
+		Description:  "casual tabletop session",
+		CategoryID:   categoryID,
+		Lat:          38.4248,
+		Lon:          27.1438,
+		StartTime:    startTime.Add(time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	tagID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Morning Stretch",
+		Description:  "easy pace",
+		CategoryID:   categoryID,
+		Lat:          38.4254,
+		Lon:          27.1444,
+		StartTime:    startTime.Add(2 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+		Tags:         []string{"yoga"},
+	})
+
+	// when
+	titleQuery := "ist"
+	titleResult, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:   &originLat,
+		Lon:   &originLon,
+		Query: &titleQuery,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverEvents() title query error = %v", err)
+	}
+
+	descriptionQuery := "tabl"
+	descriptionResult, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:   &originLat,
+		Lon:   &originLon,
+		Query: &descriptionQuery,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverEvents() description query error = %v", err)
+	}
+
+	tagQuery := "yog"
+	tagResult, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:   &originLat,
+		Lon:   &originLon,
+		Query: &tagQuery,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() tag query error = %v", err)
+	}
+	assertDiscoverEventIDsInOrder(t, titleResult.Items, titleID)
+	assertDiscoverEventIDsInOrder(t, descriptionResult.Items, descriptionID)
+	assertDiscoverEventIDsInOrder(t, tagResult.Items, tagID)
+}
+
+func TestDiscoverEventsAppliesPrivacyLevelFilter(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 35.8989
+	originLon := 14.5146
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+
+	publicID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Public Event",
+		Description:  "visible to everyone",
+		CategoryID:   categoryID,
+		Lat:          35.8992,
+		Lon:          14.5150,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	_ = createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Protected Event",
+		Description:  "needs approval",
+		CategoryID:   categoryID,
+		Lat:          35.8994,
+		Lon:          14.5152,
+		StartTime:    startTime.Add(time.Hour),
+		PrivacyLevel: domain.PrivacyProtected,
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:           &originLat,
+		Lon:           &originLon,
+		PrivacyLevels: []domain.EventPrivacyLevel{domain.PrivacyPublic},
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	assertDiscoverEventIDsInOrder(t, result.Items, publicID)
+}
+
+func TestDiscoverEventsAppliesSearchAndFiltersTogether(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	originLat := 36.8969
+	originLon := 30.7133
+	targetCategoryID := common.GivenEventCategory(t)
+	otherCategoryID := common.GivenEventCategory(t)
+	startTime := time.Now().UTC().Add(48 * time.Hour)
+	startFrom := startTime.Add(-time.Hour)
+	startTo := startTime.Add(time.Hour)
+	query := "trail"
+
+	matchID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Trail Coffee Meetup",
+		Description:  "best trail stories",
+		CategoryID:   targetCategoryID,
+		Lat:          36.8975,
+		Lon:          30.7140,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+		Tags:         []string{"outdoor", "coffee"},
+	})
+	insertFavoriteEvent(t, viewer.ID, matchID)
+
+	otherCategoryEventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Trail Category Mismatch",
+		Description:  "same text, wrong category",
+		CategoryID:   otherCategoryID,
+		Lat:          36.8977,
+		Lon:          30.7142,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+		Tags:         []string{"outdoor"},
+	})
+	insertFavoriteEvent(t, viewer.ID, otherCategoryEventID)
+
+	_ = createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Trail Tag Mismatch",
+		Description:  "same text, wrong tag",
+		CategoryID:   targetCategoryID,
+		Lat:          36.8979,
+		Lon:          30.7144,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+		Tags:         []string{"indoor"},
+	})
+	_ = createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Trail Not Favorite",
+		Description:  "same text, not favorited",
+		CategoryID:   targetCategoryID,
+		Lat:          36.8981,
+		Lon:          30.7146,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+		Tags:         []string{"outdoor"},
+	})
+	_ = createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Trail Date Mismatch",
+		Description:  "same text, wrong date",
+		CategoryID:   targetCategoryID,
+		Lat:          36.8983,
+		Lon:          30.7148,
+		StartTime:    startTime.Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+		Tags:         []string{"outdoor"},
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:           &originLat,
+		Lon:           &originLon,
+		Query:         &query,
+		CategoryIDs:   []int{targetCategoryID},
+		StartFrom:     &startFrom,
+		StartTo:       &startTo,
+		TagNames:      []string{"outdoor"},
+		OnlyFavorited: true,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	assertDiscoverEventIDsInOrder(t, result.Items, matchID)
+}
+
+func TestDiscoverEventsSortsByDistance(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 37.0000
+	originLon := 35.3213
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	sortBy := domain.EventDiscoverySortDistance
+
+	nearest := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Nearest",
+		Description:  "closest",
+		CategoryID:   categoryID,
+		Lat:          37.0004,
+		Lon:          35.3217,
+		StartTime:    startTime.Add(2 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	middle := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Middle",
+		Description:  "middle distance",
+		CategoryID:   categoryID,
+		Lat:          37.0120,
+		Lon:          35.3290,
+		StartTime:    startTime.Add(time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	farthest := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Farthest",
+		Description:  "still within radius",
+		CategoryID:   categoryID,
+		Lat:          37.0350,
+		Lon:          35.3450,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:    &originLat,
+		Lon:    &originLon,
+		SortBy: &sortBy,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	assertDiscoverEventIDsInOrder(t, result.Items, nearest, middle, farthest)
+}
+
+func TestDiscoverEventsReflectsFavoriteStateForCurrentUser(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 40.7667
+	originLon := 29.9167
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+
+	favoritedID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Favorited Event",
+		Description:  "saved by viewer",
+		CategoryID:   categoryID,
+		Lat:          40.7672,
+		Lon:          29.9172,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	plainID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Plain Event",
+		Description:  "not saved",
+		CategoryID:   categoryID,
+		Lat:          40.7680,
+		Lon:          29.9180,
+		StartTime:    startTime.Add(time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	insertFavoriteEvent(t, viewer.ID, favoritedID)
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat: &originLat,
+		Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(result.Items))
+	}
+
+	favoriteState := make(map[string]bool, len(result.Items))
+	for _, item := range result.Items {
+		favoriteState[item.ID] = item.IsFavorited
+	}
+	if !favoriteState[favoritedID.String()] {
+		t.Fatalf("expected event %s to be favorited", favoritedID)
+	}
+	if favoriteState[plainID.String()] {
+		t.Fatalf("expected event %s to not be favorited", plainID)
+	}
+}
+
+func TestDiscoverEventsCursorPaginationIsStableAndNonOverlapping(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 41.2867
+	originLon := 36.3300
+	limit := 2
+	now := time.Now().UTC()
+
+	first := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "First Page Item",
+		Description:  "first",
+		CategoryID:   categoryID,
+		Lat:          41.2872,
+		Lon:          36.3305,
+		StartTime:    now.Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	second := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Second Page Item",
+		Description:  "second",
+		CategoryID:   categoryID,
+		Lat:          41.2874,
+		Lon:          36.3307,
+		StartTime:    now.Add(25 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	third := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Third Page Item",
+		Description:  "third",
+		CategoryID:   categoryID,
+		Lat:          41.2876,
+		Lon:          36.3309,
+		StartTime:    now.Add(26 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+
+	// when
+	firstPage, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:   &originLat,
+		Lon:   &originLon,
+		Limit: &limit,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverEvents() first page error = %v", err)
+	}
+	if firstPage.PageInfo.NextCursor == nil {
+		t.Fatal("expected first page to return next_cursor")
+	}
+
+	secondPage, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat:    &originLat,
+		Lon:    &originLon,
+		Limit:  &limit,
+		Cursor: firstPage.PageInfo.NextCursor,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() second page error = %v", err)
+	}
+	assertDiscoverEventIDsInOrder(t, firstPage.Items, first, second)
+	assertDiscoverEventIDsInOrder(t, secondPage.Items, third)
+	if secondPage.PageInfo.HasNext {
+		t.Fatal("expected second page to be terminal")
+	}
+}
+
 // ---------------------------------------------------------
 // JoinEvent tests
 // ---------------------------------------------------------
@@ -522,4 +1105,120 @@ func TestRequestJoinRejectsNonExistentEvent(t *testing.T) {
 	_, err := harness.Service.RequestJoin(context.Background(), requester.ID, uuid.New(), eventapp.RequestJoinInput{})
 
 	common.RequireAppErrorCode(t, err, domain.ErrorCodeEventNotFound)
+}
+
+type discoveryEventSeed struct {
+	HostID       uuid.UUID
+	Title        string
+	Description  string
+	CategoryID   int
+	Lat          float64
+	Lon          float64
+	StartTime    time.Time
+	PrivacyLevel domain.EventPrivacyLevel
+	Tags         []string
+}
+
+type routeDiscoveryEventSeed struct {
+	HostID       uuid.UUID
+	Title        string
+	Description  string
+	CategoryID   int
+	StartTime    time.Time
+	PrivacyLevel domain.EventPrivacyLevel
+	RoutePoints  []eventapp.RoutePointInput
+}
+
+func createDiscoveryEvent(t *testing.T, harness *common.EventHarness, seed discoveryEventSeed) uuid.UUID {
+	t.Helper()
+
+	result, err := harness.Service.CreateEvent(context.Background(), seed.HostID, eventapp.CreateEventInput{
+		Title:        seed.Title,
+		Description:  common.StringPtr(seed.Description),
+		CategoryID:   &seed.CategoryID,
+		LocationType: domain.LocationPoint,
+		Lat:          &seed.Lat,
+		Lon:          &seed.Lon,
+		StartTime:    seed.StartTime,
+		PrivacyLevel: seed.PrivacyLevel,
+		Tags:         seed.Tags,
+	})
+	if err != nil {
+		t.Fatalf("CreateEvent() discovery seed error = %v", err)
+	}
+
+	eventID, err := uuid.Parse(result.ID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() error = %v", err)
+	}
+
+	return eventID
+}
+
+func createRouteDiscoveryEvent(t *testing.T, harness *common.EventHarness, seed routeDiscoveryEventSeed) uuid.UUID {
+	t.Helper()
+
+	result, err := harness.Service.CreateEvent(context.Background(), seed.HostID, eventapp.CreateEventInput{
+		Title:        seed.Title,
+		Description:  common.StringPtr(seed.Description),
+		CategoryID:   &seed.CategoryID,
+		LocationType: domain.LocationRoute,
+		StartTime:    seed.StartTime,
+		PrivacyLevel: seed.PrivacyLevel,
+		RoutePoints:  seed.RoutePoints,
+	})
+	if err != nil {
+		t.Fatalf("CreateEvent() route discovery seed error = %v", err)
+	}
+
+	eventID, err := uuid.Parse(result.ID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() error = %v", err)
+	}
+
+	return eventID
+}
+
+func updateEventStatus(t *testing.T, eventID uuid.UUID, status string) {
+	t.Helper()
+
+	commandTag, err := common.RequirePool(t).Exec(
+		context.Background(),
+		`UPDATE event SET status = $2 WHERE id = $1`,
+		eventID,
+		status,
+	)
+	if err != nil {
+		t.Fatalf("update event status error = %v", err)
+	}
+	if commandTag.RowsAffected() != 1 {
+		t.Fatalf("expected 1 updated row, got %d", commandTag.RowsAffected())
+	}
+}
+
+func insertFavoriteEvent(t *testing.T, userID, eventID uuid.UUID) {
+	t.Helper()
+
+	if _, err := common.RequirePool(t).Exec(
+		context.Background(),
+		`INSERT INTO favorite_event (user_id, event_id) VALUES ($1, $2)`,
+		userID,
+		eventID,
+	); err != nil {
+		t.Fatalf("insert favorite_event error = %v", err)
+	}
+}
+
+func assertDiscoverEventIDsInOrder(t *testing.T, items []eventapp.DiscoverableEventItem, want ...uuid.UUID) {
+	t.Helper()
+
+	if len(items) != len(want) {
+		t.Fatalf("expected %d items, got %d", len(want), len(items))
+	}
+
+	for i, expectedID := range want {
+		if items[i].ID != expectedID.String() {
+			t.Fatalf("expected item %d to be %s, got %s", i, expectedID, items[i].ID)
+		}
+	}
 }

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -251,6 +251,226 @@ paths:
                 $ref: '#/components/schemas/ErrorEnvelope'
 
   /events:
+    get:
+      tags: [Events]
+      summary: Discover nearby events
+      description: |
+        Returns a cursor-paginated list of nearby discoverable events for the authenticated user.
+
+        Discovery rules:
+        - Only events with `status: ACTIVE` are returned.
+        - Only events with `privacy_level: PUBLIC` or `PROTECTED` are returned.
+        - The caller must provide `lat` and `lon`; the server filters within a radius around that origin.
+        - Text search (`q`) and structured filters can be combined in the same request.
+        - `is_favorited` is resolved for the authenticated user.
+        - For `ROUTE` events, radius filtering matches when any stored route point falls within the requested radius.
+
+        Sorting defaults:
+        - If `q` is omitted and `sort_by` is omitted, sorting defaults to `START_TIME`.
+        - If `q` is present and `sort_by` is omitted, sorting defaults to `RELEVANCE`.
+        - `sort_by=RELEVANCE` is only valid when `q` is present.
+        - When sorting by distance, `ROUTE` events use the first route point as their anchor location.
+
+        Pagination:
+        - Uses opaque keyset cursors returned in `page_info.next_cursor`.
+        - Reuse the same filters and sort order when requesting the next page.
+      operationId: discoverEvents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: lat
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+            minimum: -90
+            maximum: 90
+          description: Latitude of the search origin in WGS 84.
+          example: 41.0082
+        - name: lon
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+            minimum: -180
+            maximum: 180
+          description: Longitude of the search origin in WGS 84.
+          example: 28.9784
+        - name: radius_meters
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50000
+          description: Radius around (`lat`, `lon`) in meters. Defaults to `10000` when omitted.
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional prefix-aware full-text search query applied to title, description, and denormalized tags.
+        - name: privacy_levels
+          in: query
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [PUBLIC, PROTECTED]
+          description: Optional comma-separated discoverability filter. `PRIVATE` is not allowed because private events are never returned by this endpoint.
+        - name: category_ids
+          in: query
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: integer
+              minimum: 1
+          description: Optional comma-separated category ids. Matches events whose `category_id` is in the provided set.
+        - name: start_from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Optional inclusive lower bound for `event.start_time`.
+        - name: start_to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Optional inclusive upper bound for `event.start_time`.
+        - name: tag_names
+          in: query
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+          description: Optional comma-separated tags. v1 uses OR semantics, so an event matches if it has any listed tag.
+        - name: only_favorited
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: When `true`, only returns events favorited by the authenticated user. Defaults to `false` when omitted.
+        - name: sort_by
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [START_TIME, DISTANCE, RELEVANCE]
+          description: |
+            Optional sort mode.
+            - `START_TIME`: soonest starting events first.
+            - `DISTANCE`: nearest events first.
+            - `RELEVANCE`: highest full-text rank first; requires `q`.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+          description: Maximum number of items to return in one page. Defaults to `20` when omitted.
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Opaque cursor returned by a previous page of the same query.
+      responses:
+        '200':
+          description: Discovery results returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverEventsResponse'
+              examples:
+                nearby_events:
+                  value:
+                    items:
+                      - id: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+                        title: Istanbul Trail Run
+                        category_name: Sports
+                        image_url: https://example.com/trail.jpg
+                        start_time: "2026-05-01T08:00:00+03:00"
+                        location_address: Belgrad Forest, Istanbul
+                        privacy_level: PUBLIC
+                        approved_participant_count: 42
+                        is_favorited: true
+                      - id: 7a2c8b1e-3d4f-5e6a-bcde-f90123456789
+                        title: Bosphorus Ride
+                        category_name: Fitness
+                        image_url: null
+                        start_time: "2026-05-01T09:30:00+03:00"
+                        location_address: Besiktas, Istanbul
+                        privacy_level: PROTECTED
+                        approved_participant_count: 18
+                        is_favorited: false
+                    page_info:
+                      next_cursor: eyJzb3J0X2J5IjoiU1RBUlRfVElNRSIsImZpbHRlcl9maW5nZXJwcmludCI6IjQ2MmEifQ
+                      has_next: true
+        '400':
+          description: |
+            Validation error for query parameters, cursor reuse, or unsupported sort combinations.
+            `error.details` contains field-specific messages.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                invalid_query:
+                  value:
+                    error:
+                      code: validation_error
+                      message: The request body contains invalid fields. See error.details for field-specific messages.
+                      details:
+                        lat: lat is required
+                        lon: lon is required
+                invalid_sort:
+                  value:
+                    error:
+                      code: validation_error
+                      message: The request body contains invalid fields. See error.details for field-specific messages.
+                      details:
+                        sort_by: sort_by=RELEVANCE requires q
+                invalid_privacy_filter:
+                  value:
+                    error:
+                      code: validation_error
+                      message: The request body contains invalid fields. See error.details for field-specific messages.
+                      details:
+                        privacy_levels: "privacy_levels must contain only: PUBLIC, PROTECTED"
+                invalid_cursor:
+                  value:
+                    error:
+                      code: validation_error
+                      message: The request body contains invalid fields. See error.details for field-specific messages.
+                      details:
+                        cursor: cursor does not match the active filters or sort order
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '500':
+          description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
     post:
       tags: [Events]
       summary: Create a new event
@@ -597,6 +817,91 @@ components:
           type: string
           description: Human-readable description of the constraint.
           example: Trail running shoes required
+
+    DiscoverEventsResponse:
+      type: object
+      additionalProperties: false
+      required: [items, page_info]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/DiscoverEventItem'
+        page_info:
+          $ref: '#/components/schemas/DiscoverEventsPageInfo'
+
+    DiscoverEventItem:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - category_name
+        - start_time
+        - privacy_level
+        - approved_participant_count
+        - is_favorited
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: UUID of the event.
+          example: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+        title:
+          type: string
+          description: Event title.
+          example: Istanbul Trail Run
+        category_name:
+          type: string
+          description: Human-readable event category name.
+          example: Sports
+        image_url:
+          type:
+            - string
+            - "null"
+          description: Optional event cover image URL.
+          example: https://example.com/trail.jpg
+        start_time:
+          type: string
+          format: date-time
+          description: Event start time.
+          example: "2026-05-01T08:00:00+03:00"
+        location_address:
+          type:
+            - string
+            - "null"
+          description: Optional human-readable location address.
+          example: Belgrad Forest, Istanbul
+        privacy_level:
+          type: string
+          enum: [PUBLIC, PROTECTED]
+          description: Visibility level for the discoverable event.
+          example: PUBLIC
+        approved_participant_count:
+          type: integer
+          minimum: 0
+          description: Current count of approved participants.
+          example: 42
+        is_favorited:
+          type: boolean
+          description: Whether the authenticated user has favorited the event.
+          example: true
+
+    DiscoverEventsPageInfo:
+      type: object
+      additionalProperties: false
+      required: [next_cursor, has_next]
+      properties:
+        next_cursor:
+          type:
+            - string
+            - "null"
+          description: Opaque cursor for the next page, or `null` when there is no next page.
+          example: eyJzb3J0X2J5IjoiU1RBUlRfVElNRSIsImZpbHRlcl9maW5nZXJwcmludCI6IjQ2MmEifQ
+        has_next:
+          type: boolean
+          description: Indicates whether more results are available.
+          example: true
 
     CreateEventResponse:
       type: object


### PR DESCRIPTION
## 📋 Summary
Add an authenticated event discovery endpoint for the home feed with nearby search, cursor pagination, full-text search, and combined filters. This PR also improves discovery behavior for route-based events, adds visibility filtering for discoverable events, and makes prefix text search work for partial queries.

## 🔄 Changes
- Added `GET /events` as an authenticated discovery endpoint for nearby `ACTIVE` events with `PUBLIC` or `PROTECTED` visibility.
- Implemented cursor-based pagination with stable keyset ordering for `START_TIME`, `DISTANCE`, and `RELEVANCE` sorting.
- Added combined filtering support for:
  - radius
  - text search
  - visibility (`PUBLIC`, `PROTECTED`)
  - category ids
  - start time range
  - tag names
  - only favorited
- Returned compact event cards with:
  - `id`
  - `title`
  - `category_name`
  - `image_url`
  - `start_time`
  - `location_address`
  - `privacy_level`
  - `approved_participant_count`
  - `is_favorited`
- Reused the existing search-vector/tag trigger setup, but updated search to support prefix matching so partial inputs like `Ist` can match `Istanbul`.
- Fixed route discovery behavior:
  - route events are included when any route point falls within the requested radius
  - distance sorting uses the first route point as the route anchor
- Added validation and normalization for discovery query params, including safe handling of empty optional params such as `privacy_levels=`, `tag_names=`, and `category_ids=`.
- Added a partial Postgres index for the default discovery feed path on active public/protected events.
- Updated OpenAPI documentation for the new endpoint and adjusted optional query parameter docs so Swagger UI does not prefill unnecessary values into generated curl commands.
- Added unit and integration tests covering:
  - handler parsing and validation
  - service defaults and cursor validation
  - nearby discovery rules
  - search behavior
  - combined filters
  - favorite state
  - route event inclusion
  - distance sorting
  - cursor pagination stability

## 🧪 Testing
- Ran `go test ./internal/application/event`
- Ran `go test ./internal/adapter/out/httpapi/event_handler`
- Ran `go test -tags integration ./tests_integration -run DiscoverEvents`
- Ran `./shipcheck.sh`

## 🔗 Related
Closes #201 