### PR TITLE
feat(backend): add mutual rating system for events and participants

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/generic-issue-template.md
@@ -10,10 +10,6 @@ assignees: ''
 ## 📋 Description
 <!-- Provide a clear explanation of the issue, task, or goal -->
 
-**⏱️ Expected Time**: ... (in hours)
-
-**📅 Due Date:** ... (YYYY-MM-DD)
-
 ## ✅ Acceptance Criteria
 - [ ] Goals and expectations are well-defined
 - [ ] Work follows applicable conventions and standards

--- a/backend/config/application.dev.yaml
+++ b/backend/config/application.dev.yaml
@@ -19,3 +19,5 @@ availability_rate_limit: 20
 availability_rate_window: 15m
 mail_provider: resend   # set to "resend" for real mail delivery or "mock" for logging emails to the console
 mail_domain: socialeventmapper.com
+rating_global_prior: 4.0
+rating_bayesian_m: 5

--- a/backend/config/application.local.yaml
+++ b/backend/config/application.local.yaml
@@ -19,3 +19,5 @@ availability_rate_limit: 20
 availability_rate_window: 15m
 mail_provider: mock   # set this to "resend" for real mail delivery or set to "mock" for mock mail delivery to logs
 mail_domain: socialeventmapper.com
+rating_global_prior: 4.0
+rating_bayesian_m: 5

--- a/backend/internal/adapter/in/postgres/auth_repo.go
+++ b/backend/internal/adapter/in/postgres/auth_repo.go
@@ -20,6 +20,7 @@ import (
 // transparently inside or outside a transaction.
 type execer interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 

--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -40,6 +40,10 @@ func (r *EventRepository) CreateEvent(ctx context.Context, params eventapp.Creat
 		return nil, mapEventInsertError(err)
 	}
 
+	if err := insertHostParticipation(ctx, tx, event); err != nil {
+		return nil, err
+	}
+
 	if err := insertEventLocation(ctx, tx, event.ID, params.Address, params.LocationType, params.Point, params.RoutePoints); err != nil {
 		return nil, err
 	}
@@ -119,6 +123,20 @@ func insertEventRow(ctx context.Context, tx pgx.Tx, params eventapp.CreateEventP
 	}
 
 	return event, nil
+}
+
+// insertHostParticipation creates the host's internal APPROVED participation
+// row so downstream authorization can treat the host as part of the event
+// membership set without exposing them as a normal participant.
+func insertHostParticipation(ctx context.Context, tx pgx.Tx, event *domain.Event) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO participation (event_id, user_id, status, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`, event.ID, event.HostID, domain.ParticipationStatusApproved, event.CreatedAt, event.UpdatedAt); err != nil {
+		return fmt.Errorf("insert host participation: %w", err)
+	}
+
+	return nil
 }
 
 // mapEventInsertError maps Postgres insert constraint violations on events to
@@ -327,12 +345,15 @@ func (r *EventRepository) ListDiscoverableEvents(
 				e.privacy_level,
 				e.approved_participant_count,
 				(fav.event_id IS NOT NULL) AS is_favorited,
+				us.final_score AS host_final_score,
+				COALESCE(us.hosted_event_rating_count, 0) AS host_rating_count,
 				%s AS distance_meters,
 				%s AS relevance_score
 			FROM event e
 			JOIN event_location el ON el.event_id = e.id
 			LEFT JOIN event_category ec ON ec.id = e.category_id
 			LEFT JOIN favorite_event fav ON fav.event_id = e.id AND fav.user_id = %s
+			LEFT JOIN user_score us ON us.user_id = e.host_id
 			WHERE %s
 		)
 		SELECT
@@ -345,6 +366,8 @@ func (r *EventRepository) ListDiscoverableEvents(
 			privacy_level,
 			approved_participant_count,
 			is_favorited,
+			host_final_score,
+			host_rating_count,
 			distance_meters,
 			relevance_score
 		FROM base
@@ -371,6 +394,8 @@ func (r *EventRepository) ListDiscoverableEvents(
 			privacyLevel             string
 			approvedParticipantCount int
 			isFavorited              bool
+			hostFinalScore           pgtype.Float8
+			hostRatingCount          int
 			distanceMeters           float64
 			relevanceScore           pgtype.Float8
 		)
@@ -385,6 +410,8 @@ func (r *EventRepository) ListDiscoverableEvents(
 			&privacyLevel,
 			&approvedParticipantCount,
 			&isFavorited,
+			&hostFinalScore,
+			&hostRatingCount,
 			&distanceMeters,
 			&relevanceScore,
 		); err != nil {
@@ -399,7 +426,10 @@ func (r *EventRepository) ListDiscoverableEvents(
 			PrivacyLevel:             domain.EventPrivacyLevel(privacyLevel),
 			ApprovedParticipantCount: approvedParticipantCount,
 			IsFavorited:              isFavorited,
-			DistanceMeters:           distanceMeters,
+			HostScore: eventapp.EventHostScoreSummaryRecord{
+				HostedEventRatingCount: hostRatingCount,
+			},
+			DistanceMeters: distanceMeters,
 		}
 		if imageURL.Valid {
 			record.ImageURL = &imageURL.String
@@ -409,6 +439,9 @@ func (r *EventRepository) ListDiscoverableEvents(
 		}
 		if relevanceScore.Valid {
 			record.RelevanceScore = &relevanceScore.Float64
+		}
+		if hostFinalScore.Valid {
+			record.HostScore.FinalScore = &hostFinalScore.Float64
 		}
 
 		records = append(records, record)
@@ -511,6 +544,12 @@ func (r *EventRepository) GetEventDetail(
 	}
 	record.Constraints = constraints
 
+	viewerEventRating, err := r.loadViewerEventRating(ctx, eventID, userID)
+	if err != nil {
+		return nil, err
+	}
+	record.ViewerEventRating = viewerEventRating
+
 	if record.ViewerContext.IsHost {
 		hostContext, err := r.loadEventHostContext(ctx, eventID)
 		if err != nil {
@@ -549,6 +588,8 @@ func (r *EventRepository) loadEventDetailCore(
 		hostUsername             string
 		hostDisplayName          pgtype.Text
 		hostAvatarURL            pgtype.Text
+		hostFinalScore           pgtype.Float8
+		hostRatingCount          int
 		locationType             string
 		locationAddress          pgtype.Text
 		isHost                   bool
@@ -580,6 +621,8 @@ func (r *EventRepository) loadEventDetailCore(
 			host.username,
 			hp.display_name,
 			hp.avatar_url,
+			us.final_score,
+			COALESCE(us.hosted_event_rating_count, 0),
 			e.location_type,
 			el.address,
 			(e.host_id = $2) AS is_host,
@@ -618,6 +661,7 @@ func (r *EventRepository) loadEventDetailCore(
 		LEFT JOIN event_category ec ON ec.id = e.category_id
 		JOIN app_user host ON host.id = e.host_id
 		LEFT JOIN profile hp ON hp.user_id = host.id
+		LEFT JOIN user_score us ON us.user_id = host.id
 		WHERE e.id = $1
 		  AND (
 			e.privacy_level IN ($9, $10)
@@ -672,6 +716,8 @@ func (r *EventRepository) loadEventDetailCore(
 		&hostUsername,
 		&hostDisplayName,
 		&hostAvatarURL,
+		&hostFinalScore,
+		&hostRatingCount,
 		&locationType,
 		&locationAddress,
 		&isHost,
@@ -699,6 +745,9 @@ func (r *EventRepository) loadEventDetailCore(
 		Host: eventapp.EventDetailPersonRecord{
 			ID:       hostID,
 			Username: hostUsername,
+		},
+		HostScore: eventapp.EventHostScoreSummaryRecord{
+			HostedEventRatingCount: hostRatingCount,
 		},
 		Location: eventapp.EventDetailLocationRecord{
 			Type: domain.EventLocationType(locationType),
@@ -745,6 +794,9 @@ func (r *EventRepository) loadEventDetailCore(
 	}
 	if hostAvatarURL.Valid {
 		record.Host.AvatarURL = &hostAvatarURL.String
+	}
+	if hostFinalScore.Valid {
+		record.HostScore.FinalScore = &hostFinalScore.Float64
 	}
 	if locationAddress.Valid {
 		record.Location.Address = &locationAddress.String
@@ -903,6 +955,38 @@ func (r *EventRepository) loadEventHostContext(
 	}, nil
 }
 
+func (r *EventRepository) loadViewerEventRating(
+	ctx context.Context,
+	eventID, participantUserID uuid.UUID,
+) (*eventapp.EventDetailRatingRecord, error) {
+	var (
+		record  eventapp.EventDetailRatingRecord
+		message pgtype.Text
+	)
+
+	err := r.pool.QueryRow(ctx, `
+		SELECT id, rating, message, created_at, updated_at
+		FROM event_rating
+		WHERE event_id = $1
+		  AND participant_user_id = $2
+	`, eventID, participantUserID).Scan(
+		&record.ID,
+		&record.Rating,
+		&message,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load viewer event rating: %w", err)
+	}
+
+	record.Message = textPtr(message)
+	return &record, nil
+}
+
 func (r *EventRepository) loadApprovedParticipants(
 	ctx context.Context,
 	eventID uuid.UUID,
@@ -916,12 +1000,26 @@ func (r *EventRepository) loadApprovedParticipants(
 			u.id,
 			u.username,
 			pr.display_name,
-			pr.avatar_url
+			pr.avatar_url,
+			us.final_score,
+			COALESCE(us.participant_rating_count, 0) + COALESCE(us.hosted_event_rating_count, 0) AS rating_count,
+			prt.id,
+			prt.rating,
+			prt.message,
+			prt.created_at,
+			prt.updated_at
 		FROM participation p
+		JOIN event e ON e.id = p.event_id
 		JOIN app_user u ON u.id = p.user_id
 		LEFT JOIN profile pr ON pr.user_id = u.id
+		LEFT JOIN user_score us ON us.user_id = u.id
+		LEFT JOIN participant_rating prt
+			ON prt.event_id = p.event_id
+		   AND prt.host_user_id = e.host_id
+		   AND prt.participant_user_id = p.user_id
 		WHERE p.event_id = $1
 		  AND p.status = $2
+		  AND p.user_id <> e.host_id
 		ORDER BY p.created_at ASC, p.id ASC
 	`, eventID, domain.ParticipationStatusApproved)
 	if err != nil {
@@ -940,6 +1038,13 @@ func (r *EventRepository) loadApprovedParticipants(
 			username        string
 			displayName     pgtype.Text
 			avatarURL       pgtype.Text
+			userFinalScore  pgtype.Float8
+			userRatingCount int
+			hostRatingID    pgtype.UUID
+			hostRatingValue pgtype.Int4
+			hostMessage     pgtype.Text
+			hostCreatedAt   pgtype.Timestamptz
+			hostUpdatedAt   pgtype.Timestamptz
 		)
 		if err := rows.Scan(
 			&participationID,
@@ -950,6 +1055,13 @@ func (r *EventRepository) loadApprovedParticipants(
 			&username,
 			&displayName,
 			&avatarURL,
+			&userFinalScore,
+			&userRatingCount,
+			&hostRatingID,
+			&hostRatingValue,
+			&hostMessage,
+			&hostCreatedAt,
+			&hostUpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan approved participant: %w", err)
 		}
@@ -959,9 +1071,10 @@ func (r *EventRepository) loadApprovedParticipants(
 			Status:          status,
 			CreatedAt:       createdAt,
 			UpdatedAt:       updatedAt,
-			User: eventapp.EventDetailPersonRecord{
-				ID:       userID,
-				Username: username,
+			User: eventapp.EventDetailHostContextUserRecord{
+				ID:          userID,
+				Username:    username,
+				RatingCount: userRatingCount,
 			},
 		}
 		if displayName.Valid {
@@ -969,6 +1082,18 @@ func (r *EventRepository) loadApprovedParticipants(
 		}
 		if avatarURL.Valid {
 			participant.User.AvatarURL = &avatarURL.String
+		}
+		if userFinalScore.Valid {
+			participant.User.FinalScore = &userFinalScore.Float64
+		}
+		if hostRatingID.Valid && hostRatingValue.Valid && hostCreatedAt.Valid && hostUpdatedAt.Valid {
+			participant.HostRating = &eventapp.EventDetailRatingRecord{
+				ID:        uuid.UUID(hostRatingID.Bytes),
+				Rating:    int(hostRatingValue.Int32),
+				Message:   textPtr(hostMessage),
+				CreatedAt: hostCreatedAt.Time,
+				UpdatedAt: hostUpdatedAt.Time,
+			}
 		}
 
 		participants = append(participants, participant)
@@ -994,10 +1119,13 @@ func (r *EventRepository) loadPendingJoinRequests(
 			u.id,
 			u.username,
 			pr.display_name,
-			pr.avatar_url
+			pr.avatar_url,
+			us.final_score,
+			COALESCE(us.participant_rating_count, 0) + COALESCE(us.hosted_event_rating_count, 0) AS rating_count
 		FROM join_request jr
 		JOIN app_user u ON u.id = jr.user_id
 		LEFT JOIN profile pr ON pr.user_id = u.id
+		LEFT JOIN user_score us ON us.user_id = u.id
 		WHERE jr.event_id = $1
 		  AND jr.status = $2
 		ORDER BY jr.created_at ASC, jr.id ASC
@@ -1019,6 +1147,8 @@ func (r *EventRepository) loadPendingJoinRequests(
 			username      string
 			displayName   pgtype.Text
 			avatarURL     pgtype.Text
+			finalScore    pgtype.Float8
+			ratingCount   int
 		)
 		if err := rows.Scan(
 			&joinRequestID,
@@ -1030,6 +1160,8 @@ func (r *EventRepository) loadPendingJoinRequests(
 			&username,
 			&displayName,
 			&avatarURL,
+			&finalScore,
+			&ratingCount,
 		); err != nil {
 			return nil, fmt.Errorf("scan pending join request: %w", err)
 		}
@@ -1039,9 +1171,10 @@ func (r *EventRepository) loadPendingJoinRequests(
 			Status:        status,
 			CreatedAt:     createdAt,
 			UpdatedAt:     updatedAt,
-			User: eventapp.EventDetailPersonRecord{
-				ID:       userID,
-				Username: username,
+			User: eventapp.EventDetailHostContextUserRecord{
+				ID:          userID,
+				Username:    username,
+				RatingCount: ratingCount,
 			},
 		}
 		if message.Valid {
@@ -1052,6 +1185,9 @@ func (r *EventRepository) loadPendingJoinRequests(
 		}
 		if avatarURL.Valid {
 			request.User.AvatarURL = &avatarURL.String
+		}
+		if finalScore.Valid {
+			request.User.FinalScore = &finalScore.Float64
 		}
 
 		requests = append(requests, request)
@@ -1078,10 +1214,13 @@ func (r *EventRepository) loadInvitations(
 			u.id,
 			u.username,
 			pr.display_name,
-			pr.avatar_url
+			pr.avatar_url,
+			us.final_score,
+			COALESCE(us.participant_rating_count, 0) + COALESCE(us.hosted_event_rating_count, 0) AS rating_count
 		FROM invitation inv
 		JOIN app_user u ON u.id = inv.invited_user_id
 		LEFT JOIN profile pr ON pr.user_id = u.id
+		LEFT JOIN user_score us ON us.user_id = u.id
 		WHERE inv.event_id = $1
 		ORDER BY inv.created_at ASC, inv.id ASC
 	`, eventID)
@@ -1103,6 +1242,8 @@ func (r *EventRepository) loadInvitations(
 			username     string
 			displayName  pgtype.Text
 			avatarURL    pgtype.Text
+			finalScore   pgtype.Float8
+			ratingCount  int
 		)
 		if err := rows.Scan(
 			&invitationID,
@@ -1115,6 +1256,8 @@ func (r *EventRepository) loadInvitations(
 			&username,
 			&displayName,
 			&avatarURL,
+			&finalScore,
+			&ratingCount,
 		); err != nil {
 			return nil, fmt.Errorf("scan invitation: %w", err)
 		}
@@ -1124,9 +1267,10 @@ func (r *EventRepository) loadInvitations(
 			Status:       domain.InvitationStatus(status),
 			CreatedAt:    createdAt,
 			UpdatedAt:    updatedAt,
-			User: eventapp.EventDetailPersonRecord{
-				ID:       userID,
-				Username: username,
+			User: eventapp.EventDetailHostContextUserRecord{
+				ID:          userID,
+				Username:    username,
+				RatingCount: ratingCount,
 			},
 		}
 		if message.Valid {
@@ -1140,6 +1284,9 @@ func (r *EventRepository) loadInvitations(
 		}
 		if avatarURL.Valid {
 			invitation.User.AvatarURL = &avatarURL.String
+		}
+		if finalScore.Valid {
+			invitation.User.FinalScore = &finalScore.Float64
 		}
 
 		invitations = append(invitations, invitation)

--- a/backend/internal/adapter/in/postgres/rating_repo.go
+++ b/backend/internal/adapter/in/postgres/rating_repo.go
@@ -1,0 +1,368 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	ratingapp "github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// RatingRepository is the Postgres-backed implementation of rating.Repository.
+type RatingRepository struct {
+	pool *pgxpool.Pool
+	db   execer
+	tx   pgx.Tx
+}
+
+// NewRatingRepository returns a repository that executes queries against the given connection pool.
+func NewRatingRepository(pool *pgxpool.Pool) *RatingRepository {
+	return &RatingRepository{
+		pool: pool,
+		db:   pool,
+	}
+}
+
+func (r *RatingRepository) WithTx(ctx context.Context, fn func(repo ratingapp.Repository) error) error {
+	if r.tx != nil {
+		return fn(r)
+	}
+
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+
+	txRepo := &RatingRepository{
+		pool: r.pool,
+		db:   tx,
+		tx:   tx,
+	}
+
+	if err := fn(txRepo); err != nil {
+		_ = tx.Rollback(ctx)
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+func (r *RatingRepository) GetEventRatingContext(
+	ctx context.Context,
+	eventID, participantUserID uuid.UUID,
+) (*ratingapp.EventRatingContext, error) {
+	var (
+		status                string
+		endTime               pgtype.Timestamptz
+		ratingContext         ratingapp.EventRatingContext
+		isRequestingHost      bool
+		isApprovedParticipant bool
+	)
+
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			e.id,
+			e.host_id,
+			e.status,
+			e.start_time,
+			e.end_time,
+			(e.host_id = $2) AS is_requesting_host,
+			EXISTS (
+				SELECT 1
+				FROM participation p
+				WHERE p.event_id = e.id
+				  AND p.user_id = $2
+				  AND p.status = $3
+			) AS is_approved_participant
+		FROM event e
+		WHERE e.id = $1
+	`, eventID, participantUserID, domain.ParticipationStatusApproved).Scan(
+		&ratingContext.EventID,
+		&ratingContext.HostUserID,
+		&status,
+		&ratingContext.StartTime,
+		&endTime,
+		&isRequestingHost,
+		&isApprovedParticipant,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get event rating context: %w", err)
+	}
+
+	ratingContext.Status = domain.EventStatus(status)
+	ratingContext.IsRequestingHost = isRequestingHost
+	ratingContext.IsApprovedParticipant = isApprovedParticipant
+	if endTime.Valid {
+		ratingContext.EndTime = &endTime.Time
+	}
+
+	return &ratingContext, nil
+}
+
+func (r *RatingRepository) UpsertEventRating(
+	ctx context.Context,
+	params ratingapp.UpsertEventRatingParams,
+) (*domain.EventRating, error) {
+	row := r.db.QueryRow(ctx, `
+		INSERT INTO event_rating (participant_user_id, event_id, rating, message)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (participant_user_id, event_id)
+		DO UPDATE SET
+			rating = EXCLUDED.rating,
+			message = EXCLUDED.message,
+			updated_at = now()
+		RETURNING id, participant_user_id, event_id, rating, message, created_at, updated_at
+	`, params.ParticipantUserID, params.EventID, params.Rating, params.Message)
+
+	rating, err := scanEventRating(row)
+	if err != nil {
+		return nil, fmt.Errorf("upsert event rating: %w", err)
+	}
+
+	return rating, nil
+}
+
+func (r *RatingRepository) DeleteEventRating(ctx context.Context, eventID, participantUserID uuid.UUID) (bool, error) {
+	tag, err := r.db.Exec(ctx, `
+		DELETE FROM event_rating
+		WHERE event_id = $1
+		  AND participant_user_id = $2
+	`, eventID, participantUserID)
+	if err != nil {
+		return false, fmt.Errorf("delete event rating: %w", err)
+	}
+
+	return tag.RowsAffected() == 1, nil
+}
+
+func (r *RatingRepository) GetParticipantRatingContext(
+	ctx context.Context,
+	eventID, hostUserID, participantUserID uuid.UUID,
+) (*ratingapp.ParticipantRatingContext, error) {
+	var (
+		status                string
+		endTime               pgtype.Timestamptz
+		ratingContext         ratingapp.ParticipantRatingContext
+		isApprovedParticipant bool
+		isRequestingHost      bool
+	)
+
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			e.id,
+			e.host_id,
+			e.status,
+			e.start_time,
+			e.end_time,
+			(e.host_id = $2) AS is_requesting_host,
+			EXISTS (
+				SELECT 1
+				FROM participation p
+				WHERE p.event_id = e.id
+				  AND p.user_id = $3
+				  AND p.status = $4
+			) AS is_approved_participant
+		FROM event e
+		WHERE e.id = $1
+	`, eventID, hostUserID, participantUserID, domain.ParticipationStatusApproved).Scan(
+		&ratingContext.EventID,
+		&ratingContext.HostUserID,
+		&status,
+		&ratingContext.StartTime,
+		&endTime,
+		&isRequestingHost,
+		&isApprovedParticipant,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get participant rating context: %w", err)
+	}
+
+	ratingContext.ParticipantUserID = participantUserID
+	ratingContext.Status = domain.EventStatus(status)
+	ratingContext.IsRequestingHost = isRequestingHost
+	ratingContext.IsApprovedParticipant = isApprovedParticipant
+	if endTime.Valid {
+		ratingContext.EndTime = &endTime.Time
+	}
+
+	return &ratingContext, nil
+}
+
+func (r *RatingRepository) UpsertParticipantRating(
+	ctx context.Context,
+	params ratingapp.UpsertParticipantRatingParams,
+) (*domain.ParticipantRating, error) {
+	row := r.db.QueryRow(ctx, `
+		INSERT INTO participant_rating (host_user_id, participant_user_id, event_id, rating, message)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (host_user_id, participant_user_id, event_id)
+		DO UPDATE SET
+			rating = EXCLUDED.rating,
+			message = EXCLUDED.message,
+			updated_at = now()
+		RETURNING id, host_user_id, participant_user_id, event_id, rating, message, created_at, updated_at
+	`, params.HostUserID, params.ParticipantUserID, params.EventID, params.Rating, params.Message)
+
+	rating, err := scanParticipantRating(row)
+	if err != nil {
+		return nil, fmt.Errorf("upsert participant rating: %w", err)
+	}
+
+	return rating, nil
+}
+
+func (r *RatingRepository) DeleteParticipantRating(
+	ctx context.Context,
+	eventID, hostUserID, participantUserID uuid.UUID,
+) (bool, error) {
+	tag, err := r.db.Exec(ctx, `
+		DELETE FROM participant_rating
+		WHERE event_id = $1
+		  AND host_user_id = $2
+		  AND participant_user_id = $3
+	`, eventID, hostUserID, participantUserID)
+	if err != nil {
+		return false, fmt.Errorf("delete participant rating: %w", err)
+	}
+
+	return tag.RowsAffected() == 1, nil
+}
+
+func (r *RatingRepository) CalculateParticipantAggregate(
+	ctx context.Context,
+	userID uuid.UUID,
+) (*ratingapp.ScoreAggregate, error) {
+	var (
+		average pgtype.Float8
+		count   int
+	)
+
+	err := r.db.QueryRow(ctx, `
+		SELECT AVG(rating)::double precision, COUNT(*)
+		FROM participant_rating
+		WHERE participant_user_id = $1
+	`, userID).Scan(&average, &count)
+	if err != nil {
+		return nil, fmt.Errorf("calculate participant aggregate: %w", err)
+	}
+
+	result := &ratingapp.ScoreAggregate{Count: count}
+	if average.Valid {
+		result.Average = &average.Float64
+	}
+
+	return result, nil
+}
+
+func (r *RatingRepository) CalculateHostedEventAggregate(
+	ctx context.Context,
+	userID uuid.UUID,
+) (*ratingapp.ScoreAggregate, error) {
+	var (
+		average pgtype.Float8
+		count   int
+	)
+
+	err := r.db.QueryRow(ctx, `
+		SELECT AVG(er.rating)::double precision, COUNT(*)
+		FROM event_rating er
+		JOIN event e ON e.id = er.event_id
+		WHERE e.host_id = $1
+	`, userID).Scan(&average, &count)
+	if err != nil {
+		return nil, fmt.Errorf("calculate hosted event aggregate: %w", err)
+	}
+
+	result := &ratingapp.ScoreAggregate{Count: count}
+	if average.Valid {
+		result.Average = &average.Float64
+	}
+
+	return result, nil
+}
+
+func (r *RatingRepository) UpsertUserScore(ctx context.Context, params ratingapp.UpsertUserScoreParams) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO user_score (
+			user_id,
+			participant_score,
+			participant_rating_count,
+			hosted_event_score,
+			hosted_event_rating_count,
+			final_score
+		) VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (user_id)
+		DO UPDATE SET
+			participant_score = EXCLUDED.participant_score,
+			participant_rating_count = EXCLUDED.participant_rating_count,
+			hosted_event_score = EXCLUDED.hosted_event_score,
+			hosted_event_rating_count = EXCLUDED.hosted_event_rating_count,
+			final_score = EXCLUDED.final_score,
+			updated_at = now()
+	`, params.UserID, params.ParticipantScore, params.ParticipantRatingCount, params.HostedEventScore, params.HostedEventRatingCount, params.FinalScore)
+	if err != nil {
+		return fmt.Errorf("upsert user score: %w", err)
+	}
+
+	return nil
+}
+
+func scanEventRating(row pgx.Row) (*domain.EventRating, error) {
+	var (
+		record  domain.EventRating
+		message pgtype.Text
+	)
+
+	if err := row.Scan(
+		&record.ID,
+		&record.ParticipantUserID,
+		&record.EventID,
+		&record.Rating,
+		&message,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	record.Message = textPtr(message)
+	return &record, nil
+}
+
+func scanParticipantRating(row pgx.Row) (*domain.ParticipantRating, error) {
+	var (
+		record  domain.ParticipantRating
+		message pgtype.Text
+	)
+
+	if err := row.Scan(
+		&record.ID,
+		&record.HostUserID,
+		&record.ParticipantUserID,
+		&record.EventID,
+		&record.Rating,
+		&message,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	record.Message = textPtr(message)
+	return &record, nil
+}

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -278,6 +278,57 @@ func TestDiscoverEventsInvalidSortReturns400(t *testing.T) {
 	}
 }
 
+func TestDiscoverEventsReturnsHostScoreField(t *testing.T) {
+	// given
+	finalScore := 4.4
+	svc := &stubEventService{
+		discoverResult: &event.DiscoverEventsResult{
+			Items: []event.DiscoverableEventItem{
+				{
+					ID:                       uuid.NewString(),
+					Title:                    "Rated Event",
+					CategoryName:             "Sports",
+					StartTime:                time.Now().UTC(),
+					PrivacyLevel:             string(domain.PrivacyPublic),
+					ApprovedParticipantCount: 12,
+					IsFavorited:              true,
+					HostScore: event.EventHostScoreSummary{
+						FinalScore:             &finalScore,
+						HostedEventRatingCount: 7,
+					},
+				},
+			},
+			PageInfo: event.DiscoverEventsPageInfo{HasNext: false},
+		},
+	}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/?lat=41.01&lon=29.02", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	var body event.DiscoverEventsResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if len(body.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(body.Items))
+	}
+	if body.Items[0].HostScore.HostedEventRatingCount != 7 {
+		t.Fatalf("expected host rating count 7, got %d", body.Items[0].HostScore.HostedEventRatingCount)
+	}
+	if body.Items[0].HostScore.FinalScore == nil || *body.Items[0].HostScore.FinalScore != finalScore {
+		t.Fatalf("expected host final score %v, got %v", finalScore, body.Items[0].HostScore.FinalScore)
+	}
+}
+
 func TestDiscoverEventsIgnoresEmptyOptionalListParams(t *testing.T) {
 	// given
 	svc := &stubEventService{}
@@ -348,6 +399,81 @@ func TestGetEventDetailReturns200(t *testing.T) {
 	}
 	if body.ID != eventID.String() {
 		t.Fatalf("expected response id %s, got %s", eventID, body.ID)
+	}
+}
+
+func TestGetEventDetailReturnsRatingMetadata(t *testing.T) {
+	// given
+	finalScore := 4.2
+	message := "Great event."
+	svc := &stubEventService{
+		detailResult: &event.GetEventDetailResult{
+			ID:           uuid.NewString(),
+			Title:        "Detailed Event",
+			PrivacyLevel: string(domain.PrivacyPublic),
+			Status:       string(domain.EventStatusActive),
+			StartTime:    time.Now().UTC().Add(-2 * time.Hour),
+			Host: event.EventDetailPerson{
+				ID:       uuid.NewString(),
+				Username: "host_user",
+			},
+			HostScore: event.EventHostScoreSummary{
+				HostedEventRatingCount: 9,
+				FinalScore:             &finalScore,
+			},
+			Location: event.EventDetailLocation{
+				Type: string(domain.LocationPoint),
+				Point: &event.EventDetailPoint{
+					Lat: 41,
+					Lon: 29,
+				},
+			},
+			Tags:        []string{},
+			Constraints: []event.EventDetailConstraint{},
+			RatingWindow: event.EventDetailRatingWindow{
+				OpensAt:  time.Now().UTC().Add(-time.Hour),
+				ClosesAt: time.Now().UTC().Add(6 * 24 * time.Hour),
+				IsActive: true,
+			},
+			ViewerEventRating: &event.EventDetailRating{
+				ID:        uuid.NewString(),
+				Rating:    5,
+				Message:   &message,
+				CreatedAt: time.Now().UTC().Add(-30 * time.Minute),
+				UpdatedAt: time.Now().UTC(),
+			},
+			ViewerContext: event.EventDetailViewerContext{
+				IsHost:              false,
+				IsFavorited:         false,
+				ParticipationStatus: string(domain.EventDetailParticipationStatusJoined),
+			},
+		},
+	}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/"+svc.detailResult.ID, nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	var body event.GetEventDetailResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.HostScore.HostedEventRatingCount != 9 {
+		t.Fatalf("expected host rating count 9, got %d", body.HostScore.HostedEventRatingCount)
+	}
+	if body.ViewerEventRating == nil || body.ViewerEventRating.Rating != 5 {
+		t.Fatalf("expected viewer_event_rating in response, got %+v", body.ViewerEventRating)
+	}
+	if !body.RatingWindow.IsActive {
+		t.Fatal("expected rating_window.is_active to be true")
 	}
 }
 

--- a/backend/internal/adapter/out/httpapi/rating_handler/dto.go
+++ b/backend/internal/adapter/out/httpapi/rating_handler/dto.go
@@ -1,0 +1,7 @@
+package rating_handler
+
+// upsertRatingBody is the shared JSON request body for PUT rating endpoints.
+type upsertRatingBody struct {
+	Rating  int     `json:"rating"`
+	Message *string `json:"message"`
+}

--- a/backend/internal/adapter/out/httpapi/rating_handler/rating_handler.go
+++ b/backend/internal/adapter/out/httpapi/rating_handler/rating_handler.go
@@ -1,0 +1,124 @@
+package rating_handler
+
+import (
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	ratingapp "github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// RatingHandler groups HTTP handlers that delegate to the rating use-case port.
+type RatingHandler struct {
+	service ratingapp.UseCase
+}
+
+// NewRatingHandler creates a rating handler backed by the given rating use case.
+func NewRatingHandler(service ratingapp.UseCase) *RatingHandler {
+	return &RatingHandler{service: service}
+}
+
+// RegisterRatingRoutes mounts all rating endpoints under /events.
+func RegisterRatingRoutes(router fiber.Router, handler *RatingHandler, auth fiber.Handler) {
+	group := router.Group("/events")
+	group.Put("/:id/rating", auth, handler.UpsertEventRating)
+	group.Delete("/:id/rating", auth, handler.DeleteEventRating)
+	group.Put("/:id/participants/:participantUserId/rating", auth, handler.UpsertParticipantRating)
+	group.Delete("/:id/participants/:participantUserId/rating", auth, handler.DeleteParticipantRating)
+}
+
+// UpsertEventRating handles PUT /events/:id/rating.
+func (h *RatingHandler) UpsertEventRating(c *fiber.Ctx) error {
+	eventID, err := parseUUIDParam(c, "id")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+
+	input, err := parseUpsertRatingBody(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, svcErr := h.service.UpsertEventRating(c.UserContext(), claims.UserID, eventID, input)
+	if svcErr != nil {
+		return httpapi.WriteError(c, svcErr)
+	}
+
+	return c.JSON(result)
+}
+
+// DeleteEventRating handles DELETE /events/:id/rating.
+func (h *RatingHandler) DeleteEventRating(c *fiber.Ctx) error {
+	eventID, err := parseUUIDParam(c, "id")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+
+	claims := httpapi.UserClaims(c)
+	if err := h.service.DeleteEventRating(c.UserContext(), claims.UserID, eventID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// UpsertParticipantRating handles PUT /events/:id/participants/:participantUserId/rating.
+func (h *RatingHandler) UpsertParticipantRating(c *fiber.Ctx) error {
+	eventID, err := parseUUIDParam(c, "id")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+	participantUserID, err := parseUUIDParam(c, "participantUserId")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"participantUserId": "must be a valid UUID"}))
+	}
+
+	input, err := parseUpsertRatingBody(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, svcErr := h.service.UpsertParticipantRating(c.UserContext(), claims.UserID, eventID, participantUserID, input)
+	if svcErr != nil {
+		return httpapi.WriteError(c, svcErr)
+	}
+
+	return c.JSON(result)
+}
+
+// DeleteParticipantRating handles DELETE /events/:id/participants/:participantUserId/rating.
+func (h *RatingHandler) DeleteParticipantRating(c *fiber.Ctx) error {
+	eventID, err := parseUUIDParam(c, "id")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+	participantUserID, err := parseUUIDParam(c, "participantUserId")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"participantUserId": "must be a valid UUID"}))
+	}
+
+	claims := httpapi.UserClaims(c)
+	if err := h.service.DeleteParticipantRating(c.UserContext(), claims.UserID, eventID, participantUserID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func parseUUIDParam(c *fiber.Ctx, name string) (uuid.UUID, error) {
+	return uuid.Parse(c.Params(name))
+}
+
+func parseUpsertRatingBody(c *fiber.Ctx) (ratingapp.UpsertRatingInput, error) {
+	var body upsertRatingBody
+	if err := c.BodyParser(&body); err != nil {
+		return ratingapp.UpsertRatingInput{}, domain.ValidationError(map[string]string{"body": "must be valid JSON"})
+	}
+
+	return ratingapp.UpsertRatingInput{
+		Rating:  body.Rating,
+		Message: body.Message,
+	}, nil
+}

--- a/backend/internal/adapter/out/httpapi/rating_handler/rating_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/rating_handler/rating_handler_test.go
@@ -1,0 +1,232 @@
+package rating_handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	ratingapp "github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+type stubRatingService struct {
+	upsertEventResult            *ratingapp.RatingResult
+	upsertParticipantResult      *ratingapp.RatingResult
+	err                          error
+	upsertEventCallCount         int
+	deleteEventCallCount         int
+	upsertParticipantCallCount   int
+	deleteParticipantCallCount   int
+	lastUpsertEventInput         ratingapp.UpsertRatingInput
+	lastUpsertEventID            uuid.UUID
+	lastDeleteEventID            uuid.UUID
+	lastUpsertParticipantInput   ratingapp.UpsertRatingInput
+	lastUpsertParticipantEventID uuid.UUID
+	lastUpsertParticipantUserID  uuid.UUID
+	lastDeleteParticipantEventID uuid.UUID
+	lastDeleteParticipantUserID  uuid.UUID
+}
+
+func (s *stubRatingService) UpsertEventRating(_ context.Context, _ uuid.UUID, eventID uuid.UUID, input ratingapp.UpsertRatingInput) (*ratingapp.RatingResult, error) {
+	s.upsertEventCallCount++
+	s.lastUpsertEventID = eventID
+	s.lastUpsertEventInput = input
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.upsertEventResult != nil {
+		return s.upsertEventResult, nil
+	}
+	return &ratingapp.RatingResult{
+		ID:        uuid.NewString(),
+		Rating:    input.Rating,
+		Message:   input.Message,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}, nil
+}
+
+func (s *stubRatingService) DeleteEventRating(_ context.Context, _, eventID uuid.UUID) error {
+	s.deleteEventCallCount++
+	s.lastDeleteEventID = eventID
+	return s.err
+}
+
+func (s *stubRatingService) UpsertParticipantRating(_ context.Context, _, eventID, participantUserID uuid.UUID, input ratingapp.UpsertRatingInput) (*ratingapp.RatingResult, error) {
+	s.upsertParticipantCallCount++
+	s.lastUpsertParticipantEventID = eventID
+	s.lastUpsertParticipantUserID = participantUserID
+	s.lastUpsertParticipantInput = input
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.upsertParticipantResult != nil {
+		return s.upsertParticipantResult, nil
+	}
+	return &ratingapp.RatingResult{
+		ID:        uuid.NewString(),
+		Rating:    input.Rating,
+		Message:   input.Message,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}, nil
+}
+
+func (s *stubRatingService) DeleteParticipantRating(_ context.Context, _, eventID, participantUserID uuid.UUID) error {
+	s.deleteParticipantCallCount++
+	s.lastDeleteParticipantEventID = eventID
+	s.lastDeleteParticipantUserID = participantUserID
+	return s.err
+}
+
+type fakeVerifier struct {
+	claims *domain.AuthClaims
+	err    error
+}
+
+func (f *fakeVerifier) VerifyAccessToken(_ string) (*domain.AuthClaims, error) {
+	return f.claims, f.err
+}
+
+func authedVerifier() *fakeVerifier {
+	return &fakeVerifier{
+		claims: &domain.AuthClaims{
+			UserID:   uuid.New(),
+			Username: "testuser",
+			Email:    "test@example.com",
+		},
+	}
+}
+
+func newRatingTestApp(service ratingapp.UseCase, verifier domain.TokenVerifier) *fiber.App {
+	app := fiber.New()
+	handler := NewRatingHandler(service)
+	RegisterRatingRoutes(app, handler, httpapi.RequireAuth(verifier))
+	return app
+}
+
+func TestUpsertEventRatingParsesBodyAndReturns200(t *testing.T) {
+	// given
+	svc := &stubRatingService{}
+	app := newRatingTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+	message := "Very well organized."
+
+	req := httptest.NewRequest(fiber.MethodPut, "/events/"+eventID.String()+"/rating", bytes.NewBufferString(`{"rating":5,"message":"`+message+`"}`))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.upsertEventCallCount != 1 {
+		t.Fatalf("expected upsert event rating to be called once, got %d", svc.upsertEventCallCount)
+	}
+	if svc.lastUpsertEventID != eventID {
+		t.Fatalf("expected event id %s, got %s", eventID, svc.lastUpsertEventID)
+	}
+	if svc.lastUpsertEventInput.Rating != 5 {
+		t.Fatalf("expected rating 5, got %d", svc.lastUpsertEventInput.Rating)
+	}
+	if svc.lastUpsertEventInput.Message == nil || *svc.lastUpsertEventInput.Message != message {
+		t.Fatalf("expected message %q, got %v", message, svc.lastUpsertEventInput.Message)
+	}
+
+	var body ratingapp.RatingResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.Rating != 5 {
+		t.Fatalf("expected response rating 5, got %d", body.Rating)
+	}
+}
+
+func TestDeleteEventRatingReturns204(t *testing.T) {
+	// given
+	svc := &stubRatingService{}
+	app := newRatingTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodDelete, "/events/"+eventID.String()+"/rating", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", fiber.StatusNoContent, resp.StatusCode)
+	}
+	if svc.deleteEventCallCount != 1 {
+		t.Fatalf("expected delete event rating to be called once, got %d", svc.deleteEventCallCount)
+	}
+	if svc.lastDeleteEventID != eventID {
+		t.Fatalf("expected event id %s, got %s", eventID, svc.lastDeleteEventID)
+	}
+}
+
+func TestUpsertParticipantRatingInvalidParticipantIDReturns400(t *testing.T) {
+	// given
+	app := newRatingTestApp(&stubRatingService{}, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodPut, "/events/"+eventID.String()+"/participants/not-a-uuid/rating", bytes.NewBufferString(`{"rating":4}`))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+}
+
+func TestUpsertEventRatingInvalidJSONReturns400(t *testing.T) {
+	// given
+	svc := &stubRatingService{}
+	app := newRatingTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodPut, "/events/"+eventID.String()+"/rating", bytes.NewBufferString(`not-json`))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+	if svc.upsertEventCallCount != 0 {
+		t.Fatalf("expected service not to be called, got %d", svc.upsertEventCallCount)
+	}
+}

--- a/backend/internal/application/event/helpers.go
+++ b/backend/internal/application/event/helpers.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"strings"
+	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
@@ -74,10 +75,17 @@ func toDiscoverableEventItem(record DiscoverableEventRecord) DiscoverableEventIt
 		PrivacyLevel:             string(record.PrivacyLevel),
 		ApprovedParticipantCount: record.ApprovedParticipantCount,
 		IsFavorited:              record.IsFavorited,
+		HostScore:                toEventHostScoreSummary(record.HostScore),
 	}
 }
 
-func toEventDetailResult(record *EventDetailRecord) *GetEventDetailResult {
+func toEventDetailResult(record *EventDetailRecord, now time.Time) *GetEventDetailResult {
+	ratingWindow := domain.NewRatingWindow(record.StartTime, record.EndTime)
+	isRatingWindowActive := ratingWindow.IsActive(now)
+	if record.Status == domain.EventStatusCanceled {
+		isRatingWindowActive = false
+	}
+
 	result := &GetEventDetailResult{
 		ID:                       record.ID.String(),
 		Title:                    record.Title,
@@ -95,9 +103,16 @@ func toEventDetailResult(record *EventDetailRecord) *GetEventDetailResult {
 		CreatedAt:                record.CreatedAt,
 		UpdatedAt:                record.UpdatedAt,
 		Host:                     toEventDetailPerson(record.Host),
+		HostScore:                toEventHostScoreSummary(record.HostScore),
 		Location:                 toEventDetailLocation(record.Location),
 		Tags:                     append([]string{}, record.Tags...),
 		Constraints:              toEventDetailConstraints(record.Constraints),
+		RatingWindow: EventDetailRatingWindow{
+			OpensAt:  ratingWindow.OpensAt,
+			ClosesAt: ratingWindow.ClosesAt,
+			IsActive: isRatingWindowActive,
+		},
+		ViewerEventRating: toEventDetailRating(record.ViewerEventRating),
 		ViewerContext: EventDetailViewerContext{
 			IsHost:              record.ViewerContext.IsHost,
 			IsFavorited:         record.ViewerContext.IsFavorited,
@@ -167,7 +182,8 @@ func toEventDetailApprovedParticipants(records []EventDetailApprovedParticipantR
 			Status:          record.Status,
 			CreatedAt:       record.CreatedAt,
 			UpdatedAt:       record.UpdatedAt,
-			User:            toEventDetailPerson(record.User),
+			HostRating:      toEventDetailRating(record.HostRating),
+			User:            toEventDetailHostContextUser(record.User),
 		}
 	}
 	return participants
@@ -182,7 +198,7 @@ func toEventDetailPendingJoinRequests(records []EventDetailPendingJoinRequestRec
 			Message:       record.Message,
 			CreatedAt:     record.CreatedAt,
 			UpdatedAt:     record.UpdatedAt,
-			User:          toEventDetailPerson(record.User),
+			User:          toEventDetailHostContextUser(record.User),
 		}
 	}
 	return requests
@@ -198,7 +214,7 @@ func toEventDetailInvitations(records []EventDetailInvitationRecord) []EventDeta
 			ExpiresAt:    record.ExpiresAt,
 			CreatedAt:    record.CreatedAt,
 			UpdatedAt:    record.UpdatedAt,
-			User:         toEventDetailPerson(record.User),
+			User:         toEventDetailHostContextUser(record.User),
 		}
 	}
 	return invitations
@@ -210,6 +226,35 @@ func toEventDetailPerson(record EventDetailPersonRecord) EventDetailPerson {
 		Username:    record.Username,
 		DisplayName: record.DisplayName,
 		AvatarURL:   record.AvatarURL,
+	}
+}
+
+func toEventDetailHostContextUser(record EventDetailHostContextUserRecord) EventDetailHostContextUser {
+	return EventDetailHostContextUser{
+		ID:          record.ID.String(),
+		Username:    record.Username,
+		DisplayName: record.DisplayName,
+		AvatarURL:   record.AvatarURL,
+		FinalScore:  record.FinalScore,
+		RatingCount: record.RatingCount,
+	}
+}
+
+func toEventHostScoreSummary(record EventHostScoreSummaryRecord) EventHostScoreSummary {
+	return EventHostScoreSummary(record)
+}
+
+func toEventDetailRating(record *EventDetailRatingRecord) *EventDetailRating {
+	if record == nil {
+		return nil
+	}
+
+	return &EventDetailRating{
+		ID:        record.ID.String(),
+		Rating:    record.Rating,
+		Message:   record.Message,
+		CreatedAt: record.CreatedAt,
+		UpdatedAt: record.UpdatedAt,
 	}
 }
 

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -66,6 +66,7 @@ type DiscoverableEventRecord struct {
 	PrivacyLevel             domain.EventPrivacyLevel
 	ApprovedParticipantCount int
 	IsFavorited              bool
+	HostScore                EventHostScoreSummaryRecord
 	DistanceMeters           float64
 	RelevanceScore           *float64
 }
@@ -100,9 +101,11 @@ type EventDetailRecord struct {
 	UpdatedAt                time.Time
 	Category                 *EventDetailCategoryRecord
 	Host                     EventDetailPersonRecord
+	HostScore                EventHostScoreSummaryRecord
 	Location                 EventDetailLocationRecord
 	Tags                     []string
 	Constraints              []EventDetailConstraintRecord
+	ViewerEventRating        *EventDetailRatingRecord
 	ViewerContext            EventDetailViewerContextRecord
 	HostContext              *EventDetailHostContextRecord
 }
@@ -121,6 +124,17 @@ type EventDetailPersonRecord struct {
 	AvatarURL   *string
 }
 
+// EventDetailHostContextUserRecord is the richer user summary shown only in
+// host management lists.
+type EventDetailHostContextUserRecord struct {
+	ID          uuid.UUID
+	Username    string
+	DisplayName *string
+	AvatarURL   *string
+	FinalScore  *float64
+	RatingCount int
+}
+
 // EventDetailLocationRecord carries the event geometry and address for the detail page.
 type EventDetailLocationRecord struct {
 	Type        domain.EventLocationType
@@ -133,6 +147,21 @@ type EventDetailLocationRecord struct {
 type EventDetailConstraintRecord struct {
 	Type string
 	Info string
+}
+
+// EventHostScoreSummaryRecord is the repository-level host score projection reused by event responses.
+type EventHostScoreSummaryRecord struct {
+	FinalScore             *float64
+	HostedEventRatingCount int
+}
+
+// EventDetailRatingRecord is the shared repository-level rating snapshot used by detail responses.
+type EventDetailRatingRecord struct {
+	ID        uuid.UUID
+	Rating    int
+	Message   *string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // EventDetailViewerContextRecord captures the authenticated viewer's relation to the event.
@@ -155,7 +184,8 @@ type EventDetailApprovedParticipantRecord struct {
 	Status          string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
-	User            EventDetailPersonRecord
+	HostRating      *EventDetailRatingRecord
+	User            EventDetailHostContextUserRecord
 }
 
 // EventDetailPendingJoinRequestRecord is a host-visible pending join request projection.
@@ -165,7 +195,7 @@ type EventDetailPendingJoinRequestRecord struct {
 	Message       *string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
-	User          EventDetailPersonRecord
+	User          EventDetailHostContextUserRecord
 }
 
 // EventDetailInvitationRecord is a host-visible invitation projection.
@@ -176,5 +206,5 @@ type EventDetailInvitationRecord struct {
 	ExpiresAt    *time.Time
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
-	User         EventDetailPersonRecord
+	User         EventDetailHostContextUserRecord
 }

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/participation"
@@ -15,6 +16,7 @@ type Service struct {
 	eventRepo            Repository
 	participationService participation.UseCase
 	joinRequestService   join_request.UseCase
+	now                  func() time.Time
 }
 
 var _ UseCase = (*Service)(nil)
@@ -30,6 +32,7 @@ func NewService(
 		eventRepo:            eventRepo,
 		participationService: participationService,
 		joinRequestService:   joinRequestService,
+		now:                  time.Now,
 	}
 }
 
@@ -129,7 +132,7 @@ func (s *Service) GetEventDetail(ctx context.Context, userID, eventID uuid.UUID)
 		return nil, err
 	}
 
-	return toEventDetailResult(record), nil
+	return toEventDetailResult(record, s.now().UTC()), nil
 }
 
 // JoinEvent allows a user to join a PUBLIC event directly. The resulting

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -75,15 +75,16 @@ type DiscoverEventsResult struct {
 
 // DiscoverableEventItem is the compact event-card payload returned by discovery.
 type DiscoverableEventItem struct {
-	ID                       string    `json:"id"`
-	Title                    string    `json:"title"`
-	CategoryName             string    `json:"category_name"`
-	ImageURL                 *string   `json:"image_url"`
-	StartTime                time.Time `json:"start_time"`
-	LocationAddress          *string   `json:"location_address"`
-	PrivacyLevel             string    `json:"privacy_level"`
-	ApprovedParticipantCount int       `json:"approved_participant_count"`
-	IsFavorited              bool      `json:"is_favorited"`
+	ID                       string                `json:"id"`
+	Title                    string                `json:"title"`
+	CategoryName             string                `json:"category_name"`
+	ImageURL                 *string               `json:"image_url"`
+	StartTime                time.Time             `json:"start_time"`
+	LocationAddress          *string               `json:"location_address"`
+	PrivacyLevel             string                `json:"privacy_level"`
+	ApprovedParticipantCount int                   `json:"approved_participant_count"`
+	IsFavorited              bool                  `json:"is_favorited"`
+	HostScore                EventHostScoreSummary `json:"host_score"`
 }
 
 // DiscoverEventsPageInfo contains cursor pagination metadata.
@@ -112,9 +113,12 @@ type GetEventDetailResult struct {
 	UpdatedAt                time.Time                `json:"updated_at"`
 	Category                 *EventDetailCategory     `json:"category"`
 	Host                     EventDetailPerson        `json:"host"`
+	HostScore                EventHostScoreSummary    `json:"host_score"`
 	Location                 EventDetailLocation      `json:"location"`
 	Tags                     []string                 `json:"tags"`
 	Constraints              []EventDetailConstraint  `json:"constraints"`
+	RatingWindow             EventDetailRatingWindow  `json:"rating_window"`
+	ViewerEventRating        *EventDetailRating       `json:"viewer_event_rating"`
 	ViewerContext            EventDetailViewerContext `json:"viewer_context"`
 	HostContext              *EventDetailHostContext  `json:"host_context,omitempty"`
 }
@@ -131,6 +135,17 @@ type EventDetailPerson struct {
 	Username    string  `json:"username"`
 	DisplayName *string `json:"display_name"`
 	AvatarURL   *string `json:"avatar_url"`
+}
+
+// EventDetailHostContextUser is the richer user summary returned only in
+// host-only management lists.
+type EventDetailHostContextUser struct {
+	ID          string   `json:"id"`
+	Username    string   `json:"username"`
+	DisplayName *string  `json:"display_name"`
+	AvatarURL   *string  `json:"avatar_url"`
+	FinalScore  *float64 `json:"final_score"`
+	RatingCount int      `json:"rating_count"`
 }
 
 // EventDetailLocation is the event location payload used by the detail page.
@@ -153,6 +168,28 @@ type EventDetailConstraint struct {
 	Info string `json:"info"`
 }
 
+// EventHostScoreSummary exposes the host's cached aggregate score on event payloads.
+type EventHostScoreSummary struct {
+	FinalScore             *float64 `json:"final_score"`
+	HostedEventRatingCount int      `json:"hosted_event_rating_count"`
+}
+
+// EventDetailRatingWindow exposes the event-specific rating window bounds.
+type EventDetailRatingWindow struct {
+	OpensAt  time.Time `json:"opens_at"`
+	ClosesAt time.Time `json:"closes_at"`
+	IsActive bool      `json:"is_active"`
+}
+
+// EventDetailRating is a reusable rating snapshot embedded in detail responses.
+type EventDetailRating struct {
+	ID        string    `json:"id"`
+	Rating    int       `json:"rating"`
+	Message   *string   `json:"message"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 // EventDetailViewerContext describes how the authenticated user relates to the event.
 type EventDetailViewerContext struct {
 	IsHost              bool   `json:"is_host"`
@@ -169,32 +206,33 @@ type EventDetailHostContext struct {
 
 // EventDetailApprovedParticipant is returned only to the host.
 type EventDetailApprovedParticipant struct {
-	ParticipationID string            `json:"participation_id"`
-	Status          string            `json:"status"`
-	CreatedAt       time.Time         `json:"created_at"`
-	UpdatedAt       time.Time         `json:"updated_at"`
-	User            EventDetailPerson `json:"user"`
+	ParticipationID string                     `json:"participation_id"`
+	Status          string                     `json:"status"`
+	CreatedAt       time.Time                  `json:"created_at"`
+	UpdatedAt       time.Time                  `json:"updated_at"`
+	HostRating      *EventDetailRating         `json:"host_rating"`
+	User            EventDetailHostContextUser `json:"user"`
 }
 
 // EventDetailPendingJoinRequest is returned only to the host.
 type EventDetailPendingJoinRequest struct {
-	JoinRequestID string            `json:"join_request_id"`
-	Status        string            `json:"status"`
-	Message       *string           `json:"message"`
-	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
-	User          EventDetailPerson `json:"user"`
+	JoinRequestID string                     `json:"join_request_id"`
+	Status        string                     `json:"status"`
+	Message       *string                    `json:"message"`
+	CreatedAt     time.Time                  `json:"created_at"`
+	UpdatedAt     time.Time                  `json:"updated_at"`
+	User          EventDetailHostContextUser `json:"user"`
 }
 
 // EventDetailInvitation is returned only to the host.
 type EventDetailInvitation struct {
-	InvitationID string            `json:"invitation_id"`
-	Status       string            `json:"status"`
-	Message      *string           `json:"message"`
-	ExpiresAt    *time.Time        `json:"expires_at"`
-	CreatedAt    time.Time         `json:"created_at"`
-	UpdatedAt    time.Time         `json:"updated_at"`
-	User         EventDetailPerson `json:"user"`
+	InvitationID string                     `json:"invitation_id"`
+	Status       string                     `json:"status"`
+	Message      *string                    `json:"message"`
+	ExpiresAt    *time.Time                 `json:"expires_at"`
+	CreatedAt    time.Time                  `json:"created_at"`
+	UpdatedAt    time.Time                  `json:"updated_at"`
+	User         EventDetailHostContextUser `json:"user"`
 }
 
 // JoinEventResult is returned after a user successfully joins a public event.

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -221,8 +221,14 @@ func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
 	createdAt := time.Now().UTC().Add(-time.Hour)
 	updatedAt := createdAt.Add(10 * time.Minute)
 	startTime := time.Now().UTC().Add(24 * time.Hour)
+	fixedNow := time.Now().UTC()
 	categoryID := 7
 	preferredGender := domain.GenderOther
+	hostFinalScore := 4.3
+	viewerRatingMessage := "Great event host."
+	viewerRatingCreatedAt := createdAt.Add(5 * time.Minute)
+	viewerRatingUpdatedAt := viewerRatingCreatedAt.Add(2 * time.Minute)
+	svc.now = func() time.Time { return fixedNow }
 
 	eventRepo.detailRecord = &EventDetailRecord{
 		ID:                       eventID,
@@ -250,6 +256,10 @@ func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
 			DisplayName: stringPtr("Host User"),
 			AvatarURL:   stringPtr("https://example.com/avatar.png"),
 		},
+		HostScore: EventHostScoreSummaryRecord{
+			FinalScore:             &hostFinalScore,
+			HostedEventRatingCount: 12,
+		},
 		Location: EventDetailLocationRecord{
 			Type:    domain.LocationRoute,
 			Address: stringPtr("Belgrad Forest"),
@@ -266,6 +276,13 @@ func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
 			IsHost:              false,
 			IsFavorited:         true,
 			ParticipationStatus: domain.EventDetailParticipationStatusJoined,
+		},
+		ViewerEventRating: &EventDetailRatingRecord{
+			ID:        uuid.New(),
+			Rating:    5,
+			Message:   &viewerRatingMessage,
+			CreatedAt: viewerRatingCreatedAt,
+			UpdatedAt: viewerRatingUpdatedAt,
 		},
 	}
 
@@ -288,8 +305,20 @@ func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
 	if result.HostContext != nil {
 		t.Fatal("expected non-host result to omit host_context")
 	}
+	if result.HostScore.FinalScore == nil || *result.HostScore.FinalScore != hostFinalScore {
+		t.Fatalf("expected host final score %v, got %v", hostFinalScore, result.HostScore.FinalScore)
+	}
+	if result.HostScore.HostedEventRatingCount != 12 {
+		t.Fatalf("expected host rating count 12, got %d", result.HostScore.HostedEventRatingCount)
+	}
+	if result.ViewerEventRating == nil || result.ViewerEventRating.Rating != 5 {
+		t.Fatalf("expected viewer_event_rating to be mapped, got %+v", result.ViewerEventRating)
+	}
 	if result.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusJoined) {
 		t.Fatalf("expected participation_status %q, got %q", domain.EventDetailParticipationStatusJoined, result.ViewerContext.ParticipationStatus)
+	}
+	if result.RatingWindow.IsActive {
+		t.Fatal("expected canceled event rating window to be inactive")
 	}
 	if len(result.Location.RoutePoints) != 2 {
 		t.Fatalf("expected 2 route points, got %d", len(result.Location.RoutePoints))
@@ -299,6 +328,7 @@ func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
 func TestGetEventDetailIncludesHostContextForHostViewer(t *testing.T) {
 	// given
 	svc, eventRepo, _, _ := newTestEventService()
+	hostRatingMessage := "Reliable participant."
 	eventRepo.detailRecord = &EventDetailRecord{
 		ID:           uuid.New(),
 		Title:        "Hosted Event",
@@ -330,9 +360,16 @@ func TestGetEventDetailIncludesHostContextForHostViewer(t *testing.T) {
 					Status:          domain.ParticipationStatusApproved,
 					CreatedAt:       time.Now().UTC().Add(-time.Hour),
 					UpdatedAt:       time.Now().UTC(),
-					User: EventDetailPersonRecord{
+					User: EventDetailHostContextUserRecord{
 						ID:       uuid.New(),
 						Username: "participant_user",
+					},
+					HostRating: &EventDetailRatingRecord{
+						ID:        uuid.New(),
+						Rating:    4,
+						Message:   &hostRatingMessage,
+						CreatedAt: time.Now().UTC().Add(-30 * time.Minute),
+						UpdatedAt: time.Now().UTC(),
 					},
 				},
 			},
@@ -353,6 +390,9 @@ func TestGetEventDetailIncludesHostContextForHostViewer(t *testing.T) {
 	}
 	if len(result.HostContext.ApprovedParticipants) != 1 {
 		t.Fatalf("expected 1 approved participant, got %d", len(result.HostContext.ApprovedParticipants))
+	}
+	if result.HostContext.ApprovedParticipants[0].HostRating == nil || result.HostContext.ApprovedParticipants[0].HostRating.Rating != 4 {
+		t.Fatalf("expected participant host_rating to be mapped, got %+v", result.HostContext.ApprovedParticipants[0].HostRating)
 	}
 }
 

--- a/backend/internal/application/rating/helpers.go
+++ b/backend/internal/application/rating/helpers.go
@@ -1,0 +1,98 @@
+package rating
+
+import (
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+)
+
+func normalizeMessage(message *string) *string {
+	if message == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(*message)
+	if trimmed == "" {
+		return nil
+	}
+
+	return &trimmed
+}
+
+func validateUpsertRatingInput(input UpsertRatingInput) map[string]string {
+	errs := make(map[string]string)
+
+	if input.Rating < domain.RatingMin || input.Rating > domain.RatingMax {
+		errs["rating"] = "rating must be between 1 and 5"
+	}
+
+	if input.Message != nil {
+		length := utf8.RuneCountInString(*input.Message)
+		if length < domain.RatingMessageMinLength || length > domain.RatingMessageMaxLength {
+			errs["message"] = "message must be between 10 and 100 characters when provided"
+		}
+	}
+
+	return errs
+}
+
+func toRatingResult(id string, ratingValue int, message *string, createdAt, updatedAt time.Time) *RatingResult {
+	return &RatingResult{
+		ID:        id,
+		Rating:    ratingValue,
+		Message:   message,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+}
+
+func toEventRatingResult(record *domain.EventRating) *RatingResult {
+	return toRatingResult(
+		record.ID.String(),
+		record.Rating,
+		record.Message,
+		record.CreatedAt,
+		record.UpdatedAt,
+	)
+}
+
+func toParticipantRatingResult(record *domain.ParticipantRating) *RatingResult {
+	return toRatingResult(
+		record.ID.String(),
+		record.Rating,
+		record.Message,
+		record.CreatedAt,
+		record.UpdatedAt,
+	)
+}
+
+func calculateBayesianAverage(average *float64, count int, settings Settings) *float64 {
+	if average == nil || count == 0 {
+		return nil
+	}
+
+	m := float64(settings.BayesianM)
+	score := ((*average * float64(count)) + (settings.GlobalPrior * m)) / (float64(count) + m)
+	return &score
+}
+
+func calculateFinalScore(participantAggregate, hostedAggregate *ScoreAggregate, settings Settings) *float64 {
+	var (
+		participantBayesian = calculateBayesianAverage(participantAggregate.Average, participantAggregate.Count, settings)
+		hostedBayesian      = calculateBayesianAverage(hostedAggregate.Average, hostedAggregate.Count, settings)
+	)
+
+	switch {
+	case participantBayesian == nil && hostedBayesian == nil:
+		return nil
+	case participantBayesian == nil:
+		return hostedBayesian
+	case hostedBayesian == nil:
+		return participantBayesian
+	default:
+		score := (0.6 * *hostedBayesian) + (0.4 * *participantBayesian)
+		return &score
+	}
+}

--- a/backend/internal/application/rating/repository.go
+++ b/backend/internal/application/rating/repository.go
@@ -1,0 +1,22 @@
+package rating
+
+import (
+	"context"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// Repository is the application-layer persistence port for rating flows.
+type Repository interface {
+	WithTx(ctx context.Context, fn func(repo Repository) error) error
+	GetEventRatingContext(ctx context.Context, eventID, participantUserID uuid.UUID) (*EventRatingContext, error)
+	UpsertEventRating(ctx context.Context, params UpsertEventRatingParams) (*domain.EventRating, error)
+	DeleteEventRating(ctx context.Context, eventID, participantUserID uuid.UUID) (bool, error)
+	GetParticipantRatingContext(ctx context.Context, eventID, hostUserID, participantUserID uuid.UUID) (*ParticipantRatingContext, error)
+	UpsertParticipantRating(ctx context.Context, params UpsertParticipantRatingParams) (*domain.ParticipantRating, error)
+	DeleteParticipantRating(ctx context.Context, eventID, hostUserID, participantUserID uuid.UUID) (bool, error)
+	CalculateParticipantAggregate(ctx context.Context, userID uuid.UUID) (*ScoreAggregate, error)
+	CalculateHostedEventAggregate(ctx context.Context, userID uuid.UUID) (*ScoreAggregate, error)
+	UpsertUserScore(ctx context.Context, params UpsertUserScoreParams) error
+}

--- a/backend/internal/application/rating/repository_dto.go
+++ b/backend/internal/application/rating/repository_dto.go
@@ -1,0 +1,88 @@
+package rating
+
+import (
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// UpsertRatingInput carries the write payload used by both rating resources.
+type UpsertRatingInput struct {
+	Rating  int
+	Message *string
+}
+
+// RatingResult is the shared API-facing payload for rating resources.
+type RatingResult struct {
+	ID        string    `json:"id"`
+	Rating    int       `json:"rating"`
+	Message   *string   `json:"message"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Settings contains the score calculation parameters for Bayesian smoothing.
+type Settings struct {
+	GlobalPrior float64
+	BayesianM   int
+}
+
+// EventRatingContext contains the event and participation state required to
+// authorize participant -> event ratings.
+type EventRatingContext struct {
+	EventID               uuid.UUID
+	HostUserID            uuid.UUID
+	Status                domain.EventStatus
+	StartTime             time.Time
+	EndTime               *time.Time
+	IsRequestingHost      bool
+	IsApprovedParticipant bool
+}
+
+// ParticipantRatingContext contains the event and participation state required
+// to authorize host -> participant ratings.
+type ParticipantRatingContext struct {
+	EventID               uuid.UUID
+	HostUserID            uuid.UUID
+	ParticipantUserID     uuid.UUID
+	Status                domain.EventStatus
+	StartTime             time.Time
+	EndTime               *time.Time
+	IsRequestingHost      bool
+	IsApprovedParticipant bool
+}
+
+// UpsertEventRatingParams carries the data needed to persist an event rating.
+type UpsertEventRatingParams struct {
+	EventID           uuid.UUID
+	ParticipantUserID uuid.UUID
+	Rating            int
+	Message           *string
+}
+
+// UpsertParticipantRatingParams carries the data needed to persist a
+// participant rating.
+type UpsertParticipantRatingParams struct {
+	EventID           uuid.UUID
+	HostUserID        uuid.UUID
+	ParticipantUserID uuid.UUID
+	Rating            int
+	Message           *string
+}
+
+// ScoreAggregate is the raw aggregate read from one rating source.
+type ScoreAggregate struct {
+	Average *float64
+	Count   int
+}
+
+// UpsertUserScoreParams carries the derived score snapshot to cache for a user.
+type UpsertUserScoreParams struct {
+	UserID                 uuid.UUID
+	ParticipantScore       *float64
+	ParticipantRatingCount int
+	HostedEventScore       *float64
+	HostedEventRatingCount int
+	FinalScore             *float64
+}

--- a/backend/internal/application/rating/service.go
+++ b/backend/internal/application/rating/service.go
@@ -1,0 +1,229 @@
+package rating
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// Service owns rating-specific application behavior.
+type Service struct {
+	repo     Repository
+	settings Settings
+	now      func() time.Time
+}
+
+var _ UseCase = (*Service)(nil)
+
+// NewService constructs a rating service backed by its own repository.
+func NewService(repo Repository, settings Settings) *Service {
+	return &Service{
+		repo:     repo,
+		settings: settings,
+		now:      time.Now,
+	}
+}
+
+// UpsertEventRating creates or updates the caller's rating for an event.
+func (s *Service) UpsertEventRating(
+	ctx context.Context,
+	participantUserID, eventID uuid.UUID,
+	input UpsertRatingInput,
+) (*RatingResult, error) {
+	input.Message = normalizeMessage(input.Message)
+	if errs := validateUpsertRatingInput(input); len(errs) > 0 {
+		return nil, domain.ValidationError(errs)
+	}
+
+	var result *domain.EventRating
+	err := s.repo.WithTx(ctx, func(repo Repository) error {
+		ratingContext, err := repo.GetEventRatingContext(ctx, eventID, participantUserID)
+		if err != nil {
+			return s.mapContextError(err)
+		}
+		if err := s.validateEventRatingContext(ratingContext); err != nil {
+			return err
+		}
+
+		result, err = repo.UpsertEventRating(ctx, UpsertEventRatingParams{
+			EventID:           eventID,
+			ParticipantUserID: participantUserID,
+			Rating:            input.Rating,
+			Message:           input.Message,
+		})
+		if err != nil {
+			return err
+		}
+
+		return s.refreshUserScore(ctx, repo, ratingContext.HostUserID)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toEventRatingResult(result), nil
+}
+
+// DeleteEventRating hard deletes the caller's rating for an event.
+func (s *Service) DeleteEventRating(ctx context.Context, participantUserID, eventID uuid.UUID) error {
+	return s.repo.WithTx(ctx, func(repo Repository) error {
+		ratingContext, err := repo.GetEventRatingContext(ctx, eventID, participantUserID)
+		if err != nil {
+			return s.mapContextError(err)
+		}
+		if err := s.validateEventRatingContext(ratingContext); err != nil {
+			return err
+		}
+
+		deleted, err := repo.DeleteEventRating(ctx, eventID, participantUserID)
+		if err != nil {
+			return err
+		}
+		if !deleted {
+			return domain.NotFoundError(domain.ErrorCodeEventRatingNotFound, "The requested event rating does not exist.")
+		}
+
+		return s.refreshUserScore(ctx, repo, ratingContext.HostUserID)
+	})
+}
+
+// UpsertParticipantRating creates or updates the host's rating for an approved participant.
+func (s *Service) UpsertParticipantRating(
+	ctx context.Context,
+	hostUserID, eventID, participantUserID uuid.UUID,
+	input UpsertRatingInput,
+) (*RatingResult, error) {
+	input.Message = normalizeMessage(input.Message)
+	if errs := validateUpsertRatingInput(input); len(errs) > 0 {
+		return nil, domain.ValidationError(errs)
+	}
+
+	var result *domain.ParticipantRating
+	err := s.repo.WithTx(ctx, func(repo Repository) error {
+		ratingContext, err := repo.GetParticipantRatingContext(ctx, eventID, hostUserID, participantUserID)
+		if err != nil {
+			return s.mapContextError(err)
+		}
+		if err := s.validateParticipantRatingContext(hostUserID, participantUserID, ratingContext); err != nil {
+			return err
+		}
+
+		result, err = repo.UpsertParticipantRating(ctx, UpsertParticipantRatingParams{
+			EventID:           eventID,
+			HostUserID:        hostUserID,
+			ParticipantUserID: participantUserID,
+			Rating:            input.Rating,
+			Message:           input.Message,
+		})
+		if err != nil {
+			return err
+		}
+
+		return s.refreshUserScore(ctx, repo, participantUserID)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toParticipantRatingResult(result), nil
+}
+
+// DeleteParticipantRating hard deletes the host's rating for a participant.
+func (s *Service) DeleteParticipantRating(
+	ctx context.Context,
+	hostUserID, eventID, participantUserID uuid.UUID,
+) error {
+	return s.repo.WithTx(ctx, func(repo Repository) error {
+		ratingContext, err := repo.GetParticipantRatingContext(ctx, eventID, hostUserID, participantUserID)
+		if err != nil {
+			return s.mapContextError(err)
+		}
+		if err := s.validateParticipantRatingContext(hostUserID, participantUserID, ratingContext); err != nil {
+			return err
+		}
+
+		deleted, err := repo.DeleteParticipantRating(ctx, eventID, hostUserID, participantUserID)
+		if err != nil {
+			return err
+		}
+		if !deleted {
+			return domain.NotFoundError(domain.ErrorCodeParticipantRatingNotFound, "The requested participant rating does not exist.")
+		}
+
+		return s.refreshUserScore(ctx, repo, participantUserID)
+	})
+}
+
+func (s *Service) mapContextError(err error) error {
+	if errors.Is(err, domain.ErrNotFound) {
+		return domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+	}
+	return err
+}
+
+func (s *Service) validateEventRatingContext(ratingContext *EventRatingContext) error {
+	if ratingContext.IsRequestingHost {
+		return domain.ForbiddenError(domain.ErrorCodeHostCannotRateSelf, "The event host cannot rate their own event.")
+	}
+	if ratingContext.Status == domain.EventStatusCanceled {
+		return domain.ConflictError(domain.ErrorCodeRatingNotAllowed, "Ratings are not allowed for canceled events.")
+	}
+	if !ratingContext.IsApprovedParticipant {
+		return domain.ForbiddenError(domain.ErrorCodeRatingNotAllowed, "Only approved participants can rate this event.")
+	}
+
+	return s.validateWindow(ratingContext.StartTime, ratingContext.EndTime)
+}
+
+func (s *Service) validateParticipantRatingContext(
+	hostUserID, participantUserID uuid.UUID,
+	ratingContext *ParticipantRatingContext,
+) error {
+	if hostUserID == participantUserID {
+		return domain.ForbiddenError(domain.ErrorCodeHostCannotRateSelf, "The event host cannot rate themselves.")
+	}
+	if !ratingContext.IsRequestingHost || ratingContext.HostUserID != hostUserID {
+		return domain.ForbiddenError(domain.ErrorCodeRatingNotAllowed, "Only the event host can rate participants for this event.")
+	}
+	if ratingContext.Status == domain.EventStatusCanceled {
+		return domain.ConflictError(domain.ErrorCodeRatingNotAllowed, "Ratings are not allowed for canceled events.")
+	}
+	if !ratingContext.IsApprovedParticipant {
+		return domain.ForbiddenError(domain.ErrorCodeRatingNotAllowed, "Only approved participants can be rated for this event.")
+	}
+
+	return s.validateWindow(ratingContext.StartTime, ratingContext.EndTime)
+}
+
+func (s *Service) validateWindow(startTime time.Time, endTime *time.Time) error {
+	window := domain.NewRatingWindow(startTime, endTime)
+	if !window.IsActive(s.now().UTC()) {
+		return domain.ConflictError(domain.ErrorCodeRatingWindowClosed, "Ratings can only be modified within 7 days after the event ends.")
+	}
+
+	return nil
+}
+
+func (s *Service) refreshUserScore(ctx context.Context, repo Repository, userID uuid.UUID) error {
+	participantAggregate, err := repo.CalculateParticipantAggregate(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	hostedAggregate, err := repo.CalculateHostedEventAggregate(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	return repo.UpsertUserScore(ctx, UpsertUserScoreParams{
+		UserID:                 userID,
+		ParticipantScore:       participantAggregate.Average,
+		ParticipantRatingCount: participantAggregate.Count,
+		HostedEventScore:       hostedAggregate.Average,
+		HostedEventRatingCount: hostedAggregate.Count,
+		FinalScore:             calculateFinalScore(participantAggregate, hostedAggregate, s.settings),
+	})
+}

--- a/backend/internal/application/rating/service_test.go
+++ b/backend/internal/application/rating/service_test.go
@@ -1,0 +1,390 @@
+package rating
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+type fakeRatingRepo struct {
+	eventContext               *EventRatingContext
+	participantContext         *ParticipantRatingContext
+	eventContextErr            error
+	participantContextErr      error
+	eventRating                *domain.EventRating
+	participantRating          *domain.ParticipantRating
+	eventDeleteResult          bool
+	participantDeleteResult    bool
+	participantAggregate       *ScoreAggregate
+	hostedAggregate            *ScoreAggregate
+	lastEventUpsert            UpsertEventRatingParams
+	lastParticipantUpsert      UpsertParticipantRatingParams
+	lastUserScore              UpsertUserScoreParams
+	upsertEventCallCount       int
+	upsertParticipantCallCount int
+	deleteEventCallCount       int
+	deleteParticipantCallCount int
+	withTxCallCount            int
+}
+
+func (r *fakeRatingRepo) WithTx(_ context.Context, fn func(repo Repository) error) error {
+	r.withTxCallCount++
+	return fn(r)
+}
+
+func (r *fakeRatingRepo) GetEventRatingContext(_ context.Context, _, _ uuid.UUID) (*EventRatingContext, error) {
+	if r.eventContextErr != nil {
+		return nil, r.eventContextErr
+	}
+	return r.eventContext, nil
+}
+
+func (r *fakeRatingRepo) UpsertEventRating(_ context.Context, params UpsertEventRatingParams) (*domain.EventRating, error) {
+	r.upsertEventCallCount++
+	r.lastEventUpsert = params
+	if r.eventRating != nil {
+		return r.eventRating, nil
+	}
+
+	now := time.Now().UTC()
+	return &domain.EventRating{
+		ID:                uuid.New(),
+		EventID:           params.EventID,
+		ParticipantUserID: params.ParticipantUserID,
+		Rating:            params.Rating,
+		Message:           params.Message,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}, nil
+}
+
+func (r *fakeRatingRepo) DeleteEventRating(_ context.Context, _, _ uuid.UUID) (bool, error) {
+	r.deleteEventCallCount++
+	return r.eventDeleteResult, nil
+}
+
+func (r *fakeRatingRepo) GetParticipantRatingContext(_ context.Context, _, _, _ uuid.UUID) (*ParticipantRatingContext, error) {
+	if r.participantContextErr != nil {
+		return nil, r.participantContextErr
+	}
+	return r.participantContext, nil
+}
+
+func (r *fakeRatingRepo) UpsertParticipantRating(_ context.Context, params UpsertParticipantRatingParams) (*domain.ParticipantRating, error) {
+	r.upsertParticipantCallCount++
+	r.lastParticipantUpsert = params
+	if r.participantRating != nil {
+		return r.participantRating, nil
+	}
+
+	now := time.Now().UTC()
+	return &domain.ParticipantRating{
+		ID:                uuid.New(),
+		EventID:           params.EventID,
+		HostUserID:        params.HostUserID,
+		ParticipantUserID: params.ParticipantUserID,
+		Rating:            params.Rating,
+		Message:           params.Message,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}, nil
+}
+
+func (r *fakeRatingRepo) DeleteParticipantRating(_ context.Context, _, _, _ uuid.UUID) (bool, error) {
+	r.deleteParticipantCallCount++
+	return r.participantDeleteResult, nil
+}
+
+func (r *fakeRatingRepo) CalculateParticipantAggregate(_ context.Context, _ uuid.UUID) (*ScoreAggregate, error) {
+	if r.participantAggregate != nil {
+		return r.participantAggregate, nil
+	}
+	return &ScoreAggregate{}, nil
+}
+
+func (r *fakeRatingRepo) CalculateHostedEventAggregate(_ context.Context, _ uuid.UUID) (*ScoreAggregate, error) {
+	if r.hostedAggregate != nil {
+		return r.hostedAggregate, nil
+	}
+	return &ScoreAggregate{}, nil
+}
+
+func (r *fakeRatingRepo) UpsertUserScore(_ context.Context, params UpsertUserScoreParams) error {
+	r.lastUserScore = params
+	return nil
+}
+
+func TestUpsertEventRatingNormalizesBlankMessageAndRefreshesHostScore(t *testing.T) {
+	// given
+	hostUserID := uuid.New()
+	participantUserID := uuid.New()
+	eventID := uuid.New()
+	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
+	repo := &fakeRatingRepo{
+		eventContext: &EventRatingContext{
+			EventID:               eventID,
+			HostUserID:            hostUserID,
+			Status:                domain.EventStatusActive,
+			StartTime:             now.Add(-2 * time.Hour),
+			EndTime:               timePtr(now.Add(-time.Hour)),
+			IsApprovedParticipant: true,
+		},
+		hostedAggregate: &ScoreAggregate{
+			Average: floatPtr(4.5),
+			Count:   2,
+		},
+	}
+	service := NewService(repo, Settings{GlobalPrior: 4.0, BayesianM: 5})
+	service.now = func() time.Time { return now }
+
+	// when
+	result, err := service.UpsertEventRating(context.Background(), participantUserID, eventID, UpsertRatingInput{
+		Rating:  5,
+		Message: stringPtr("   "),
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("UpsertEventRating() error = %v", err)
+	}
+	if repo.lastEventUpsert.Message != nil {
+		t.Fatalf("expected normalized message to be nil, got %v", repo.lastEventUpsert.Message)
+	}
+	if result.Message != nil {
+		t.Fatalf("expected response message to be nil, got %v", result.Message)
+	}
+	if repo.lastUserScore.UserID != hostUserID {
+		t.Fatalf("expected user_score refresh for host %s, got %s", hostUserID, repo.lastUserScore.UserID)
+	}
+	expected := (4.5*2 + 4.0*5) / 7.0
+	if repo.lastUserScore.FinalScore == nil || math.Abs(*repo.lastUserScore.FinalScore-expected) > 0.00001 {
+		t.Fatalf("expected final score %.5f, got %v", expected, repo.lastUserScore.FinalScore)
+	}
+}
+
+func TestUpsertEventRatingRejectsInvalidInput(t *testing.T) {
+	// given
+	repo := &fakeRatingRepo{}
+	service := NewService(repo, Settings{GlobalPrior: 4.0, BayesianM: 5})
+
+	// when
+	_, err := service.UpsertEventRating(context.Background(), uuid.New(), uuid.New(), UpsertRatingInput{
+		Rating:  6,
+		Message: stringPtr("short"),
+	})
+
+	// then
+	_ = requireAppErrorCode(t, err, domain.ErrorCodeValidation)
+	if repo.withTxCallCount != 0 {
+		t.Fatalf("expected repository transaction not to start, got %d", repo.withTxCallCount)
+	}
+}
+
+func TestUpsertEventRatingRejectsCanceledEvent(t *testing.T) {
+	// given
+	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
+	repo := &fakeRatingRepo{
+		eventContext: &EventRatingContext{
+			EventID:               uuid.New(),
+			HostUserID:            uuid.New(),
+			Status:                domain.EventStatusCanceled,
+			StartTime:             now.Add(-2 * time.Hour),
+			EndTime:               timePtr(now.Add(-time.Hour)),
+			IsApprovedParticipant: true,
+		},
+	}
+	service := NewService(repo, Settings{GlobalPrior: 4.0, BayesianM: 5})
+	service.now = func() time.Time { return now }
+
+	// when
+	_, err := service.UpsertEventRating(context.Background(), uuid.New(), uuid.New(), UpsertRatingInput{Rating: 4})
+
+	// then
+	_ = requireAppErrorCode(t, err, domain.ErrorCodeRatingNotAllowed)
+	if repo.upsertEventCallCount != 0 {
+		t.Fatalf("expected no upsert call, got %d", repo.upsertEventCallCount)
+	}
+}
+
+func TestUpsertEventRatingRejectsHostSelfBeforeApprovedParticipantCheck(t *testing.T) {
+	// given
+	hostUserID := uuid.New()
+	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
+	repo := &fakeRatingRepo{
+		eventContext: &EventRatingContext{
+			EventID:               uuid.New(),
+			HostUserID:            hostUserID,
+			Status:                domain.EventStatusActive,
+			StartTime:             now.Add(-2 * time.Hour),
+			EndTime:               timePtr(now.Add(-time.Hour)),
+			IsRequestingHost:      true,
+			IsApprovedParticipant: false,
+		},
+	}
+	service := NewService(repo, Settings{GlobalPrior: 4.0, BayesianM: 5})
+	service.now = func() time.Time { return now }
+
+	// when
+	_, err := service.UpsertEventRating(context.Background(), hostUserID, uuid.New(), UpsertRatingInput{Rating: 4})
+
+	// then
+	appErr := requireAppErrorCode(t, err, domain.ErrorCodeHostCannotRateSelf)
+	if appErr.Message != "The event host cannot rate their own event." {
+		t.Fatalf("expected host self-rating message, got %q", appErr.Message)
+	}
+	if repo.upsertEventCallCount != 0 {
+		t.Fatalf("expected no upsert call, got %d", repo.upsertEventCallCount)
+	}
+}
+
+func TestUpsertParticipantRatingRejectsHostSelf(t *testing.T) {
+	// given
+	hostUserID := uuid.New()
+	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
+	repo := &fakeRatingRepo{
+		participantContext: &ParticipantRatingContext{
+			EventID:               uuid.New(),
+			HostUserID:            hostUserID,
+			ParticipantUserID:     hostUserID,
+			Status:                domain.EventStatusActive,
+			StartTime:             now.Add(-2 * time.Hour),
+			EndTime:               timePtr(now.Add(-time.Hour)),
+			IsRequestingHost:      true,
+			IsApprovedParticipant: true,
+		},
+	}
+	service := NewService(repo, Settings{GlobalPrior: 4.0, BayesianM: 5})
+	service.now = func() time.Time { return now }
+
+	// when
+	_, err := service.UpsertParticipantRating(context.Background(), hostUserID, uuid.New(), hostUserID, UpsertRatingInput{Rating: 4})
+
+	// then
+	_ = requireAppErrorCode(t, err, domain.ErrorCodeHostCannotRateSelf)
+}
+
+func TestUpsertParticipantRatingRefreshesWeightedFinalScore(t *testing.T) {
+	// given
+	hostUserID := uuid.New()
+	participantUserID := uuid.New()
+	eventID := uuid.New()
+	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
+	repo := &fakeRatingRepo{
+		participantContext: &ParticipantRatingContext{
+			EventID:               eventID,
+			HostUserID:            hostUserID,
+			ParticipantUserID:     participantUserID,
+			Status:                domain.EventStatusActive,
+			StartTime:             now.Add(-2 * time.Hour),
+			EndTime:               timePtr(now.Add(-time.Hour)),
+			IsRequestingHost:      true,
+			IsApprovedParticipant: true,
+		},
+		participantAggregate: &ScoreAggregate{
+			Average: floatPtr(3.0),
+			Count:   2,
+		},
+		hostedAggregate: &ScoreAggregate{
+			Average: floatPtr(4.0),
+			Count:   10,
+		},
+	}
+	service := NewService(repo, Settings{GlobalPrior: 4.0, BayesianM: 5})
+	service.now = func() time.Time { return now }
+
+	// when
+	_, err := service.UpsertParticipantRating(context.Background(), hostUserID, eventID, participantUserID, UpsertRatingInput{
+		Rating:  4,
+		Message: stringPtr("Shows up on time."),
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("UpsertParticipantRating() error = %v", err)
+	}
+	expectedParticipant := (3.0*2 + 4.0*5) / 7.0
+	expectedHosted := (4.0*10 + 4.0*5) / 15.0
+	expectedFinal := 0.6*expectedHosted + 0.4*expectedParticipant
+	if repo.lastUserScore.UserID != participantUserID {
+		t.Fatalf("expected score refresh for participant %s, got %s", participantUserID, repo.lastUserScore.UserID)
+	}
+	if repo.lastUserScore.FinalScore == nil || math.Abs(*repo.lastUserScore.FinalScore-expectedFinal) > 0.00001 {
+		t.Fatalf("expected final score %.5f, got %v", expectedFinal, repo.lastUserScore.FinalScore)
+	}
+}
+
+func TestDeleteEventRatingReturnsNotFoundWhenRecordMissing(t *testing.T) {
+	// given
+	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
+	repo := &fakeRatingRepo{
+		eventContext: &EventRatingContext{
+			EventID:               uuid.New(),
+			HostUserID:            uuid.New(),
+			Status:                domain.EventStatusActive,
+			StartTime:             now.Add(-2 * time.Hour),
+			EndTime:               timePtr(now.Add(-time.Hour)),
+			IsApprovedParticipant: true,
+		},
+		eventDeleteResult: false,
+	}
+	service := NewService(repo, Settings{GlobalPrior: 4.0, BayesianM: 5})
+	service.now = func() time.Time { return now }
+
+	// when
+	err := service.DeleteEventRating(context.Background(), uuid.New(), uuid.New())
+
+	// then
+	_ = requireAppErrorCode(t, err, domain.ErrorCodeEventRatingNotFound)
+}
+
+func TestDeleteParticipantRatingUsesStartTimeWhenEndTimeIsNil(t *testing.T) {
+	// given
+	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
+	hostUserID := uuid.New()
+	participantUserID := uuid.New()
+	repo := &fakeRatingRepo{
+		participantContext: &ParticipantRatingContext{
+			EventID:               uuid.New(),
+			HostUserID:            hostUserID,
+			ParticipantUserID:     participantUserID,
+			Status:                domain.EventStatusActive,
+			StartTime:             now.Add(-8 * 24 * time.Hour),
+			EndTime:               nil,
+			IsRequestingHost:      true,
+			IsApprovedParticipant: true,
+		},
+	}
+	service := NewService(repo, Settings{GlobalPrior: 4.0, BayesianM: 5})
+	service.now = func() time.Time { return now }
+
+	// when
+	err := service.DeleteParticipantRating(context.Background(), hostUserID, uuid.New(), participantUserID)
+
+	// then
+	_ = requireAppErrorCode(t, err, domain.ErrorCodeRatingWindowClosed)
+}
+
+func requireAppErrorCode(t *testing.T, err error, code string) *domain.AppError {
+	t.Helper()
+
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T: %v", err, err)
+	}
+	if appErr.Code != code {
+		t.Fatalf("expected error code %q, got %q", code, appErr.Code)
+	}
+
+	return appErr
+}
+
+func stringPtr(value string) *string { return &value }
+
+func floatPtr(value float64) *float64 { return &value }
+
+func timePtr(value time.Time) *time.Time { return &value }

--- a/backend/internal/application/rating/usecase.go
+++ b/backend/internal/application/rating/usecase.go
@@ -1,0 +1,15 @@
+package rating
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// UseCase is the inbound application port for rating flows.
+type UseCase interface {
+	UpsertEventRating(ctx context.Context, participantUserID, eventID uuid.UUID, input UpsertRatingInput) (*RatingResult, error)
+	DeleteEventRating(ctx context.Context, participantUserID, eventID uuid.UUID) error
+	UpsertParticipantRating(ctx context.Context, hostUserID, eventID, participantUserID uuid.UUID, input UpsertRatingInput) (*RatingResult, error)
+	DeleteParticipantRating(ctx context.Context, hostUserID, eventID, participantUserID uuid.UUID) error
+}

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/event"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/participation"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/bounswe/bounswe2026group11/backend/internal/infrastructure/config"
 	"github.com/bounswe/bounswe2026group11/backend/internal/infrastructure/database"
@@ -35,11 +36,13 @@ type Container struct {
 	eventRepo            *postgres.EventRepository
 	participationRepo    *postgres.ParticipationRepository
 	joinRequestRepo      *postgres.JoinRequestRepository
+	ratingRepo           *postgres.RatingRepository
 	categoryRepo         *postgres.CategoryRepository
 	AuthService          auth.UseCase
 	EventService         event.UseCase
 	ParticipationService participation.UseCase
 	JoinRequestService   join_request.UseCase
+	RatingService        rating.UseCase
 	CategoryService      category.UseCase
 	// Extend with additional services as features are added, for example:
 	// SearchService httpapi.SearchService
@@ -75,9 +78,11 @@ func New(ctx context.Context) (*Container, error) {
 	container.eventRepo = postgres.NewEventRepository(container.DB)
 	container.participationRepo = postgres.NewParticipationRepository(container.DB)
 	container.joinRequestRepo = postgres.NewJoinRequestRepository(container.DB)
+	container.ratingRepo = postgres.NewRatingRepository(container.DB)
 	container.categoryRepo = postgres.NewCategoryRepository(container.DB)
 	container.ParticipationService = newParticipationService(container)
 	container.JoinRequestService = newJoinRequestService(container)
+	container.RatingService = newRatingService(container)
 	container.AuthService = newAuthService(container)
 	container.EventService = newEventService(container)
 	container.CategoryService = newCategoryService(container)
@@ -138,6 +143,14 @@ func newJoinRequestService(c *Container) join_request.UseCase {
 // newCategoryService wires the category use-case service with its driven adapter.
 func newCategoryService(c *Container) category.UseCase {
 	return category.NewService(c.categoryRepo)
+}
+
+// newRatingService wires the rating use-case service with its driven adapter.
+func newRatingService(c *Container) rating.UseCase {
+	return rating.NewService(c.ratingRepo, rating.Settings{
+		GlobalPrior: c.Config.RatingGlobalPrior,
+		BayesianM:   c.Config.RatingBayesianM,
+	})
 }
 
 // newAuthService wires the auth use-case service with its driven adapters.

--- a/backend/internal/domain/rating.go
+++ b/backend/internal/domain/rating.go
@@ -1,0 +1,74 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	RatingMin              = 1
+	RatingMax              = 5
+	RatingMessageMinLength = 10
+	RatingMessageMaxLength = 100
+	RatingWindowDuration   = 7 * 24 * time.Hour
+)
+
+// EventRating stores a participant's rating for an event.
+type EventRating struct {
+	ID                uuid.UUID
+	ParticipantUserID uuid.UUID
+	EventID           uuid.UUID
+	Rating            int
+	Message           *string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+// ParticipantRating stores a host's rating for a participant in an event.
+type ParticipantRating struct {
+	ID                uuid.UUID
+	HostUserID        uuid.UUID
+	ParticipantUserID uuid.UUID
+	EventID           uuid.UUID
+	Rating            int
+	Message           *string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+// UserScore stores cached aggregate scores derived from rating tables.
+type UserScore struct {
+	UserID                 uuid.UUID
+	ParticipantScore       *float64
+	ParticipantRatingCount int
+	HostedEventScore       *float64
+	HostedEventRatingCount int
+	FinalScore             *float64
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+}
+
+// RatingWindow describes when rating mutations are allowed for an event.
+type RatingWindow struct {
+	OpensAt  time.Time
+	ClosesAt time.Time
+}
+
+// NewRatingWindow builds the allowed rating interval for an event.
+func NewRatingWindow(startTime time.Time, endTime *time.Time) RatingWindow {
+	opensAt := startTime
+	if endTime != nil {
+		opensAt = *endTime
+	}
+
+	return RatingWindow{
+		OpensAt:  opensAt,
+		ClosesAt: opensAt.Add(RatingWindowDuration),
+	}
+}
+
+// IsActive reports whether now falls inside the inclusive rating interval.
+func (w RatingWindow) IsActive(now time.Time) bool {
+	return !now.Before(w.OpensAt) && !now.After(w.ClosesAt)
+}

--- a/backend/internal/domain/rating_errors.go
+++ b/backend/internal/domain/rating_errors.go
@@ -1,0 +1,9 @@
+package domain
+
+const (
+	ErrorCodeRatingNotAllowed          = "rating_not_allowed"
+	ErrorCodeRatingWindowClosed        = "rating_window_closed"
+	ErrorCodeEventRatingNotFound       = "event_rating_not_found"
+	ErrorCodeParticipantRatingNotFound = "participant_rating_not_found"
+	ErrorCodeHostCannotRateSelf        = "host_cannot_rate_self"
+)

--- a/backend/internal/infrastructure/config/config.go
+++ b/backend/internal/infrastructure/config/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	MailProvider           string
 	MailDomain             string
 	ResendClientAPIKey     string
+	RatingGlobalPrior      float64
+	RatingBayesianM        int
 }
 
 // Load reads configuration using the following precedence:
@@ -88,6 +90,8 @@ func Load() (*Config, error) {
 	bind("mail_provider", "MAIL_PROVIDER")
 	bind("mail_domain", "MAIL_DOMAIN")
 	bind("resend_client_api_key", "RESEND_CLIENT_API_KEY")
+	bind("rating_global_prior", "RATING_GLOBAL_PRIOR")
+	bind("rating_bayesian_m", "RATING_BAYESIAN_M")
 
 	cfg := &Config{
 		AppPort:                v.GetInt("app_port"),
@@ -112,6 +116,8 @@ func Load() (*Config, error) {
 		MailProvider:           strings.TrimSpace(v.GetString("mail_provider")),
 		MailDomain:             strings.TrimSpace(v.GetString("mail_domain")),
 		ResendClientAPIKey:     strings.TrimSpace(v.GetString("resend_client_api_key")),
+		RatingGlobalPrior:      v.GetFloat64("rating_global_prior"),
+		RatingBayesianM:        v.GetInt("rating_bayesian_m"),
 	}
 
 	if err := validate(v, cfg); err != nil {
@@ -312,6 +318,12 @@ func validate(v *viper.Viper, c *Config) error {
 		if c.ResendClientAPIKey == "" {
 			return fmt.Errorf("RESEND_CLIENT_API_KEY is required and cannot be empty")
 		}
+	}
+	if c.RatingGlobalPrior < 1 || c.RatingGlobalPrior > 5 {
+		return fmt.Errorf("RATING_GLOBAL_PRIOR must be between 1 and 5")
+	}
+	if c.RatingBayesianM < 1 {
+		return fmt.Errorf("RATING_BAYESIAN_M must be at least 1")
 	}
 
 	return nil

--- a/backend/internal/infrastructure/config/config_test.go
+++ b/backend/internal/infrastructure/config/config_test.go
@@ -47,6 +47,9 @@ func TestLoad_OK(t *testing.T) {
 	if cfg.MailProvider != "mock" || cfg.MailDomain != "socialeventmapper.com" {
 		t.Fatalf("unexpected mail config: %+v", cfg)
 	}
+	if cfg.RatingGlobalPrior != 4.0 || cfg.RatingBayesianM != 5 {
+		t.Fatalf("unexpected rating config: %+v", cfg)
+	}
 }
 
 func TestLoad_UsesRepoRootDotEnvWhenRunningFromBackend(t *testing.T) {
@@ -66,6 +69,9 @@ func TestLoad_UsesRepoRootDotEnvWhenRunningFromBackend(t *testing.T) {
 	}
 	if cfg.JWTSecret != "from-root" || cfg.ResendClientAPIKey != "re_test" {
 		t.Fatalf("expected repo root .env values, got %+v", cfg)
+	}
+	if cfg.RatingGlobalPrior != 4.0 || cfg.RatingBayesianM != 5 {
+		t.Fatalf("expected rating config from YAML, got %+v", cfg)
 	}
 }
 
@@ -208,6 +214,8 @@ func clearConfigEnv(t *testing.T) {
 		"MAIL_PROVIDER",
 		"MAIL_DOMAIN",
 		"RESEND_CLIENT_API_KEY",
+		"RATING_GLOBAL_PRIOR",
+		"RATING_BAYESIAN_M",
 	} {
 		t.Setenv(k, "")
 	}
@@ -278,6 +286,8 @@ availability_rate_limit: 20
 availability_rate_window: 15m
 mail_provider: mock
 mail_domain: socialeventmapper.com
+rating_global_prior: 4.0
+rating_bayesian_m: 5
 `) + "\n"
 }
 
@@ -302,5 +312,7 @@ availability_rate_limit: 20
 availability_rate_window: 15m
 mail_provider: resend
 mail_domain: socialeventmapper.com
+rating_global_prior: 4.0
+rating_bayesian_m: 5
 `) + "\n"
 }

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -5,6 +5,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/auth_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/category_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/event_handler"
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/rating_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/bootstrap"
 	"github.com/gofiber/fiber/v2"
 )
@@ -32,8 +33,13 @@ func NewHTTP(container *bootstrap.Container) *fiber.App {
 	auth_handler.RegisterAuthRoutes(app, authHandler)
 
 	// Event routes
+	auth := httpapi.RequireAuth(container.TokenVerifier)
 	eventHandler := event_handler.NewEventHandler(container.EventService)
-	event_handler.RegisterEventRoutes(app, eventHandler, httpapi.RequireAuth(container.TokenVerifier))
+	event_handler.RegisterEventRoutes(app, eventHandler, auth)
+
+	// Rating routes
+	ratingHandler := rating_handler.NewRatingHandler(container.RatingService)
+	rating_handler.RegisterRatingRoutes(app, ratingHandler, auth)
 
 	// Category routes (public, no auth required)
 	categoryHandler := category_handler.NewCategoryHandler(container.CategoryService)

--- a/backend/migrations/000014_event_ratings_and_user_scores.down.sql
+++ b/backend/migrations/000014_event_ratings_and_user_scores.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS user_score;
+DROP TABLE IF EXISTS participant_rating;
+DROP TABLE IF EXISTS event_rating;

--- a/backend/migrations/000014_event_ratings_and_user_scores.up.sql
+++ b/backend/migrations/000014_event_ratings_and_user_scores.up.sql
@@ -1,0 +1,60 @@
+CREATE TABLE event_rating
+(
+    id                  UUID PRIMARY KEY                  DEFAULT gen_random_uuid(),
+    participant_user_id UUID                     NOT NULL,
+    event_id            UUID                     NOT NULL,
+    rating              INT                      NOT NULL,
+    message             TEXT,
+    created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_event_rating_participant FOREIGN KEY (participant_user_id) REFERENCES app_user (id) ON DELETE CASCADE,
+    CONSTRAINT fk_event_rating_event FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE,
+    CONSTRAINT uq_event_rating_participant_event UNIQUE (participant_user_id, event_id),
+    CONSTRAINT chk_event_rating_rating CHECK (rating BETWEEN 1 AND 5),
+    CONSTRAINT chk_event_rating_message CHECK (message IS NULL OR char_length(message) BETWEEN 10 AND 100)
+);
+
+CREATE INDEX idx_event_rating_event_id ON event_rating (event_id);
+CREATE INDEX idx_event_rating_participant_user_id ON event_rating (participant_user_id);
+
+CREATE TABLE participant_rating
+(
+    id                  UUID PRIMARY KEY                  DEFAULT gen_random_uuid(),
+    host_user_id        UUID                     NOT NULL,
+    participant_user_id UUID                     NOT NULL,
+    event_id            UUID                     NOT NULL,
+    rating              INT                      NOT NULL,
+    message             TEXT,
+    created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_participant_rating_host FOREIGN KEY (host_user_id) REFERENCES app_user (id) ON DELETE CASCADE,
+    CONSTRAINT fk_participant_rating_participant FOREIGN KEY (participant_user_id) REFERENCES app_user (id) ON DELETE CASCADE,
+    CONSTRAINT fk_participant_rating_event FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE,
+    CONSTRAINT uq_participant_rating_host_participant_event UNIQUE (host_user_id, participant_user_id, event_id),
+    CONSTRAINT chk_participant_rating_rating CHECK (rating BETWEEN 1 AND 5),
+    CONSTRAINT chk_participant_rating_message CHECK (message IS NULL OR char_length(message) BETWEEN 10 AND 100)
+);
+
+CREATE INDEX idx_participant_rating_event_id ON participant_rating (event_id);
+CREATE INDEX idx_participant_rating_host_user_id ON participant_rating (host_user_id);
+CREATE INDEX idx_participant_rating_participant_user_id ON participant_rating (participant_user_id);
+
+CREATE TABLE user_score
+(
+    user_id                    UUID PRIMARY KEY,
+    participant_score          DOUBLE PRECISION,
+    participant_rating_count   INT                      NOT NULL DEFAULT 0,
+    hosted_event_score         DOUBLE PRECISION,
+    hosted_event_rating_count  INT                      NOT NULL DEFAULT 0,
+    final_score                DOUBLE PRECISION,
+    created_at                 TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at                 TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_user_score_user FOREIGN KEY (user_id) REFERENCES app_user (id) ON DELETE CASCADE,
+    CONSTRAINT chk_user_score_counts CHECK (
+        participant_rating_count >= 0 AND
+        hosted_event_rating_count >= 0
+    )
+);

--- a/backend/migrations/000015_host_default_participation.down.sql
+++ b/backend/migrations/000015_host_default_participation.down.sql
@@ -1,0 +1,79 @@
+DELETE FROM participation p
+USING event e
+WHERE p.event_id = e.id
+  AND p.user_id = e.host_id;
+
+CREATE OR REPLACE FUNCTION sync_participation_counts() RETURNS trigger AS
+$$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE event
+        SET approved_participant_count = (SELECT COUNT(*)
+                                          FROM participation
+                                          WHERE event_id = OLD.event_id
+                                            AND status = 'APPROVED'),
+            pending_participant_count  = (SELECT COUNT(*)
+                                          FROM participation
+                                          WHERE event_id = OLD.event_id
+                                            AND status = 'PENDING')
+        WHERE id = OLD.event_id;
+    ELSIF TG_OP = 'INSERT' THEN
+        UPDATE event
+        SET approved_participant_count = (SELECT COUNT(*)
+                                          FROM participation
+                                          WHERE event_id = NEW.event_id
+                                            AND status = 'APPROVED'),
+            pending_participant_count  = (SELECT COUNT(*)
+                                          FROM participation
+                                          WHERE event_id = NEW.event_id
+                                            AND status = 'PENDING')
+        WHERE id = NEW.event_id;
+    ELSIF TG_OP = 'UPDATE' THEN
+        IF OLD.event_id IS DISTINCT FROM NEW.event_id THEN
+            UPDATE event
+            SET approved_participant_count = (SELECT COUNT(*)
+                                              FROM participation
+                                              WHERE event_id = OLD.event_id
+                                                AND status = 'APPROVED'),
+                pending_participant_count  = (SELECT COUNT(*)
+                                              FROM participation
+                                              WHERE event_id = OLD.event_id
+                                                AND status = 'PENDING')
+            WHERE id = OLD.event_id;
+            UPDATE event
+            SET approved_participant_count = (SELECT COUNT(*)
+                                              FROM participation
+                                              WHERE event_id = NEW.event_id
+                                                AND status = 'APPROVED'),
+                pending_participant_count  = (SELECT COUNT(*)
+                                              FROM participation
+                                              WHERE event_id = NEW.event_id
+                                                AND status = 'PENDING')
+            WHERE id = NEW.event_id;
+        ELSE
+            UPDATE event
+            SET approved_participant_count = (SELECT COUNT(*)
+                                              FROM participation
+                                              WHERE event_id = NEW.event_id
+                                                AND status = 'APPROVED'),
+                pending_participant_count  = (SELECT COUNT(*)
+                                              FROM participation
+                                              WHERE event_id = NEW.event_id
+                                                AND status = 'PENDING')
+            WHERE id = NEW.event_id;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+UPDATE event e
+SET approved_participant_count = (SELECT COUNT(*)
+                                  FROM participation p
+                                  WHERE p.event_id = e.id
+                                    AND p.status = 'APPROVED'),
+    pending_participant_count  = (SELECT COUNT(*)
+                                  FROM participation p
+                                  WHERE p.event_id = e.id
+                                    AND p.status = 'PENDING');

--- a/backend/migrations/000015_host_default_participation.up.sql
+++ b/backend/migrations/000015_host_default_participation.up.sql
@@ -1,0 +1,100 @@
+-- Keep host membership internal by excluding host-owned participation rows from
+-- the denormalized participant counters on the event table.
+CREATE OR REPLACE FUNCTION sync_participation_counts() RETURNS trigger AS
+$$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE event e
+        SET approved_participant_count = (SELECT COUNT(*)
+                                          FROM participation p
+                                          WHERE p.event_id = OLD.event_id
+                                            AND p.status = 'APPROVED'
+                                            AND p.user_id <> e.host_id),
+            pending_participant_count  = (SELECT COUNT(*)
+                                          FROM participation p
+                                          WHERE p.event_id = OLD.event_id
+                                            AND p.status = 'PENDING'
+                                            AND p.user_id <> e.host_id)
+        WHERE e.id = OLD.event_id;
+    ELSIF TG_OP = 'INSERT' THEN
+        UPDATE event e
+        SET approved_participant_count = (SELECT COUNT(*)
+                                          FROM participation p
+                                          WHERE p.event_id = NEW.event_id
+                                            AND p.status = 'APPROVED'
+                                            AND p.user_id <> e.host_id),
+            pending_participant_count  = (SELECT COUNT(*)
+                                          FROM participation p
+                                          WHERE p.event_id = NEW.event_id
+                                            AND p.status = 'PENDING'
+                                            AND p.user_id <> e.host_id)
+        WHERE e.id = NEW.event_id;
+    ELSIF TG_OP = 'UPDATE' THEN
+        IF OLD.event_id IS DISTINCT FROM NEW.event_id THEN
+            UPDATE event e
+            SET approved_participant_count = (SELECT COUNT(*)
+                                              FROM participation p
+                                              WHERE p.event_id = OLD.event_id
+                                                AND p.status = 'APPROVED'
+                                                AND p.user_id <> e.host_id),
+                pending_participant_count  = (SELECT COUNT(*)
+                                              FROM participation p
+                                              WHERE p.event_id = OLD.event_id
+                                                AND p.status = 'PENDING'
+                                                AND p.user_id <> e.host_id)
+            WHERE e.id = OLD.event_id;
+            UPDATE event e
+            SET approved_participant_count = (SELECT COUNT(*)
+                                              FROM participation p
+                                              WHERE p.event_id = NEW.event_id
+                                                AND p.status = 'APPROVED'
+                                                AND p.user_id <> e.host_id),
+                pending_participant_count  = (SELECT COUNT(*)
+                                              FROM participation p
+                                              WHERE p.event_id = NEW.event_id
+                                                AND p.status = 'PENDING'
+                                                AND p.user_id <> e.host_id)
+            WHERE e.id = NEW.event_id;
+        ELSE
+            UPDATE event e
+            SET approved_participant_count = (SELECT COUNT(*)
+                                              FROM participation p
+                                              WHERE p.event_id = NEW.event_id
+                                                AND p.status = 'APPROVED'
+                                                AND p.user_id <> e.host_id),
+                pending_participant_count  = (SELECT COUNT(*)
+                                              FROM participation p
+                                              WHERE p.event_id = NEW.event_id
+                                                AND p.status = 'PENDING'
+                                                AND p.user_id <> e.host_id)
+            WHERE e.id = NEW.event_id;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Backfill an internal APPROVED participation row for every host-event pair.
+INSERT INTO participation (event_id, user_id, status, created_at, updated_at)
+SELECT e.id, e.host_id, 'APPROVED', e.created_at, e.updated_at
+FROM event e
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM participation p
+    WHERE p.event_id = e.id
+      AND p.user_id = e.host_id
+);
+
+-- Recompute counters so the snapshot stays aligned after the backfill.
+UPDATE event e
+SET approved_participant_count = (SELECT COUNT(*)
+                                  FROM participation p
+                                  WHERE p.event_id = e.id
+                                    AND p.status = 'APPROVED'
+                                    AND p.user_id <> e.host_id),
+    pending_participant_count  = (SELECT COUNT(*)
+                                  FROM participation p
+                                  WHERE p.event_id = e.id
+                                    AND p.status = 'PENDING'
+                                    AND p.user_id <> e.host_id);

--- a/backend/tests_integration/common/harness.go
+++ b/backend/tests_integration/common/harness.go
@@ -16,6 +16,7 @@ import (
 	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
 	joinrequestapp "github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
 	participationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/participation"
+	ratingapp "github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/jackc/pgx/v5"
 )
@@ -76,8 +77,9 @@ func NewAuthHarness(t *testing.T) *AuthHarness {
 
 // EventHarness bundles the shared wiring used by event integration tests.
 type EventHarness struct {
-	Service  eventapp.UseCase
-	AuthRepo authapp.Repository
+	Service       eventapp.UseCase
+	RatingService ratingapp.UseCase
+	AuthRepo      authapp.Repository
 }
 
 // NewEventHarness creates an event service that shares the package-level pool.
@@ -88,6 +90,7 @@ func NewEventHarness(t *testing.T) *EventHarness {
 	eventRepo := postgresrepo.NewEventRepository(pool)
 	participationRepo := postgresrepo.NewParticipationRepository(pool)
 	joinRequestRepo := postgresrepo.NewJoinRequestRepository(pool)
+	ratingRepo := postgresrepo.NewRatingRepository(pool)
 	participationService := participationapp.NewService(participationRepo)
 	joinRequestService := joinrequestapp.NewService(joinRequestRepo)
 
@@ -97,6 +100,10 @@ func NewEventHarness(t *testing.T) *EventHarness {
 			participationService,
 			joinRequestService,
 		),
+		RatingService: ratingapp.NewService(ratingRepo, ratingapp.Settings{
+			GlobalPrior: 4.0,
+			BayesianM:   5,
+		}),
 		AuthRepo: postgresrepo.NewAuthRepository(pool),
 	}
 }

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -69,6 +69,73 @@ func TestCreateEventSuccessPath(t *testing.T) {
 	}
 }
 
+func TestCreateEventPersistsInternalHostParticipationWithoutChangingVisibleCounts(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("internal_host"))
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	categoryID := common.GivenEventCategory(t)
+	lat := 41.11
+	lon := 29.11
+
+	// when
+	result, err := harness.Service.CreateEvent(context.Background(), host.ID, eventapp.CreateEventInput{
+		Title:        "Internal Host Participation Event",
+		Description:  common.StringPtr("host should get an internal membership row"),
+		CategoryID:   &categoryID,
+		LocationType: domain.LocationPoint,
+		Lat:          &lat,
+		Lon:          &lon,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	if err != nil {
+		t.Fatalf("CreateEvent() error = %v", err)
+	}
+
+	eventID, err := uuid.Parse(result.ID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() error = %v", err)
+	}
+
+	var participationStatus string
+	if err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`SELECT status
+		 FROM participation
+		 WHERE event_id = $1
+		   AND user_id = $2`,
+		eventID,
+		host.ID,
+	).Scan(&participationStatus); err != nil {
+		t.Fatalf("load host participation error = %v", err)
+	}
+
+	detail, err := harness.Service.GetEventDetail(context.Background(), host.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+
+	// then
+	if participationStatus != domain.ParticipationStatusApproved {
+		t.Fatalf("expected host participation status %q, got %q", domain.ParticipationStatusApproved, participationStatus)
+	}
+	if detail.ApprovedParticipantCount != 0 {
+		t.Fatalf("expected visible approved_participant_count 0, got %d", detail.ApprovedParticipantCount)
+	}
+	if detail.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusNone) {
+		t.Fatalf("expected host participation_status %q, got %q", domain.EventDetailParticipationStatusNone, detail.ViewerContext.ParticipationStatus)
+	}
+	if detail.HostContext == nil {
+		t.Fatal("expected host_context for host viewer")
+	}
+	if len(detail.HostContext.ApprovedParticipants) != 0 {
+		t.Fatalf("expected host_context approved participants to exclude host, got %d entries", len(detail.HostContext.ApprovedParticipants))
+	}
+}
+
 func TestCreateEventWithoutEndTime(t *testing.T) {
 	t.Parallel()
 
@@ -1279,6 +1346,9 @@ func TestGetEventDetailReturnsHostOnlyManagementLists(t *testing.T) {
 	insertParticipation(t, eventID, participant.ID, domain.ParticipationStatusApproved)
 	insertPendingJoinRequest(t, eventID, requester.ID, host.ID, common.StringPtr("I would like to join"))
 	insertInvitation(t, eventID, host.ID, invitee.ID, domain.InvitationStatusPending, common.StringPtr("Come with us"), nil)
+	insertUserScore(t, participant.ID, nil, 2, nil, 3, float64Ptr(4.4))
+	insertUserScore(t, requester.ID, nil, 1, nil, 1, float64Ptr(3.8))
+	insertUserScore(t, invitee.ID, nil, 0, nil, 6, float64Ptr(4.1))
 
 	// when
 	hostResult, err := harness.Service.GetEventDetail(context.Background(), host.ID, eventID)
@@ -1306,11 +1376,29 @@ func TestGetEventDetailReturnsHostOnlyManagementLists(t *testing.T) {
 	if hostResult.HostContext.ApprovedParticipants[0].User.Username != "approved_user" {
 		t.Fatalf("expected approved participant username %q, got %q", "approved_user", hostResult.HostContext.ApprovedParticipants[0].User.Username)
 	}
+	if hostResult.HostContext.ApprovedParticipants[0].User.FinalScore == nil || *hostResult.HostContext.ApprovedParticipants[0].User.FinalScore != 4.4 {
+		t.Fatalf("expected approved participant final_score 4.4, got %v", hostResult.HostContext.ApprovedParticipants[0].User.FinalScore)
+	}
+	if hostResult.HostContext.ApprovedParticipants[0].User.RatingCount != 5 {
+		t.Fatalf("expected approved participant rating_count 5, got %d", hostResult.HostContext.ApprovedParticipants[0].User.RatingCount)
+	}
 	if hostResult.HostContext.PendingJoinRequests[0].User.Username != "pending_user" {
 		t.Fatalf("expected pending join request username %q, got %q", "pending_user", hostResult.HostContext.PendingJoinRequests[0].User.Username)
 	}
+	if hostResult.HostContext.PendingJoinRequests[0].User.FinalScore == nil || *hostResult.HostContext.PendingJoinRequests[0].User.FinalScore != 3.8 {
+		t.Fatalf("expected pending user final_score 3.8, got %v", hostResult.HostContext.PendingJoinRequests[0].User.FinalScore)
+	}
+	if hostResult.HostContext.PendingJoinRequests[0].User.RatingCount != 2 {
+		t.Fatalf("expected pending user rating_count 2, got %d", hostResult.HostContext.PendingJoinRequests[0].User.RatingCount)
+	}
 	if hostResult.HostContext.Invitations[0].User.Username != "invited_user" {
 		t.Fatalf("expected invitation username %q, got %q", "invited_user", hostResult.HostContext.Invitations[0].User.Username)
+	}
+	if hostResult.HostContext.Invitations[0].User.FinalScore == nil || *hostResult.HostContext.Invitations[0].User.FinalScore != 4.1 {
+		t.Fatalf("expected invited user final_score 4.1, got %v", hostResult.HostContext.Invitations[0].User.FinalScore)
+	}
+	if hostResult.HostContext.Invitations[0].User.RatingCount != 6 {
+		t.Fatalf("expected invited user rating_count 6, got %d", hostResult.HostContext.Invitations[0].User.RatingCount)
 	}
 	if nonHostResult.HostContext != nil {
 		t.Fatal("expected non-host response to omit host_context")
@@ -1655,6 +1743,38 @@ func insertParticipation(t *testing.T, eventID, userID uuid.UUID, status string)
 	return participationID
 }
 
+func insertUserScore(
+	t *testing.T,
+	userID uuid.UUID,
+	participantScore *float64,
+	participantRatingCount int,
+	hostedEventScore *float64,
+	hostedEventRatingCount int,
+	finalScore *float64,
+) {
+	t.Helper()
+
+	if _, err := common.RequirePool(t).Exec(
+		context.Background(),
+		`INSERT INTO user_score (
+			user_id,
+			participant_score,
+			participant_rating_count,
+			hosted_event_score,
+			hosted_event_rating_count,
+			final_score
+		) VALUES ($1, $2, $3, $4, $5, $6)`,
+		userID,
+		participantScore,
+		participantRatingCount,
+		hostedEventScore,
+		hostedEventRatingCount,
+		finalScore,
+	); err != nil {
+		t.Fatalf("insert user_score error = %v", err)
+	}
+}
+
 func insertPendingJoinRequest(t *testing.T, eventID, userID, hostUserID uuid.UUID, message *string) uuid.UUID {
 	t.Helper()
 
@@ -1700,6 +1820,10 @@ func insertInvitation(
 	}
 
 	return invitationID
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
 }
 
 func assertDiscoverEventIDsInOrder(t *testing.T, items []eventapp.DiscoverableEventItem, want ...uuid.UUID) {

--- a/backend/tests_integration/rating_test.go
+++ b/backend/tests_integration/rating_test.go
@@ -1,0 +1,380 @@
+//go:build integration
+
+package tests_integration
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
+	ratingapp "github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestEventRatingUpdatesHostScoreAndEventReadModels(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("rated_host"))
+	participant := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("rated_participant"))
+	startTime := time.Now().UTC().Add(-2 * time.Hour)
+	lat := 41.015
+	lon := 29.02
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Recently Finished Event",
+		Description:  "still inside rating window",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          lat,
+		Lon:          lon,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	insertParticipation(t, eventID, participant.ID, domain.ParticipationStatusApproved)
+	initialMessage := "Excellent hosting."
+	updatedMessage := "Solid overall host."
+
+	// when
+	_, err := harness.RatingService.UpsertEventRating(context.Background(), participant.ID, eventID, ratingapp.UpsertRatingInput{
+		Rating:  5,
+		Message: &initialMessage,
+	})
+	if err != nil {
+		t.Fatalf("UpsertEventRating() create error = %v", err)
+	}
+
+	detailAfterCreate, err := harness.Service.GetEventDetail(context.Background(), participant.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() after create error = %v", err)
+	}
+
+	discoveryAfterCreate, err := harness.Service.DiscoverEvents(context.Background(), participant.ID, eventapp.DiscoverEventsInput{
+		Lat: &lat,
+		Lon: &lon,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverEvents() after create error = %v", err)
+	}
+
+	_, err = harness.RatingService.UpsertEventRating(context.Background(), participant.ID, eventID, ratingapp.UpsertRatingInput{
+		Rating:  3,
+		Message: &updatedMessage,
+	})
+	if err != nil {
+		t.Fatalf("UpsertEventRating() update error = %v", err)
+	}
+
+	detailAfterUpdate, err := harness.Service.GetEventDetail(context.Background(), participant.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() after update error = %v", err)
+	}
+
+	if err := harness.RatingService.DeleteEventRating(context.Background(), participant.ID, eventID); err != nil {
+		t.Fatalf("DeleteEventRating() error = %v", err)
+	}
+
+	detailAfterDelete, err := harness.Service.GetEventDetail(context.Background(), participant.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() after delete error = %v", err)
+	}
+
+	// then
+	expectedCreatedScore := (5.0*1 + 4.0*5) / 6.0
+	if detailAfterCreate.ViewerEventRating == nil || detailAfterCreate.ViewerEventRating.Rating != 5 {
+		t.Fatalf("expected viewer_event_rating after create, got %+v", detailAfterCreate.ViewerEventRating)
+	}
+	requireApproxFloat(t, detailAfterCreate.HostScore.FinalScore, expectedCreatedScore)
+	if detailAfterCreate.HostScore.HostedEventRatingCount != 1 {
+		t.Fatalf("expected host rating count 1 after create, got %d", detailAfterCreate.HostScore.HostedEventRatingCount)
+	}
+	if !detailAfterCreate.RatingWindow.IsActive {
+		t.Fatal("expected rating window to be active")
+	}
+
+	discovered := findDiscoveredEvent(discoveryAfterCreate.Items, eventID)
+	if discovered == nil {
+		t.Fatalf("expected discovery result to contain event %s", eventID)
+	}
+	requireApproxFloat(t, discovered.HostScore.FinalScore, expectedCreatedScore)
+	if discovered.HostScore.HostedEventRatingCount != 1 {
+		t.Fatalf("expected discovery host rating count 1, got %d", discovered.HostScore.HostedEventRatingCount)
+	}
+
+	expectedUpdatedScore := (3.0*1 + 4.0*5) / 6.0
+	if detailAfterUpdate.ViewerEventRating == nil || detailAfterUpdate.ViewerEventRating.Rating != 3 {
+		t.Fatalf("expected viewer_event_rating after update, got %+v", detailAfterUpdate.ViewerEventRating)
+	}
+	requireApproxFloat(t, detailAfterUpdate.HostScore.FinalScore, expectedUpdatedScore)
+
+	if detailAfterDelete.ViewerEventRating != nil {
+		t.Fatalf("expected viewer_event_rating to be nil after delete, got %+v", detailAfterDelete.ViewerEventRating)
+	}
+	if detailAfterDelete.HostScore.FinalScore != nil {
+		t.Fatalf("expected host final score nil after delete, got %v", detailAfterDelete.HostScore.FinalScore)
+	}
+	if detailAfterDelete.HostScore.HostedEventRatingCount != 0 {
+		t.Fatalf("expected host rating count 0 after delete, got %d", detailAfterDelete.HostScore.HostedEventRatingCount)
+	}
+}
+
+func TestHostCannotRateOwnEvent(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("self_rating_host"))
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Host Self Rating Event",
+		Description:  "host should be blocked with the dedicated error",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.02,
+		Lon:          29.03,
+		StartTime:    time.Now().UTC().Add(-2 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+
+	// when
+	_, err := harness.RatingService.UpsertEventRating(context.Background(), host.ID, eventID, ratingapp.UpsertRatingInput{
+		Rating:  5,
+		Message: common.StringPtr("I hosted this perfectly."),
+	})
+
+	// then
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeHostCannotRateSelf)
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T: %v", err, err)
+	}
+	if appErr.Message != "The event host cannot rate their own event." {
+		t.Fatalf("expected host self-rating message, got %q", appErr.Message)
+	}
+}
+
+func TestParticipantRatingUpdatesParticipantScoreAndHostContext(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("participant_rating_host"))
+	participant := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("participant_rating_target"))
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Participant Rated Event",
+		Description:  "host can rate approved users",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.05,
+		Lon:          29.05,
+		StartTime:    time.Now().UTC().Add(-2 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	insertParticipation(t, eventID, participant.ID, domain.ParticipationStatusApproved)
+	initialMessage := "Always communicative."
+	updatedMessage := "Could improve punctuality."
+
+	// when
+	_, err := harness.RatingService.UpsertParticipantRating(context.Background(), host.ID, eventID, participant.ID, ratingapp.UpsertRatingInput{
+		Rating:  5,
+		Message: &initialMessage,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipantRating() create error = %v", err)
+	}
+
+	detailAfterCreate, err := harness.Service.GetEventDetail(context.Background(), host.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() after create error = %v", err)
+	}
+	scoreAfterCreate := queryUserScore(t, participant.ID)
+
+	_, err = harness.RatingService.UpsertParticipantRating(context.Background(), host.ID, eventID, participant.ID, ratingapp.UpsertRatingInput{
+		Rating:  2,
+		Message: &updatedMessage,
+	})
+	if err != nil {
+		t.Fatalf("UpsertParticipantRating() update error = %v", err)
+	}
+
+	detailAfterUpdate, err := harness.Service.GetEventDetail(context.Background(), host.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() after update error = %v", err)
+	}
+	scoreAfterUpdate := queryUserScore(t, participant.ID)
+
+	if err := harness.RatingService.DeleteParticipantRating(context.Background(), host.ID, eventID, participant.ID); err != nil {
+		t.Fatalf("DeleteParticipantRating() error = %v", err)
+	}
+
+	detailAfterDelete, err := harness.Service.GetEventDetail(context.Background(), host.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() after delete error = %v", err)
+	}
+	scoreAfterDelete := queryUserScore(t, participant.ID)
+
+	// then
+	requireParticipantHostRating(t, detailAfterCreate, participant.ID, 5)
+	requireParticipantUserScoreSummary(t, detailAfterCreate, participant.ID, (5.0*1+4.0*5)/6.0, 1)
+	if scoreAfterCreate.ParticipantRatingCount != 1 {
+		t.Fatalf("expected participant rating count 1 after create, got %d", scoreAfterCreate.ParticipantRatingCount)
+	}
+	requireApproxFloat(t, scoreAfterCreate.ParticipantScore, 5.0)
+	requireApproxFloat(t, scoreAfterCreate.FinalScore, (5.0*1+4.0*5)/6.0)
+
+	requireParticipantHostRating(t, detailAfterUpdate, participant.ID, 2)
+	requireParticipantUserScoreSummary(t, detailAfterUpdate, participant.ID, (2.0*1+4.0*5)/6.0, 1)
+	requireApproxFloat(t, scoreAfterUpdate.ParticipantScore, 2.0)
+	requireApproxFloat(t, scoreAfterUpdate.FinalScore, (2.0*1+4.0*5)/6.0)
+
+	requireParticipantHostRatingNil(t, detailAfterDelete, participant.ID)
+	requireParticipantUserScoreSummaryNil(t, detailAfterDelete, participant.ID)
+	if scoreAfterDelete.ParticipantRatingCount != 0 {
+		t.Fatalf("expected participant rating count 0 after delete, got %d", scoreAfterDelete.ParticipantRatingCount)
+	}
+	if scoreAfterDelete.ParticipantScore != nil {
+		t.Fatalf("expected participant score nil after delete, got %v", scoreAfterDelete.ParticipantScore)
+	}
+	if scoreAfterDelete.FinalScore != nil {
+		t.Fatalf("expected final score nil after delete, got %v", scoreAfterDelete.FinalScore)
+	}
+}
+
+func queryUserScore(t *testing.T, userID uuid.UUID) *domain.UserScore {
+	t.Helper()
+
+	var (
+		record           domain.UserScore
+		participantScore pgtype.Float8
+		hostedEventScore pgtype.Float8
+		finalScore       pgtype.Float8
+	)
+
+	err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`SELECT user_id, participant_score, participant_rating_count, hosted_event_score, hosted_event_rating_count, final_score, created_at, updated_at
+		 FROM user_score
+		 WHERE user_id = $1`,
+		userID,
+	).Scan(
+		&record.UserID,
+		&participantScore,
+		&record.ParticipantRatingCount,
+		&hostedEventScore,
+		&record.HostedEventRatingCount,
+		&finalScore,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+	)
+	if err != nil {
+		t.Fatalf("query user_score error = %v", err)
+	}
+
+	if participantScore.Valid {
+		record.ParticipantScore = &participantScore.Float64
+	}
+	if hostedEventScore.Valid {
+		record.HostedEventScore = &hostedEventScore.Float64
+	}
+	if finalScore.Valid {
+		record.FinalScore = &finalScore.Float64
+	}
+
+	return &record
+}
+
+func findDiscoveredEvent(items []eventapp.DiscoverableEventItem, eventID uuid.UUID) *eventapp.DiscoverableEventItem {
+	for i := range items {
+		if items[i].ID == eventID.String() {
+			return &items[i]
+		}
+	}
+
+	return nil
+}
+
+func requireParticipantUserScoreSummary(
+	t *testing.T,
+	detail *eventapp.GetEventDetailResult,
+	participantUserID uuid.UUID,
+	expectedFinalScore float64,
+	expectedRatingCount int,
+) {
+	t.Helper()
+
+	participant := requireApprovedParticipant(t, detail, participantUserID)
+	requireApproxFloat(t, participant.User.FinalScore, expectedFinalScore)
+	if participant.User.RatingCount != expectedRatingCount {
+		t.Fatalf("expected participant rating_count %d, got %d", expectedRatingCount, participant.User.RatingCount)
+	}
+}
+
+func requireParticipantUserScoreSummaryNil(t *testing.T, detail *eventapp.GetEventDetailResult, participantUserID uuid.UUID) {
+	t.Helper()
+
+	participant := requireApprovedParticipant(t, detail, participantUserID)
+	if participant.User.FinalScore != nil {
+		t.Fatalf("expected nil participant final_score, got %v", participant.User.FinalScore)
+	}
+	if participant.User.RatingCount != 0 {
+		t.Fatalf("expected participant rating_count 0, got %d", participant.User.RatingCount)
+	}
+}
+
+func requireParticipantHostRating(t *testing.T, detail *eventapp.GetEventDetailResult, participantUserID uuid.UUID, expectedRating int) {
+	t.Helper()
+
+	participant := requireApprovedParticipant(t, detail, participantUserID)
+	if participant.HostRating == nil {
+		t.Fatalf("expected host_rating for participant %s", participantUserID)
+	}
+	if participant.HostRating.Rating != expectedRating {
+		t.Fatalf("expected host_rating %d, got %d", expectedRating, participant.HostRating.Rating)
+	}
+}
+
+func requireParticipantHostRatingNil(t *testing.T, detail *eventapp.GetEventDetailResult, participantUserID uuid.UUID) {
+	t.Helper()
+
+	participant := requireApprovedParticipant(t, detail, participantUserID)
+	if participant.HostRating != nil {
+		t.Fatalf("expected nil host_rating for participant %s, got %+v", participantUserID, participant.HostRating)
+	}
+}
+
+func requireApprovedParticipant(
+	t *testing.T,
+	detail *eventapp.GetEventDetailResult,
+	participantUserID uuid.UUID,
+) eventapp.EventDetailApprovedParticipant {
+	t.Helper()
+
+	if detail.HostContext == nil {
+		t.Fatal("expected host_context")
+	}
+
+	for _, participant := range detail.HostContext.ApprovedParticipants {
+		if participant.User.ID == participantUserID.String() {
+			return participant
+		}
+	}
+
+	t.Fatalf("expected participant %s in approved list", participantUserID)
+	return eventapp.EventDetailApprovedParticipant{}
+}
+
+func requireApproxFloat(t *testing.T, actual *float64, expected float64) {
+	t.Helper()
+
+	if actual == nil {
+		t.Fatalf("expected %.6f, got nil", expected)
+	}
+	if math.Abs(*actual-expected) > 0.00001 {
+		t.Fatalf("expected %.6f, got %.6f", expected, *actual)
+	}
+}

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -245,6 +245,73 @@ CREATE INDEX idx_participation_event_id ON participation(event_id);
 CREATE INDEX idx_participation_user_id ON participation(user_id);
 
 -- =========================
+-- EVENT RATING
+-- =========================
+CREATE TABLE event_rating (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    participant_user_id UUID NOT NULL,
+    event_id UUID NOT NULL,
+    rating INT NOT NULL,
+    message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_event_rating_participant FOREIGN KEY (participant_user_id) REFERENCES app_user(id) ON DELETE CASCADE,
+    CONSTRAINT fk_event_rating_event FOREIGN KEY (event_id) REFERENCES event(id) ON DELETE CASCADE,
+    CONSTRAINT uq_event_rating_participant_event UNIQUE (participant_user_id, event_id),
+    CONSTRAINT chk_event_rating_rating CHECK (rating BETWEEN 1 AND 5),
+    CONSTRAINT chk_event_rating_message CHECK (message IS NULL OR char_length(message) BETWEEN 10 AND 100)
+);
+
+CREATE INDEX idx_event_rating_event_id ON event_rating(event_id);
+CREATE INDEX idx_event_rating_participant_user_id ON event_rating(participant_user_id);
+
+-- =========================
+-- PARTICIPANT RATING
+-- =========================
+CREATE TABLE participant_rating (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    host_user_id UUID NOT NULL,
+    participant_user_id UUID NOT NULL,
+    event_id UUID NOT NULL,
+    rating INT NOT NULL,
+    message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_participant_rating_host FOREIGN KEY (host_user_id) REFERENCES app_user(id) ON DELETE CASCADE,
+    CONSTRAINT fk_participant_rating_participant FOREIGN KEY (participant_user_id) REFERENCES app_user(id) ON DELETE CASCADE,
+    CONSTRAINT fk_participant_rating_event FOREIGN KEY (event_id) REFERENCES event(id) ON DELETE CASCADE,
+    CONSTRAINT uq_participant_rating_host_participant_event UNIQUE (host_user_id, participant_user_id, event_id),
+    CONSTRAINT chk_participant_rating_rating CHECK (rating BETWEEN 1 AND 5),
+    CONSTRAINT chk_participant_rating_message CHECK (message IS NULL OR char_length(message) BETWEEN 10 AND 100)
+);
+
+CREATE INDEX idx_participant_rating_event_id ON participant_rating(event_id);
+CREATE INDEX idx_participant_rating_host_user_id ON participant_rating(host_user_id);
+CREATE INDEX idx_participant_rating_participant_user_id ON participant_rating(participant_user_id);
+
+-- =========================
+-- USER SCORE
+-- =========================
+CREATE TABLE user_score (
+    user_id UUID PRIMARY KEY,
+    participant_score DOUBLE PRECISION,
+    participant_rating_count INT NOT NULL DEFAULT 0,
+    hosted_event_score DOUBLE PRECISION,
+    hosted_event_rating_count INT NOT NULL DEFAULT 0,
+    final_score DOUBLE PRECISION,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_user_score_user FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE,
+    CONSTRAINT chk_user_score_counts CHECK (
+        participant_rating_count >= 0 AND
+        hosted_event_rating_count >= 0
+    )
+);
+
+-- =========================
 -- FAVORITE EVENT
 -- =========================
 CREATE TABLE favorite_event (
@@ -501,65 +568,85 @@ EXECUTE FUNCTION refresh_event_tag_text();
 CREATE OR REPLACE FUNCTION sync_participation_counts() RETURNS trigger AS $$
 BEGIN
     IF TG_OP = 'DELETE' THEN
-        UPDATE event
+        UPDATE event e
         SET
             approved_participant_count = (
-                SELECT COUNT(*) FROM participation
-                WHERE event_id = OLD.event_id AND status = 'APPROVED'
+                SELECT COUNT(*) FROM participation p
+                WHERE p.event_id = OLD.event_id
+                  AND p.status = 'APPROVED'
+                  AND p.user_id <> e.host_id
             ),
             pending_participant_count = (
-                SELECT COUNT(*) FROM participation
-                WHERE event_id = OLD.event_id AND status = 'PENDING'
+                SELECT COUNT(*) FROM participation p
+                WHERE p.event_id = OLD.event_id
+                  AND p.status = 'PENDING'
+                  AND p.user_id <> e.host_id
             )
-        WHERE id = OLD.event_id;
+        WHERE e.id = OLD.event_id;
     ELSIF TG_OP = 'INSERT' THEN
-        UPDATE event
+        UPDATE event e
         SET
             approved_participant_count = (
-                SELECT COUNT(*) FROM participation
-                WHERE event_id = NEW.event_id AND status = 'APPROVED'
+                SELECT COUNT(*) FROM participation p
+                WHERE p.event_id = NEW.event_id
+                  AND p.status = 'APPROVED'
+                  AND p.user_id <> e.host_id
             ),
             pending_participant_count = (
-                SELECT COUNT(*) FROM participation
-                WHERE event_id = NEW.event_id AND status = 'PENDING'
+                SELECT COUNT(*) FROM participation p
+                WHERE p.event_id = NEW.event_id
+                  AND p.status = 'PENDING'
+                  AND p.user_id <> e.host_id
             )
-        WHERE id = NEW.event_id;
+        WHERE e.id = NEW.event_id;
     ELSIF TG_OP = 'UPDATE' THEN
         IF OLD.event_id IS DISTINCT FROM NEW.event_id THEN
-            UPDATE event
+            UPDATE event e
             SET
                 approved_participant_count = (
-                    SELECT COUNT(*) FROM participation
-                    WHERE event_id = OLD.event_id AND status = 'APPROVED'
+                    SELECT COUNT(*) FROM participation p
+                    WHERE p.event_id = OLD.event_id
+                      AND p.status = 'APPROVED'
+                      AND p.user_id <> e.host_id
                 ),
                 pending_participant_count = (
-                    SELECT COUNT(*) FROM participation
-                    WHERE event_id = OLD.event_id AND status = 'PENDING'
+                    SELECT COUNT(*) FROM participation p
+                    WHERE p.event_id = OLD.event_id
+                      AND p.status = 'PENDING'
+                      AND p.user_id <> e.host_id
                 )
-            WHERE id = OLD.event_id;
-            UPDATE event
+            WHERE e.id = OLD.event_id;
+            UPDATE event e
             SET
                 approved_participant_count = (
-                    SELECT COUNT(*) FROM participation
-                    WHERE event_id = NEW.event_id AND status = 'APPROVED'
+                    SELECT COUNT(*) FROM participation p
+                    WHERE p.event_id = NEW.event_id
+                      AND p.status = 'APPROVED'
+                      AND p.user_id <> e.host_id
                 ),
                 pending_participant_count = (
-                    SELECT COUNT(*) FROM participation
-                    WHERE event_id = NEW.event_id AND status = 'PENDING'
+                    SELECT COUNT(*) FROM participation p
+                    WHERE p.event_id = NEW.event_id
+                      AND p.status = 'PENDING'
+                      AND p.user_id <> e.host_id
                 )
-            WHERE id = NEW.event_id;
+            WHERE e.id = NEW.event_id;
         ELSE
-            UPDATE event
+            UPDATE event e
             SET
                 approved_participant_count = (
-                    SELECT COUNT(*) FROM participation
-                    WHERE event_id = NEW.event_id AND status = 'APPROVED'
+                    SELECT COUNT(*) FROM participation p
+                    WHERE p.event_id = NEW.event_id
+                      AND p.status = 'APPROVED'
+                      AND p.user_id <> e.host_id
                 ),
                 pending_participant_count = (
-                    SELECT COUNT(*) FROM participation
-                    WHERE event_id = NEW.event_id AND status = 'PENDING'
+                    SELECT COUNT(*) FROM participation p
+                    WHERE p.event_id = NEW.event_id
+                      AND p.status = 'PENDING'
+                      AND p.user_id <> e.host_id
                 )
-            WHERE id = NEW.event_id;
+            WHERE e.id = NEW.event_id;
         END IF;
     END IF;
 

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -39,9 +39,13 @@ paths:
         Response notes:
         - `status` is returned exactly as stored on the event row; canceled and completed
           events remain readable.
+        - `host_score` returns the host's cached aggregate rating summary used by discovery cards.
+        - `rating_window` describes the event-specific 7-day mutation window computed from `COALESCE(end_time, start_time)`.
+        - `viewer_event_rating` returns the authenticated participant's current rating for the event, if one exists.
         - `viewer_context` is always present and resolves the caller's favorite and
           participation state.
-        - `host_context` is included only when the authenticated user is the event host.
+        - `host_context` is included only when the authenticated user is the event host; approved participants may include a `host_rating`.
+        - `host_context.*.user` includes the managed user's cached `final_score` and total `rating_count`.
       operationId: getEventDetail
       security:
         - bearerAuth: []
@@ -88,6 +92,9 @@ paths:
                       username: host_user
                       display_name: Host User
                       avatar_url: https://example.com/avatar.png
+                    host_score:
+                      final_score: 4.18
+                      hosted_event_rating_count: 9
                     location:
                       type: POINT
                       address: Belgrad Forest, Istanbul
@@ -98,6 +105,16 @@ paths:
                     constraints:
                       - type: equipment
                         info: Trail running shoes required
+                    rating_window:
+                      opens_at: "2026-05-01T12:00:00+03:00"
+                      closes_at: "2026-05-08T12:00:00+03:00"
+                      is_active: true
+                    viewer_event_rating:
+                      id: 09d1e583-7554-43a7-b21f-3e7f03804e0f
+                      rating: 5
+                      message: Great event host.
+                      created_at: "2026-05-02T11:00:00+03:00"
+                      updated_at: "2026-05-02T11:00:00+03:00"
                     viewer_context:
                       is_host: false
                       is_favorited: true
@@ -128,6 +145,9 @@ paths:
                       username: host_user
                       display_name: Host User
                       avatar_url: https://example.com/avatar.png
+                    host_score:
+                      final_score: 4.18
+                      hosted_event_rating_count: 9
                     location:
                       type: ROUTE
                       address: Belgrad Forest, Istanbul
@@ -140,6 +160,11 @@ paths:
                     constraints:
                       - type: equipment
                         info: Trail running shoes required
+                    rating_window:
+                      opens_at: "2026-05-01T12:00:00+03:00"
+                      closes_at: "2026-05-08T12:00:00+03:00"
+                      is_active: false
+                    viewer_event_rating: null
                     viewer_context:
                       is_host: true
                       is_favorited: false
@@ -150,11 +175,19 @@ paths:
                           status: APPROVED
                           created_at: "2026-03-26T13:00:00+03:00"
                           updated_at: "2026-03-26T13:00:00+03:00"
+                          host_rating:
+                            id: 8395efb1-053b-4d14-8da5-ded573efbf5d
+                            rating: 4
+                            message: Reliable participant.
+                            created_at: "2026-05-02T12:15:00+03:00"
+                            updated_at: "2026-05-02T12:15:00+03:00"
                           user:
                             id: 6a5d08d6-b9f2-49c8-baea-0f39c34082f8
                             username: approved_user
                             display_name: Approved User
                             avatar_url: https://example.com/approved.png
+                            final_score: 4.4
+                            rating_count: 5
                       pending_join_requests:
                         - join_request_id: b2c3d4e5-f6a7-8901-bcde-f01234567890
                           status: PENDING
@@ -166,6 +199,8 @@ paths:
                             username: pending_user
                             display_name: Pending User
                             avatar_url: https://example.com/pending.png
+                            final_score: 3.8
+                            rating_count: 2
                       invitations:
                         - invitation_id: c3d4e5f6-a7b8-9012-cdef-012345678901
                           status: ACCEPTED
@@ -178,6 +213,8 @@ paths:
                             username: invited_user
                             display_name: Invited User
                             avatar_url: https://example.com/invited.png
+                            final_score: 4.1
+                            rating_count: 6
         '400':
           description: Invalid event ID format.
           content:
@@ -212,6 +249,250 @@ paths:
                       message: The requested event does not exist.
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /events/{id}/rating:
+    put:
+      tags: [Events]
+      summary: Create or update the caller's event rating
+      description: |
+        Creates or updates the authenticated participant's rating for the event.
+
+        Rules:
+        - The authenticated user must be an `APPROVED` participant of the event.
+        - The event host cannot rate their own event, even though hosts have an internal approved participation row.
+        - Ratings are allowed only within the 7-day window computed from `COALESCE(end_time, start_time)`.
+        - `CANCELED` events cannot be rated.
+        - The resource is singular per `(participant_user_id, event_id)`, so repeated `PUT` requests update the same record.
+      operationId: upsertEventRating
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RatingWriteRequest'
+      responses:
+        '200':
+          description: Event rating created or updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatingResponse'
+        '400':
+          description: Invalid event id or request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Caller is not allowed to rate this event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Rating window is closed or the event is not rateable in its current state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+    delete:
+      tags: [Events]
+      summary: Delete the caller's event rating
+      description: |
+        Hard deletes the authenticated participant's rating for the event.
+        The same authorization and rating-window rules used by `PUT /events/{id}/rating` also apply here.
+      operationId: deleteEventRating
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Event rating deleted successfully.
+        '400':
+          description: Invalid event id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Caller is not allowed to delete this event rating.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event or rating record does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Rating window is closed or the event is not rateable in its current state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /events/{id}/participants/{participantUserId}/rating:
+    put:
+      tags: [Events]
+      summary: Create or update a host rating for a participant
+      description: |
+        Creates or updates the authenticated host's rating for an approved participant of the event.
+
+        Rules:
+        - The authenticated user must host the event.
+        - The target user must be an `APPROVED` participant of the same event.
+        - Hosts cannot rate themselves.
+        - Ratings are allowed only within the 7-day window computed from `COALESCE(end_time, start_time)`.
+        - `CANCELED` events cannot be rated.
+      operationId: upsertParticipantRating
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: participantUserId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RatingWriteRequest'
+      responses:
+        '200':
+          description: Participant rating created or updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatingResponse'
+        '400':
+          description: Invalid path id or request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Caller is not allowed to rate this participant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Rating window is closed or the event is not rateable in its current state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+    delete:
+      tags: [Events]
+      summary: Delete a host rating for a participant
+      description: |
+        Hard deletes the authenticated host's rating for an approved participant of the event.
+        The same authorization and rating-window rules used by `PUT /events/{id}/participants/{participantUserId}/rating` also apply here.
+      operationId: deleteParticipantRating
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: participantUserId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Participant rating deleted successfully.
+        '400':
+          description: Invalid path id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Caller is not allowed to delete this participant rating.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event or rating record does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Rating window is closed or the event is not rateable in its current state.
           content:
             application/json:
               schema:
@@ -604,6 +885,9 @@ paths:
                         privacy_level: PUBLIC
                         approved_participant_count: 42
                         is_favorited: true
+                        host_score:
+                          final_score: 4.18
+                          hosted_event_rating_count: 9
                       - id: 7a2c8b1e-3d4f-5e6a-bcde-f90123456789
                         title: Bosphorus Ride
                         category_name: Fitness
@@ -613,6 +897,9 @@ paths:
                         privacy_level: PROTECTED
                         approved_participant_count: 18
                         is_favorited: false
+                        host_score:
+                          final_score: null
+                          hosted_event_rating_count: 0
                     page_info:
                       next_cursor: eyJzb3J0X2J5IjoiU1RBUlRfVElNRSIsImZpbHRlcl9maW5nZXJwcmludCI6IjQ2MmEifQ
                       has_next: true
@@ -1036,6 +1323,7 @@ components:
         - privacy_level
         - approved_participant_count
         - is_favorited
+        - host_score
       properties:
         id:
           type: string
@@ -1081,6 +1369,8 @@ components:
           type: boolean
           description: Whether the authenticated user has favorited the event.
           example: true
+        host_score:
+          $ref: '#/components/schemas/EventHostScoreSummary'
 
     DiscoverEventsPageInfo:
       type: object
@@ -1113,9 +1403,12 @@ components:
         - created_at
         - updated_at
         - host
+        - host_score
         - location
         - tags
         - constraints
+        - rating_window
+        - viewer_event_rating
         - viewer_context
       properties:
         id:
@@ -1196,6 +1489,8 @@ components:
             - type: "null"
         host:
           $ref: '#/components/schemas/EventDetailUserSummary'
+        host_score:
+          $ref: '#/components/schemas/EventHostScoreSummary'
         location:
           $ref: '#/components/schemas/EventDetailLocation'
         tags:
@@ -1207,6 +1502,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConstraintInput'
+        rating_window:
+          $ref: '#/components/schemas/EventDetailRatingWindow'
+        viewer_event_rating:
+          oneOf:
+            - $ref: '#/components/schemas/EventDetailEmbeddedRating'
+            - type: "null"
         viewer_context:
           $ref: '#/components/schemas/EventDetailViewerContext'
         host_context:
@@ -1247,6 +1548,38 @@ components:
             - string
             - "null"
           example: https://example.com/avatar.png
+
+    EventDetailHostContextUserSummary:
+      type: object
+      additionalProperties: false
+      required: [id, username, final_score, rating_count]
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+          example: approved_user
+        display_name:
+          type:
+            - string
+            - "null"
+          example: Approved User
+        avatar_url:
+          type:
+            - string
+            - "null"
+          example: https://example.com/avatar.png
+        final_score:
+          type:
+            - number
+            - "null"
+          format: double
+          example: 4.4
+        rating_count:
+          type: integer
+          minimum: 0
+          example: 5
 
     EventDetailLocation:
       type: object
@@ -1301,6 +1634,59 @@ components:
             approved participation -> `JOINED`, pending join request -> `PENDING`,
             invitation row -> `INVITED`, otherwise `NONE`.
 
+    EventHostScoreSummary:
+      type: object
+      additionalProperties: false
+      required: [final_score, hosted_event_rating_count]
+      properties:
+        final_score:
+          type:
+            - number
+            - "null"
+          format: double
+          example: 4.18
+        hosted_event_rating_count:
+          type: integer
+          minimum: 0
+          example: 9
+
+    EventDetailRatingWindow:
+      type: object
+      additionalProperties: false
+      required: [opens_at, closes_at, is_active]
+      properties:
+        opens_at:
+          type: string
+          format: date-time
+        closes_at:
+          type: string
+          format: date-time
+        is_active:
+          type: boolean
+
+    EventDetailEmbeddedRating:
+      type: object
+      additionalProperties: false
+      required: [id, rating, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+        message:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
     EventDetailHostContext:
       type: object
       additionalProperties: false
@@ -1322,7 +1708,7 @@ components:
     EventDetailApprovedParticipant:
       type: object
       additionalProperties: false
-      required: [participation_id, status, created_at, updated_at, user]
+      required: [participation_id, status, created_at, updated_at, host_rating, user]
       properties:
         participation_id:
           type: string
@@ -1336,8 +1722,12 @@ components:
         updated_at:
           type: string
           format: date-time
+        host_rating:
+          oneOf:
+            - $ref: '#/components/schemas/EventDetailEmbeddedRating'
+            - type: "null"
         user:
-          $ref: '#/components/schemas/EventDetailUserSummary'
+          $ref: '#/components/schemas/EventDetailHostContextUserSummary'
 
     EventDetailPendingJoinRequest:
       type: object
@@ -1362,7 +1752,7 @@ components:
           type: string
           format: date-time
         user:
-          $ref: '#/components/schemas/EventDetailUserSummary'
+          $ref: '#/components/schemas/EventDetailHostContextUserSummary'
 
     EventDetailInvitation:
       type: object
@@ -1393,7 +1783,49 @@ components:
           type: string
           format: date-time
         user:
-          $ref: '#/components/schemas/EventDetailUserSummary'
+          $ref: '#/components/schemas/EventDetailHostContextUserSummary'
+
+    RatingWriteRequest:
+      type: object
+      additionalProperties: false
+      required: [rating]
+      properties:
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+          example: 5
+        message:
+          type:
+            - string
+            - "null"
+          minLength: 10
+          maxLength: 100
+          description: Optional feedback message. Blank-after-trim strings are treated as `null`.
+          example: Great event host.
+
+    RatingResponse:
+      type: object
+      additionalProperties: false
+      required: [id, rating, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+        message:
+          type:
+            - string
+            - "null"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
 
     CreateEventResponse:
       type: object


### PR DESCRIPTION
## 📋 Summary
This PR adds the backend for the post-event mutual rating system. Participants can rate events, hosts can rate approved participants, ratings are stored in separate tables, aggregate user scores are recalculated with Bayesian smoothing, and host score data is embedded into event responses.

## 🔄 Changes
- Added `event_rating`, `participant_rating`, and `user_score` tables with the required `CHECK`, `UNIQUE`, and foreign key constraints.
- Introduced a new backend rating module for both participant -> event and host -> participant rating flows.
- Added new endpoints:
  - `PUT /events/{id}/rating`
  - `DELETE /events/{id}/rating`
  - `PUT /events/{id}/participants/{participantUserId}/rating`
  - `DELETE /events/{id}/participants/{participantUserId}/rating`
- Implemented score refresh logic so every rating create/update/delete recalculates the affected user’s aggregates from the database and upserts `user_score`.
- Implemented Bayesian smoothing plus weighted final score calculation (`0.6 hosted + 0.4 participant`) in the backend.
- Extended `GET /events` responses with the host’s `final_score` and `hosted_event_rating_count`.
- Extended `GET /events/{id}` responses with `host_score`, `rating_window`, `viewer_event_rating`, and participant-level `host_rating` for hosts.
- Added a dedicated self-rating guard so hosts cannot rate their own events and now receive a host-specific error instead of the generic approved-participant error.
- Added an internal default `APPROVED` participation for each host at event creation time, plus a backfill migration for existing events.
- Updated trigger/query logic so the host’s internal participation does not affect visible participant counts or appear in the host_context approved participant list.
- Enriched `host_context.approved_participants`, `pending_join_requests`, and `invitations` user objects in event details with `final_score` and total `rating_count`.
- Added `rating_global_prior` and `rating_bayesian_m` to backend config.
- Updated OpenAPI docs and `docs/db/schema.sql`.
- Expanded unit, handler, and integration test coverage for the new rating flows and read model changes.

## 🧪 Testing
- `go test ./...`
- `go test -tags=integration ./tests_integration/...`
- `./shipcheck.sh`

## 🔗 Related
Closes #149
