### PR TITLE
feat(frontend): add create event page with form, validation, and succ…

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -10,7 +10,6 @@ const PUBLIC_NAV = [
 
 const AUTH_NAV = [
   { to: '/discover', label: 'Discover' },
-  { to: '/events/create', label: 'Create Event' },
   { to: '/my-events', label: 'My Events' },
   { to: '/invitations', label: 'Invitations' },
   { to: '/favorites', label: 'Favorites' },
@@ -76,34 +75,39 @@ export default function AppShell() {
 
           <div className="shell-header-right">
             {isLoggedIn ? (
-              <div className="shell-user-menu" ref={userMenuRef}>
-                <button
-                  className="shell-user-btn"
-                  onClick={() => setUserMenuOpen((prev) => !prev)}
-                >
-                  <span className="shell-avatar">
-                    {username ? username[0].toUpperCase() : '?'}
-                  </span>
-                  <span className="shell-username">{username}</span>
-                </button>
-                {userMenuOpen && (
-                  <div className="shell-dropdown">
-                    <NavLink
-                      to="/profile"
-                      className="shell-dropdown-item"
-                      onClick={() => setUserMenuOpen(false)}
-                    >
-                      Profile
-                    </NavLink>
-                    <button
-                      className="shell-dropdown-item shell-dropdown-logout"
-                      onClick={handleLogout}
-                    >
-                      Sign Out
-                    </button>
-                  </div>
-                )}
-              </div>
+              <>
+                <NavLink to="/events/create" className="shell-create-btn">
+                  + Create Event
+                </NavLink>
+                <div className="shell-user-menu" ref={userMenuRef}>
+                  <button
+                    className="shell-user-btn"
+                    onClick={() => setUserMenuOpen((prev) => !prev)}
+                  >
+                    <span className="shell-avatar">
+                      {username ? username[0].toUpperCase() : '?'}
+                    </span>
+                    <span className="shell-username">{username}</span>
+                  </button>
+                  {userMenuOpen && (
+                    <div className="shell-dropdown">
+                      <NavLink
+                        to="/profile"
+                        className="shell-dropdown-item"
+                        onClick={() => setUserMenuOpen(false)}
+                      >
+                        Profile
+                      </NavLink>
+                      <button
+                        className="shell-dropdown-item shell-dropdown-logout"
+                        onClick={handleLogout}
+                      >
+                        Sign Out
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </>
             ) : (
               <div className="shell-auth-buttons">
                 <NavLink to="/login" className="shell-signin-btn">

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,0 +1,58 @@
+export type PrivacyLevel = 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+export type LocationType = 'POINT' | 'ROUTE';
+export type PreferredGender = 'MALE' | 'FEMALE' | 'OTHER';
+
+export interface EventConstraint {
+  type: string;
+  info: string;
+}
+
+export interface RoutePoint {
+  lat: number;
+  lon: number;
+}
+
+export interface CreateEventRequest {
+  title: string;
+  description: string;
+  image_url?: string;
+  category_id: number;
+  address?: string;
+  lat?: number;
+  lon?: number;
+  location_type: LocationType;
+  route_points?: RoutePoint[];
+  start_time: string;
+  end_time?: string;
+  capacity?: number;
+  privacy_level: PrivacyLevel;
+  tags?: string[];
+  constraints?: EventConstraint[];
+  minimum_age?: number;
+  preferred_gender?: PreferredGender;
+}
+
+export interface CreateEventResponse {
+  id: string;
+  title: string;
+  privacy_level: PrivacyLevel;
+  status: string;
+  start_time: string;
+  end_time?: string;
+  created_at: string;
+}
+
+export interface CategoryItem {
+  id: number;
+  name: string;
+}
+
+export interface ListCategoriesResponse {
+  items: CategoryItem[];
+}
+
+export interface LocationSuggestion {
+  display_name: string;
+  lat: string;
+  lon: string;
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -15,6 +15,18 @@ export class ApiError extends Error {
   }
 }
 
+async function handleErrorResponse(response: Response): Promise<never> {
+  try {
+    const errorBody: ErrorResponse = await response.json();
+    throw new ApiError(response.status, errorBody);
+  } catch (err) {
+    if (err instanceof ApiError) throw err;
+    throw new ApiError(response.status, {
+      error: { code: 'network_error', message: `Request failed (${response.status})` },
+    });
+  }
+}
+
 export async function apiPost<T>(endpoint: string, body: unknown): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${endpoint}`, {
     method: 'POST',
@@ -23,12 +35,49 @@ export async function apiPost<T>(endpoint: string, body: unknown): Promise<T> {
   });
 
   if (!response.ok) {
-    const errorBody: ErrorResponse = await response.json();
-    throw new ApiError(response.status, errorBody);
+    await handleErrorResponse(response);
   }
 
   if (response.status === 204) {
     return undefined as T;
+  }
+
+  return response.json();
+}
+
+export async function apiPostAuth<T>(
+  endpoint: string,
+  body: unknown,
+  token: string,
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json();
+}
+
+export async function apiGet<T>(endpoint: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
   }
 
   return response.json();

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -1,0 +1,35 @@
+import { apiPostAuth, apiGet } from './api';
+import {
+  CreateEventRequest,
+  CreateEventResponse,
+  ListCategoriesResponse,
+  LocationSuggestion,
+} from '@/models/event';
+
+const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
+
+export function createEvent(
+  request: CreateEventRequest,
+  token: string,
+): Promise<CreateEventResponse> {
+  return apiPostAuth<CreateEventResponse>('/events/', request, token);
+}
+
+export function listCategories(): Promise<ListCategoriesResponse> {
+  return apiGet<ListCategoriesResponse>('/categories/');
+}
+
+export async function searchLocation(
+  query: string,
+): Promise<LocationSuggestion[]> {
+  const params = new URLSearchParams({
+    q: query,
+    format: 'json',
+    limit: '5',
+  });
+  const response = await fetch(`${NOMINATIM_BASE}/search?${params}`, {
+    headers: { 'User-Agent': 'SocialEventMapper/1.0' },
+  });
+  if (!response.ok) return [];
+  return response.json();
+}

--- a/frontend/src/styles/create-event.css
+++ b/frontend/src/styles/create-event.css
@@ -1,0 +1,347 @@
+.create-event-page {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.create-event-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 8px;
+}
+
+.create-event-subtitle {
+  font-size: 15px;
+  color: #6b7280;
+  margin-bottom: 32px;
+}
+
+.create-event-form {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Success banner */
+.success-banner {
+  background-color: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+  color: #16a34a;
+  font-size: 14px;
+}
+
+/* Host info */
+.ce-host-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 24px;
+  padding: 12px 16px;
+  background-color: #f9fafb;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+}
+
+.ce-host-label {
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.ce-host-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+}
+
+/* Character count */
+.ce-char-count {
+  text-align: right;
+  font-size: 12px;
+  color: #9ca3af;
+  margin-top: 4px;
+}
+
+/* Textarea */
+.ce-textarea {
+  resize: vertical;
+  min-height: 100px;
+  font-family: inherit;
+}
+
+/* Row layout */
+.ce-row {
+  display: flex;
+  gap: 16px;
+}
+
+.ce-flex-1 {
+  flex: 1;
+}
+
+/* Short input */
+.ce-short-input {
+  max-width: 200px;
+}
+
+/* Category grid */
+.ce-category-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ce-category-chip {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid #d1d5db;
+  background-color: #f9fafb;
+  font-size: 13px;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ce-category-chip:hover {
+  border-color: #2563eb;
+}
+
+.ce-category-chip.selected {
+  background-color: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+/* Privacy chips */
+.ce-privacy-row {
+  display: flex;
+  gap: 8px;
+}
+
+.ce-privacy-chip {
+  padding: 8px 18px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background-color: #f9fafb;
+  font-size: 14px;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ce-privacy-chip:hover {
+  border-color: #2563eb;
+}
+
+.ce-privacy-chip.selected {
+  background-color: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+/* Location */
+.ce-location-wrapper {
+  position: relative;
+}
+
+.ce-location-searching {
+  font-size: 13px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.ce-location-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-height: 220px;
+  overflow-y: auto;
+  z-index: 50;
+  list-style: none;
+  margin-top: 4px;
+}
+
+.ce-location-item {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 14px;
+  color: #374151;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.ce-location-item:hover {
+  background-color: #f3f4f6;
+}
+
+.ce-selected-location {
+  font-size: 13px;
+  color: #16a34a;
+  margin-top: 6px;
+}
+
+/* Tags */
+.ce-tag-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.ce-tag-input {
+  flex: 1;
+}
+
+.ce-tag-add-btn {
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: 1px solid #2563eb;
+  background-color: #2563eb;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s;
+}
+
+.ce-tag-add-btn:hover:not(:disabled) {
+  background-color: #1d4ed8;
+}
+
+.ce-tag-add-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ce-tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.ce-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 20px;
+  background-color: #eff6ff;
+  color: #2563eb;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.ce-tag-remove {
+  background: none;
+  border: none;
+  color: #2563eb;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.ce-tag-remove:hover {
+  color: #dc2626;
+}
+
+/* Constraints section */
+.ce-constraints-section {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.ce-constraints-section legend {
+  padding: 0 8px;
+}
+
+.ce-sub-label {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+/* Submit button */
+.ce-submit {
+  margin-top: 12px;
+  margin-bottom: 40px;
+}
+
+/* Success popup */
+.ce-popup-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.ce-popup {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 32px 40px;
+  text-align: center;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+  max-width: 360px;
+  width: 90%;
+}
+
+.ce-popup-icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 16px;
+  background-color: #dcfce7;
+  color: #16a34a;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.ce-popup-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 8px;
+}
+
+.ce-popup-message {
+  font-size: 14px;
+  color: #6b7280;
+  margin-bottom: 24px;
+}
+
+.ce-popup-btn {
+  min-width: 120px;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .ce-row {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .ce-short-input {
+    max-width: 100%;
+  }
+
+  .ce-privacy-row {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -69,6 +69,23 @@
   gap: 12px;
 }
 
+/* Create Event button */
+.shell-create-btn {
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+  background-color: #2563eb;
+  text-decoration: none;
+  border-radius: 8px;
+  white-space: nowrap;
+  transition: background-color 0.15s;
+}
+
+.shell-create-btn:hover {
+  background-color: #1d4ed8;
+}
+
 /* User menu */
 .shell-user-menu {
   position: relative;

--- a/frontend/src/viewmodels/event/useCreateEventViewModel.ts
+++ b/frontend/src/viewmodels/event/useCreateEventViewModel.ts
@@ -1,0 +1,348 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  createEvent,
+  listCategories,
+  searchLocation,
+} from '@/services/eventService';
+import {
+  CreateEventResponse,
+  CategoryItem,
+  LocationSuggestion,
+  type PrivacyLevel,
+  type PreferredGender,
+  type EventConstraint,
+} from '@/models/event';
+import { ApiError } from '@/services/api';
+
+const TITLE_MIN = 10;
+const TITLE_MAX = 60;
+const DESC_MIN = 20;
+const DESC_MAX = 600;
+const CAPACITY_MIN = 2;
+const MAX_TAGS = 5;
+const TAG_MAX_LENGTH = 20;
+export const MAX_CONSTRAINTS = 5;
+
+export const PRIVACY_OPTIONS: { label: string; value: PrivacyLevel }[] = [
+  { label: 'Public', value: 'PUBLIC' },
+  { label: 'Protected', value: 'PROTECTED' },
+];
+
+export type ConstraintType = 'gender' | 'age' | 'capacity' | 'other';
+
+export interface CreateEventFormData {
+  title: string;
+  description: string;
+  imageUrl: string;
+  categoryId: number | null;
+  locationQuery: string;
+  address: string;
+  lat: number | null;
+  lon: number | null;
+  startDate: string;
+  startTime: string;
+  endDate: string;
+  endTime: string;
+  privacyLevel: PrivacyLevel;
+  tags: string[];
+  tagInput: string;
+  capacity: string;
+  minimumAge: string;
+  preferredGender: PreferredGender | '';
+  constraints: EventConstraint[];
+  constraintType: ConstraintType;
+  otherConstraintInput: string;
+}
+
+export interface CreateEventFormErrors {
+  title?: string | null;
+  description?: string | null;
+  categoryId?: string | null;
+  location?: string | null;
+  startDate?: string | null;
+  startTime?: string | null;
+  endDate?: string | null;
+  endTime?: string | null;
+  imageUrl?: string | null;
+  tags?: string | null;
+  capacity?: string | null;
+  minimumAge?: string | null;
+}
+
+const INITIAL: CreateEventFormData = {
+  title: '',
+  description: '',
+  imageUrl: '',
+  categoryId: null,
+  locationQuery: '',
+  address: '',
+  lat: null,
+  lon: null,
+  startDate: '',
+  startTime: '',
+  endDate: '',
+  endTime: '',
+  privacyLevel: 'PUBLIC',
+  tags: [],
+  tagInput: '',
+  capacity: '',
+  minimumAge: '',
+  preferredGender: '',
+  constraints: [],
+  constraintType: 'other',
+  otherConstraintInput: '',
+};
+
+function toISODateTime(date: string, time: string): string | null {
+  if (!date || !time) return null;
+  try {
+    const dt = new Date(`${date}T${time}`);
+    if (isNaN(dt.getTime())) return null;
+    return dt.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+function validateForm(form: CreateEventFormData): CreateEventFormErrors {
+  const errors: CreateEventFormErrors = {};
+
+  if (!form.title.trim()) {
+    errors.title = 'Title is required.';
+  } else if (form.title.trim().length < TITLE_MIN) {
+    errors.title = `Title must be at least ${TITLE_MIN} characters.`;
+  } else if (form.title.trim().length > TITLE_MAX) {
+    errors.title = `Title must be at most ${TITLE_MAX} characters.`;
+  }
+
+  if (!form.description.trim()) {
+    errors.description = 'Description is required.';
+  } else if (form.description.trim().length < DESC_MIN) {
+    errors.description = `Description must be at least ${DESC_MIN} characters.`;
+  } else if (form.description.trim().length > DESC_MAX) {
+    errors.description = `Description must be at most ${DESC_MAX} characters.`;
+  }
+
+  if (!form.categoryId) {
+    errors.categoryId = 'Please select a category.';
+  }
+
+  if (form.lat === null || form.lon === null) {
+    errors.location = 'Please search and select a location.';
+  }
+
+  if (!form.startDate) {
+    errors.startDate = 'Start date is required.';
+  }
+  if (!form.startTime) {
+    errors.startTime = 'Start time is required.';
+  }
+
+  const startISO = toISODateTime(form.startDate, form.startTime);
+  if (form.startDate && form.startTime && !startISO) {
+    errors.startDate = 'Invalid start date/time.';
+  } else if (startISO && new Date(startISO) <= new Date()) {
+    errors.startDate = 'Start time must be in the future.';
+  }
+
+  if (form.endDate || form.endTime) {
+    if (!form.endDate) errors.endDate = 'End date is required if end time is set.';
+    if (!form.endTime) errors.endTime = 'End time is required if end date is set.';
+    const endISO = toISODateTime(form.endDate, form.endTime);
+    if (form.endDate && form.endTime && !endISO) {
+      errors.endDate = 'Invalid end date/time.';
+    } else if (startISO && endISO && new Date(endISO) <= new Date(startISO)) {
+      errors.endDate = 'End time must be after start time.';
+    }
+  }
+
+  if (form.capacity) {
+    const cap = parseInt(form.capacity, 10);
+    if (isNaN(cap) || cap < CAPACITY_MIN) {
+      errors.capacity = `Capacity must be at least ${CAPACITY_MIN}.`;
+    }
+  }
+
+  if (form.minimumAge) {
+    const age = parseInt(form.minimumAge, 10);
+    if (isNaN(age) || age < 1 || age > 120) {
+      errors.minimumAge = 'Enter a valid age (1-120).';
+    }
+  }
+
+  return errors;
+}
+
+export function useCreateEventViewModel() {
+  const [form, setForm] = useState<CreateEventFormData>(INITIAL);
+  const [errors, setErrors] = useState<CreateEventFormErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [categories, setCategories] = useState<CategoryItem[]>([]);
+  const [locationResults, setLocationResults] = useState<LocationSuggestion[]>([]);
+  const [locationSearching, setLocationSearching] = useState(false);
+  const searchTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    listCategories()
+      .then((res) => setCategories(res.items))
+      .catch(() => {});
+  }, []);
+
+  const updateField = useCallback(
+    <K extends keyof CreateEventFormData>(field: K, value: CreateEventFormData[K]) => {
+      setForm((prev) => ({ ...prev, [field]: value }));
+      setErrors((prev) => ({ ...prev, [field]: null }));
+      setApiError(null);
+      setSuccessMessage(null);
+    },
+    [],
+  );
+
+  const handleLocationSearch = useCallback((query: string) => {
+    updateField('locationQuery', query);
+    updateField('lat', null);
+    updateField('lon', null);
+    updateField('address', '');
+    setLocationResults([]);
+
+    if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    if (query.trim().length < 3) return;
+
+    searchTimeout.current = setTimeout(async () => {
+      setLocationSearching(true);
+      try {
+        const results = await searchLocation(query);
+        setLocationResults(results);
+      } catch {
+        setLocationResults([]);
+      } finally {
+        setLocationSearching(false);
+      }
+    }, 400);
+  }, [updateField]);
+
+  const selectLocation = useCallback((suggestion: LocationSuggestion) => {
+    setForm((prev) => ({
+      ...prev,
+      locationQuery: suggestion.display_name,
+      address: suggestion.display_name,
+      lat: parseFloat(suggestion.lat),
+      lon: parseFloat(suggestion.lon),
+    }));
+    setLocationResults([]);
+    setErrors((prev) => ({ ...prev, location: null }));
+  }, []);
+
+  const addTag = useCallback(() => {
+    setForm((prev) => {
+      const tag = prev.tagInput.trim();
+      if (!tag || prev.tags.length >= MAX_TAGS || tag.length > TAG_MAX_LENGTH) return prev;
+      if (prev.tags.some((t) => t.toLowerCase() === tag.toLowerCase())) return prev;
+      return { ...prev, tags: [...prev.tags, tag], tagInput: '' };
+    });
+  }, []);
+
+  const removeTag = useCallback((index: number) => {
+    setForm((prev) => ({
+      ...prev,
+      tags: prev.tags.filter((_, i) => i !== index),
+    }));
+  }, []);
+
+  const addConstraint = useCallback(() => {
+    setForm((prev) => {
+      if (prev.constraints.length >= MAX_CONSTRAINTS) return prev;
+      let constraint: EventConstraint | null = null;
+
+      if (prev.constraintType === 'other' && prev.otherConstraintInput.trim()) {
+        constraint = { type: 'other', info: prev.otherConstraintInput.trim() };
+      }
+
+      if (!constraint) return prev;
+      return {
+        ...prev,
+        constraints: [...prev.constraints, constraint],
+        otherConstraintInput: '',
+      };
+    });
+  }, []);
+
+  const removeConstraint = useCallback((index: number) => {
+    setForm((prev) => ({
+      ...prev,
+      constraints: prev.constraints.filter((_, i) => i !== index),
+    }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (token: string): Promise<CreateEventResponse | null> => {
+      const validationErrors = validateForm(form);
+      const hasErrors = Object.values(validationErrors).some((e) => e != null);
+      if (hasErrors) {
+        setErrors(validationErrors);
+        return null;
+      }
+
+      setIsLoading(true);
+      setApiError(null);
+      try {
+        const startTime = toISODateTime(form.startDate, form.startTime)!;
+        const endTime = toISODateTime(form.endDate, form.endTime);
+
+        const request = {
+          title: form.title.trim(),
+          description: form.description.trim(),
+          image_url: form.imageUrl.trim() || undefined,
+          category_id: form.categoryId!,
+          address: form.address || undefined,
+          lat: form.lat!,
+          lon: form.lon!,
+          location_type: 'POINT' as const,
+          start_time: startTime,
+          end_time: endTime || undefined,
+          capacity: form.capacity ? parseInt(form.capacity, 10) : undefined,
+          privacy_level: form.privacyLevel,
+          tags: form.tags.length > 0 ? form.tags : undefined,
+          constraints: form.constraints.length > 0 ? form.constraints : undefined,
+          minimum_age: form.minimumAge ? parseInt(form.minimumAge, 10) : undefined,
+          preferred_gender: form.preferredGender || undefined,
+        };
+
+        const result = await createEvent(request, token);
+        setSuccessMessage('Event created successfully!');
+        return result;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setApiError(err.message);
+        } else {
+          setApiError('An unexpected error occurred. Please try again.');
+        }
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [form],
+  );
+
+  return {
+    form,
+    errors,
+    isLoading,
+    apiError,
+    successMessage,
+    categories,
+    locationResults,
+    locationSearching,
+    updateField,
+    handleLocationSearch,
+    selectLocation,
+    addTag,
+    removeTag,
+    addConstraint,
+    removeConstraint,
+    handleSubmit,
+  };
+}

--- a/frontend/src/views/events/CreateEventPage.tsx
+++ b/frontend/src/views/events/CreateEventPage.tsx
@@ -1,8 +1,510 @@
-export default function CreateEventPage() {
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  useCreateEventViewModel,
+  PRIVACY_OPTIONS,
+  MAX_CONSTRAINTS,
+} from '@/viewmodels/event/useCreateEventViewModel';
+import type { PreferredGender } from '@/models/event';
+import '@/styles/create-event.css';
+
+const GENDER_OPTIONS: { label: string; value: PreferredGender }[] = [
+  { label: 'Male', value: 'MALE' },
+  { label: 'Female', value: 'FEMALE' },
+  { label: 'Other', value: 'OTHER' },
+];
+
+function CreateEventForm() {
+  const { token, username } = useAuth();
+  const navigate = useNavigate();
+  const vm = useCreateEventViewModel();
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    const result = await vm.handleSubmit(token);
+    if (result) {
+      setShowSuccess(true);
+    }
+  };
+
+  const handleSuccessDismiss = () => {
+    setShowSuccess(false);
+    navigate('/my-events', { replace: true });
+  };
+
   return (
-    <div className="placeholder-page">
-      <h1>Create Event</h1>
-      <p>Set up a new event for others to discover and join.</p>
+    <>
+      {showSuccess && (
+        <div className="ce-popup-overlay" onClick={handleSuccessDismiss}>
+          <div className="ce-popup" onClick={(e) => e.stopPropagation()}>
+            <div className="ce-popup-icon">&#10003;</div>
+            <h2 className="ce-popup-title">Event Created!</h2>
+            <p className="ce-popup-message">
+              Your event has been successfully created.
+            </p>
+            <button
+              type="button"
+              className="btn-primary ce-popup-btn"
+              onClick={handleSuccessDismiss}
+            >
+              OK
+            </button>
+          </div>
+        </div>
+      )}
+      {vm.apiError && <div className="error-banner">{vm.apiError}</div>}
+
+      <form className="create-event-form" onSubmit={handleSubmit}>
+        {/* Host info */}
+        <div className="ce-host-info">
+          <span className="ce-host-label">Host:</span>
+          <span className="ce-host-name">{username}</span>
+        </div>
+
+        {/* Title */}
+        <div className="field-group">
+          <label className="field-label" htmlFor="event-title">
+            Title
+          </label>
+          <input
+            id="event-title"
+            className={`field-input ${vm.errors.title ? 'has-error' : ''}`}
+            type="text"
+            placeholder="Give your event a catchy title"
+            maxLength={60}
+            value={vm.form.title}
+            onChange={(e) => vm.updateField('title', e.target.value)}
+            disabled={vm.isLoading}
+          />
+          <div className="ce-char-count">
+            {vm.form.title.length}/60
+          </div>
+          {vm.errors.title && (
+            <p className="field-error">{vm.errors.title}</p>
+          )}
+        </div>
+
+        {/* Description */}
+        <div className="field-group">
+          <label className="field-label" htmlFor="event-desc">
+            Description
+          </label>
+          <textarea
+            id="event-desc"
+            className={`field-input ce-textarea ${vm.errors.description ? 'has-error' : ''}`}
+            placeholder="Describe your event in detail"
+            maxLength={600}
+            rows={4}
+            value={vm.form.description}
+            onChange={(e) => vm.updateField('description', e.target.value)}
+            disabled={vm.isLoading}
+          />
+          <div className="ce-char-count">
+            {vm.form.description.length}/600
+          </div>
+          {vm.errors.description && (
+            <p className="field-error">{vm.errors.description}</p>
+          )}
+        </div>
+
+        {/* Category */}
+        <div className="field-group">
+          <label className="field-label">Category</label>
+          <div className="ce-category-grid">
+            {vm.categories.map((cat) => (
+              <button
+                key={cat.id}
+                type="button"
+                className={`ce-category-chip ${vm.form.categoryId === cat.id ? 'selected' : ''}`}
+                onClick={() => vm.updateField('categoryId', cat.id)}
+                disabled={vm.isLoading}
+              >
+                {cat.name}
+              </button>
+            ))}
+          </div>
+          {vm.errors.categoryId && (
+            <p className="field-error">{vm.errors.categoryId}</p>
+          )}
+        </div>
+
+        {/* Image URL */}
+        <div className="field-group">
+          <label className="field-label" htmlFor="event-image">
+            Image URL <span className="optional">(optional)</span>
+          </label>
+          <input
+            id="event-image"
+            className="field-input"
+            type="url"
+            placeholder="https://example.com/image.jpg"
+            value={vm.form.imageUrl}
+            onChange={(e) => vm.updateField('imageUrl', e.target.value)}
+            disabled={vm.isLoading}
+          />
+        </div>
+
+        {/* Location */}
+        <div className="field-group">
+          <label className="field-label" htmlFor="event-location">
+            Location
+          </label>
+          <div className="ce-location-wrapper">
+            <input
+              id="event-location"
+              className={`field-input ${vm.errors.location ? 'has-error' : ''}`}
+              type="text"
+              placeholder="Search for a location..."
+              value={vm.form.locationQuery}
+              onChange={(e) => vm.handleLocationSearch(e.target.value)}
+              disabled={vm.isLoading}
+            />
+            {vm.locationSearching && (
+              <div className="ce-location-searching">Searching...</div>
+            )}
+            {vm.locationResults.length > 0 && (
+              <ul className="ce-location-results">
+                {vm.locationResults.map((loc, i) => (
+                  <li key={i}>
+                    <button
+                      type="button"
+                      className="ce-location-item"
+                      onClick={() => vm.selectLocation(loc)}
+                    >
+                      {loc.display_name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          {vm.form.address && (
+            <p className="ce-selected-location">{vm.form.address}</p>
+          )}
+          {vm.errors.location && (
+            <p className="field-error">{vm.errors.location}</p>
+          )}
+        </div>
+
+        {/* Date & Time */}
+        <div className="ce-row">
+          <div className="field-group ce-flex-1">
+            <label className="field-label" htmlFor="start-date">
+              Start Date
+            </label>
+            <input
+              id="start-date"
+              className={`field-input ${vm.errors.startDate ? 'has-error' : ''}`}
+              type="date"
+              value={vm.form.startDate}
+              onChange={(e) => vm.updateField('startDate', e.target.value)}
+              disabled={vm.isLoading}
+            />
+            {vm.errors.startDate && (
+              <p className="field-error">{vm.errors.startDate}</p>
+            )}
+          </div>
+          <div className="field-group ce-flex-1">
+            <label className="field-label" htmlFor="start-time">
+              Start Time
+            </label>
+            <input
+              id="start-time"
+              className={`field-input ${vm.errors.startTime ? 'has-error' : ''}`}
+              type="time"
+              value={vm.form.startTime}
+              onChange={(e) => vm.updateField('startTime', e.target.value)}
+              disabled={vm.isLoading}
+            />
+            {vm.errors.startTime && (
+              <p className="field-error">{vm.errors.startTime}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="ce-row">
+          <div className="field-group ce-flex-1">
+            <label className="field-label" htmlFor="end-date">
+              End Date <span className="optional">(optional)</span>
+            </label>
+            <input
+              id="end-date"
+              className={`field-input ${vm.errors.endDate ? 'has-error' : ''}`}
+              type="date"
+              value={vm.form.endDate}
+              onChange={(e) => vm.updateField('endDate', e.target.value)}
+              disabled={vm.isLoading}
+            />
+            {vm.errors.endDate && (
+              <p className="field-error">{vm.errors.endDate}</p>
+            )}
+          </div>
+          <div className="field-group ce-flex-1">
+            <label className="field-label" htmlFor="end-time">
+              End Time <span className="optional">(optional)</span>
+            </label>
+            <input
+              id="end-time"
+              className={`field-input ${vm.errors.endTime ? 'has-error' : ''}`}
+              type="time"
+              value={vm.form.endTime}
+              onChange={(e) => vm.updateField('endTime', e.target.value)}
+              disabled={vm.isLoading}
+            />
+            {vm.errors.endTime && (
+              <p className="field-error">{vm.errors.endTime}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Privacy Level */}
+        <div className="field-group">
+          <label className="field-label">Privacy</label>
+          <div className="ce-privacy-row">
+            {PRIVACY_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className={`ce-privacy-chip ${vm.form.privacyLevel === opt.value ? 'selected' : ''}`}
+                onClick={() => vm.updateField('privacyLevel', opt.value)}
+                disabled={vm.isLoading}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Capacity */}
+        <div className="field-group">
+          <label className="field-label" htmlFor="event-capacity">
+            Capacity <span className="optional">(optional)</span>
+          </label>
+          <input
+            id="event-capacity"
+            className={`field-input ce-short-input ${vm.errors.capacity ? 'has-error' : ''}`}
+            type="number"
+            min={2}
+            placeholder="e.g. 50"
+            value={vm.form.capacity}
+            onChange={(e) => vm.updateField('capacity', e.target.value)}
+            disabled={vm.isLoading}
+          />
+          {vm.errors.capacity && (
+            <p className="field-error">{vm.errors.capacity}</p>
+          )}
+        </div>
+
+        {/* Tags */}
+        <div className="field-group">
+          <label className="field-label">
+            Tags <span className="optional">(up to 5)</span>
+          </label>
+          <div className="ce-tag-input-row">
+            <input
+              className="field-input ce-tag-input"
+              type="text"
+              placeholder="Add a tag"
+              maxLength={20}
+              value={vm.form.tagInput}
+              onChange={(e) => vm.updateField('tagInput', e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  vm.addTag();
+                }
+              }}
+              disabled={vm.isLoading || vm.form.tags.length >= 5}
+            />
+            <button
+              type="button"
+              className="ce-tag-add-btn"
+              onClick={vm.addTag}
+              disabled={vm.isLoading || vm.form.tags.length >= 5 || !vm.form.tagInput.trim()}
+            >
+              Add
+            </button>
+          </div>
+          {vm.form.tags.length > 0 && (
+            <div className="ce-tags-list">
+              {vm.form.tags.map((tag, i) => (
+                <span key={i} className="ce-tag">
+                  {tag}
+                  <button
+                    type="button"
+                    className="ce-tag-remove"
+                    onClick={() => vm.removeTag(i)}
+                  >
+                    &times;
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Participation Constraints */}
+        <fieldset className="ce-constraints-section">
+          <legend className="field-label">
+            Participation Constraints <span className="optional">(optional)</span>
+          </legend>
+
+          {/* Minimum Age */}
+          <div className="field-group">
+            <label className="field-label ce-sub-label" htmlFor="min-age">
+              Minimum Age
+            </label>
+            <input
+              id="min-age"
+              className={`field-input ce-short-input ${vm.errors.minimumAge ? 'has-error' : ''}`}
+              type="number"
+              min={1}
+              max={120}
+              placeholder="e.g. 18"
+              value={vm.form.minimumAge}
+              onChange={(e) => vm.updateField('minimumAge', e.target.value)}
+              disabled={vm.isLoading}
+            />
+            {vm.errors.minimumAge && (
+              <p className="field-error">{vm.errors.minimumAge}</p>
+            )}
+          </div>
+
+          {/* Preferred Gender */}
+          <div className="field-group">
+            <label className="field-label ce-sub-label">Preferred Gender</label>
+            <div className="ce-privacy-row">
+              {GENDER_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`ce-privacy-chip ${vm.form.preferredGender === opt.value ? 'selected' : ''}`}
+                  onClick={() =>
+                    vm.updateField(
+                      'preferredGender',
+                      vm.form.preferredGender === opt.value ? '' : opt.value,
+                    )
+                  }
+                  disabled={vm.isLoading}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Custom Constraints */}
+          <div className="field-group">
+            <label className="field-label ce-sub-label">Other Constraints</label>
+            <div className="ce-tag-input-row">
+              <input
+                className="field-input ce-tag-input"
+                type="text"
+                placeholder="e.g. Bring your own equipment"
+                value={vm.form.otherConstraintInput}
+                onChange={(e) => vm.updateField('otherConstraintInput', e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    vm.addConstraint();
+                  }
+                }}
+                disabled={vm.isLoading || vm.form.constraints.length >= 5}
+              />
+              <button
+                type="button"
+                className="ce-tag-add-btn"
+                onClick={vm.addConstraint}
+                disabled={
+                  vm.isLoading ||
+                  vm.form.constraints.length >= MAX_CONSTRAINTS ||
+                  !vm.form.otherConstraintInput.trim()
+                }
+              >
+                Add
+              </button>
+            </div>
+            {vm.form.constraints.length > 0 && (
+              <div className="ce-tags-list">
+                {vm.form.constraints.map((c, i) => (
+                  <span key={i} className="ce-tag">
+                    {c.info}
+                    <button
+                      type="button"
+                      className="ce-tag-remove"
+                      onClick={() => vm.removeConstraint(i)}
+                    >
+                      &times;
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </fieldset>
+
+        {/* Submit */}
+        <button
+          type="submit"
+          className="btn-primary ce-submit"
+          disabled={vm.isLoading}
+        >
+          {vm.isLoading ? <span className="spinner" /> : 'Create Event'}
+        </button>
+      </form>
+    </>
+  );
+}
+
+export default function CreateEventPage() {
+  const [hasError, setHasError] = useState(false);
+
+  if (hasError) {
+    return (
+      <div className="create-event-page">
+        <h1 className="create-event-title">Create a New Event</h1>
+        <div className="error-banner">
+          Something went wrong loading the form. Please try refreshing the page.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="create-event-page">
+      <h1 className="create-event-title">Create a New Event</h1>
+      <p className="create-event-subtitle">
+        Fill in the details below to set up your event.
+      </p>
+      <ErrorBoundary onError={() => setHasError(true)}>
+        <CreateEventForm />
+      </ErrorBoundary>
     </div>
   );
+}
+
+class ErrorBoundary extends React.Component<
+  { children: React.ReactNode; onError: () => void },
+  { hasError: boolean }
+> {
+  constructor(props: { children: React.ReactNode; onError: () => void }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch() {
+    this.props.onError();
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
 }


### PR DESCRIPTION
### 📋 Summary
Implement the Create Event page on the web frontend so authenticated users can enter event details and submit a new event. Also fix the current frontend issues related to category response handling and the page crash.

### 🔄 Main Tasks
- Create the web Create Event page and add it to the authenticated user flow
- Build the event creation form UI
- Add frontend validation for required fields and form rules
- Implement category fetching and category selection
- Implement location search and selection
- Add tag and constraint input management
- Implement event creation submission flow
- Add success and error handling for form submission
- Create or update the event-related types and models
- Add required event service methods for create event and supporting fetches
- Add navigation entry for Create Event in the app shell
- Update shared API helpers if needed for authenticated requests
- Add styling for the create event page and related UI elements
- Fix frontend crash issues caused by import/runtime problems
- Fix category API response mapping to match backend contract
- Remove unsupported privacy options from the frontend for now

### ✅ Acceptance Criteria
- Authenticated users can open the Create Event page from the navigation
- Users can fill in event details and submit the form successfully
- Validation errors are shown for invalid or missing required inputs
- Category and location inputs work correctly
- Tags and constraints can be added through the UI
- A success feedback flow is shown after event creation
- Users are redirected appropriately after successful creation
- The page renders without the previous white-page crash
- Frontend category handling matches backend API response format

### 🏷 Labels
- frontend
- events
- web

## 🔗 Related
Link issues with: #170 
