### PR TITLE
feat(frontend): add approve/reject join request flow for protected events

### DIFF
--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -244,3 +244,20 @@ export interface JoinRequestResponse {
   status: string;
   created_at: string;
 }
+
+export interface ApproveJoinRequestResponse {
+  join_request_id: string;
+  event_id: string;
+  join_request_status: string;
+  participation_id: string;
+  participation_status: string;
+  updated_at: string;
+}
+
+export interface RejectJoinRequestResponse {
+  join_request_id: string;
+  event_id: string;
+  status: string;
+  updated_at: string;
+  cooldown_ends_at: string;
+}

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -9,6 +9,8 @@ import {
   EventDetailResponse,
   JoinEventResponse,
   JoinRequestResponse,
+  ApproveJoinRequestResponse,
+  RejectJoinRequestResponse,
 } from '@/models/event';
 
 const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
@@ -67,6 +69,30 @@ export function requestJoinEvent(
   return apiPostAuth<JoinRequestResponse>(
     `/events/${eventId}/join-request`,
     message ? { message } : {},
+    token,
+  );
+}
+
+export function approveJoinRequest(
+  eventId: string,
+  joinRequestId: string,
+  token: string,
+): Promise<ApproveJoinRequestResponse> {
+  return apiPostAuth<ApproveJoinRequestResponse>(
+    `/events/${eventId}/join-requests/${joinRequestId}/approve`,
+    {},
+    token,
+  );
+}
+
+export function rejectJoinRequest(
+  eventId: string,
+  joinRequestId: string,
+  token: string,
+): Promise<RejectJoinRequestResponse> {
+  return apiPostAuth<RejectJoinRequestResponse>(
+    `/events/${eventId}/join-requests/${joinRequestId}/reject`,
+    {},
     token,
   );
 }

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -501,6 +501,67 @@
   flex-shrink: 0;
 }
 
+/* Pending request item */
+.ed-mgmt-item-pending {
+  flex-wrap: wrap;
+}
+
+.ed-mgmt-user-score {
+  font-size: 12px;
+  color: #f59e0b;
+  font-weight: 500;
+}
+
+.ed-mgmt-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.ed-approve-btn {
+  padding: 6px 16px;
+  border-radius: 8px;
+  border: 1px solid #16a34a;
+  background-color: #16a34a;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ed-approve-btn:hover:not(:disabled) {
+  background-color: #15803d;
+  border-color: #15803d;
+}
+
+.ed-approve-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ed-reject-btn {
+  padding: 6px 16px;
+  border-radius: 8px;
+  border: 1px solid #dc2626;
+  background: none;
+  color: #dc2626;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ed-reject-btn:hover:not(:disabled) {
+  background-color: #fef2f2;
+}
+
+.ed-reject-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Invitation status */
 .ed-invitation-status {
   padding: 3px 10px;

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getEventDetail, joinEvent, requestJoinEvent } from '@/services/eventService';
+import { getEventDetail, joinEvent, requestJoinEvent, approveJoinRequest, rejectJoinRequest } from '@/services/eventService';
 import type { EventDetailResponse } from '@/models/event';
 import { ApiError } from '@/services/api';
 
@@ -102,7 +102,61 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     }
   }, [eventId, token, event]);
 
+  const [moderatingId, setModeratingId] = useState<string | null>(null);
+  const [moderateError, setModerateError] = useState<string | null>(null);
+
+  const handleApprove = useCallback(async (joinRequestId: string) => {
+    if (!eventId || !token) return;
+    setModeratingId(joinRequestId);
+    setModerateError(null);
+
+    try {
+      await approveJoinRequest(eventId, joinRequestId, token);
+      const updated = await getEventDetail(eventId, token);
+      setEvent(updated);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const errorMap: Record<string, string> = {
+          join_request_state_invalid: 'This request is no longer pending.',
+          capacity_exceeded: 'Cannot approve — event is full.',
+          already_participating: 'This user is already participating.',
+          join_request_moderation_not_allowed: 'Only the host can moderate requests.',
+        };
+        setModerateError(errorMap[err.code] ?? err.message);
+      } else {
+        setModerateError('Failed to approve request. Please try again.');
+      }
+    } finally {
+      setModeratingId(null);
+    }
+  }, [eventId, token]);
+
+  const handleReject = useCallback(async (joinRequestId: string) => {
+    if (!eventId || !token) return;
+    setModeratingId(joinRequestId);
+    setModerateError(null);
+
+    try {
+      await rejectJoinRequest(eventId, joinRequestId, token);
+      const updated = await getEventDetail(eventId, token);
+      setEvent(updated);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const errorMap: Record<string, string> = {
+          join_request_state_invalid: 'This request is no longer pending.',
+          join_request_moderation_not_allowed: 'Only the host can moderate requests.',
+        };
+        setModerateError(errorMap[err.code] ?? err.message);
+      } else {
+        setModerateError('Failed to reject request. Please try again.');
+      }
+    } finally {
+      setModeratingId(null);
+    }
+  }, [eventId, token]);
+
   const dismissJoinError = useCallback(() => setJoinError(null), []);
+  const dismissModerateError = useCallback(() => setModerateError(null), []);
 
   return {
     event,
@@ -110,9 +164,14 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     errorMessage,
     joinLoading,
     joinError,
+    moderatingId,
+    moderateError,
     retry: fetchDetail,
     handleJoin,
     handleRequestJoin,
+    handleApprove,
+    handleReject,
     dismissJoinError,
+    dismissModerateError,
   };
 }

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -203,6 +203,11 @@ function EventContent({
   onJoin,
   onRequestJoin,
   onDismissError,
+  moderatingId,
+  moderateError,
+  onApprove,
+  onReject,
+  onDismissModerateError,
 }: {
   event: EventDetailResponse;
   joinLoading: boolean;
@@ -210,6 +215,11 @@ function EventContent({
   onJoin: () => void;
   onRequestJoin: (message?: string) => void;
   onDismissError: () => void;
+  moderatingId: string | null;
+  moderateError: string | null;
+  onApprove: (joinRequestId: string) => void;
+  onReject: (joinRequestId: string) => void;
+  onDismissModerateError: () => void;
 }) {
   const navigate = useNavigate();
 
@@ -445,9 +455,15 @@ function EventContent({
                 <h3 className="ed-mgmt-title">
                   Pending Requests ({event.host_context.pending_join_requests.length})
                 </h3>
+                {moderateError && (
+                  <div className="ed-join-error" style={{ marginBottom: 10 }}>
+                    <span>{moderateError}</span>
+                    <button type="button" className="ed-join-error-dismiss" onClick={onDismissModerateError}>&times;</button>
+                  </div>
+                )}
                 <ul className="ed-mgmt-list">
                   {event.host_context.pending_join_requests.map((r) => (
-                    <li key={r.join_request_id} className="ed-mgmt-item">
+                    <li key={r.join_request_id} className="ed-mgmt-item ed-mgmt-item-pending">
                       <div className="ed-mgmt-avatar">
                         {r.user.avatar_url ? (
                           <img src={r.user.avatar_url} alt={r.user.username} className="ed-avatar-img" />
@@ -459,8 +475,28 @@ function EventContent({
                         <span className="ed-mgmt-name">{r.user.display_name ?? r.user.username}</span>
                         <span className="ed-mgmt-username">@{r.user.username}</span>
                         {r.message && <span className="ed-mgmt-message">"{r.message}"</span>}
+                        {r.user.final_score != null && (
+                          <span className="ed-mgmt-user-score">{'★'} {r.user.final_score.toFixed(1)} ({r.user.rating_count})</span>
+                        )}
                       </div>
-                      <span className="ed-mgmt-date">{formatShortDate(r.created_at)}</span>
+                      <div className="ed-mgmt-actions">
+                        <button
+                          type="button"
+                          className="ed-approve-btn"
+                          onClick={() => onApprove(r.join_request_id)}
+                          disabled={moderatingId === r.join_request_id}
+                        >
+                          {moderatingId === r.join_request_id ? '...' : 'Approve'}
+                        </button>
+                        <button
+                          type="button"
+                          className="ed-reject-btn"
+                          onClick={() => onReject(r.join_request_id)}
+                          disabled={moderatingId === r.join_request_id}
+                        >
+                          Reject
+                        </button>
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -575,6 +611,11 @@ export default function EventDetailPage() {
       onJoin={vm.handleJoin}
       onRequestJoin={vm.handleRequestJoin}
       onDismissError={vm.dismissJoinError}
+      moderatingId={vm.moderatingId}
+      moderateError={vm.moderateError}
+      onApprove={vm.handleApprove}
+      onReject={vm.handleReject}
+      onDismissModerateError={vm.dismissModerateError}
     />
   );
 }


### PR DESCRIPTION
## 📋 Summary
Add approve/reject join request moderation for hosts on protected events, completing the protected event participation flow.

## 🔄 Changes
- Added "Approve" and "Reject" buttons on each pending join request in the host management section
- Added `approveJoinRequest()` and `rejectJoinRequest()` service functions calling `POST /events/{id}/join-requests/{joinRequestId}/approve|reject`
- Added `handleApprove` and `handleReject` to `useEventDetailViewModel` with per-request loading state (`moderatingId`) and error handling
- Added `ApproveJoinRequestResponse` and `RejectJoinRequestResponse` types to `event.ts`
- After approve/reject, page re-fetches to reflect updated participant list and pending requests
- Shows requester's score and rating count in pending request cards
- Dismissable error banner for moderation errors (capacity exceeded, invalid state, not authorized, etc.)
- Added CSS for approve (green filled) and reject (red outlined) buttons with hover/disabled states

## 🧪 Testing
1. Run `docker compose -f deploy/docker-compose.local.yml up --build`
2. Create a **protected** event with User A
3. With User B, navigate to the event and click "Request to Join" — optionally add a message
4. Switch to User A, open the event — verify pending request appears with user info, message, score, and Approve/Reject buttons
5. Click "Approve" — verify the user moves from pending requests to approved participants and participant count increments
6. Repeat with another user and click "Reject" — verify the request disappears from the pending list
7. Try approving when event is full — verify "Cannot approve — event is full" error appears
8. Verify buttons are disabled while a request is being processed

## 🔗 Related
Link issues with: Closes #181, #183
