### PR TITLE
feat(backend): add event details endpoint

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -481,6 +481,676 @@ func toPrivacyLevelStringSlice(values []domain.EventPrivacyLevel) []string {
 	return converted
 }
 
+// GetEventDetail loads the full detail projection for an event if the
+// authenticated user is allowed to read it.
+func (r *EventRepository) GetEventDetail(
+	ctx context.Context,
+	userID, eventID uuid.UUID,
+) (*eventapp.EventDetailRecord, error) {
+	record, err := r.loadEventDetailCore(ctx, userID, eventID)
+	if err != nil {
+		return nil, err
+	}
+
+	location, err := r.loadEventDetailLocation(ctx, eventID, record.Location.Type)
+	if err != nil {
+		return nil, err
+	}
+	location.Address = record.Location.Address
+	record.Location = location
+
+	tags, err := r.loadEventTags(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+	record.Tags = tags
+
+	constraints, err := r.loadEventConstraints(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+	record.Constraints = constraints
+
+	if record.ViewerContext.IsHost {
+		hostContext, err := r.loadEventHostContext(ctx, eventID)
+		if err != nil {
+			return nil, err
+		}
+		record.HostContext = hostContext
+	}
+
+	return record, nil
+}
+
+func (r *EventRepository) loadEventDetailCore(
+	ctx context.Context,
+	userID, eventID uuid.UUID,
+) (*eventapp.EventDetailRecord, error) {
+	var (
+		id                       uuid.UUID
+		title                    string
+		description              pgtype.Text
+		imageURL                 pgtype.Text
+		privacyLevel             string
+		status                   string
+		startTime                time.Time
+		endTime                  pgtype.Timestamptz
+		capacity                 pgtype.Int4
+		minimumAge               pgtype.Int4
+		preferredGender          pgtype.Text
+		approvedParticipantCount int
+		pendingParticipantCount  int
+		favoriteCount            int
+		createdAt                time.Time
+		updatedAt                time.Time
+		categoryID               pgtype.Int4
+		categoryName             pgtype.Text
+		hostID                   uuid.UUID
+		hostUsername             string
+		hostDisplayName          pgtype.Text
+		hostAvatarURL            pgtype.Text
+		locationType             string
+		locationAddress          pgtype.Text
+		isHost                   bool
+		isFavorited              bool
+		participationStatus      string
+	)
+
+	err := r.pool.QueryRow(ctx, `
+		SELECT
+			e.id,
+			e.title,
+			e.description,
+			e.image_url,
+			e.privacy_level,
+			e.status,
+			e.start_time,
+			e.end_time,
+			e.capacity,
+			e.minimum_age,
+			e.preferred_gender,
+			e.approved_participant_count,
+			e.pending_participant_count,
+			e.favorite_count,
+			e.created_at,
+			e.updated_at,
+			ec.id,
+			ec.name,
+			host.id,
+			host.username,
+			hp.display_name,
+			hp.avatar_url,
+			e.location_type,
+			el.address,
+			(e.host_id = $2) AS is_host,
+			EXISTS (
+				SELECT 1
+				FROM favorite_event fav
+				WHERE fav.event_id = e.id
+				  AND fav.user_id = $2
+			) AS is_favorited,
+			CASE
+				WHEN e.host_id = $2 THEN $3
+				WHEN EXISTS (
+					SELECT 1
+					FROM participation p
+					WHERE p.event_id = e.id
+					  AND p.user_id = $2
+					  AND p.status = $4
+				) THEN $5
+				WHEN EXISTS (
+					SELECT 1
+					FROM join_request jr
+					WHERE jr.event_id = e.id
+					  AND jr.user_id = $2
+					  AND jr.status = $6
+				) THEN $7
+				WHEN EXISTS (
+					SELECT 1
+					FROM invitation inv
+					WHERE inv.event_id = e.id
+					  AND inv.invited_user_id = $2
+				) THEN $8
+				ELSE $3
+			END AS participation_status
+		FROM event e
+		JOIN event_location el ON el.event_id = e.id
+		LEFT JOIN event_category ec ON ec.id = e.category_id
+		JOIN app_user host ON host.id = e.host_id
+		LEFT JOIN profile hp ON hp.user_id = host.id
+		WHERE e.id = $1
+		  AND (
+			e.privacy_level IN ($9, $10)
+			OR e.host_id = $2
+			OR EXISTS (
+				SELECT 1
+				FROM participation p
+				WHERE p.event_id = e.id
+				  AND p.user_id = $2
+				  AND p.status = $4
+			)
+			OR EXISTS (
+				SELECT 1
+				FROM invitation inv
+				WHERE inv.event_id = e.id
+				  AND inv.invited_user_id = $2
+				  AND inv.status = $11
+			)
+		  )
+	`,
+		eventID,
+		userID,
+		string(domain.EventDetailParticipationStatusNone),
+		domain.ParticipationStatusApproved,
+		string(domain.EventDetailParticipationStatusJoined),
+		domain.ParticipationStatusPending,
+		string(domain.EventDetailParticipationStatusPending),
+		string(domain.EventDetailParticipationStatusInvited),
+		string(domain.PrivacyPublic),
+		string(domain.PrivacyProtected),
+		string(domain.InvitationStatusAccepted),
+	).Scan(
+		&id,
+		&title,
+		&description,
+		&imageURL,
+		&privacyLevel,
+		&status,
+		&startTime,
+		&endTime,
+		&capacity,
+		&minimumAge,
+		&preferredGender,
+		&approvedParticipantCount,
+		&pendingParticipantCount,
+		&favoriteCount,
+		&createdAt,
+		&updatedAt,
+		&categoryID,
+		&categoryName,
+		&hostID,
+		&hostUsername,
+		&hostDisplayName,
+		&hostAvatarURL,
+		&locationType,
+		&locationAddress,
+		&isHost,
+		&isFavorited,
+		&participationStatus,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get event detail: %w", err)
+	}
+
+	record := &eventapp.EventDetailRecord{
+		ID:                       id,
+		Title:                    title,
+		PrivacyLevel:             domain.EventPrivacyLevel(privacyLevel),
+		Status:                   domain.EventStatus(status),
+		StartTime:                startTime,
+		ApprovedParticipantCount: approvedParticipantCount,
+		PendingParticipantCount:  pendingParticipantCount,
+		FavoriteCount:            favoriteCount,
+		CreatedAt:                createdAt,
+		UpdatedAt:                updatedAt,
+		Host: eventapp.EventDetailPersonRecord{
+			ID:       hostID,
+			Username: hostUsername,
+		},
+		Location: eventapp.EventDetailLocationRecord{
+			Type: domain.EventLocationType(locationType),
+		},
+		ViewerContext: eventapp.EventDetailViewerContextRecord{
+			IsHost:              isHost,
+			IsFavorited:         isFavorited,
+			ParticipationStatus: domain.EventDetailParticipationStatus(participationStatus),
+		},
+		Tags:        make([]string, 0),
+		Constraints: make([]eventapp.EventDetailConstraintRecord, 0),
+	}
+	if description.Valid {
+		record.Description = &description.String
+	}
+	if imageURL.Valid {
+		record.ImageURL = &imageURL.String
+	}
+	if endTime.Valid {
+		record.EndTime = &endTime.Time
+	}
+	if capacity.Valid {
+		record.Capacity = new(int)
+		*record.Capacity = int(capacity.Int32)
+	}
+	if minimumAge.Valid {
+		record.MinimumAge = new(int)
+		*record.MinimumAge = int(minimumAge.Int32)
+	}
+	if preferredGender.Valid {
+		gender := domain.EventParticipantGender(preferredGender.String)
+		record.PreferredGender = &gender
+	}
+	if categoryID.Valid {
+		record.Category = &eventapp.EventDetailCategoryRecord{
+			ID: int(categoryID.Int32),
+		}
+		if categoryName.Valid {
+			record.Category.Name = categoryName.String
+		}
+	}
+	if hostDisplayName.Valid {
+		record.Host.DisplayName = &hostDisplayName.String
+	}
+	if hostAvatarURL.Valid {
+		record.Host.AvatarURL = &hostAvatarURL.String
+	}
+	if locationAddress.Valid {
+		record.Location.Address = &locationAddress.String
+	}
+
+	return record, nil
+}
+
+func (r *EventRepository) loadEventDetailLocation(
+	ctx context.Context,
+	eventID uuid.UUID,
+	locationType domain.EventLocationType,
+) (eventapp.EventDetailLocationRecord, error) {
+	location := eventapp.EventDetailLocationRecord{
+		Type:        locationType,
+		RoutePoints: make([]domain.GeoPoint, 0),
+	}
+
+	switch locationType {
+	case domain.LocationPoint:
+		var point domain.GeoPoint
+		err := r.pool.QueryRow(ctx, `
+			SELECT
+				ST_Y(el.geom::geometry) AS lat,
+				ST_X(el.geom::geometry) AS lon
+			FROM event_location el
+			WHERE el.event_id = $1
+		`, eventID).Scan(&point.Lat, &point.Lon)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return location, domain.ErrNotFound
+			}
+			return location, fmt.Errorf("load event detail point: %w", err)
+		}
+		location.Point = &point
+	case domain.LocationRoute:
+		rows, err := r.pool.Query(ctx, `
+			SELECT
+				ST_Y(dp.geom) AS lat,
+				ST_X(dp.geom) AS lon
+			FROM event_location el
+			CROSS JOIN LATERAL ST_DumpPoints(el.geom::geometry) AS dp
+			WHERE el.event_id = $1
+			ORDER BY dp.path
+		`, eventID)
+		if err != nil {
+			return location, fmt.Errorf("load event detail route points: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var point domain.GeoPoint
+			if err := rows.Scan(&point.Lat, &point.Lon); err != nil {
+				return location, fmt.Errorf("scan event detail route point: %w", err)
+			}
+			location.RoutePoints = append(location.RoutePoints, point)
+		}
+		if err := rows.Err(); err != nil {
+			return location, fmt.Errorf("iterate event detail route points: %w", err)
+		}
+	default:
+		return location, nil
+	}
+
+	return location, nil
+}
+
+func (r *EventRepository) loadEventTags(ctx context.Context, eventID uuid.UUID) ([]string, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT name
+		FROM event_tag
+		WHERE event_id = $1
+		ORDER BY name ASC
+	`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load event tags: %w", err)
+	}
+	defer rows.Close()
+
+	tags := make([]string, 0)
+	for rows.Next() {
+		var tag string
+		if err := rows.Scan(&tag); err != nil {
+			return nil, fmt.Errorf("scan event tag: %w", err)
+		}
+		tags = append(tags, tag)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate event tags: %w", err)
+	}
+
+	return tags, nil
+}
+
+func (r *EventRepository) loadEventConstraints(
+	ctx context.Context,
+	eventID uuid.UUID,
+) ([]eventapp.EventDetailConstraintRecord, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT constraint_type, constraint_info
+		FROM event_constraint
+		WHERE event_id = $1
+		ORDER BY created_at ASC, id ASC
+	`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load event constraints: %w", err)
+	}
+	defer rows.Close()
+
+	constraints := make([]eventapp.EventDetailConstraintRecord, 0)
+	for rows.Next() {
+		var (
+			constraintType string
+			constraintInfo pgtype.Text
+		)
+		if err := rows.Scan(&constraintType, &constraintInfo); err != nil {
+			return nil, fmt.Errorf("scan event constraint: %w", err)
+		}
+
+		constraint := eventapp.EventDetailConstraintRecord{Type: constraintType}
+		if constraintInfo.Valid {
+			constraint.Info = constraintInfo.String
+		}
+		constraints = append(constraints, constraint)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate event constraints: %w", err)
+	}
+
+	return constraints, nil
+}
+
+func (r *EventRepository) loadEventHostContext(
+	ctx context.Context,
+	eventID uuid.UUID,
+) (*eventapp.EventDetailHostContextRecord, error) {
+	approvedParticipants, err := r.loadApprovedParticipants(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+
+	pendingJoinRequests, err := r.loadPendingJoinRequests(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+
+	invitations, err := r.loadInvitations(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &eventapp.EventDetailHostContextRecord{
+		ApprovedParticipants: approvedParticipants,
+		PendingJoinRequests:  pendingJoinRequests,
+		Invitations:          invitations,
+	}, nil
+}
+
+func (r *EventRepository) loadApprovedParticipants(
+	ctx context.Context,
+	eventID uuid.UUID,
+) ([]eventapp.EventDetailApprovedParticipantRecord, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT
+			p.id,
+			p.status,
+			p.created_at,
+			p.updated_at,
+			u.id,
+			u.username,
+			pr.display_name,
+			pr.avatar_url
+		FROM participation p
+		JOIN app_user u ON u.id = p.user_id
+		LEFT JOIN profile pr ON pr.user_id = u.id
+		WHERE p.event_id = $1
+		  AND p.status = $2
+		ORDER BY p.created_at ASC, p.id ASC
+	`, eventID, domain.ParticipationStatusApproved)
+	if err != nil {
+		return nil, fmt.Errorf("load approved participants: %w", err)
+	}
+	defer rows.Close()
+
+	participants := make([]eventapp.EventDetailApprovedParticipantRecord, 0)
+	for rows.Next() {
+		var (
+			participationID uuid.UUID
+			status          string
+			createdAt       time.Time
+			updatedAt       time.Time
+			userID          uuid.UUID
+			username        string
+			displayName     pgtype.Text
+			avatarURL       pgtype.Text
+		)
+		if err := rows.Scan(
+			&participationID,
+			&status,
+			&createdAt,
+			&updatedAt,
+			&userID,
+			&username,
+			&displayName,
+			&avatarURL,
+		); err != nil {
+			return nil, fmt.Errorf("scan approved participant: %w", err)
+		}
+
+		participant := eventapp.EventDetailApprovedParticipantRecord{
+			ParticipationID: participationID,
+			Status:          status,
+			CreatedAt:       createdAt,
+			UpdatedAt:       updatedAt,
+			User: eventapp.EventDetailPersonRecord{
+				ID:       userID,
+				Username: username,
+			},
+		}
+		if displayName.Valid {
+			participant.User.DisplayName = &displayName.String
+		}
+		if avatarURL.Valid {
+			participant.User.AvatarURL = &avatarURL.String
+		}
+
+		participants = append(participants, participant)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate approved participants: %w", err)
+	}
+
+	return participants, nil
+}
+
+func (r *EventRepository) loadPendingJoinRequests(
+	ctx context.Context,
+	eventID uuid.UUID,
+) ([]eventapp.EventDetailPendingJoinRequestRecord, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT
+			jr.id,
+			jr.status,
+			jr.message,
+			jr.created_at,
+			jr.updated_at,
+			u.id,
+			u.username,
+			pr.display_name,
+			pr.avatar_url
+		FROM join_request jr
+		JOIN app_user u ON u.id = jr.user_id
+		LEFT JOIN profile pr ON pr.user_id = u.id
+		WHERE jr.event_id = $1
+		  AND jr.status = $2
+		ORDER BY jr.created_at ASC, jr.id ASC
+	`, eventID, domain.ParticipationStatusPending)
+	if err != nil {
+		return nil, fmt.Errorf("load pending join requests: %w", err)
+	}
+	defer rows.Close()
+
+	requests := make([]eventapp.EventDetailPendingJoinRequestRecord, 0)
+	for rows.Next() {
+		var (
+			joinRequestID uuid.UUID
+			status        string
+			message       pgtype.Text
+			createdAt     time.Time
+			updatedAt     time.Time
+			userID        uuid.UUID
+			username      string
+			displayName   pgtype.Text
+			avatarURL     pgtype.Text
+		)
+		if err := rows.Scan(
+			&joinRequestID,
+			&status,
+			&message,
+			&createdAt,
+			&updatedAt,
+			&userID,
+			&username,
+			&displayName,
+			&avatarURL,
+		); err != nil {
+			return nil, fmt.Errorf("scan pending join request: %w", err)
+		}
+
+		request := eventapp.EventDetailPendingJoinRequestRecord{
+			JoinRequestID: joinRequestID,
+			Status:        status,
+			CreatedAt:     createdAt,
+			UpdatedAt:     updatedAt,
+			User: eventapp.EventDetailPersonRecord{
+				ID:       userID,
+				Username: username,
+			},
+		}
+		if message.Valid {
+			request.Message = &message.String
+		}
+		if displayName.Valid {
+			request.User.DisplayName = &displayName.String
+		}
+		if avatarURL.Valid {
+			request.User.AvatarURL = &avatarURL.String
+		}
+
+		requests = append(requests, request)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending join requests: %w", err)
+	}
+
+	return requests, nil
+}
+
+func (r *EventRepository) loadInvitations(
+	ctx context.Context,
+	eventID uuid.UUID,
+) ([]eventapp.EventDetailInvitationRecord, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT
+			inv.id,
+			inv.status,
+			inv.message,
+			inv.expires_at,
+			inv.created_at,
+			inv.updated_at,
+			u.id,
+			u.username,
+			pr.display_name,
+			pr.avatar_url
+		FROM invitation inv
+		JOIN app_user u ON u.id = inv.invited_user_id
+		LEFT JOIN profile pr ON pr.user_id = u.id
+		WHERE inv.event_id = $1
+		ORDER BY inv.created_at ASC, inv.id ASC
+	`, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load invitations: %w", err)
+	}
+	defer rows.Close()
+
+	invitations := make([]eventapp.EventDetailInvitationRecord, 0)
+	for rows.Next() {
+		var (
+			invitationID uuid.UUID
+			status       string
+			message      pgtype.Text
+			expiresAt    pgtype.Timestamptz
+			createdAt    time.Time
+			updatedAt    time.Time
+			userID       uuid.UUID
+			username     string
+			displayName  pgtype.Text
+			avatarURL    pgtype.Text
+		)
+		if err := rows.Scan(
+			&invitationID,
+			&status,
+			&message,
+			&expiresAt,
+			&createdAt,
+			&updatedAt,
+			&userID,
+			&username,
+			&displayName,
+			&avatarURL,
+		); err != nil {
+			return nil, fmt.Errorf("scan invitation: %w", err)
+		}
+
+		invitation := eventapp.EventDetailInvitationRecord{
+			InvitationID: invitationID,
+			Status:       domain.InvitationStatus(status),
+			CreatedAt:    createdAt,
+			UpdatedAt:    updatedAt,
+			User: eventapp.EventDetailPersonRecord{
+				ID:       userID,
+				Username: username,
+			},
+		}
+		if message.Valid {
+			invitation.Message = &message.String
+		}
+		if expiresAt.Valid {
+			invitation.ExpiresAt = &expiresAt.Time
+		}
+		if displayName.Valid {
+			invitation.User.DisplayName = &displayName.String
+		}
+		if avatarURL.Valid {
+			invitation.User.AvatarURL = &avatarURL.String
+		}
+
+		invitations = append(invitations, invitation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate invitations: %w", err)
+	}
+
+	return invitations, nil
+}
+
 // GetEventByID fetches a single event row by its primary key.
 // Returns domain.ErrNotFound when no matching row exists.
 func (r *EventRepository) GetEventByID(ctx context.Context, eventID uuid.UUID) (*domain.Event, error) {

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
@@ -29,6 +29,7 @@ func NewEventHandler(service event.UseCase) *EventHandler {
 func RegisterEventRoutes(router fiber.Router, handler *EventHandler, auth fiber.Handler) {
 	group := router.Group("/events")
 	group.Get("/", auth, handler.DiscoverEvents)
+	group.Get("/:id", auth, handler.GetEventDetail)
 	group.Post("/", auth, handler.CreateEvent)
 	group.Post("/:id/join", auth, handler.JoinEvent)
 	group.Post("/:id/join-request", auth, handler.RequestJoin)
@@ -43,6 +44,22 @@ func (h *EventHandler) DiscoverEvents(c *fiber.Ctx) error {
 
 	claims := httpapi.UserClaims(c)
 	result, err := h.service.DiscoverEvents(c.UserContext(), claims.UserID, input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.JSON(result)
+}
+
+// GetEventDetail handles GET /events/:id.
+func (h *EventHandler) GetEventDetail(c *fiber.Ctx) error {
+	eventID, err := parseEventIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.GetEventDetail(c.UserContext(), claims.UserID, eventID)
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -19,12 +19,15 @@ import (
 type stubEventService struct {
 	result               *event.CreateEventResult
 	discoverResult       *event.DiscoverEventsResult
+	detailResult         *event.GetEventDetailResult
 	err                  error
 	callCount            int
 	discoverCallCount    int
+	detailCallCount      int
 	requestJoinCallCount int
 	lastInput            event.CreateEventInput
 	lastDiscoverInput    event.DiscoverEventsInput
+	lastDetailEventID    uuid.UUID
 	lastRequestJoinInput event.RequestJoinInput
 }
 
@@ -61,6 +64,42 @@ func (s *stubEventService) DiscoverEvents(_ context.Context, _ uuid.UUID, input 
 		Items: []event.DiscoverableEventItem{},
 		PageInfo: event.DiscoverEventsPageInfo{
 			HasNext: false,
+		},
+	}, nil
+}
+
+func (s *stubEventService) GetEventDetail(_ context.Context, _, eventID uuid.UUID) (*event.GetEventDetailResult, error) {
+	s.detailCallCount++
+	s.lastDetailEventID = eventID
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.detailResult != nil {
+		return s.detailResult, nil
+	}
+	return &event.GetEventDetailResult{
+		ID:           eventID.String(),
+		Title:        "Detailed Event",
+		PrivacyLevel: string(domain.PrivacyPublic),
+		Status:       string(domain.EventStatusActive),
+		StartTime:    time.Now().UTC(),
+		Host: event.EventDetailPerson{
+			ID:       uuid.NewString(),
+			Username: "host_user",
+		},
+		Location: event.EventDetailLocation{
+			Type: string(domain.LocationPoint),
+			Point: &event.EventDetailPoint{
+				Lat: 41,
+				Lon: 29,
+			},
+		},
+		Tags:        []string{},
+		Constraints: []event.EventDetailConstraint{},
+		ViewerContext: event.EventDetailViewerContext{
+			IsHost:              false,
+			IsFavorited:         false,
+			ParticipationStatus: string(domain.EventDetailParticipationStatusNone),
 		},
 	}, nil
 }
@@ -273,6 +312,86 @@ func TestDiscoverEventsIgnoresEmptyOptionalListParams(t *testing.T) {
 	}
 	if len(svc.lastDiscoverInput.TagNames) != 0 {
 		t.Fatalf("expected empty tag_names, got %v", svc.lastDiscoverInput.TagNames)
+	}
+}
+
+func TestGetEventDetailReturns200(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/"+eventID.String(), nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.detailCallCount != 1 {
+		t.Fatalf("expected detail service to be called once, got %d", svc.detailCallCount)
+	}
+	if svc.lastDetailEventID != eventID {
+		t.Fatalf("expected detail service to receive event %s, got %s", eventID, svc.lastDetailEventID)
+	}
+
+	var body event.GetEventDetailResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.ID != eventID.String() {
+		t.Fatalf("expected response id %s, got %s", eventID, body.ID)
+	}
+}
+
+func TestGetEventDetailInvalidIDReturns400(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/not-a-uuid", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+	if svc.detailCallCount != 0 {
+		t.Fatalf("expected detail service not to be called, got %d", svc.detailCallCount)
+	}
+}
+
+func TestGetEventDetailWithoutAuthReturns401(t *testing.T) {
+	// given
+	app := newEventTestApp(&stubEventService{}, &fakeVerifier{err: fiber.ErrUnauthorized})
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/"+eventID.String(), nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", fiber.StatusUnauthorized, resp.StatusCode)
 	}
 }
 

--- a/backend/internal/application/event/helpers.go
+++ b/backend/internal/application/event/helpers.go
@@ -77,6 +77,142 @@ func toDiscoverableEventItem(record DiscoverableEventRecord) DiscoverableEventIt
 	}
 }
 
+func toEventDetailResult(record *EventDetailRecord) *GetEventDetailResult {
+	result := &GetEventDetailResult{
+		ID:                       record.ID.String(),
+		Title:                    record.Title,
+		Description:              record.Description,
+		ImageURL:                 record.ImageURL,
+		PrivacyLevel:             string(record.PrivacyLevel),
+		Status:                   string(record.Status),
+		StartTime:                record.StartTime,
+		EndTime:                  record.EndTime,
+		Capacity:                 record.Capacity,
+		MinimumAge:               record.MinimumAge,
+		ApprovedParticipantCount: record.ApprovedParticipantCount,
+		PendingParticipantCount:  record.PendingParticipantCount,
+		FavoriteCount:            record.FavoriteCount,
+		CreatedAt:                record.CreatedAt,
+		UpdatedAt:                record.UpdatedAt,
+		Host:                     toEventDetailPerson(record.Host),
+		Location:                 toEventDetailLocation(record.Location),
+		Tags:                     append([]string{}, record.Tags...),
+		Constraints:              toEventDetailConstraints(record.Constraints),
+		ViewerContext: EventDetailViewerContext{
+			IsHost:              record.ViewerContext.IsHost,
+			IsFavorited:         record.ViewerContext.IsFavorited,
+			ParticipationStatus: string(record.ViewerContext.ParticipationStatus),
+		},
+	}
+
+	if record.Category != nil {
+		result.Category = &EventDetailCategory{
+			ID:   record.Category.ID,
+			Name: record.Category.Name,
+		}
+	}
+	if record.PreferredGender != nil {
+		preferredGender := string(*record.PreferredGender)
+		result.PreferredGender = &preferredGender
+	}
+	if record.HostContext != nil {
+		result.HostContext = &EventDetailHostContext{
+			ApprovedParticipants: toEventDetailApprovedParticipants(record.HostContext.ApprovedParticipants),
+			PendingJoinRequests:  toEventDetailPendingJoinRequests(record.HostContext.PendingJoinRequests),
+			Invitations:          toEventDetailInvitations(record.HostContext.Invitations),
+		}
+	}
+
+	return result
+}
+
+func toEventDetailLocation(record EventDetailLocationRecord) EventDetailLocation {
+	location := EventDetailLocation{
+		Type:    string(record.Type),
+		Address: record.Address,
+	}
+
+	if record.Point != nil {
+		location.Point = &EventDetailPoint{
+			Lat: record.Point.Lat,
+			Lon: record.Point.Lon,
+		}
+	}
+	if len(record.RoutePoints) > 0 {
+		location.RoutePoints = make([]EventDetailPoint, len(record.RoutePoints))
+		for i, point := range record.RoutePoints {
+			location.RoutePoints[i] = EventDetailPoint{
+				Lat: point.Lat,
+				Lon: point.Lon,
+			}
+		}
+	}
+
+	return location
+}
+
+func toEventDetailConstraints(records []EventDetailConstraintRecord) []EventDetailConstraint {
+	constraints := make([]EventDetailConstraint, len(records))
+	for i, record := range records {
+		constraints[i] = EventDetailConstraint(record)
+	}
+	return constraints
+}
+
+func toEventDetailApprovedParticipants(records []EventDetailApprovedParticipantRecord) []EventDetailApprovedParticipant {
+	participants := make([]EventDetailApprovedParticipant, len(records))
+	for i, record := range records {
+		participants[i] = EventDetailApprovedParticipant{
+			ParticipationID: record.ParticipationID.String(),
+			Status:          record.Status,
+			CreatedAt:       record.CreatedAt,
+			UpdatedAt:       record.UpdatedAt,
+			User:            toEventDetailPerson(record.User),
+		}
+	}
+	return participants
+}
+
+func toEventDetailPendingJoinRequests(records []EventDetailPendingJoinRequestRecord) []EventDetailPendingJoinRequest {
+	requests := make([]EventDetailPendingJoinRequest, len(records))
+	for i, record := range records {
+		requests[i] = EventDetailPendingJoinRequest{
+			JoinRequestID: record.JoinRequestID.String(),
+			Status:        record.Status,
+			Message:       record.Message,
+			CreatedAt:     record.CreatedAt,
+			UpdatedAt:     record.UpdatedAt,
+			User:          toEventDetailPerson(record.User),
+		}
+	}
+	return requests
+}
+
+func toEventDetailInvitations(records []EventDetailInvitationRecord) []EventDetailInvitation {
+	invitations := make([]EventDetailInvitation, len(records))
+	for i, record := range records {
+		invitations[i] = EventDetailInvitation{
+			InvitationID: record.InvitationID.String(),
+			Status:       string(record.Status),
+			Message:      record.Message,
+			ExpiresAt:    record.ExpiresAt,
+			CreatedAt:    record.CreatedAt,
+			UpdatedAt:    record.UpdatedAt,
+			User:         toEventDetailPerson(record.User),
+		}
+	}
+	return invitations
+}
+
+func toEventDetailPerson(record EventDetailPersonRecord) EventDetailPerson {
+	return EventDetailPerson{
+		ID:          record.ID.String(),
+		Username:    record.Username,
+		DisplayName: record.DisplayName,
+		AvatarURL:   record.AvatarURL,
+	}
+}
+
 func toDomainRoutePoints(points []RoutePointInput) []domain.GeoPoint {
 	domainPoints := make([]domain.GeoPoint, len(points))
 	for i, point := range points {

--- a/backend/internal/application/event/repository.go
+++ b/backend/internal/application/event/repository.go
@@ -11,5 +11,6 @@ import (
 type Repository interface {
 	CreateEvent(ctx context.Context, params CreateEventParams) (*domain.Event, error)
 	ListDiscoverableEvents(ctx context.Context, userID uuid.UUID, params DiscoverEventsParams) ([]DiscoverableEventRecord, error)
+	GetEventDetail(ctx context.Context, userID, eventID uuid.UUID) (*EventDetailRecord, error)
 	GetEventByID(ctx context.Context, eventID uuid.UUID) (*domain.Event, error)
 }

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -79,3 +79,102 @@ type DiscoverEventsCursor struct {
 	DistanceMeters    *float64                  `json:"distance_meters,omitempty"`
 	RelevanceScore    *float64                  `json:"relevance_score,omitempty"`
 }
+
+// EventDetailRecord is the repository-level projection used for event detail responses.
+type EventDetailRecord struct {
+	ID                       uuid.UUID
+	Title                    string
+	Description              *string
+	ImageURL                 *string
+	PrivacyLevel             domain.EventPrivacyLevel
+	Status                   domain.EventStatus
+	StartTime                time.Time
+	EndTime                  *time.Time
+	Capacity                 *int
+	MinimumAge               *int
+	PreferredGender          *domain.EventParticipantGender
+	ApprovedParticipantCount int
+	PendingParticipantCount  int
+	FavoriteCount            int
+	CreatedAt                time.Time
+	UpdatedAt                time.Time
+	Category                 *EventDetailCategoryRecord
+	Host                     EventDetailPersonRecord
+	Location                 EventDetailLocationRecord
+	Tags                     []string
+	Constraints              []EventDetailConstraintRecord
+	ViewerContext            EventDetailViewerContextRecord
+	HostContext              *EventDetailHostContextRecord
+}
+
+// EventDetailCategoryRecord is the category projection attached to an event detail payload.
+type EventDetailCategoryRecord struct {
+	ID   int
+	Name string
+}
+
+// EventDetailPersonRecord is a safe user summary reused across event detail payloads.
+type EventDetailPersonRecord struct {
+	ID          uuid.UUID
+	Username    string
+	DisplayName *string
+	AvatarURL   *string
+}
+
+// EventDetailLocationRecord carries the event geometry and address for the detail page.
+type EventDetailLocationRecord struct {
+	Type        domain.EventLocationType
+	Address     *string
+	Point       *domain.GeoPoint
+	RoutePoints []domain.GeoPoint
+}
+
+// EventDetailConstraintRecord is a repository-level projection of an event constraint.
+type EventDetailConstraintRecord struct {
+	Type string
+	Info string
+}
+
+// EventDetailViewerContextRecord captures the authenticated viewer's relation to the event.
+type EventDetailViewerContextRecord struct {
+	IsHost              bool
+	IsFavorited         bool
+	ParticipationStatus domain.EventDetailParticipationStatus
+}
+
+// EventDetailHostContextRecord contains host-only management lists for the event.
+type EventDetailHostContextRecord struct {
+	ApprovedParticipants []EventDetailApprovedParticipantRecord
+	PendingJoinRequests  []EventDetailPendingJoinRequestRecord
+	Invitations          []EventDetailInvitationRecord
+}
+
+// EventDetailApprovedParticipantRecord is a host-visible approved participation projection.
+type EventDetailApprovedParticipantRecord struct {
+	ParticipationID uuid.UUID
+	Status          string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	User            EventDetailPersonRecord
+}
+
+// EventDetailPendingJoinRequestRecord is a host-visible pending join request projection.
+type EventDetailPendingJoinRequestRecord struct {
+	JoinRequestID uuid.UUID
+	Status        string
+	Message       *string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	User          EventDetailPersonRecord
+}
+
+// EventDetailInvitationRecord is a host-visible invitation projection.
+type EventDetailInvitationRecord struct {
+	InvitationID uuid.UUID
+	Status       domain.InvitationStatus
+	Message      *string
+	ExpiresAt    *time.Time
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	User         EventDetailPersonRecord
+}

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -118,6 +118,20 @@ func (s *Service) DiscoverEvents(ctx context.Context, userID uuid.UUID, input Di
 	}, nil
 }
 
+// GetEventDetail returns the maximum event detail payload visible to the
+// authenticated user, enforcing event visibility rules in the repository read path.
+func (s *Service) GetEventDetail(ctx context.Context, userID, eventID uuid.UUID) (*GetEventDetailResult, error) {
+	record, err := s.eventRepo.GetEventDetail(ctx, userID, eventID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+		return nil, err
+	}
+
+	return toEventDetailResult(record), nil
+}
+
 // JoinEvent allows a user to join a PUBLIC event directly. The resulting
 // participation record has status APPROVED.
 //

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -92,6 +92,111 @@ type DiscoverEventsPageInfo struct {
 	HasNext    bool    `json:"has_next"`
 }
 
+// GetEventDetailResult is the full event payload used by the detail page.
+type GetEventDetailResult struct {
+	ID                       string                   `json:"id"`
+	Title                    string                   `json:"title"`
+	Description              *string                  `json:"description"`
+	ImageURL                 *string                  `json:"image_url"`
+	PrivacyLevel             string                   `json:"privacy_level"`
+	Status                   string                   `json:"status"`
+	StartTime                time.Time                `json:"start_time"`
+	EndTime                  *time.Time               `json:"end_time"`
+	Capacity                 *int                     `json:"capacity"`
+	MinimumAge               *int                     `json:"minimum_age"`
+	PreferredGender          *string                  `json:"preferred_gender"`
+	ApprovedParticipantCount int                      `json:"approved_participant_count"`
+	PendingParticipantCount  int                      `json:"pending_participant_count"`
+	FavoriteCount            int                      `json:"favorite_count"`
+	CreatedAt                time.Time                `json:"created_at"`
+	UpdatedAt                time.Time                `json:"updated_at"`
+	Category                 *EventDetailCategory     `json:"category"`
+	Host                     EventDetailPerson        `json:"host"`
+	Location                 EventDetailLocation      `json:"location"`
+	Tags                     []string                 `json:"tags"`
+	Constraints              []EventDetailConstraint  `json:"constraints"`
+	ViewerContext            EventDetailViewerContext `json:"viewer_context"`
+	HostContext              *EventDetailHostContext  `json:"host_context,omitempty"`
+}
+
+// EventDetailCategory is the category object returned by event detail responses.
+type EventDetailCategory struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// EventDetailPerson is the safe user summary returned in event detail responses.
+type EventDetailPerson struct {
+	ID          string  `json:"id"`
+	Username    string  `json:"username"`
+	DisplayName *string `json:"display_name"`
+	AvatarURL   *string `json:"avatar_url"`
+}
+
+// EventDetailLocation is the event location payload used by the detail page.
+type EventDetailLocation struct {
+	Type        string             `json:"type"`
+	Address     *string            `json:"address"`
+	Point       *EventDetailPoint  `json:"point,omitempty"`
+	RoutePoints []EventDetailPoint `json:"route_points,omitempty"`
+}
+
+// EventDetailPoint is a single coordinate returned in event detail responses.
+type EventDetailPoint struct {
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
+}
+
+// EventDetailConstraint is a single event constraint returned by the detail endpoint.
+type EventDetailConstraint struct {
+	Type string `json:"type"`
+	Info string `json:"info"`
+}
+
+// EventDetailViewerContext describes how the authenticated user relates to the event.
+type EventDetailViewerContext struct {
+	IsHost              bool   `json:"is_host"`
+	IsFavorited         bool   `json:"is_favorited"`
+	ParticipationStatus string `json:"participation_status"`
+}
+
+// EventDetailHostContext contains host-only management lists.
+type EventDetailHostContext struct {
+	ApprovedParticipants []EventDetailApprovedParticipant `json:"approved_participants"`
+	PendingJoinRequests  []EventDetailPendingJoinRequest  `json:"pending_join_requests"`
+	Invitations          []EventDetailInvitation          `json:"invitations"`
+}
+
+// EventDetailApprovedParticipant is returned only to the host.
+type EventDetailApprovedParticipant struct {
+	ParticipationID string            `json:"participation_id"`
+	Status          string            `json:"status"`
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+	User            EventDetailPerson `json:"user"`
+}
+
+// EventDetailPendingJoinRequest is returned only to the host.
+type EventDetailPendingJoinRequest struct {
+	JoinRequestID string            `json:"join_request_id"`
+	Status        string            `json:"status"`
+	Message       *string           `json:"message"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
+	User          EventDetailPerson `json:"user"`
+}
+
+// EventDetailInvitation is returned only to the host.
+type EventDetailInvitation struct {
+	InvitationID string            `json:"invitation_id"`
+	Status       string            `json:"status"`
+	Message      *string           `json:"message"`
+	ExpiresAt    *time.Time        `json:"expires_at"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+	User         EventDetailPerson `json:"user"`
+}
+
 // JoinEventResult is returned after a user successfully joins a public event.
 type JoinEventResult struct {
 	ParticipationID string    `json:"participation_id"`

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -15,11 +15,15 @@ import (
 type fakeEventRepo struct {
 	err                error
 	discoverErr        error
+	detailErr          error
 	events             map[uuid.UUID]*domain.Event
 	discoverRecords    []DiscoverableEventRecord
+	detailRecord       *EventDetailRecord
 	discoverCallCount  int
 	lastDiscoverUserID uuid.UUID
 	lastDiscoverParams DiscoverEventsParams
+	lastDetailUserID   uuid.UUID
+	lastDetailEventID  uuid.UUID
 }
 
 func (r *fakeEventRepo) CreateEvent(_ context.Context, params CreateEventParams) (*domain.Event, error) {
@@ -44,6 +48,19 @@ func (r *fakeEventRepo) CreateEvent(_ context.Context, params CreateEventParams)
 func (r *fakeEventRepo) GetEventByID(_ context.Context, id uuid.UUID) (*domain.Event, error) {
 	if e, ok := r.events[id]; ok {
 		return e, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (r *fakeEventRepo) GetEventDetail(_ context.Context, userID, eventID uuid.UUID) (*EventDetailRecord, error) {
+	r.lastDetailUserID = userID
+	r.lastDetailEventID = eventID
+
+	if r.detailErr != nil {
+		return nil, r.detailErr
+	}
+	if r.detailRecord != nil {
+		return r.detailRecord, nil
 	}
 	return nil, domain.ErrNotFound
 }
@@ -193,6 +210,168 @@ func TestCreateEventWithEndTime(t *testing.T) {
 	}
 	if result.EndTime == nil {
 		t.Fatal("expected non-nil end_time")
+	}
+}
+
+func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
+	// given
+	svc, eventRepo, _, _ := newTestEventService()
+	userID := uuid.New()
+	eventID := uuid.New()
+	createdAt := time.Now().UTC().Add(-time.Hour)
+	updatedAt := createdAt.Add(10 * time.Minute)
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	categoryID := 7
+	preferredGender := domain.GenderOther
+
+	eventRepo.detailRecord = &EventDetailRecord{
+		ID:                       eventID,
+		Title:                    "Detail Event",
+		Description:              stringPtr("Full payload"),
+		ImageURL:                 stringPtr("https://example.com/event.png"),
+		PrivacyLevel:             domain.PrivacyPrivate,
+		Status:                   domain.EventStatusCanceled,
+		StartTime:                startTime,
+		Capacity:                 intPtr(15),
+		MinimumAge:               intPtr(21),
+		PreferredGender:          &preferredGender,
+		ApprovedParticipantCount: 3,
+		PendingParticipantCount:  1,
+		FavoriteCount:            5,
+		CreatedAt:                createdAt,
+		UpdatedAt:                updatedAt,
+		Category: &EventDetailCategoryRecord{
+			ID:   categoryID,
+			Name: "Outdoors",
+		},
+		Host: EventDetailPersonRecord{
+			ID:          uuid.New(),
+			Username:    "host_user",
+			DisplayName: stringPtr("Host User"),
+			AvatarURL:   stringPtr("https://example.com/avatar.png"),
+		},
+		Location: EventDetailLocationRecord{
+			Type:    domain.LocationRoute,
+			Address: stringPtr("Belgrad Forest"),
+			RoutePoints: []domain.GeoPoint{
+				{Lat: 41.01, Lon: 29.02},
+				{Lat: 41.02, Lon: 29.03},
+			},
+		},
+		Tags: []string{"trail", "forest"},
+		Constraints: []EventDetailConstraintRecord{
+			{Type: "equipment", Info: "Bring hiking boots"},
+		},
+		ViewerContext: EventDetailViewerContextRecord{
+			IsHost:              false,
+			IsFavorited:         true,
+			ParticipationStatus: domain.EventDetailParticipationStatusJoined,
+		},
+	}
+
+	// when
+	result, err := svc.GetEventDetail(context.Background(), userID, eventID)
+
+	// then
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if eventRepo.lastDetailUserID != userID || eventRepo.lastDetailEventID != eventID {
+		t.Fatalf("expected detail repo to receive user %s and event %s", userID, eventID)
+	}
+	if result.ID != eventID.String() {
+		t.Fatalf("expected event id %s, got %s", eventID, result.ID)
+	}
+	if result.Status != string(domain.EventStatusCanceled) {
+		t.Fatalf("expected status %q, got %q", domain.EventStatusCanceled, result.Status)
+	}
+	if result.HostContext != nil {
+		t.Fatal("expected non-host result to omit host_context")
+	}
+	if result.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusJoined) {
+		t.Fatalf("expected participation_status %q, got %q", domain.EventDetailParticipationStatusJoined, result.ViewerContext.ParticipationStatus)
+	}
+	if len(result.Location.RoutePoints) != 2 {
+		t.Fatalf("expected 2 route points, got %d", len(result.Location.RoutePoints))
+	}
+}
+
+func TestGetEventDetailIncludesHostContextForHostViewer(t *testing.T) {
+	// given
+	svc, eventRepo, _, _ := newTestEventService()
+	eventRepo.detailRecord = &EventDetailRecord{
+		ID:           uuid.New(),
+		Title:        "Hosted Event",
+		PrivacyLevel: domain.PrivacyPublic,
+		Status:       domain.EventStatusCompleted,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		Host: EventDetailPersonRecord{
+			ID:       uuid.New(),
+			Username: "host_user",
+		},
+		Location: EventDetailLocationRecord{
+			Type: domain.LocationPoint,
+			Point: &domain.GeoPoint{
+				Lat: 40,
+				Lon: 29,
+			},
+		},
+		Tags:        []string{},
+		Constraints: []EventDetailConstraintRecord{},
+		ViewerContext: EventDetailViewerContextRecord{
+			IsHost:              true,
+			IsFavorited:         false,
+			ParticipationStatus: domain.EventDetailParticipationStatusNone,
+		},
+		HostContext: &EventDetailHostContextRecord{
+			ApprovedParticipants: []EventDetailApprovedParticipantRecord{
+				{
+					ParticipationID: uuid.New(),
+					Status:          domain.ParticipationStatusApproved,
+					CreatedAt:       time.Now().UTC().Add(-time.Hour),
+					UpdatedAt:       time.Now().UTC(),
+					User: EventDetailPersonRecord{
+						ID:       uuid.New(),
+						Username: "participant_user",
+					},
+				},
+			},
+			PendingJoinRequests: []EventDetailPendingJoinRequestRecord{},
+			Invitations:         []EventDetailInvitationRecord{},
+		},
+	}
+
+	// when
+	result, err := svc.GetEventDetail(context.Background(), uuid.New(), uuid.New())
+
+	// then
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if result.HostContext == nil {
+		t.Fatal("expected host_context for host viewer")
+	}
+	if len(result.HostContext.ApprovedParticipants) != 1 {
+		t.Fatalf("expected 1 approved participant, got %d", len(result.HostContext.ApprovedParticipants))
+	}
+}
+
+func TestGetEventDetailReturnsNotFoundWhenRepositoryMisses(t *testing.T) {
+	// given
+	svc, eventRepo, _, _ := newTestEventService()
+	eventRepo.detailErr = domain.ErrNotFound
+
+	// when
+	_, err := svc.GetEventDetail(context.Background(), uuid.New(), uuid.New())
+
+	// then
+	commonAppErrCode := domain.ErrorCodeEventNotFound
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T", err)
+	}
+	if appErr.Code != commonAppErrCode {
+		t.Fatalf("expected error code %q, got %q", commonAppErrCode, appErr.Code)
 	}
 }
 
@@ -957,5 +1136,7 @@ func TestRequestJoinRejectsPublicEvent(t *testing.T) {
 }
 
 func stringPtr(v string) *string { return &v }
+
+func intPtr(v int) *int { return &v }
 
 func floatPtr(v float64) *float64 { return &v }

--- a/backend/internal/application/event/usecase.go
+++ b/backend/internal/application/event/usecase.go
@@ -8,6 +8,7 @@ import "github.com/google/uuid"
 type UseCase interface {
 	CreateEvent(ctx context.Context, hostID uuid.UUID, input CreateEventInput) (*CreateEventResult, error)
 	DiscoverEvents(ctx context.Context, userID uuid.UUID, input DiscoverEventsInput) (*DiscoverEventsResult, error)
+	GetEventDetail(ctx context.Context, userID, eventID uuid.UUID) (*GetEventDetailResult, error)
 	JoinEvent(ctx context.Context, userID, eventID uuid.UUID) (*JoinEventResult, error)
 	RequestJoin(ctx context.Context, userID, eventID uuid.UUID, input RequestJoinInput) (*RequestJoinResult, error)
 }

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -27,6 +27,10 @@ type EventCategory struct {
 	Name string
 }
 
+// EventDetailParticipationStatus describes the authenticated viewer's relation
+// to an event detail payload.
+type EventDetailParticipationStatus string
+
 // Accepted values for event fields.
 const (
 	PrivacyPublic    EventPrivacyLevel = "PUBLIC"
@@ -40,11 +44,18 @@ const (
 	GenderFemale EventParticipantGender = "FEMALE"
 	GenderOther  EventParticipantGender = "OTHER"
 
-	EventStatusActive EventStatus = "ACTIVE"
+	EventStatusActive    EventStatus = "ACTIVE"
+	EventStatusCanceled  EventStatus = "CANCELED"
+	EventStatusCompleted EventStatus = "COMPLETED"
 
 	EventDiscoverySortStartTime EventDiscoverySort = "START_TIME"
 	EventDiscoverySortDistance  EventDiscoverySort = "DISTANCE"
 	EventDiscoverySortRelevance EventDiscoverySort = "RELEVANCE"
+
+	EventDetailParticipationStatusJoined  EventDetailParticipationStatus = "JOINED"
+	EventDetailParticipationStatusPending EventDetailParticipationStatus = "PENDING"
+	EventDetailParticipationStatusInvited EventDetailParticipationStatus = "INVITED"
+	EventDetailParticipationStatusNone    EventDetailParticipationStatus = "NONE"
 
 	MaxEventTags        = 5
 	MaxEventConstraints = 5

--- a/backend/internal/domain/invitation.go
+++ b/backend/internal/domain/invitation.go
@@ -1,0 +1,11 @@
+package domain
+
+// InvitationStatus defines the lifecycle state of an invitation row.
+type InvitationStatus string
+
+const (
+	InvitationStatusPending  InvitationStatus = "PENDING"
+	InvitationStatusAccepted InvitationStatus = "ACCEPTED"
+	InvitationStatusDeclined InvitationStatus = "DECLINED"
+	InvitationStatusExpired  InvitationStatus = "EXPIRED"
+)

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -904,6 +904,420 @@ func TestDiscoverEventsCursorPaginationIsStableAndNonOverlapping(t *testing.T) {
 }
 
 // ---------------------------------------------------------
+// GetEventDetail tests
+// ---------------------------------------------------------
+
+func TestGetEventDetailReadsPublicEventForAuthenticatedUser(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("public_host"))
+	categoryID := common.GivenEventCategory(t)
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Detailed Public Event",
+		Description:  "full event detail",
+		CategoryID:   categoryID,
+		Lat:          41.0082,
+		Lon:          28.9784,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+		Tags:         []string{"music", "outdoor"},
+	})
+	insertFavoriteEvent(t, viewer.ID, eventID)
+	insertEventConstraint(t, eventID, "dress_code", "Wear something comfortable")
+
+	// when
+	result, err := harness.Service.GetEventDetail(context.Background(), viewer.ID, eventID)
+
+	// then
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if result.ID != eventID.String() {
+		t.Fatalf("expected event id %s, got %s", eventID, result.ID)
+	}
+	if result.Title != "Detailed Public Event" {
+		t.Fatalf("expected title %q, got %q", "Detailed Public Event", result.Title)
+	}
+	if result.Category == nil || result.Category.ID != categoryID {
+		t.Fatalf("expected category id %d, got %#v", categoryID, result.Category)
+	}
+	if result.Host.Username != "public_host" {
+		t.Fatalf("expected host username %q, got %q", "public_host", result.Host.Username)
+	}
+	if result.Location.Type != string(domain.LocationPoint) {
+		t.Fatalf("expected location type %q, got %q", domain.LocationPoint, result.Location.Type)
+	}
+	if result.Location.Point == nil {
+		t.Fatal("expected point location")
+	}
+	if !result.ViewerContext.IsFavorited {
+		t.Fatal("expected viewer to see is_favorited=true")
+	}
+	if result.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusNone) {
+		t.Fatalf("expected participation_status %q, got %q", domain.EventDetailParticipationStatusNone, result.ViewerContext.ParticipationStatus)
+	}
+	if result.HostContext != nil {
+		t.Fatal("expected non-host response to omit host_context")
+	}
+	if len(result.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(result.Tags))
+	}
+	if len(result.Constraints) != 1 {
+		t.Fatalf("expected 1 constraint, got %d", len(result.Constraints))
+	}
+}
+
+func TestGetEventDetailReadsProtectedEventForAnyAuthenticatedUser(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	eventID := common.GivenProtectedEvent(t, harness.Service, host.ID).ID
+
+	// when
+	result, err := harness.Service.GetEventDetail(context.Background(), viewer.ID, eventID)
+
+	// then
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if result.ID != eventID.String() {
+		t.Fatalf("expected event id %s, got %s", eventID, result.ID)
+	}
+}
+
+func TestGetEventDetailReadsPrivateEventForHost(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Private Host Event",
+		Description:  "host can read",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          40.0,
+		Lon:          29.0,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPrivate,
+	})
+
+	// when
+	result, err := harness.Service.GetEventDetail(context.Background(), host.ID, eventID)
+
+	// then
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if !result.ViewerContext.IsHost {
+		t.Fatal("expected host viewer_context.is_host to be true")
+	}
+	if result.HostContext == nil {
+		t.Fatal("expected host_context for host")
+	}
+}
+
+func TestGetEventDetailReadsPrivateEventForApprovedParticipant(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Private Approved Event",
+		Description:  "participant can read",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.1,
+		Lon:          29.1,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPrivate,
+	})
+	insertParticipation(t, eventID, participant.ID, domain.ParticipationStatusApproved)
+
+	// when
+	result, err := harness.Service.GetEventDetail(context.Background(), participant.ID, eventID)
+
+	// then
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if result.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusJoined) {
+		t.Fatalf("expected participation_status %q, got %q", domain.EventDetailParticipationStatusJoined, result.ViewerContext.ParticipationStatus)
+	}
+}
+
+func TestGetEventDetailReadsPrivateEventForAcceptedInvitee(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	invitee := common.GivenUser(t, harness.AuthRepo)
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Private Invitation Event",
+		Description:  "invitee can read",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.2,
+		Lon:          29.2,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPrivate,
+	})
+	insertInvitation(t, eventID, host.ID, invitee.ID, domain.InvitationStatusAccepted, common.StringPtr("Join us"), nil)
+
+	// when
+	result, err := harness.Service.GetEventDetail(context.Background(), invitee.ID, eventID)
+
+	// then
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if result.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusInvited) {
+		t.Fatalf("expected participation_status %q, got %q", domain.EventDetailParticipationStatusInvited, result.ViewerContext.ParticipationStatus)
+	}
+}
+
+func TestGetEventDetailRejectsPrivateEventForUnrelatedUser(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Private Hidden Event",
+		Description:  "should not leak",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.3,
+		Lon:          29.3,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPrivate,
+	})
+
+	// when
+	_, err := harness.Service.GetEventDetail(context.Background(), viewer.ID, eventID)
+
+	// then
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeEventNotFound)
+}
+
+func TestGetEventDetailReportsViewerParticipationStatuses(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	joinedUser := common.GivenUser(t, harness.AuthRepo)
+	pendingUser := common.GivenUser(t, harness.AuthRepo)
+	invitedUser := common.GivenUser(t, harness.AuthRepo)
+	noneUser := common.GivenUser(t, harness.AuthRepo)
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Status Event",
+		Description:  "viewer statuses",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.4,
+		Lon:          29.4,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	insertParticipation(t, eventID, joinedUser.ID, domain.ParticipationStatusApproved)
+	insertPendingJoinRequest(t, eventID, pendingUser.ID, host.ID, common.StringPtr("please accept"))
+	insertInvitation(t, eventID, host.ID, invitedUser.ID, domain.InvitationStatusPending, nil, nil)
+
+	// when
+	joinedDetail, err := harness.Service.GetEventDetail(context.Background(), joinedUser.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() joined error = %v", err)
+	}
+	pendingDetail, err := harness.Service.GetEventDetail(context.Background(), pendingUser.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() pending error = %v", err)
+	}
+	invitedDetail, err := harness.Service.GetEventDetail(context.Background(), invitedUser.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() invited error = %v", err)
+	}
+	noneDetail, err := harness.Service.GetEventDetail(context.Background(), noneUser.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() none error = %v", err)
+	}
+
+	// then
+	if joinedDetail.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusJoined) {
+		t.Fatalf("expected joined status %q, got %q", domain.EventDetailParticipationStatusJoined, joinedDetail.ViewerContext.ParticipationStatus)
+	}
+	if pendingDetail.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusPending) {
+		t.Fatalf("expected pending status %q, got %q", domain.EventDetailParticipationStatusPending, pendingDetail.ViewerContext.ParticipationStatus)
+	}
+	if invitedDetail.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusInvited) {
+		t.Fatalf("expected invited status %q, got %q", domain.EventDetailParticipationStatusInvited, invitedDetail.ViewerContext.ParticipationStatus)
+	}
+	if noneDetail.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusNone) {
+		t.Fatalf("expected none status %q, got %q", domain.EventDetailParticipationStatusNone, noneDetail.ViewerContext.ParticipationStatus)
+	}
+}
+
+func TestGetEventDetailReturnsCanceledAndCompletedStatuses(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	categoryID := common.GivenEventCategory(t)
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	canceledID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Canceled Event",
+		Description:  "still readable",
+		CategoryID:   categoryID,
+		Lat:          41.5,
+		Lon:          29.5,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	completedID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Completed Event",
+		Description:  "still readable",
+		CategoryID:   categoryID,
+		Lat:          41.6,
+		Lon:          29.6,
+		StartTime:    startTime.Add(time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	updateEventStatus(t, canceledID, string(domain.EventStatusCanceled))
+	updateEventStatus(t, completedID, string(domain.EventStatusCompleted))
+
+	// when
+	canceledDetail, err := harness.Service.GetEventDetail(context.Background(), viewer.ID, canceledID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() canceled error = %v", err)
+	}
+	completedDetail, err := harness.Service.GetEventDetail(context.Background(), viewer.ID, completedID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() completed error = %v", err)
+	}
+
+	// then
+	if canceledDetail.Status != string(domain.EventStatusCanceled) {
+		t.Fatalf("expected canceled status %q, got %q", domain.EventStatusCanceled, canceledDetail.Status)
+	}
+	if completedDetail.Status != string(domain.EventStatusCompleted) {
+		t.Fatalf("expected completed status %q, got %q", domain.EventStatusCompleted, completedDetail.Status)
+	}
+}
+
+func TestGetEventDetailReturnsRoutePoints(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	viewer := common.GivenUser(t, harness.AuthRepo)
+	host := common.GivenUser(t, harness.AuthRepo)
+	eventID := createRouteDiscoveryEvent(t, harness, routeDiscoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Route Detail Event",
+		Description:  "route detail",
+		CategoryID:   common.GivenEventCategory(t),
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyProtected,
+		RoutePoints: []eventapp.RoutePointInput{
+			{Lat: common.Float64Ptr(41.0001), Lon: common.Float64Ptr(29.0001)},
+			{Lat: common.Float64Ptr(41.0002), Lon: common.Float64Ptr(29.0002)},
+			{Lat: common.Float64Ptr(41.0003), Lon: common.Float64Ptr(29.0003)},
+		},
+	})
+
+	// when
+	result, err := harness.Service.GetEventDetail(context.Background(), viewer.ID, eventID)
+
+	// then
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if result.Location.Type != string(domain.LocationRoute) {
+		t.Fatalf("expected location type %q, got %q", domain.LocationRoute, result.Location.Type)
+	}
+	if len(result.Location.RoutePoints) != 3 {
+		t.Fatalf("expected 3 route points, got %d", len(result.Location.RoutePoints))
+	}
+}
+
+func TestGetEventDetailReturnsHostOnlyManagementLists(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("detail_host"))
+	participant := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("approved_user"))
+	requester := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("pending_user"))
+	invitee := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("invited_user"))
+	nonHostViewer := common.GivenUser(t, harness.AuthRepo)
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Managed Event",
+		Description:  "host details",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.7,
+		Lon:          29.7,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	insertParticipation(t, eventID, participant.ID, domain.ParticipationStatusApproved)
+	insertPendingJoinRequest(t, eventID, requester.ID, host.ID, common.StringPtr("I would like to join"))
+	insertInvitation(t, eventID, host.ID, invitee.ID, domain.InvitationStatusPending, common.StringPtr("Come with us"), nil)
+
+	// when
+	hostResult, err := harness.Service.GetEventDetail(context.Background(), host.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() host error = %v", err)
+	}
+	nonHostResult, err := harness.Service.GetEventDetail(context.Background(), nonHostViewer.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() non-host error = %v", err)
+	}
+
+	// then
+	if hostResult.HostContext == nil {
+		t.Fatal("expected host_context for host viewer")
+	}
+	if len(hostResult.HostContext.ApprovedParticipants) != 1 {
+		t.Fatalf("expected 1 approved participant, got %d", len(hostResult.HostContext.ApprovedParticipants))
+	}
+	if len(hostResult.HostContext.PendingJoinRequests) != 1 {
+		t.Fatalf("expected 1 pending join request, got %d", len(hostResult.HostContext.PendingJoinRequests))
+	}
+	if len(hostResult.HostContext.Invitations) != 1 {
+		t.Fatalf("expected 1 invitation, got %d", len(hostResult.HostContext.Invitations))
+	}
+	if hostResult.HostContext.ApprovedParticipants[0].User.Username != "approved_user" {
+		t.Fatalf("expected approved participant username %q, got %q", "approved_user", hostResult.HostContext.ApprovedParticipants[0].User.Username)
+	}
+	if hostResult.HostContext.PendingJoinRequests[0].User.Username != "pending_user" {
+		t.Fatalf("expected pending join request username %q, got %q", "pending_user", hostResult.HostContext.PendingJoinRequests[0].User.Username)
+	}
+	if hostResult.HostContext.Invitations[0].User.Username != "invited_user" {
+		t.Fatalf("expected invitation username %q, got %q", "invited_user", hostResult.HostContext.Invitations[0].User.Username)
+	}
+	if nonHostResult.HostContext != nil {
+		t.Fatal("expected non-host response to omit host_context")
+	}
+}
+
+// ---------------------------------------------------------
 // JoinEvent tests
 // ---------------------------------------------------------
 
@@ -1207,6 +1621,85 @@ func insertFavoriteEvent(t *testing.T, userID, eventID uuid.UUID) {
 	); err != nil {
 		t.Fatalf("insert favorite_event error = %v", err)
 	}
+}
+
+func insertEventConstraint(t *testing.T, eventID uuid.UUID, constraintType, info string) {
+	t.Helper()
+
+	if _, err := common.RequirePool(t).Exec(
+		context.Background(),
+		`INSERT INTO event_constraint (event_id, constraint_type, constraint_info) VALUES ($1, $2, $3)`,
+		eventID,
+		constraintType,
+		info,
+	); err != nil {
+		t.Fatalf("insert event_constraint error = %v", err)
+	}
+}
+
+func insertParticipation(t *testing.T, eventID, userID uuid.UUID, status string) uuid.UUID {
+	t.Helper()
+
+	var participationID uuid.UUID
+	err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`INSERT INTO participation (event_id, user_id, status) VALUES ($1, $2, $3) RETURNING id`,
+		eventID,
+		userID,
+		status,
+	).Scan(&participationID)
+	if err != nil {
+		t.Fatalf("insert participation error = %v", err)
+	}
+
+	return participationID
+}
+
+func insertPendingJoinRequest(t *testing.T, eventID, userID, hostUserID uuid.UUID, message *string) uuid.UUID {
+	t.Helper()
+
+	var joinRequestID uuid.UUID
+	err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`INSERT INTO join_request (event_id, user_id, host_user_id, status, message) VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+		eventID,
+		userID,
+		hostUserID,
+		domain.ParticipationStatusPending,
+		message,
+	).Scan(&joinRequestID)
+	if err != nil {
+		t.Fatalf("insert join_request error = %v", err)
+	}
+
+	return joinRequestID
+}
+
+func insertInvitation(
+	t *testing.T,
+	eventID, hostID, invitedUserID uuid.UUID,
+	status domain.InvitationStatus,
+	message *string,
+	expiresAt *time.Time,
+) uuid.UUID {
+	t.Helper()
+
+	var invitationID uuid.UUID
+	err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`INSERT INTO invitation (event_id, host_id, invited_user_id, status, message, expires_at) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+		eventID,
+		hostID,
+		invitedUserID,
+		string(status),
+		message,
+		expiresAt,
+	).Scan(&invitationID)
+	if err != nil {
+		t.Fatalf("insert invitation error = %v", err)
+	}
+
+	return invitationID
 }
 
 func assertDiscoverEventIDsInOrder(t *testing.T, items []eventapp.DiscoverableEventItem, want ...uuid.UUID) {

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -22,6 +22,201 @@ tags:
   - name: Events
     description: Event creation and related request/response contracts.
 paths:
+  /events/{id}:
+    get:
+      tags: [Events]
+      summary: Get event detail
+      description: |
+        Returns the full event-detail payload for the authenticated user.
+
+        Visibility rules:
+        - `PUBLIC` and `PROTECTED` events are readable by any authenticated user.
+        - `PRIVATE` events are readable only by the host, users with an `APPROVED`
+          participation, or users with an `ACCEPTED` invitation.
+        - When a `PRIVATE` event is not readable by the caller, the API responds with
+          `404 event_not_found` to avoid leaking the event's existence.
+
+        Response notes:
+        - `status` is returned exactly as stored on the event row; canceled and completed
+          events remain readable.
+        - `viewer_context` is always present and resolves the caller's favorite and
+          participation state.
+        - `host_context` is included only when the authenticated user is the event host.
+      operationId: getEventDetail
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: UUID of the event to fetch.
+          example: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+      responses:
+        '200':
+          description: Event detail returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetEventDetailResponse'
+              examples:
+                non_host:
+                  value:
+                    id: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+                    title: Istanbul Trail Run
+                    description: A 10 km trail run through Belgrad Forest.
+                    image_url: https://example.com/trail.jpg
+                    privacy_level: PROTECTED
+                    status: ACTIVE
+                    start_time: "2026-05-01T08:00:00+03:00"
+                    end_time: "2026-05-01T12:00:00+03:00"
+                    capacity: 25
+                    minimum_age: 18
+                    preferred_gender: null
+                    approved_participant_count: 12
+                    pending_participant_count: 0
+                    favorite_count: 8
+                    created_at: "2026-03-26T11:00:00+03:00"
+                    updated_at: "2026-03-27T09:30:00+03:00"
+                    category:
+                      id: 7
+                      name: Outdoors
+                    host:
+                      id: 2df86e13-2d2b-4dca-8d60-f6d9f8d6bb1d
+                      username: host_user
+                      display_name: Host User
+                      avatar_url: https://example.com/avatar.png
+                    location:
+                      type: POINT
+                      address: Belgrad Forest, Istanbul
+                      point:
+                        lat: 41.1722
+                        lon: 28.9744
+                    tags: [trail, running]
+                    constraints:
+                      - type: equipment
+                        info: Trail running shoes required
+                    viewer_context:
+                      is_host: false
+                      is_favorited: true
+                      participation_status: PENDING
+                host:
+                  value:
+                    id: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+                    title: Istanbul Trail Run
+                    description: A 10 km trail run through Belgrad Forest.
+                    image_url: https://example.com/trail.jpg
+                    privacy_level: PRIVATE
+                    status: CANCELED
+                    start_time: "2026-05-01T08:00:00+03:00"
+                    end_time: "2026-05-01T12:00:00+03:00"
+                    capacity: 25
+                    minimum_age: 18
+                    preferred_gender: FEMALE
+                    approved_participant_count: 12
+                    pending_participant_count: 0
+                    favorite_count: 8
+                    created_at: "2026-03-26T11:00:00+03:00"
+                    updated_at: "2026-03-27T09:30:00+03:00"
+                    category:
+                      id: 7
+                      name: Outdoors
+                    host:
+                      id: 2df86e13-2d2b-4dca-8d60-f6d9f8d6bb1d
+                      username: host_user
+                      display_name: Host User
+                      avatar_url: https://example.com/avatar.png
+                    location:
+                      type: ROUTE
+                      address: Belgrad Forest, Istanbul
+                      route_points:
+                        - lat: 41.1722
+                          lon: 28.9744
+                        - lat: 41.1780
+                          lon: 28.9801
+                    tags: [trail, running]
+                    constraints:
+                      - type: equipment
+                        info: Trail running shoes required
+                    viewer_context:
+                      is_host: true
+                      is_favorited: false
+                      participation_status: NONE
+                    host_context:
+                      approved_participants:
+                        - participation_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                          status: APPROVED
+                          created_at: "2026-03-26T13:00:00+03:00"
+                          updated_at: "2026-03-26T13:00:00+03:00"
+                          user:
+                            id: 6a5d08d6-b9f2-49c8-baea-0f39c34082f8
+                            username: approved_user
+                            display_name: Approved User
+                            avatar_url: https://example.com/approved.png
+                      pending_join_requests:
+                        - join_request_id: b2c3d4e5-f6a7-8901-bcde-f01234567890
+                          status: PENDING
+                          message: I have attended similar events before.
+                          created_at: "2026-03-26T14:00:00+03:00"
+                          updated_at: "2026-03-26T14:00:00+03:00"
+                          user:
+                            id: 48095dc7-6dc1-4479-955f-70ce45e0ef64
+                            username: pending_user
+                            display_name: Pending User
+                            avatar_url: https://example.com/pending.png
+                      invitations:
+                        - invitation_id: c3d4e5f6-a7b8-9012-cdef-012345678901
+                          status: ACCEPTED
+                          message: Join us if you are available.
+                          expires_at: "2026-04-30T23:59:59+03:00"
+                          created_at: "2026-03-26T15:00:00+03:00"
+                          updated_at: "2026-03-26T15:00:00+03:00"
+                          user:
+                            id: 27b3b93d-5f4c-4958-b0e1-0d4df6fc5c02
+                            username: invited_user
+                            display_name: Invited User
+                            avatar_url: https://example.com/invited.png
+        '400':
+          description: Invalid event ID format.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                invalid_id:
+                  value:
+                    error:
+                      code: validation_error
+                      message: The request body contains invalid fields. See error.details for field-specific messages.
+                      details:
+                        id: must be a valid UUID
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist or is not visible to the authenticated user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                not_found:
+                  value:
+                    error:
+                      code: event_not_found
+                      message: The requested event does not exist.
+        '500':
+          description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
   /events/{id}/join:
     post:
       tags: [Events]
@@ -902,6 +1097,303 @@ components:
           type: boolean
           description: Indicates whether more results are available.
           example: true
+
+    GetEventDetailResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - privacy_level
+        - status
+        - start_time
+        - approved_participant_count
+        - pending_participant_count
+        - favorite_count
+        - created_at
+        - updated_at
+        - host
+        - location
+        - tags
+        - constraints
+        - viewer_context
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+        title:
+          type: string
+          example: Istanbul Trail Run
+        description:
+          type:
+            - string
+            - "null"
+          example: A 10 km trail run through Belgrad Forest.
+        image_url:
+          type:
+            - string
+            - "null"
+          example: https://example.com/trail.jpg
+        privacy_level:
+          type: string
+          enum: [PUBLIC, PROTECTED, PRIVATE]
+        status:
+          type: string
+          description: Current event status as stored in the database, for example `ACTIVE`, `CANCELED`, or `COMPLETED`.
+          example: ACTIVE
+        start_time:
+          type: string
+          format: date-time
+          example: "2026-05-01T08:00:00+03:00"
+        end_time:
+          type:
+            - string
+            - "null"
+          format: date-time
+          example: "2026-05-01T12:00:00+03:00"
+        capacity:
+          type:
+            - integer
+            - "null"
+          minimum: 1
+          example: 25
+        minimum_age:
+          type:
+            - integer
+            - "null"
+          minimum: 0
+          maximum: 120
+          example: 18
+        preferred_gender:
+          oneOf:
+            - type: string
+              enum: [MALE, FEMALE, OTHER]
+            - type: "null"
+        approved_participant_count:
+          type: integer
+          minimum: 0
+          example: 12
+        pending_participant_count:
+          type: integer
+          minimum: 0
+          example: 0
+        favorite_count:
+          type: integer
+          minimum: 0
+          example: 8
+        created_at:
+          type: string
+          format: date-time
+          example: "2026-03-26T11:00:00+03:00"
+        updated_at:
+          type: string
+          format: date-time
+          example: "2026-03-27T09:30:00+03:00"
+        category:
+          oneOf:
+            - $ref: '#/components/schemas/EventDetailCategory'
+            - type: "null"
+        host:
+          $ref: '#/components/schemas/EventDetailUserSummary'
+        location:
+          $ref: '#/components/schemas/EventDetailLocation'
+        tags:
+          type: array
+          items:
+            type: string
+          example: [trail, running]
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConstraintInput'
+        viewer_context:
+          $ref: '#/components/schemas/EventDetailViewerContext'
+        host_context:
+          $ref: '#/components/schemas/EventDetailHostContext'
+          description: Present only when the authenticated user is the event host.
+
+    EventDetailCategory:
+      type: object
+      additionalProperties: false
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          minimum: 1
+          example: 7
+        name:
+          type: string
+          example: Outdoors
+
+    EventDetailUserSummary:
+      type: object
+      additionalProperties: false
+      required: [id, username]
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+          example: host_user
+        display_name:
+          type:
+            - string
+            - "null"
+          example: Host User
+        avatar_url:
+          type:
+            - string
+            - "null"
+          example: https://example.com/avatar.png
+
+    EventDetailLocation:
+      type: object
+      additionalProperties: false
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum: [POINT, ROUTE]
+        address:
+          type:
+            - string
+            - "null"
+          example: Belgrad Forest, Istanbul
+        point:
+          oneOf:
+            - $ref: '#/components/schemas/EventDetailPoint'
+            - type: "null"
+        route_points:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventDetailPoint'
+
+    EventDetailPoint:
+      type: object
+      additionalProperties: false
+      required: [lat, lon]
+      properties:
+        lat:
+          type: number
+          format: double
+          example: 41.1722
+        lon:
+          type: number
+          format: double
+          example: 28.9744
+
+    EventDetailViewerContext:
+      type: object
+      additionalProperties: false
+      required: [is_host, is_favorited, participation_status]
+      properties:
+        is_host:
+          type: boolean
+        is_favorited:
+          type: boolean
+        participation_status:
+          type: string
+          enum: [JOINED, PENDING, INVITED, NONE]
+          description: |
+            Resolved for the authenticated user with the following precedence:
+            approved participation -> `JOINED`, pending join request -> `PENDING`,
+            invitation row -> `INVITED`, otherwise `NONE`.
+
+    EventDetailHostContext:
+      type: object
+      additionalProperties: false
+      required: [approved_participants, pending_join_requests, invitations]
+      properties:
+        approved_participants:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventDetailApprovedParticipant'
+        pending_join_requests:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventDetailPendingJoinRequest'
+        invitations:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventDetailInvitation'
+
+    EventDetailApprovedParticipant:
+      type: object
+      additionalProperties: false
+      required: [participation_id, status, created_at, updated_at, user]
+      properties:
+        participation_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          example: APPROVED
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        user:
+          $ref: '#/components/schemas/EventDetailUserSummary'
+
+    EventDetailPendingJoinRequest:
+      type: object
+      additionalProperties: false
+      required: [join_request_id, status, created_at, updated_at, user]
+      properties:
+        join_request_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          example: PENDING
+        message:
+          type:
+            - string
+            - "null"
+          example: I have attended similar events before.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        user:
+          $ref: '#/components/schemas/EventDetailUserSummary'
+
+    EventDetailInvitation:
+      type: object
+      additionalProperties: false
+      required: [invitation_id, status, created_at, updated_at, user]
+      properties:
+        invitation_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [PENDING, ACCEPTED, DECLINED, EXPIRED]
+        message:
+          type:
+            - string
+            - "null"
+          example: Join us if you are available.
+        expires_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+          example: "2026-04-30T23:59:59+03:00"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        user:
+          $ref: '#/components/schemas/EventDetailUserSummary'
 
     CreateEventResponse:
       type: object


### PR DESCRIPTION
## 📋 Summary
Add an authenticated `GET /events/{id}` backend endpoint that returns the full event detail payload for the event detail page, with visibility rules enforced for `PUBLIC`, `PROTECTED`, and `PRIVATE` events. The response now includes viewer-specific state, host-only management data when applicable, and OpenAPI documentation for the new contract.

## 🔄 Changes
- Added `GET /events/{id}` to the event HTTP handler and wired it through the event use case.
- Implemented a dedicated event-detail read path in the Postgres event repository.
- Enforced detail visibility rules:
  - `PUBLIC` and `PROTECTED` are readable by any authenticated user.
  - `PRIVATE` is readable only by the host, users with `APPROVED` participation, or users with an `ACCEPTED` invitation.
  - Unauthorized private access returns `404 event_not_found`.
- Added full event detail response mapping, including:
  - event metadata, category, host summary, location, tags, and constraints
  - `viewer_context` with `is_host`, `is_favorited`, and `participation_status`
  - optional `host_context` with approved participants, pending join requests, and invitations
- Added typed invitation status constants and viewer participation status values (`JOINED`, `PENDING`, `INVITED`, `NONE`).
- Kept canceled and completed events readable and returned their stored status as-is.
- Added/updated handler tests, event service tests, and integration tests covering visibility, viewer status resolution, host-only payloads, and route-location details.
- Added OpenAPI documentation for the new event detail endpoint and response schema.

## 🧪 Testing
- Ran `go test ./internal/application/event ./internal/adapter/out/httpapi/event_handler`
- Ran targeted integration tests for the new event detail flow
- Ran `./shipcheck.sh` successfully

## 🔗 Related
Closes #198