### PR TITLE
feat(frontend): add event detail page with full event info and host m…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import AppShell from './components/AppShell';
 import ProtectedRoute from './components/ProtectedRoute';
 import DiscoverPage from './views/discover/DiscoverPage';
 import CreateEventPage from './views/events/CreateEventPage';
+import EventDetailPage from './views/events/EventDetailPage';
 import MyEventsPage from './views/events/MyEventsPage';
 import InvitationsPage from './views/invitations/InvitationsPage';
 import FavoritesPage from './views/favorites/FavoritesPage';
@@ -28,6 +29,7 @@ export default function App() {
 
         {/* Protected routes — require auth */}
         <Route path="/events/create" element={<ProtectedRoute><CreateEventPage /></ProtectedRoute>} />
+        <Route path="/events/:id" element={<EventDetailPage />} />
         <Route path="/my-events" element={<ProtectedRoute><MyEventsPage /></ProtectedRoute>} />
         <Route path="/invitations" element={<ProtectedRoute><InvitationsPage /></ProtectedRoute>} />
         <Route path="/favorites" element={<ProtectedRoute><FavoritesPage /></ProtectedRoute>} />

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -105,3 +105,126 @@ export interface DiscoverEventsResponse {
   items: DiscoverEventItem[];
   page_info: DiscoverPageInfo;
 }
+
+/* ── Event Detail ── */
+
+export interface EventDetailCategory {
+  id: number;
+  name: string;
+}
+
+export interface EventDetailPoint {
+  lat: number;
+  lon: number;
+}
+
+export interface EventDetailLocation {
+  type: 'POINT' | 'ROUTE';
+  address: string | null;
+  point: EventDetailPoint | null;
+  route_points: EventDetailPoint[];
+}
+
+export interface EventDetailUserSummary {
+  id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+}
+
+export interface EventDetailConstraint {
+  type: string;
+  info: string;
+}
+
+export interface EventDetailRatingWindow {
+  opens_at: string;
+  closes_at: string;
+  is_active: boolean;
+}
+
+export interface EventDetailEmbeddedRating {
+  id: string;
+  rating: number;
+  message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EventDetailViewerContext {
+  is_host: boolean;
+  is_favorited: boolean;
+  participation_status: 'JOINED' | 'PENDING' | 'INVITED' | 'NONE';
+}
+
+export interface EventDetailHostContextUser {
+  id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  final_score: number | null;
+  rating_count: number;
+}
+
+export interface EventDetailApprovedParticipant {
+  participation_id: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  host_rating: EventDetailEmbeddedRating | null;
+  user: EventDetailHostContextUser;
+}
+
+export interface EventDetailPendingJoinRequest {
+  join_request_id: string;
+  status: string;
+  message: string | null;
+  created_at: string;
+  updated_at: string;
+  user: EventDetailHostContextUser;
+}
+
+export interface EventDetailInvitation {
+  invitation_id: string;
+  status: string;
+  message: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  user: EventDetailHostContextUser;
+}
+
+export interface EventDetailHostContext {
+  approved_participants: EventDetailApprovedParticipant[];
+  pending_join_requests: EventDetailPendingJoinRequest[];
+  invitations: EventDetailInvitation[];
+}
+
+export interface EventDetailResponse {
+  id: string;
+  title: string;
+  description: string | null;
+  image_url: string | null;
+  privacy_level: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+  status: string;
+  start_time: string;
+  end_time: string | null;
+  capacity: number | null;
+  minimum_age: number | null;
+  preferred_gender: string | null;
+  approved_participant_count: number;
+  pending_participant_count: number;
+  favorite_count: number;
+  created_at: string;
+  updated_at: string;
+  category: EventDetailCategory | null;
+  host: EventDetailUserSummary;
+  host_score: HostScoreSummary;
+  location: EventDetailLocation;
+  tags: string[];
+  constraints: EventDetailConstraint[];
+  rating_window: EventDetailRatingWindow;
+  viewer_event_rating: EventDetailEmbeddedRating | null;
+  viewer_context: EventDetailViewerContext;
+  host_context: EventDetailHostContext | null;
+}

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -6,6 +6,7 @@ import {
   LocationSuggestion,
   DiscoverEventsParams,
   DiscoverEventsResponse,
+  EventDetailResponse,
 } from '@/models/event';
 
 const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
@@ -40,6 +41,13 @@ export function discoverEvents(
   if (params.limit != null) qs.set('limit', String(params.limit));
   if (params.cursor) qs.set('cursor', params.cursor);
   return apiGetAuth<DiscoverEventsResponse>(`/events/?${qs}`, token);
+}
+
+export function getEventDetail(
+  eventId: string,
+  token: string,
+): Promise<EventDetailResponse> {
+  return apiGetAuth<EventDetailResponse>(`/events/${eventId}`, token);
 }
 
 export async function searchLocation(

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -1,0 +1,587 @@
+.ed-page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding-bottom: 40px;
+}
+
+/* Back button */
+.ed-back-btn {
+  display: inline-block;
+  margin-bottom: 16px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background: none;
+  color: #374151;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ed-back-btn:hover {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+/* Hero image */
+.ed-hero {
+  position: relative;
+  width: 100%;
+  height: 300px;
+  border-radius: 16px;
+  overflow: hidden;
+  background-color: #f3f4f6;
+  margin-bottom: 20px;
+}
+
+.ed-hero-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ed-hero-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+}
+
+.ed-hero-placeholder span {
+  font-size: 72px;
+  font-weight: 700;
+  color: #2563eb;
+  opacity: 0.4;
+}
+
+.ed-hero-badges {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: flex;
+  gap: 8px;
+}
+
+/* Status badges */
+.ed-status-badge {
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.ed-status-active {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+.ed-status-canceled {
+  background-color: #fee2e2;
+  color: #dc2626;
+}
+
+.ed-status-completed {
+  background-color: #e5e7eb;
+  color: #6b7280;
+}
+
+/* Privacy badges */
+.ed-privacy-badge {
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.ed-privacy-public {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+.ed-privacy-protected {
+  background-color: #fef3c7;
+  color: #d97706;
+}
+
+.ed-privacy-private {
+  background-color: #fee2e2;
+  color: #dc2626;
+}
+
+/* Header */
+.ed-header {
+  margin-bottom: 20px;
+}
+
+.ed-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 6px 0;
+  line-height: 1.3;
+}
+
+.ed-category {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 14px;
+  background-color: #eff6ff;
+  color: #2563eb;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+/* Metrics row */
+.ed-metrics {
+  display: flex;
+  gap: 24px;
+  padding: 16px 0;
+  border-top: 1px solid #f3f4f6;
+  border-bottom: 1px solid #f3f4f6;
+  margin-bottom: 24px;
+}
+
+.ed-metric {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.ed-metric-value {
+  font-size: 18px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.ed-metric-label {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+/* Sections */
+.ed-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.ed-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ed-section-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+/* Info rows */
+.ed-info-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.ed-info-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.ed-info-primary {
+  font-size: 15px;
+  color: #111827;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.ed-info-secondary {
+  font-size: 13px;
+  color: #9ca3af;
+  margin: 2px 0 0 0;
+}
+
+/* Description */
+.ed-description {
+  font-size: 15px;
+  color: #374151;
+  line-height: 1.7;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+/* Host */
+.ed-host {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+}
+
+.ed-host-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background-color: #2563eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.ed-host-avatar span {
+  font-size: 18px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.ed-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ed-host-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.ed-host-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.ed-host-username {
+  font-size: 13px;
+  color: #9ca3af;
+  margin: 0;
+}
+
+.ed-host-score {
+  font-size: 15px;
+  font-weight: 600;
+  color: #f59e0b;
+  flex-shrink: 0;
+}
+
+.ed-host-rating-count {
+  font-size: 12px;
+  font-weight: 400;
+  color: #9ca3af;
+}
+
+/* Details grid */
+.ed-details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.ed-detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 16px;
+  border-radius: 10px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+}
+
+.ed-detail-label {
+  font-size: 12px;
+  color: #9ca3af;
+  font-weight: 500;
+}
+
+.ed-detail-value {
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+}
+
+/* Tags */
+.ed-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ed-tag {
+  padding: 5px 14px;
+  border-radius: 16px;
+  background-color: #eff6ff;
+  color: #2563eb;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* Constraints */
+.ed-constraints {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ed-constraint {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background-color: #fffbeb;
+  border: 1px solid #fde68a;
+}
+
+.ed-constraint-type {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #d97706;
+  flex-shrink: 0;
+}
+
+.ed-constraint-info {
+  font-size: 14px;
+  color: #374151;
+}
+
+/* Participation banners */
+.ed-participation-banner {
+  padding: 12px 16px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+}
+
+.ed-participation-joined {
+  background-color: #dcfce7;
+  color: #16a34a;
+  border: 1px solid #bbf7d0;
+}
+
+.ed-participation-pending {
+  background-color: #fef3c7;
+  color: #d97706;
+  border: 1px solid #fde68a;
+}
+
+.ed-participation-invited {
+  background-color: #eff6ff;
+  color: #2563eb;
+  border: 1px solid #bfdbfe;
+}
+
+/* Rating banner */
+.ed-rating-banner {
+  padding: 12px 16px;
+  border-radius: 10px;
+  background-color: #eff6ff;
+  color: #2563eb;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  border: 1px solid #bfdbfe;
+}
+
+/* Management section */
+.ed-mgmt-group {
+  margin-bottom: 16px;
+}
+
+.ed-mgmt-group:last-child {
+  margin-bottom: 0;
+}
+
+.ed-mgmt-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 10px 0;
+}
+
+.ed-mgmt-empty {
+  font-size: 13px;
+  color: #9ca3af;
+  margin: 0;
+  padding: 8px 0;
+}
+
+.ed-mgmt-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ed-mgmt-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+}
+
+.ed-mgmt-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.ed-mgmt-avatar span {
+  font-size: 14px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.ed-mgmt-user-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.ed-mgmt-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.ed-mgmt-username {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.ed-mgmt-message {
+  font-size: 12px;
+  color: #6b7280;
+  font-style: italic;
+  margin-top: 2px;
+}
+
+.ed-mgmt-score {
+  font-size: 13px;
+  font-weight: 600;
+  color: #f59e0b;
+  flex-shrink: 0;
+}
+
+.ed-mgmt-date {
+  font-size: 12px;
+  color: #9ca3af;
+  flex-shrink: 0;
+}
+
+/* Invitation status */
+.ed-invitation-status {
+  padding: 3px 10px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.ed-inv-pending {
+  background-color: #fef3c7;
+  color: #d97706;
+}
+
+.ed-inv-accepted {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+.ed-inv-declined {
+  background-color: #fee2e2;
+  color: #dc2626;
+}
+
+.ed-inv-expired {
+  background-color: #e5e7eb;
+  color: #6b7280;
+}
+
+/* State containers (loading, error, not-found) */
+.ed-state-container {
+  text-align: center;
+  padding: 80px 20px;
+  color: #6b7280;
+}
+
+.ed-state-container h2 {
+  font-size: 22px;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 8px;
+}
+
+.ed-state-container p {
+  font-size: 15px;
+  color: #9ca3af;
+  margin-bottom: 20px;
+}
+
+.ed-back-link {
+  display: inline-block;
+  padding: 10px 28px;
+  text-decoration: none;
+}
+
+.ed-retry-btn {
+  padding: 10px 28px;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .ed-hero {
+    height: 200px;
+    border-radius: 12px;
+  }
+
+  .ed-title {
+    font-size: 22px;
+  }
+
+  .ed-metrics {
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+
+  .ed-details-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .ed-host {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getEventDetail } from '@/services/eventService';
+import type { EventDetailResponse } from '@/models/event';
+import { ApiError } from '@/services/api';
+
+export type DetailStatus = 'loading' | 'ready' | 'not-found' | 'forbidden' | 'error';
+
+export function useEventDetailViewModel(eventId: string | undefined, token: string | null) {
+  const [event, setEvent] = useState<EventDetailResponse | null>(null);
+  const [status, setStatus] = useState<DetailStatus>('loading');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const fetchDetail = useCallback(async () => {
+    if (!eventId || !token) {
+      setStatus('error');
+      setErrorMessage(!token ? 'You must be signed in to view this event.' : 'Invalid event ID.');
+      return;
+    }
+
+    setStatus('loading');
+    setErrorMessage(null);
+
+    try {
+      const data = await getEventDetail(eventId, token);
+      setEvent(data);
+      setStatus('ready');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 404) {
+          setStatus('not-found');
+        } else if (err.status === 403) {
+          setStatus('forbidden');
+        } else {
+          setStatus('error');
+          setErrorMessage(err.message);
+        }
+      } else {
+        setStatus('error');
+        setErrorMessage('Failed to load event. Please try again.');
+      }
+    }
+  }, [eventId, token]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  return {
+    event,
+    status,
+    errorMessage,
+    retry: fetchDetail,
+  };
+}

--- a/frontend/src/views/discover/DiscoverPage.tsx
+++ b/frontend/src/views/discover/DiscoverPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import {
   useDiscoverViewModel,
@@ -39,7 +40,7 @@ function formatTime(iso: string): string {
 
 function EventCard({ event }: { event: DiscoverEventItem }) {
   return (
-    <a href={`/events/${event.id}`} className="dc-card">
+    <Link to={`/events/${event.id}`} className="dc-card">
       <div className="dc-card-image-wrapper">
         {event.image_url ? (
           <img src={event.image_url} alt={event.title} className="dc-card-image" />
@@ -78,7 +79,7 @@ function EventCard({ event }: { event: DiscoverEventItem }) {
           )}
         </div>
       </div>
-    </a>
+    </Link>
   );
 }
 

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -1,0 +1,405 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import { useEventDetailViewModel } from '@/viewmodels/event/useEventDetailViewModel';
+import type { EventDetailResponse } from '@/models/event';
+import '@/styles/event-detail.css';
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }) + ' at ' + d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function formatShortDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cls = status === 'ACTIVE' ? 'ed-status-active'
+    : status === 'CANCELED' ? 'ed-status-canceled'
+    : 'ed-status-completed';
+  return <span className={`ed-status-badge ${cls}`}>{status}</span>;
+}
+
+function PrivacyBadge({ level }: { level: string }) {
+  const label = level === 'PUBLIC' ? 'Public' : level === 'PROTECTED' ? 'Protected' : 'Private';
+  return (
+    <span className={`ed-privacy-badge ed-privacy-${level.toLowerCase()}`}>
+      {label}
+    </span>
+  );
+}
+
+function EventContent({ event }: { event: EventDetailResponse }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="ed-page">
+      <button type="button" className="ed-back-btn" onClick={() => navigate(-1)}>
+        &larr; Back
+      </button>
+
+      {/* Hero image */}
+      <div className="ed-hero">
+        {event.image_url ? (
+          <img src={event.image_url} alt={event.title} className="ed-hero-image" />
+        ) : (
+          <div className="ed-hero-placeholder">
+            <span>{event.category?.name?.charAt(0) ?? 'E'}</span>
+          </div>
+        )}
+        <div className="ed-hero-badges">
+          <StatusBadge status={event.status} />
+          <PrivacyBadge level={event.privacy_level} />
+        </div>
+      </div>
+
+      {/* Title & category */}
+      <div className="ed-header">
+        <h1 className="ed-title">{event.title}</h1>
+        {event.category && (
+          <span className="ed-category">{event.category.name}</span>
+        )}
+      </div>
+
+      {/* Metrics row */}
+      <div className="ed-metrics">
+        <div className="ed-metric">
+          <span className="ed-metric-value">{event.approved_participant_count}</span>
+          <span className="ed-metric-label">Participant{event.approved_participant_count !== 1 ? 's' : ''}</span>
+        </div>
+        {event.viewer_context.is_host && (
+          <div className="ed-metric">
+            <span className="ed-metric-value">{event.pending_participant_count}</span>
+            <span className="ed-metric-label">Pending</span>
+          </div>
+        )}
+        <div className="ed-metric">
+          <span className="ed-metric-value">{event.favorite_count}</span>
+          <span className="ed-metric-label">Save{event.favorite_count !== 1 ? 's' : ''}</span>
+        </div>
+        {event.host_score.final_score != null && (
+          <div className="ed-metric">
+            <span className="ed-metric-value">{'★'} {event.host_score.final_score.toFixed(1)}</span>
+            <span className="ed-metric-label">Host Score</span>
+          </div>
+        )}
+      </div>
+
+      {/* Info sections */}
+      <div className="ed-sections">
+        {/* Date & time */}
+        <div className="ed-section">
+          <h2 className="ed-section-title">Date & Time</h2>
+          <div className="ed-info-row">
+            <span className="ed-info-icon">&#128197;</span>
+            <div>
+              <p className="ed-info-primary">{formatDateTime(event.start_time)}</p>
+              {event.end_time && (
+                <p className="ed-info-secondary">
+                  Until {formatDateTime(event.end_time)}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Location */}
+        <div className="ed-section">
+          <h2 className="ed-section-title">Location</h2>
+          <div className="ed-info-row">
+            <span className="ed-info-icon">&#128205;</span>
+            <div>
+              {event.location.address ? (
+                <p className="ed-info-primary">{event.location.address}</p>
+              ) : (
+                <p className="ed-info-secondary">No address provided</p>
+              )}
+              <p className="ed-info-secondary">
+                {event.location.type === 'ROUTE' ? 'Route-based event' : 'Point location'}
+                {event.location.point && (
+                  <> &middot; {event.location.point.lat.toFixed(4)}, {event.location.point.lon.toFixed(4)}</>
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Description */}
+        {event.description && (
+          <div className="ed-section">
+            <h2 className="ed-section-title">Description</h2>
+            <p className="ed-description">{event.description}</p>
+          </div>
+        )}
+
+        {/* Host */}
+        <div className="ed-section">
+          <h2 className="ed-section-title">Host</h2>
+          <div className="ed-host">
+            <div className="ed-host-avatar">
+              {event.host.avatar_url ? (
+                <img src={event.host.avatar_url} alt={event.host.username} className="ed-avatar-img" />
+              ) : (
+                <span>{event.host.username.charAt(0).toUpperCase()}</span>
+              )}
+            </div>
+            <div className="ed-host-info">
+              <p className="ed-host-name">{event.host.display_name ?? event.host.username}</p>
+              <p className="ed-host-username">@{event.host.username}</p>
+            </div>
+            {event.host_score.final_score != null && (
+              <span className="ed-host-score">
+                {'★'} {event.host_score.final_score.toFixed(1)}
+                <span className="ed-host-rating-count"> ({event.host_score.hosted_event_rating_count})</span>
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Details grid */}
+        <div className="ed-section">
+          <h2 className="ed-section-title">Details</h2>
+          <div className="ed-details-grid">
+            {event.capacity != null && (
+              <div className="ed-detail-item">
+                <span className="ed-detail-label">Capacity</span>
+                <span className="ed-detail-value">{event.approved_participant_count} / {event.capacity}</span>
+              </div>
+            )}
+            {event.minimum_age != null && (
+              <div className="ed-detail-item">
+                <span className="ed-detail-label">Minimum Age</span>
+                <span className="ed-detail-value">{event.minimum_age}+</span>
+              </div>
+            )}
+            {event.preferred_gender && (
+              <div className="ed-detail-item">
+                <span className="ed-detail-label">Preferred Gender</span>
+                <span className="ed-detail-value">{event.preferred_gender}</span>
+              </div>
+            )}
+            <div className="ed-detail-item">
+              <span className="ed-detail-label">Privacy</span>
+              <span className="ed-detail-value">{event.privacy_level}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Tags */}
+        {event.tags.length > 0 && (
+          <div className="ed-section">
+            <h2 className="ed-section-title">Tags</h2>
+            <div className="ed-tags">
+              {event.tags.map((tag) => (
+                <span key={tag} className="ed-tag">{tag}</span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Constraints */}
+        {event.constraints.length > 0 && (
+          <div className="ed-section">
+            <h2 className="ed-section-title">Requirements</h2>
+            <ul className="ed-constraints">
+              {event.constraints.map((c, i) => (
+                <li key={i} className="ed-constraint">
+                  <span className="ed-constraint-type">{c.type}</span>
+                  <span className="ed-constraint-info">{c.info}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Viewer participation status */}
+        {!event.viewer_context.is_host && event.viewer_context.participation_status !== 'NONE' && (
+          <div className="ed-section">
+            <div className={`ed-participation-banner ed-participation-${event.viewer_context.participation_status.toLowerCase()}`}>
+              {event.viewer_context.participation_status === 'JOINED' && 'You are participating in this event'}
+              {event.viewer_context.participation_status === 'PENDING' && 'Your join request is pending approval'}
+              {event.viewer_context.participation_status === 'INVITED' && 'You have been invited to this event'}
+            </div>
+          </div>
+        )}
+
+        {/* Host management section */}
+        {event.viewer_context.is_host && event.host_context && (
+          <div className="ed-section">
+            <h2 className="ed-section-title">Management</h2>
+
+            {/* Approved participants */}
+            <div className="ed-mgmt-group">
+              <h3 className="ed-mgmt-title">
+                Approved Participants ({event.host_context.approved_participants.length})
+              </h3>
+              {event.host_context.approved_participants.length === 0 ? (
+                <p className="ed-mgmt-empty">No participants yet</p>
+              ) : (
+                <ul className="ed-mgmt-list">
+                  {event.host_context.approved_participants.map((p) => (
+                    <li key={p.participation_id} className="ed-mgmt-item">
+                      <div className="ed-mgmt-avatar">
+                        {p.user.avatar_url ? (
+                          <img src={p.user.avatar_url} alt={p.user.username} className="ed-avatar-img" />
+                        ) : (
+                          <span>{p.user.username.charAt(0).toUpperCase()}</span>
+                        )}
+                      </div>
+                      <div className="ed-mgmt-user-info">
+                        <span className="ed-mgmt-name">{p.user.display_name ?? p.user.username}</span>
+                        <span className="ed-mgmt-username">@{p.user.username}</span>
+                      </div>
+                      {p.user.final_score != null && (
+                        <span className="ed-mgmt-score">{'★'} {p.user.final_score.toFixed(1)}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {/* Pending requests */}
+            {event.host_context.pending_join_requests.length > 0 && (
+              <div className="ed-mgmt-group">
+                <h3 className="ed-mgmt-title">
+                  Pending Requests ({event.host_context.pending_join_requests.length})
+                </h3>
+                <ul className="ed-mgmt-list">
+                  {event.host_context.pending_join_requests.map((r) => (
+                    <li key={r.join_request_id} className="ed-mgmt-item">
+                      <div className="ed-mgmt-avatar">
+                        {r.user.avatar_url ? (
+                          <img src={r.user.avatar_url} alt={r.user.username} className="ed-avatar-img" />
+                        ) : (
+                          <span>{r.user.username.charAt(0).toUpperCase()}</span>
+                        )}
+                      </div>
+                      <div className="ed-mgmt-user-info">
+                        <span className="ed-mgmt-name">{r.user.display_name ?? r.user.username}</span>
+                        <span className="ed-mgmt-username">@{r.user.username}</span>
+                        {r.message && <span className="ed-mgmt-message">"{r.message}"</span>}
+                      </div>
+                      <span className="ed-mgmt-date">{formatShortDate(r.created_at)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Invitations */}
+            {event.host_context.invitations.length > 0 && (
+              <div className="ed-mgmt-group">
+                <h3 className="ed-mgmt-title">
+                  Invitations ({event.host_context.invitations.length})
+                </h3>
+                <ul className="ed-mgmt-list">
+                  {event.host_context.invitations.map((inv) => (
+                    <li key={inv.invitation_id} className="ed-mgmt-item">
+                      <div className="ed-mgmt-avatar">
+                        {inv.user.avatar_url ? (
+                          <img src={inv.user.avatar_url} alt={inv.user.username} className="ed-avatar-img" />
+                        ) : (
+                          <span>{inv.user.username.charAt(0).toUpperCase()}</span>
+                        )}
+                      </div>
+                      <div className="ed-mgmt-user-info">
+                        <span className="ed-mgmt-name">{inv.user.display_name ?? inv.user.username}</span>
+                        <span className="ed-mgmt-username">@{inv.user.username}</span>
+                      </div>
+                      <span className={`ed-invitation-status ed-inv-${inv.status.toLowerCase()}`}>
+                        {inv.status}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Rating window info */}
+        {event.rating_window.is_active && (
+          <div className="ed-section">
+            <div className="ed-rating-banner">
+              Rating window is open until {formatShortDate(event.rating_window.closes_at)}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function EventDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { token } = useAuth();
+  const { event, status, errorMessage, retry } = useEventDetailViewModel(id, token);
+
+  if (status === 'loading') {
+    return (
+      <div className="ed-page">
+        <div className="ed-state-container">
+          <span className="spinner" />
+          <p>Loading event...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'not-found') {
+    return (
+      <div className="ed-page">
+        <div className="ed-state-container">
+          <h2>Event Not Found</h2>
+          <p>This event doesn't exist or has been removed.</p>
+          <a href="/discover" className="btn-primary ed-back-link">Back to Discover</a>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'forbidden') {
+    return (
+      <div className="ed-page">
+        <div className="ed-state-container">
+          <h2>Access Denied</h2>
+          <p>You don't have permission to view this event.</p>
+          <a href="/discover" className="btn-primary ed-back-link">Back to Discover</a>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="ed-page">
+        <div className="ed-state-container">
+          <h2>Something Went Wrong</h2>
+          <p>{errorMessage}</p>
+          <button type="button" className="btn-primary ed-retry-btn" onClick={retry}>
+            Try Again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!event) return null;
+
+  return <EventContent event={event} />;
+}


### PR DESCRIPTION
## 📋 Summary
Add event detail page that displays full event information when users click an event card from the discover page.

## 🔄 Changes
- Created `EventDetailPage.tsx` — renders full event detail with hero image, badges, metrics, host info, tags, constraints, and host management section
- Created `useEventDetailViewModel.ts` — fetches event data from `GET /events/{id}` API with loading/error/not-found/forbidden state handling
- Created `event-detail.css` — responsive styles for the event detail page
- Updated `event.ts` — added all event detail TypeScript types matching the backend API spec
- Updated `eventService.ts` — added `getEventDetail()` service function
- Updated `App.tsx` — added `/events/:id` route
- Updated `DiscoverPage.tsx` — changed event card links from `<a>` to React Router `<Link>` for SPA navigation

## 🧪 Testing
1. Run `docker compose -f deploy/docker-compose.local.yml up --build`
2. Sign in and navigate to the Discover page
3. Click any event card — should navigate to `/events/:id` and display full event detail
4. Verify: hero image (or placeholder), status/privacy badges, date/time, location, description, host info with score, capacity, tags, constraints
5. If you are the host: verify management section shows approved participants, pending requests, and invitations
6. If you are a participant: verify participation status banner (joined/pending/invited)
7. Navigate to `/events/invalid-id` — should show "Event Not Found" state
8. Click "Back" button — should return to previous page

## 🔗 Related
Link issues with: #179
