### PR TITLE
feat(frontend): implement profile editing flow #168

### DIFF
--- a/frontend/src/models/profile.ts
+++ b/frontend/src/models/profile.ts
@@ -1,0 +1,34 @@
+export interface EventSummary {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time?: string;
+  status: string;
+  category?: string;
+  image_url?: string;
+}
+
+export interface UserProfile {
+  id: string;
+  username: string;
+  email: string;
+  phone_number?: string;
+  gender?: string;
+  birth_date?: string;
+  email_verified: boolean;
+  status: string;
+  default_location_address?: string;
+  default_location_lat?: number;
+  default_location_lon?: number;
+  display_name?: string;
+  bio?: string;
+  avatar_url?: string;
+  created_events?: EventSummary[];
+  attended_events?: EventSummary[];
+}
+
+export interface UpdateProfileRequest {
+  display_name?: string | null;
+  bio?: string | null;
+  avatar_url?: string | null;
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -70,6 +70,31 @@ export async function apiPostAuth<T>(
   return response.json();
 }
 
+export async function apiPatchAuth<T>(
+  endpoint: string,
+  body: unknown,
+  token: string,
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json();
+}
+
 export async function apiGetAuth<T>(endpoint: string, token: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${endpoint}`, {
     method: 'GET',

--- a/frontend/src/services/profileService.ts
+++ b/frontend/src/services/profileService.ts
@@ -1,0 +1,21 @@
+import { apiGetAuth, apiPatchAuth } from './api';
+import { UserProfile, UpdateProfileRequest } from '../models/profile';
+
+/**
+ * Profile service for dealing with the /me endpoints
+ */
+export const profileService = {
+  /**
+   * Fetches the profile of the currently authenticated user
+   */
+  async getMyProfile(token: string): Promise<UserProfile> {
+    return apiGetAuth<UserProfile>('/me', token);
+  },
+
+  /**
+   * Updates the profile of the currently authenticated user
+   */
+  async updateMyProfile(data: UpdateProfileRequest, token: string): Promise<void> {
+    return apiPatchAuth<void>('/me', data, token);
+  },
+};

--- a/frontend/src/styles/profile.css
+++ b/frontend/src/styles/profile.css
@@ -1,0 +1,181 @@
+.profile-container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+  color: #111827;
+}
+
+.profile-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 1rem;
+}
+
+.profile-header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  color: #111827;
+}
+
+.edit-toggle-btn {
+  background-color: transparent;
+  color: #2563eb;
+  border: 1px solid #2563eb;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.edit-toggle-btn:hover {
+  background-color: #2563eb;
+  color: white;
+}
+
+.avatar-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.avatar-preview img {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid #2563eb;
+  background-color: #e5e7eb;
+}
+
+.avatar-placeholder {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background-color: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  color: #6b7280;
+  border: 3px solid #e5e7eb;
+}
+
+.profile-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.info-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.info-group label {
+  font-size: 0.85rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+}
+
+.info-group p {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.empty-state {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+.profile-form form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-group label {
+  font-weight: 500;
+  color: #374151;
+}
+
+.form-group input,
+.form-group textarea {
+  padding: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background-color: #f9fafb;
+  color: #111827;
+  font-family: inherit;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.save-btn {
+  flex: 1;
+  background-color: #2563eb;
+  color: #ffffff;
+  border: none;
+  padding: 0.75rem;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.save-btn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.save-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cancel-btn {
+  flex: 1;
+  background-color: #f3f4f6;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  padding: 0.75rem;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cancel-btn:hover {
+  background-color: #e5e7eb;
+}

--- a/frontend/src/viewmodels/profile/useProfileViewModel.ts
+++ b/frontend/src/viewmodels/profile/useProfileViewModel.ts
@@ -1,0 +1,111 @@
+import { useState, useCallback, useEffect } from 'react';
+import { UserProfile, UpdateProfileRequest } from '../../models/profile';
+import { profileService } from '../../services/profileService';
+
+export function useProfileViewModel(token: string | null) {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  
+  // UI states
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  
+  // Form Draft states
+  const [displayName, setDisplayName] = useState('');
+  const [bio, setBio] = useState('');
+  const [avatarUrl, setAvatarUrl] = useState('');
+
+  const fetchProfile = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await profileService.getMyProfile(token);
+      setProfile(data);
+      // Pre-fill form values with current profile data
+      setDisplayName(data.display_name || '');
+      setBio(data.bio || '');
+      setAvatarUrl(data.avatar_url || '');
+    } catch (err: any) {
+      setError(err.message || 'Failed to load profile');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  const handleEditToggle = () => {
+    if (isEditing) {
+      // Cancel edit mode: reset draft values back to active profile values
+      setDisplayName(profile?.display_name || '');
+      setBio(profile?.bio || '');
+      setAvatarUrl(profile?.avatar_url || '');
+      setError(null);
+      setSuccess(null);
+    }
+    setIsEditing(!isEditing);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setIsSaving(true);
+    
+    // Minimal frontend validation for URL safety
+    if (avatarUrl.trim() && !/^https?:\/\/.+/.test(avatarUrl.trim())) {
+      setError("Please enter a valid URL starting with 'http://' or 'https://'");
+      setIsSaving(false);
+      return;
+    }
+
+    try {
+      if (!token) throw new Error("Authentication token is missing.");
+
+      const updatePayload: UpdateProfileRequest = {
+        display_name: displayName.trim() || null,
+        bio: bio.trim() || null,
+        avatar_url: avatarUrl.trim() || null,
+      };
+
+      await profileService.updateMyProfile(updatePayload, token);
+      
+      // Re-fetch profile to ensure data consistency with DB
+      await fetchProfile();
+      
+      // Close editing mode on success
+      setIsEditing(false);
+      setSuccess("Profile updated successfully!");
+      
+      // Auto-hide success message after 5 seconds
+      setTimeout(() => setSuccess(null), 5000);
+      
+    } catch (err: any) {
+      setError(err.message || 'Failed to update profile');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    profile,
+    isLoading,
+    isEditing,
+    isSaving,
+    error,
+    success,
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    avatarUrl,
+    setAvatarUrl,
+    handleEditToggle,
+    handleSave,
+  };
+}

--- a/frontend/src/views/profile/ProfilePage.tsx
+++ b/frontend/src/views/profile/ProfilePage.tsx
@@ -1,12 +1,168 @@
+import '@/styles/profile.css';
 import { useAuth } from '@/contexts/AuthContext';
+import { useProfileViewModel } from '../../viewmodels/profile/useProfileViewModel';
 
 export default function ProfilePage() {
-  const { username } = useAuth();
+  const { token } = useAuth();
+  const {
+    profile,
+    isLoading,
+    isEditing,
+    isSaving,
+    error,
+    success,
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    avatarUrl,
+    setAvatarUrl,
+    handleEditToggle,
+    handleSave,
+  } = useProfileViewModel(token);
+
+  if (isLoading) {
+    return (
+      <div className="profile-container" style={{ textAlign: 'center' }}>
+        <p>Loading profile...</p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="profile-container" style={{ textAlign: 'center' }}>
+        <p>User profile could not be loaded.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="placeholder-page">
-      <h1>Profile</h1>
-      <p>{username ? `Signed in as ${username}` : 'Your profile details.'}</p>
+    <div className="profile-container">
+      <div className="profile-header">
+        <h1>Your Profile</h1>
+        <button
+          className="edit-toggle-btn"
+          onClick={handleEditToggle}
+          disabled={isSaving}
+        >
+          {isEditing ? 'Cancel Edit' : 'Edit Profile'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="form-error" style={{ marginBottom: '1.5rem', padding: '1rem', backgroundColor: 'rgba(239, 68, 68, 0.1)', color: '#ef4444', borderRadius: '6px' }}>
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="form-success" style={{ marginBottom: '1.5rem', padding: '1rem', backgroundColor: '#dcfce7', color: '#16a34a', border: '1px solid #bbf7d0', borderRadius: '6px', fontWeight: '500' }}>
+          {success}
+        </div>
+      )}
+
+      {/* Avatar Preview Section used in both Read Only and Edit modes */}
+      <div className="avatar-preview">
+        {avatarUrl || profile.avatar_url ? (
+          <img
+            src={isEditing ? avatarUrl : profile.avatar_url!}
+            alt="Profile Avatar"
+            onError={(e) => { (e.target as HTMLImageElement).src = 'https://via.placeholder.com/120?text=Invalid+Image'; }}
+          />
+        ) : (
+          <div className="avatar-placeholder">
+            {profile.display_name ? profile.display_name.charAt(0).toUpperCase() : profile.username.charAt(0).toUpperCase()}
+          </div>
+        )}
+      </div>
+
+      {!isEditing ? (
+        // READ-ONLY STATE
+        <div className="profile-info">
+          <div className="info-group">
+            <label>Username</label>
+            <p>@{profile.username}</p>
+          </div>
+
+          <div className="info-group">
+            <label>Email</label>
+            <p>
+              {profile.email}
+              <span style={{ fontSize: '0.8rem', marginLeft: '0.5rem', color: profile.email_verified ? 'green' : 'gray' }}>
+                ({profile.email_verified ? 'Verified' : 'Unverified'})
+              </span>
+            </p>
+          </div>
+
+          <div className="info-group">
+            <label>Display Name</label>
+            {profile.display_name ? <p>{profile.display_name}</p> : <p className="empty-state">No display name set</p>}
+          </div>
+
+          <div className="info-group">
+            <label>Bio</label>
+            {profile.bio ? <p>{profile.bio}</p> : <p className="empty-state">No bio provided</p>}
+          </div>
+        </div>
+      ) : (
+        // EDIT MODE STATE
+        <div className="profile-form">
+          <form onSubmit={handleSave}>
+            <div className="form-group">
+              <label>Avatar Image URL</label>
+              <input
+                type="text"
+                placeholder="https://example.com/avatar.jpg"
+                value={avatarUrl}
+                onChange={(e) => setAvatarUrl(e.target.value)}
+                disabled={isSaving}
+              />
+            </div>
+
+            <div className="form-group">
+              <label>Display Name</label>
+              <input
+                type="text"
+                placeholder="Enter your public display name"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                maxLength={50}
+                disabled={isSaving}
+              />
+            </div>
+
+            <div className="form-group">
+              <label>Biography</label>
+              <textarea
+                placeholder="Tell us a bit about yourself"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                maxLength={500}
+                disabled={isSaving}
+              />
+            </div>
+
+            <div className="form-actions">
+              <button
+                type="button"
+                className="cancel-btn"
+                onClick={handleEditToggle}
+                disabled={isSaving}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="save-btn"
+                disabled={isSaving || (displayName === profile.display_name && bio === profile.bio && avatarUrl === profile.avatar_url)}
+              >
+                {isSaving ? 'Saving...' : 'Save Profile'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📋 Summary
Add the profile editing form to the web frontend, allowing authenticated users to update their external-facing details (avatar, display name, bio) and saving changes securely via the /me backend endpoints.

## 🔄 Changes

ProfilePage.tsx — Replaced the placeholder with the full profile page featuring a read-only viewer mode and a conditional edit mode containing the inputs for updating Avatar URL, Display Name, and Biography. Includes basic frontend validation and dynamically triggered success/error banners.
useProfileViewModel.ts — Profile state management: handles all internal state, draft form bindings, loading toggles, fetching, PATCH API calls, and automatically dismissing success message alerts following the MVVM architecture.
profile.css — Styled the profile page layout: hardcoded hex color constraints matching global components, rounded containers, avatar image placeholder fallbacks, hover effects, and strict button themes ensuring exact parity with our auth.css standard.
profile.ts — Added UserProfile, UpdateProfileRequest, and EventSummary interfaces matching the precise JSON tags output from the backend OpenAPI schema.
profileService.ts — Added getMyProfile() and updateMyProfile() functions encapsulating API calls for the /me routes natively handling current session tokens.
api.ts — Added the apiPatchAuth helper for authorized PATCH requests securely.
## 🧪 Testing

Run docker-compose -f deploy/docker-compose.local.yml up -d --build backend
Navigate to /login and log into your account.
Navigate to /profile. Verify the user's primary information renders perfectly inside the read-only state.
Click "Edit Profile" — verify the data fields instantly convert into interactive text input and textarea boxes holding draft inputs.
Test Avatar URL: Enter a valid image address structure (http) and verify validation checks it.
Test Display Name & Bio: Write sample traits and hit "Save Profile".
Verify a green "Profile updated successfully!" banner conditionally appears directly at the top of the container, resetting the form correctly to read-only mode automatically.
Refresh the page to guarantee the payload properly reached the PATCH /me endpoint and successfully pulls the saved updates.
##  🔗 Related 
Closes  #168