### PR TITLE
(feat(frontend): add event discovery page with filters and pagination

### DIFF
--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -57,3 +57,51 @@ export interface LocationSuggestion {
   lat: string;
   lon: string;
 }
+
+/* ── Discovery ── */
+
+export type DiscoverSortBy = 'START_TIME' | 'DISTANCE' | 'RELEVANCE';
+
+export interface DiscoverEventsParams {
+  lat: number;
+  lon: number;
+  radius_meters?: number;
+  q?: string;
+  privacy_levels?: string;
+  category_ids?: string;
+  start_from?: string;
+  start_to?: string;
+  tag_names?: string;
+  only_favorited?: boolean;
+  sort_by?: DiscoverSortBy;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface HostScoreSummary {
+  final_score: number | null;
+  hosted_event_rating_count: number;
+}
+
+export interface DiscoverEventItem {
+  id: string;
+  title: string;
+  category_name: string;
+  image_url: string | null;
+  start_time: string;
+  location_address: string | null;
+  privacy_level: 'PUBLIC' | 'PROTECTED';
+  approved_participant_count: number;
+  is_favorited: boolean;
+  host_score: HostScoreSummary;
+}
+
+export interface DiscoverPageInfo {
+  next_cursor: string | null;
+  has_next: boolean;
+}
+
+export interface DiscoverEventsResponse {
+  items: DiscoverEventItem[];
+  page_info: DiscoverPageInfo;
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -70,6 +70,22 @@ export async function apiPostAuth<T>(
   return response.json();
 }
 
+export async function apiGetAuth<T>(endpoint: string, token: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
+  return response.json();
+}
+
 export async function apiGet<T>(endpoint: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${endpoint}`, {
     method: 'GET',

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -1,9 +1,11 @@
-import { apiPostAuth, apiGet } from './api';
+import { apiPostAuth, apiGet, apiGetAuth } from './api';
 import {
   CreateEventRequest,
   CreateEventResponse,
   ListCategoriesResponse,
   LocationSuggestion,
+  DiscoverEventsParams,
+  DiscoverEventsResponse,
 } from '@/models/event';
 
 const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
@@ -17,6 +19,27 @@ export function createEvent(
 
 export function listCategories(): Promise<ListCategoriesResponse> {
   return apiGet<ListCategoriesResponse>('/categories/');
+}
+
+export function discoverEvents(
+  params: DiscoverEventsParams,
+  token: string,
+): Promise<DiscoverEventsResponse> {
+  const qs = new URLSearchParams();
+  qs.set('lat', String(params.lat));
+  qs.set('lon', String(params.lon));
+  if (params.radius_meters != null) qs.set('radius_meters', String(params.radius_meters));
+  if (params.q) qs.set('q', params.q);
+  if (params.privacy_levels) qs.set('privacy_levels', params.privacy_levels);
+  if (params.category_ids) qs.set('category_ids', params.category_ids);
+  if (params.start_from) qs.set('start_from', params.start_from);
+  if (params.start_to) qs.set('start_to', params.start_to);
+  if (params.tag_names) qs.set('tag_names', params.tag_names);
+  if (params.only_favorited) qs.set('only_favorited', 'true');
+  if (params.sort_by) qs.set('sort_by', params.sort_by);
+  if (params.limit != null) qs.set('limit', String(params.limit));
+  if (params.cursor) qs.set('cursor', params.cursor);
+  return apiGetAuth<DiscoverEventsResponse>(`/events/?${qs}`, token);
 }
 
 export async function searchLocation(

--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -1,0 +1,541 @@
+.dc-page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.dc-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 4px;
+}
+
+.dc-subtitle {
+  font-size: 15px;
+  color: #6b7280;
+  margin-bottom: 24px;
+}
+
+/* Login prompt */
+.dc-login-prompt {
+  text-align: center;
+  padding: 60px 20px;
+  color: #6b7280;
+  font-size: 16px;
+}
+
+.dc-login-btn {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 10px 32px;
+  text-decoration: none;
+  width: auto;
+}
+
+/* Filters */
+.dc-filters {
+  margin-bottom: 24px;
+}
+
+/* Search row */
+.dc-search-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.dc-search {
+  flex: 1;
+}
+
+.dc-filter-toggle {
+  padding: 8px 16px;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  font-size: 14px;
+  color: #374151;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+
+.dc-filter-toggle:hover,
+.dc-filter-toggle.active {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.dc-filter-toggle.has-filters {
+  background-color: #eff6ff;
+  border-color: #2563eb;
+  color: #2563eb;
+  font-weight: 600;
+}
+
+/* Filter panel */
+.dc-filter-panel {
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.dc-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dc-filter-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.dc-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dc-filter-chip {
+  padding: 5px 14px;
+  border-radius: 18px;
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  font-size: 13px;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.dc-filter-chip:hover {
+  border-color: #2563eb;
+}
+
+.dc-filter-chip.selected {
+  background-color: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+.dc-date-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dc-date-input {
+  flex: 1;
+  max-width: 200px;
+}
+
+.dc-date-sep {
+  font-size: 13px;
+  color: #9ca3af;
+}
+
+.dc-tag-input {
+  max-width: 400px;
+}
+
+.dc-clear-btn {
+  align-self: flex-start;
+  padding: 6px 16px;
+  border-radius: 8px;
+  border: 1px solid #dc2626;
+  background: none;
+  color: #dc2626;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.dc-clear-btn:hover {
+  background-color: #fef2f2;
+}
+
+/* Location filter */
+.dc-location-current {
+  font-size: 13px;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.dc-location-current strong {
+  color: #111827;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.dc-use-my-loc {
+  padding: 2px 10px;
+  border-radius: 12px;
+  border: 1px solid #2563eb;
+  background: none;
+  color: #2563eb;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.dc-use-my-loc:hover {
+  background-color: #eff6ff;
+}
+
+.dc-location-wrapper {
+  position: relative;
+}
+
+.dc-location-input {
+  width: 100%;
+  max-width: 400px;
+}
+
+.dc-location-searching {
+  font-size: 12px;
+  color: #9ca3af;
+  margin-top: 4px;
+}
+
+.dc-location-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  max-width: 400px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 50;
+  list-style: none;
+  margin-top: 4px;
+  padding: 0;
+}
+
+.dc-location-item {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: #374151;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.dc-location-item:hover {
+  background-color: #f3f4f6;
+}
+
+.dc-sort-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.dc-sort-chip {
+  padding: 6px 16px;
+  border-radius: 20px;
+  border: 1px solid #d1d5db;
+  background-color: #f9fafb;
+  font-size: 13px;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.dc-sort-chip:hover {
+  border-color: #2563eb;
+}
+
+.dc-sort-chip.selected {
+  background-color: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+.dc-category-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.dc-category-chip {
+  padding: 5px 12px;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+  font-size: 12px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.dc-category-chip:hover {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.dc-category-chip.selected {
+  background-color: #eff6ff;
+  border-color: #2563eb;
+  color: #2563eb;
+  font-weight: 600;
+}
+
+/* Loading */
+.dc-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 60px 20px;
+  gap: 12px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+/* Empty state */
+.dc-empty {
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.dc-empty h2 {
+  font-size: 20px;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 8px;
+}
+
+.dc-empty p {
+  font-size: 14px;
+  color: #9ca3af;
+}
+
+/* Retry */
+.dc-retry-btn {
+  margin-left: 12px;
+  padding: 4px 14px;
+  border-radius: 6px;
+  border: 1px solid #dc2626;
+  background: none;
+  color: #dc2626;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.dc-retry-btn:hover {
+  background-color: #fef2f2;
+}
+
+/* Event grid */
+.dc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+/* Event card */
+.dc-card {
+  display: flex;
+  flex-direction: column;
+  border-radius: 14px;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.dc-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+.dc-card-image-wrapper {
+  position: relative;
+  width: 100%;
+  height: 160px;
+  overflow: hidden;
+  background-color: #f3f4f6;
+}
+
+.dc-card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.dc-card-image-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+}
+
+.dc-card-image-placeholder span {
+  font-size: 40px;
+  font-weight: 700;
+  color: #2563eb;
+  opacity: 0.5;
+}
+
+.dc-privacy-badge {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.dc-privacy-public {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+.dc-privacy-protected {
+  background-color: #fef3c7;
+  color: #d97706;
+}
+
+.dc-card-body {
+  padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.dc-card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+}
+
+.dc-card-category {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.dc-card-date {
+  color: #9ca3af;
+}
+
+.dc-card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+  line-height: 1.3;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.dc-card-location {
+  font-size: 13px;
+  color: #6b7280;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dc-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid #f3f4f6;
+  font-size: 13px;
+}
+
+.dc-card-participants {
+  color: #6b7280;
+}
+
+.dc-card-score {
+  color: #f59e0b;
+  font-weight: 600;
+}
+
+/* Load more */
+.dc-load-more {
+  display: flex;
+  justify-content: center;
+  padding: 32px 0 16px;
+}
+
+.dc-load-more-btn {
+  padding: 10px 32px;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+  min-width: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dc-load-more-btn:hover:not(:disabled) {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.dc-load-more-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .dc-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dc-category-row {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .dc-category-chip {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}

--- a/frontend/src/viewmodels/discover/useDiscoverViewModel.ts
+++ b/frontend/src/viewmodels/discover/useDiscoverViewModel.ts
@@ -1,0 +1,263 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { discoverEvents, listCategories, searchLocation } from '@/services/eventService';
+import type {
+  DiscoverEventItem,
+  DiscoverEventsParams,
+  DiscoverSortBy,
+  CategoryItem,
+  LocationSuggestion,
+} from '@/models/event';
+import { ApiError } from '@/services/api';
+
+// Default: Istanbul center
+const DEFAULT_LAT = 41.0082;
+const DEFAULT_LON = 28.9784;
+const DEFAULT_RADIUS = 50000;
+const PAGE_SIZE = 20;
+
+export type PrivacyFilter = 'ALL' | 'PUBLIC' | 'PROTECTED';
+
+export interface DiscoverFilters {
+  q: string;
+  categoryId: number | null;
+  sortBy: DiscoverSortBy;
+  radiusMeters: number;
+  privacy: PrivacyFilter;
+  startFrom: string;
+  startTo: string;
+  tagNames: string;
+}
+
+const INITIAL_FILTERS: DiscoverFilters = {
+  q: '',
+  categoryId: null,
+  sortBy: 'START_TIME',
+  radiusMeters: DEFAULT_RADIUS,
+  privacy: 'ALL',
+  startFrom: '',
+  startTo: '',
+  tagNames: '',
+};
+
+export const RADIUS_OPTIONS = [
+  { label: '1 km', value: 1000 },
+  { label: '5 km', value: 5000 },
+  { label: '10 km', value: 10000 },
+  { label: '25 km', value: 25000 },
+  { label: '50 km', value: 50000 },
+];
+
+export function useDiscoverViewModel(token: string | null) {
+  const [events, setEvents] = useState<DiscoverEventItem[]>([]);
+  const [filters, setFilters] = useState<DiscoverFilters>(INITIAL_FILTERS);
+  const [categories, setCategories] = useState<CategoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [hasNext, setHasNext] = useState(false);
+  const [userLocation, setUserLocation] = useState<{ lat: number; lon: number }>({
+    lat: DEFAULT_LAT,
+    lon: DEFAULT_LON,
+  });
+  const [locationReady, setLocationReady] = useState(false);
+  const [debouncedQ, setDebouncedQ] = useState('');
+  const [locationQuery, setLocationQuery] = useState('');
+  const [locationLabel, setLocationLabel] = useState('Istanbul, Turkey (default)');
+  const [locationResults, setLocationResults] = useState<LocationSuggestion[]>([]);
+  const [locationSearching, setLocationSearching] = useState(false);
+  const searchTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const locationTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const browserLocation = useRef<{ lat: number; lon: number }>({ lat: DEFAULT_LAT, lon: DEFAULT_LON });
+  const defaultLabel = useRef('Istanbul, Turkey (default)');
+
+  // Request user geolocation on mount
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const loc = { lat: pos.coords.latitude, lon: pos.coords.longitude };
+          setUserLocation(loc);
+          browserLocation.current = loc;
+          const label = `${loc.lat.toFixed(4)}, ${loc.lon.toFixed(4)} (your location)`;
+          setLocationLabel(label);
+          defaultLabel.current = label;
+          setLocationReady(true);
+        },
+        () => {
+          setLocationReady(true);
+        },
+        { timeout: 5000 },
+      );
+    } else {
+      setLocationReady(true);
+    }
+  }, []);
+
+  // Load categories on mount
+  useEffect(() => {
+    listCategories()
+      .then((res) => setCategories(res.items))
+      .catch(() => {});
+  }, []);
+
+  const buildParams = useCallback(
+    (cursor?: string): DiscoverEventsParams => {
+      const params: DiscoverEventsParams = {
+        lat: userLocation.lat,
+        lon: userLocation.lon,
+        radius_meters: filters.radiusMeters,
+        limit: PAGE_SIZE,
+        sort_by: filters.sortBy,
+      };
+      if (debouncedQ.trim()) params.q = debouncedQ.trim();
+      if (filters.categoryId) params.category_ids = String(filters.categoryId);
+      if (filters.privacy !== 'ALL') params.privacy_levels = filters.privacy;
+      if (filters.startFrom) params.start_from = new Date(filters.startFrom).toISOString();
+      if (filters.startTo) params.start_to = new Date(filters.startTo).toISOString();
+      if (filters.tagNames.trim()) params.tag_names = filters.tagNames.trim();
+      if (cursor) params.cursor = cursor;
+      return params;
+    },
+    [userLocation, filters.sortBy, filters.categoryId, filters.radiusMeters, filters.privacy, filters.startFrom, filters.startTo, filters.tagNames, debouncedQ],
+  );
+
+  const fetchEvents = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await discoverEvents(buildParams(), token);
+      setEvents(res.items);
+      setNextCursor(res.page_info.next_cursor);
+      setHasNext(res.page_info.has_next);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const details = err.details ? ` (${Object.entries(err.details).map(([k, v]) => `${k}: ${v}`).join(', ')})` : '';
+        setError(err.message + details);
+      } else {
+        setError('Failed to load events. Please try again.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, buildParams]);
+
+  const loadMore = useCallback(async () => {
+    if (!token || !nextCursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const res = await discoverEvents(buildParams(nextCursor), token);
+      setEvents((prev) => [...prev, ...res.items]);
+      setNextCursor(res.page_info.next_cursor);
+      setHasNext(res.page_info.has_next);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      }
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [token, nextCursor, isLoadingMore, buildParams]);
+
+  // Fetch when location is ready and token is present
+  useEffect(() => {
+    if (locationReady && token) {
+      fetchEvents();
+    }
+  }, [locationReady, token, fetchEvents]);
+
+  const updateSearch = useCallback(
+    (q: string) => {
+      setFilters((prev) => ({ ...prev, q }));
+      if (searchTimeout.current) clearTimeout(searchTimeout.current);
+      searchTimeout.current = setTimeout(() => {
+        setDebouncedQ(q);
+      }, 400);
+    },
+    [],
+  );
+
+  const updateFilter = useCallback(
+    <K extends keyof DiscoverFilters>(key: K, value: DiscoverFilters[K]) => {
+      setFilters((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const updateCategory = useCallback((categoryId: number | null) => {
+    setFilters((prev) => ({
+      ...prev,
+      categoryId: prev.categoryId === categoryId ? null : categoryId,
+    }));
+  }, []);
+
+  const updateSort = useCallback((sortBy: DiscoverSortBy) => {
+    setFilters((prev) => ({ ...prev, sortBy }));
+  }, []);
+
+  const handleLocationSearch = useCallback((query: string) => {
+    setLocationQuery(query);
+    setLocationResults([]);
+    if (locationTimeout.current) clearTimeout(locationTimeout.current);
+    if (query.trim().length < 3) return;
+    locationTimeout.current = setTimeout(async () => {
+      setLocationSearching(true);
+      try {
+        const results = await searchLocation(query);
+        setLocationResults(results);
+      } catch {
+        setLocationResults([]);
+      } finally {
+        setLocationSearching(false);
+      }
+    }, 400);
+  }, []);
+
+  const selectLocation = useCallback((suggestion: LocationSuggestion) => {
+    setUserLocation({ lat: parseFloat(suggestion.lat), lon: parseFloat(suggestion.lon) });
+    setLocationLabel(suggestion.display_name);
+    setLocationQuery('');
+    setLocationResults([]);
+  }, []);
+
+  const useMyLocation = useCallback(() => {
+    setUserLocation(browserLocation.current);
+    setLocationLabel(defaultLabel.current);
+    setLocationQuery('');
+    setLocationResults([]);
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setFilters(INITIAL_FILTERS);
+    setDebouncedQ('');
+    setUserLocation(browserLocation.current);
+    setLocationLabel(defaultLabel.current);
+    setLocationQuery('');
+    setLocationResults([]);
+  }, []);
+
+  return {
+    events,
+    filters,
+    categories,
+    isLoading,
+    isLoadingMore,
+    error,
+    hasNext,
+    locationQuery,
+    locationLabel,
+    locationResults,
+    locationSearching,
+    updateSearch,
+    updateFilter,
+    updateCategory,
+    updateSort,
+    handleLocationSearch,
+    selectLocation,
+    useMyLocation,
+    clearFilters,
+    loadMore,
+    refresh: fetchEvents,
+  };
+}

--- a/frontend/src/views/discover/DiscoverPage.tsx
+++ b/frontend/src/views/discover/DiscoverPage.tsx
@@ -1,8 +1,346 @@
-export default function DiscoverPage() {
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  useDiscoverViewModel,
+  RADIUS_OPTIONS,
+  type PrivacyFilter,
+} from '@/viewmodels/discover/useDiscoverViewModel';
+import type { DiscoverEventItem, DiscoverSortBy } from '@/models/event';
+import '@/styles/discover.css';
+
+const SORT_OPTIONS: { label: string; value: DiscoverSortBy }[] = [
+  { label: 'Soonest', value: 'START_TIME' },
+  { label: 'Nearest', value: 'DISTANCE' },
+];
+
+const PRIVACY_OPTIONS: { label: string; value: PrivacyFilter }[] = [
+  { label: 'All', value: 'ALL' },
+  { label: 'Public', value: 'PUBLIC' },
+  { label: 'Protected', value: 'PROTECTED' },
+];
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function EventCard({ event }: { event: DiscoverEventItem }) {
   return (
-    <div className="placeholder-page">
-      <h1>Discover Events</h1>
-      <p>Browse and search for events near you.</p>
+    <a href={`/events/${event.id}`} className="dc-card">
+      <div className="dc-card-image-wrapper">
+        {event.image_url ? (
+          <img src={event.image_url} alt={event.title} className="dc-card-image" />
+        ) : (
+          <div className="dc-card-image-placeholder">
+            <span>{event.category_name.charAt(0)}</span>
+          </div>
+        )}
+        <span className={`dc-privacy-badge dc-privacy-${event.privacy_level.toLowerCase()}`}>
+          {event.privacy_level === 'PUBLIC' ? 'Public' : 'Protected'}
+        </span>
+      </div>
+
+      <div className="dc-card-body">
+        <div className="dc-card-meta">
+          <span className="dc-card-category">{event.category_name}</span>
+          <span className="dc-card-date">
+            {formatDate(event.start_time)} &middot; {formatTime(event.start_time)}
+          </span>
+        </div>
+
+        <h3 className="dc-card-title">{event.title}</h3>
+
+        {event.location_address && (
+          <p className="dc-card-location">{event.location_address}</p>
+        )}
+
+        <div className="dc-card-footer">
+          <span className="dc-card-participants">
+            {event.approved_participant_count} participant{event.approved_participant_count !== 1 ? 's' : ''}
+          </span>
+          {event.host_score.final_score != null && (
+            <span className="dc-card-score">
+              {'★'} {event.host_score.final_score.toFixed(1)}
+            </span>
+          )}
+        </div>
+      </div>
+    </a>
+  );
+}
+
+export default function DiscoverPage() {
+  const { token } = useAuth();
+  const vm = useDiscoverViewModel(token);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+
+  const hasActiveFilters =
+    vm.filters.privacy !== 'ALL' ||
+    vm.filters.startFrom !== '' ||
+    vm.filters.startTo !== '' ||
+    vm.filters.tagNames !== '' ||
+    vm.filters.radiusMeters !== 50000 ||
+    vm.filters.categoryId !== null ||
+    (!vm.locationLabel.endsWith('(default)') && !vm.locationLabel.endsWith('(your location)'));
+
+  if (!token) {
+    return (
+      <div className="dc-page">
+        <h1 className="dc-title">Discover Events</h1>
+        <div className="dc-login-prompt">
+          <p>Sign in to discover events near you.</p>
+          <a href="/login" className="btn-primary dc-login-btn">Sign In</a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dc-page">
+      <h1 className="dc-title">Discover Events</h1>
+      <p className="dc-subtitle">Find events happening near you</p>
+
+      {/* Search */}
+      <div className="dc-filters">
+        <div className="dc-search-row">
+          <input
+            type="text"
+            className="field-input dc-search"
+            placeholder="Search events..."
+            value={vm.filters.q}
+            onChange={(e) => vm.updateSearch(e.target.value)}
+          />
+          <button
+            type="button"
+            className={`dc-filter-toggle ${filtersOpen ? 'active' : ''} ${hasActiveFilters ? 'has-filters' : ''}`}
+            onClick={() => setFiltersOpen(!filtersOpen)}
+          >
+            Filters{hasActiveFilters ? ' *' : ''}
+          </button>
+        </div>
+
+        {/* Sort */}
+        <div className="dc-sort-row">
+          {SORT_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`dc-sort-chip ${vm.filters.sortBy === opt.value ? 'selected' : ''}`}
+              onClick={() => vm.updateSort(opt.value)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Collapsible filters panel */}
+        {filtersOpen && (
+          <div className="dc-filter-panel">
+            {/* Location */}
+            <div className="dc-filter-group">
+              <label className="dc-filter-label">Location</label>
+              <div className="dc-location-current">
+                Searching near: <strong>{vm.locationLabel}</strong>
+                {!vm.locationLabel.endsWith('(default)') && !vm.locationLabel.endsWith('(your location)') && (
+                  <button
+                    type="button"
+                    className="dc-use-my-loc"
+                    onClick={vm.useMyLocation}
+                  >
+                    Use Istanbul, Turkey (default)
+                  </button>
+                )}
+              </div>
+              <div className="dc-location-wrapper">
+                <input
+                  type="text"
+                  className="field-input dc-location-input"
+                  placeholder="Search for a location..."
+                  value={vm.locationQuery}
+                  onChange={(e) => vm.handleLocationSearch(e.target.value)}
+                />
+                {vm.locationSearching && (
+                  <div className="dc-location-searching">Searching...</div>
+                )}
+                {vm.locationResults.length > 0 && (
+                  <ul className="dc-location-results">
+                    {vm.locationResults.map((loc, i) => (
+                      <li key={i}>
+                        <button
+                          type="button"
+                          className="dc-location-item"
+                          onClick={() => vm.selectLocation(loc)}
+                        >
+                          {loc.display_name}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+
+            {/* Radius */}
+            <div className="dc-filter-group">
+              <label className="dc-filter-label">Radius</label>
+              <div className="dc-chip-row">
+                {RADIUS_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`dc-filter-chip ${vm.filters.radiusMeters === opt.value ? 'selected' : ''}`}
+                    onClick={() => vm.updateFilter('radiusMeters', opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Privacy */}
+            <div className="dc-filter-group">
+              <label className="dc-filter-label">Privacy</label>
+              <div className="dc-chip-row">
+                {PRIVACY_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`dc-filter-chip ${vm.filters.privacy === opt.value ? 'selected' : ''}`}
+                    onClick={() => vm.updateFilter('privacy', opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Date range */}
+            <div className="dc-filter-group">
+              <label className="dc-filter-label">Date Range</label>
+              <div className="dc-date-row">
+                <input
+                  type="date"
+                  className="field-input dc-date-input"
+                  value={vm.filters.startFrom}
+                  onChange={(e) => vm.updateFilter('startFrom', e.target.value)}
+                  placeholder="From"
+                />
+                <span className="dc-date-sep">to</span>
+                <input
+                  type="date"
+                  className="field-input dc-date-input"
+                  value={vm.filters.startTo}
+                  onChange={(e) => vm.updateFilter('startTo', e.target.value)}
+                  placeholder="To"
+                />
+              </div>
+            </div>
+
+            {/* Tags */}
+            <div className="dc-filter-group">
+              <label className="dc-filter-label">Tags</label>
+              <input
+                type="text"
+                className="field-input dc-tag-input"
+                placeholder="e.g. hiking, outdoor (comma-separated)"
+                value={vm.filters.tagNames}
+                onChange={(e) => vm.updateFilter('tagNames', e.target.value)}
+              />
+            </div>
+
+            {/* Clear */}
+            {hasActiveFilters && (
+              <button
+                type="button"
+                className="dc-clear-btn"
+                onClick={vm.clearFilters}
+              >
+                Clear All Filters
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Categories */}
+        {vm.categories.length > 0 && (
+          <div className="dc-category-row">
+            {vm.categories.map((cat) => (
+              <button
+                key={cat.id}
+                type="button"
+                className={`dc-category-chip ${vm.filters.categoryId === cat.id ? 'selected' : ''}`}
+                onClick={() => vm.updateCategory(cat.id)}
+              >
+                {cat.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Error */}
+      {vm.error && (
+        <div className="error-banner">
+          {vm.error}
+          <button type="button" className="dc-retry-btn" onClick={vm.refresh}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Loading */}
+      {vm.isLoading && (
+        <div className="dc-loading">
+          <span className="spinner" />
+          <p>Loading events...</p>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!vm.isLoading && !vm.error && vm.events.length === 0 && (
+        <div className="dc-empty">
+          <h2>No events found</h2>
+          <p>Try adjusting your filters or search to find events.</p>
+        </div>
+      )}
+
+      {/* Event list */}
+      {!vm.isLoading && vm.events.length > 0 && (
+        <>
+          <div className="dc-grid">
+            {vm.events.map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </div>
+
+          {/* Load more */}
+          {vm.hasNext && (
+            <div className="dc-load-more">
+              <button
+                type="button"
+                className="dc-load-more-btn"
+                onClick={vm.loadMore}
+                disabled={vm.isLoadingMore}
+              >
+                {vm.isLoadingMore ? <span className="spinner" /> : 'Load More'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📋 Summary
Add the event discovery page to the web frontend, allowing authenticated users to browse, search, and filter visible events in a card-based list with cursor-based pagination.

## 🔄 Changes
- **`DiscoverPage.tsx`** — Replaced placeholder with full discovery page: search bar, collapsible filter panel, sort chips, category chips, event card grid, load more pagination, login prompt for unauthenticated users
- **`useDiscoverViewModel.ts`** — Discovery state management: browser geolocation with Istanbul fallback, debounced text search, category/sort/radius/privacy/date range/tag/location filters, cursor-based pagination, Nominatim location search for custom center point
- **`discover.css`** — Styles for the discovery page: search row with filter toggle, collapsible filter panel, radius/privacy chips, date range inputs, location search with dropdown, event card grid with hover effects, privacy badges, loading/empty/error states, responsive layout
- **`event.ts`** — Added `DiscoverEventItem`, `DiscoverEventsResponse`, `DiscoverEventsParams`, `DiscoverPageInfo`, `HostScoreSummary`, `DiscoverSortBy` types matching the backend OpenAPI spec
- **`eventService.ts`** — Added `discoverEvents()` function that builds query params and calls `GET /events/`
- **`api.ts`** — Added `apiGetAuth` helper for authenticated GET requests

### Filters (all backed by API)
| Filter | API Parameter | UI |
|--------|--------------|-----|
| Location | `lat`, `lon` | Location search input (Nominatim) with "Use My Location" reset |
| Radius | `radius_meters` | Chip buttons: 1km, 5km, 10km, 25km, 50km |
| Privacy | `privacy_levels` | Chips: All, Public, Protected |
| Date range | `start_from`, `start_to` | Two date pickers (From / To) |
| Tags | `tag_names` | Comma-separated text input |
| Category | `category_ids` | Category chips |
| Search | `q` | Text input with 400ms debounce |
| Sort | `sort_by` | Chips: Soonest (START_TIME), Nearest (DISTANCE) |

## 🧪 Testing
1. Run `docker compose -f deploy/docker-compose.local.yml up --build`
2. Navigate to `/discover` without logging in — should see "Sign in to discover events near you" prompt
3. Log in, navigate to `/discover` — browser may ask for location permission
4. Verify event cards render with image (or placeholder), title, category, date/time, location, participant count, host rating, privacy badge
5. Test search: type in the search bar, verify results update after debounce
6. Click "Filters" button — verify filter panel opens with Location, Radius, Privacy, Date Range, Tags sections
7. Test location filter: type a location, select from dropdown, verify "Searching near" label updates; click "Use My Location" to reset
8. Test radius chips: select different radii, verify results change
9. Test privacy chips: select Public or Protected, verify filtering works
10. Test date range: set From/To dates, verify events outside range are excluded
11. Test category chips: select a category, click again to deselect
12. Click "Clear All Filters" — verify all filters reset
13. If enough events exist, verify "Load More" button appears and loads next page
14. Click an event card — should navigate to `/events/{id}`

## 🔗 Related
Link issues with: #175 
