### PR TITLE
feat(frontend): add My Events page with organized, upcoming, and past…

### DIFF
--- a/frontend/src/styles/my-events.css
+++ b/frontend/src/styles/my-events.css
@@ -1,0 +1,244 @@
+.me-page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.me-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 4px;
+}
+
+.me-subtitle {
+  font-size: 15px;
+  color: #6b7280;
+  margin-bottom: 24px;
+}
+
+/* Tabs */
+.me-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 24px;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.me-tab {
+  padding: 10px 20px;
+  font-size: 15px;
+  font-weight: 500;
+  color: #6b7280;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.me-tab:hover {
+  color: #374151;
+}
+
+.me-tab.active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+  font-weight: 600;
+}
+
+.me-tab-count {
+  padding: 1px 8px;
+  border-radius: 10px;
+  background-color: #f3f4f6;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.me-tab.active .me-tab-count {
+  background-color: #eff6ff;
+  color: #2563eb;
+}
+
+/* Loading */
+.me-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 60px 20px;
+  gap: 12px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+/* Error */
+.me-error {
+  text-align: center;
+  padding: 40px 20px;
+  color: #dc2626;
+  font-size: 14px;
+}
+
+.me-retry-btn {
+  margin-top: 12px;
+  padding: 8px 20px;
+  border-radius: 8px;
+  border: 1px solid #dc2626;
+  background: none;
+  color: #dc2626;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.me-retry-btn:hover {
+  background-color: #fef2f2;
+}
+
+/* Empty state */
+.me-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: #9ca3af;
+  font-size: 15px;
+}
+
+/* Event grid */
+.me-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+/* Event card */
+.me-card {
+  display: flex;
+  flex-direction: column;
+  border-radius: 14px;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.me-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+.me-card-image-wrapper {
+  position: relative;
+  width: 100%;
+  height: 140px;
+  overflow: hidden;
+  background-color: #f3f4f6;
+}
+
+.me-card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.me-card-image-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+}
+
+.me-card-image-placeholder span {
+  font-size: 36px;
+  font-weight: 700;
+  color: #2563eb;
+  opacity: 0.4;
+}
+
+.me-card-body {
+  padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.me-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.me-card-category {
+  font-size: 12px;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.me-card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+  line-height: 1.3;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.me-card-date {
+  font-size: 13px;
+  color: #6b7280;
+  margin: 0;
+}
+
+/* Status badges */
+.me-status-badge {
+  padding: 3px 10px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+}
+
+.me-status-active {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+.me-status-canceled {
+  background-color: #fee2e2;
+  color: #dc2626;
+}
+
+.me-status-completed {
+  background-color: #e5e7eb;
+  color: #6b7280;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .me-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .me-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .me-tab {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}

--- a/frontend/src/viewmodels/event/useMyEventsViewModel.ts
+++ b/frontend/src/viewmodels/event/useMyEventsViewModel.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback } from 'react';
+import { profileService } from '@/services/profileService';
+import type { EventSummary } from '@/models/profile';
+import { ApiError } from '@/services/api';
+
+export type MyEventsTab = 'organized' | 'upcoming' | 'past';
+
+export function useMyEventsViewModel(token: string | null) {
+  const [organized, setOrganized] = useState<EventSummary[]>([]);
+  const [upcoming, setUpcoming] = useState<EventSummary[]>([]);
+  const [past, setPast] = useState<EventSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<MyEventsTab>('organized');
+
+  const fetchEvents = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const profile = await profileService.getMyProfile(token);
+      const now = new Date();
+
+      setOrganized(profile.created_events ?? []);
+
+      const attended = profile.attended_events ?? [];
+      setUpcoming(
+        attended.filter((e) => new Date(e.start_time) >= now)
+          .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()),
+      );
+      setPast(
+        attended.filter((e) => new Date(e.start_time) < now)
+          .sort((a, b) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime()),
+      );
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Failed to load your events. Please try again.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchEvents();
+  }, [fetchEvents]);
+
+  return {
+    organized,
+    upcoming,
+    past,
+    isLoading,
+    error,
+    activeTab,
+    setActiveTab,
+    retry: fetchEvents,
+  };
+}

--- a/frontend/src/views/events/MyEventsPage.tsx
+++ b/frontend/src/views/events/MyEventsPage.tsx
@@ -1,8 +1,158 @@
-export default function MyEventsPage() {
+import { Link } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import { useMyEventsViewModel, type MyEventsTab } from '@/viewmodels/event/useMyEventsViewModel';
+import type { EventSummary } from '@/models/profile';
+import '@/styles/my-events.css';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cls = status === 'ACTIVE' ? 'me-status-active'
+    : status === 'CANCELED' ? 'me-status-canceled'
+    : 'me-status-completed';
+  return <span className={`me-status-badge ${cls}`}>{status}</span>;
+}
+
+function EventCard({ event }: { event: EventSummary }) {
   return (
-    <div className="placeholder-page">
-      <h1>My Events</h1>
-      <p>Events you've created or joined.</p>
+    <Link to={`/events/${event.id}`} className="me-card">
+      <div className="me-card-image-wrapper">
+        {event.image_url ? (
+          <img src={event.image_url} alt={event.title} className="me-card-image" />
+        ) : (
+          <div className="me-card-image-placeholder">
+            <span>{event.category?.charAt(0) ?? 'E'}</span>
+          </div>
+        )}
+      </div>
+      <div className="me-card-body">
+        <div className="me-card-top">
+          {event.category && <span className="me-card-category">{event.category}</span>}
+          <StatusBadge status={event.status} />
+        </div>
+        <h3 className="me-card-title">{event.title}</h3>
+        <p className="me-card-date">
+          {formatDate(event.start_time)} &middot; {formatTime(event.start_time)}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+function EventList({ events, emptyMessage }: { events: EventSummary[]; emptyMessage: string }) {
+  if (events.length === 0) {
+    return (
+      <div className="me-empty">
+        <p>{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="me-grid">
+      {events.map((event) => (
+        <EventCard key={event.id} event={event} />
+      ))}
+    </div>
+  );
+}
+
+const TABS: { key: MyEventsTab; label: string }[] = [
+  { key: 'organized', label: 'Organized' },
+  { key: 'upcoming', label: 'Upcoming' },
+  { key: 'past', label: 'Past' },
+];
+
+export default function MyEventsPage() {
+  const { token } = useAuth();
+  const vm = useMyEventsViewModel(token);
+
+  const counts: Record<MyEventsTab, number> = {
+    organized: vm.organized.length,
+    upcoming: vm.upcoming.length,
+    past: vm.past.length,
+  };
+
+  return (
+    <div className="me-page">
+      <h1 className="me-title">My Events</h1>
+      <p className="me-subtitle">Events you've organized, joined, or attended</p>
+
+      {/* Tabs */}
+      <div className="me-tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            className={`me-tab ${vm.activeTab === tab.key ? 'active' : ''}`}
+            onClick={() => vm.setActiveTab(tab.key)}
+          >
+            {tab.label}
+            {!vm.isLoading && (
+              <span className="me-tab-count">{counts[tab.key]}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Loading */}
+      {vm.isLoading && (
+        <div className="me-loading">
+          <span className="spinner" />
+          <p>Loading your events...</p>
+        </div>
+      )}
+
+      {/* Error */}
+      {vm.error && (
+        <div className="me-error">
+          <p>{vm.error}</p>
+          <button type="button" className="me-retry-btn" onClick={vm.retry}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Content */}
+      {!vm.isLoading && !vm.error && (
+        <>
+          {vm.activeTab === 'organized' && (
+            <EventList
+              events={vm.organized}
+              emptyMessage="You haven't organized any events yet. Create your first event!"
+            />
+          )}
+          {vm.activeTab === 'upcoming' && (
+            <EventList
+              events={vm.upcoming}
+              emptyMessage="No upcoming events. Discover events to join!"
+            />
+          )}
+          {vm.activeTab === 'past' && (
+            <EventList
+              events={vm.past}
+              emptyMessage="No past events yet."
+            />
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📋 Summary
Add the My Events page with three tabbed sections — Organized, Upcoming, and Past — so users can view and navigate to their hosted, joined, and previously attended events.

## 🔄 Changes
- Replaced `MyEventsPage.tsx` placeholder with full implementation featuring three tabs with event counts
- Created `useMyEventsViewModel.ts` — fetches `GET /me` profile endpoint, splits `created_events` into Organized and `attended_events` into Upcoming (future start_time, soonest first) and Past (past start_time, most recent first)
- Created `my-events.css` — responsive styles for tabs, event card grid, status badges, loading/empty/error states
- Event cards display image (or placeholder), category, title, date/time, and status badge (ACTIVE/CANCELED/COMPLETED)
- Cards link to `/events/:id` using React Router `Link` for SPA navigation
- Each section has its own empty state message
- No edit/update functionality included (view and navigation only)

## 🧪 Testing
1. Run `docker compose -f deploy/docker-compose.local.yml up --build`
2. Sign in and navigate to "My Events" from the nav bar
3. Click "Organized" tab — verify it shows events you created, with correct status badges
4. Click "Upcoming" tab — verify it shows joined events with future start times, sorted soonest first
5. Click "Past" tab — verify it shows joined events with past start times, sorted most recent first
6. Click any event card — verify it navigates to the event detail page
7. Verify empty states show appropriate messages when a section has no events
8. Verify tab counts match the number of events in each section
9. Test loading state by observing spinner on initial load

## 🔗 Related
Link issues with: #173 
