### PR TITLE
fix(mobile): validate date and time ranges to reject impossible values

### DIFF
--- a/mobile/src/viewmodels/event/useCreateEventViewModel.test.tsx
+++ b/mobile/src/viewmodels/event/useCreateEventViewModel.test.tsx
@@ -130,7 +130,7 @@ describe('useCreateEventViewModel', () => {
 
   // ─── Start date validation ───
   describe('start date validation', () => {
-    it('shows error when start date/time is missing', async () => {
+    it('shows error on both fields when start date and time are missing', async () => {
       const { result } = renderHook(() => useCreateEventViewModel());
       await act(async () => {
         fillValidForm(result.current);
@@ -138,7 +138,19 @@ describe('useCreateEventViewModel', () => {
         result.current.updateField('startTime', '');
       });
       await act(async () => { await result.current.handleSubmit('token'); });
-      expect(result.current.errors.startDateTime).toBe('Start date and time are required');
+      expect(result.current.errors.startDate).toBe('Start date is required');
+      expect(result.current.errors.startTime).toBe('Start time is required');
+    });
+
+    it('shows error only on date when start date is missing but time is set', async () => {
+      const { result } = renderHook(() => useCreateEventViewModel());
+      await act(async () => {
+        fillValidForm(result.current);
+        result.current.updateField('startDate', '');
+      });
+      await act(async () => { await result.current.handleSubmit('token'); });
+      expect(result.current.errors.startDate).toBe('Start date is required');
+      expect(result.current.errors.startTime).toBeFalsy();
     });
 
     it('shows error when start date is in the past', async () => {
@@ -149,20 +161,93 @@ describe('useCreateEventViewModel', () => {
         result.current.updateField('startTime', '10:00');
       });
       await act(async () => { await result.current.handleSubmit('token'); });
-      expect(result.current.errors.startDateTime).toBe('Start date must be in the future');
+      expect(result.current.errors.startDate).toBe('Start date must be in the future');
+      expect(result.current.errors.startTime).toBeFalsy();
     });
 
     it('accepts a future start date', async () => {
       const { result } = renderHook(() => useCreateEventViewModel());
       await act(async () => { fillValidForm(result.current); });
       await act(async () => { await result.current.handleSubmit('token'); });
-      expect(result.current.errors.startDateTime).toBeFalsy();
+      expect(result.current.errors.startDate).toBeFalsy();
+      expect(result.current.errors.startTime).toBeFalsy();
+    });
+
+    it('rejects invalid day and time independently (35.21.2030 with 28:00 — example from issue)', async () => {
+      const { result } = renderHook(() => useCreateEventViewModel());
+      await act(async () => {
+        fillValidForm(result.current);
+        result.current.updateField('startDate', '35.21.2030');
+        result.current.updateField('startTime', '28:00');
+      });
+      await act(async () => { await result.current.handleSubmit('token'); });
+      expect(result.current.errors.startDate).toBeTruthy();
+      expect(result.current.errors.startTime).toBeTruthy();
+      expect(mockCreateEvent).not.toHaveBeenCalled();
+    });
+
+    it('rejects out-of-range day (35) — only date box is red', async () => {
+      const { result } = renderHook(() => useCreateEventViewModel());
+      await act(async () => {
+        fillValidForm(result.current);
+        result.current.updateField('startDate', '35.06.2030');
+        result.current.updateField('startTime', '10:00');
+      });
+      await act(async () => { await result.current.handleSubmit('token'); });
+      expect(result.current.errors.startDate).toBeTruthy();
+      expect(result.current.errors.startTime).toBeFalsy();
+    });
+
+    it('rejects out-of-range month (21) — only date box is red', async () => {
+      const { result } = renderHook(() => useCreateEventViewModel());
+      await act(async () => {
+        fillValidForm(result.current);
+        result.current.updateField('startDate', '15.21.2030');
+        result.current.updateField('startTime', '10:00');
+      });
+      await act(async () => { await result.current.handleSubmit('token'); });
+      expect(result.current.errors.startDate).toBeTruthy();
+      expect(result.current.errors.startTime).toBeFalsy();
+    });
+
+    it('rejects out-of-range hour (28:00) — only time box is red', async () => {
+      const { result } = renderHook(() => useCreateEventViewModel());
+      await act(async () => {
+        fillValidForm(result.current);
+        result.current.updateField('startTime', '28:00');
+      });
+      await act(async () => { await result.current.handleSubmit('token'); });
+      expect(result.current.errors.startTime).toBeTruthy();
+      expect(result.current.errors.startDate).toBeFalsy();
+    });
+
+    it('rejects out-of-range minute (10:70) — only time box is red', async () => {
+      const { result } = renderHook(() => useCreateEventViewModel());
+      await act(async () => {
+        fillValidForm(result.current);
+        result.current.updateField('startTime', '10:70');
+      });
+      await act(async () => { await result.current.handleSubmit('token'); });
+      expect(result.current.errors.startTime).toBeTruthy();
+      expect(result.current.errors.startDate).toBeFalsy();
+    });
+
+    it('rejects impossible calendar date (30.02.2030) — only date box is red', async () => {
+      const { result } = renderHook(() => useCreateEventViewModel());
+      await act(async () => {
+        fillValidForm(result.current);
+        result.current.updateField('startDate', '30.02.2030');
+        result.current.updateField('startTime', '10:00');
+      });
+      await act(async () => { await result.current.handleSubmit('token'); });
+      expect(result.current.errors.startDate).toBeTruthy();
+      expect(result.current.errors.startTime).toBeFalsy();
     });
   });
 
   // ─── End date validation ───
   describe('end date validation', () => {
-    it('shows error when end date is before start date', async () => {
+    it('shows error on date when end date is before start date', async () => {
       const { result } = renderHook(() => useCreateEventViewModel());
       await act(async () => {
         fillValidForm(result.current);
@@ -170,7 +255,8 @@ describe('useCreateEventViewModel', () => {
         result.current.updateField('endTime', '10:00');
       });
       await act(async () => { await result.current.handleSubmit('token'); });
-      expect(result.current.errors.endDateTime).toBe('End must be after start');
+      expect(result.current.errors.endDate).toBe('End must be after start');
+      expect(result.current.errors.endTime).toBeFalsy();
     });
 
     it('clears end date error when end date is updated', async () => {
@@ -181,12 +267,12 @@ describe('useCreateEventViewModel', () => {
         result.current.updateField('endTime', '10:00');
       });
       await act(async () => { await result.current.handleSubmit('token'); });
-      expect(result.current.errors.endDateTime).toBeTruthy();
+      expect(result.current.errors.endDate).toBeTruthy();
 
       await act(async () => {
         result.current.updateField('endDate', futureDateLater);
       });
-      expect(result.current.errors.endDateTime).toBeNull();
+      expect(result.current.errors.endDate).toBeNull();
     });
 
     it('clears end date error when end time is updated', async () => {
@@ -197,12 +283,12 @@ describe('useCreateEventViewModel', () => {
         result.current.updateField('endTime', '10:00');
       });
       await act(async () => { await result.current.handleSubmit('token'); });
-      expect(result.current.errors.endDateTime).toBeTruthy();
+      expect(result.current.errors.endDate).toBeTruthy();
 
       await act(async () => {
         result.current.updateField('endTime', '18:00');
       });
-      expect(result.current.errors.endDateTime).toBeNull();
+      expect(result.current.errors.endDate).toBeNull();
     });
   });
 
@@ -211,12 +297,12 @@ describe('useCreateEventViewModel', () => {
     it('clears start date error when start date is updated', async () => {
       const { result } = renderHook(() => useCreateEventViewModel());
       await act(async () => { await result.current.handleSubmit('token'); });
-      expect(result.current.errors.startDateTime).toBeTruthy();
+      expect(result.current.errors.startDate).toBeTruthy();
 
       await act(async () => {
         result.current.updateField('startDate', futureDate);
       });
-      expect(result.current.errors.startDateTime).toBeNull();
+      expect(result.current.errors.startDate).toBeNull();
     });
 
     it('clears location error when location query is updated', async () => {
@@ -529,7 +615,7 @@ describe('useCreateEventViewModel', () => {
       await act(async () => { fillValidForm(result.current); });
       await act(async () => { await result.current.handleSubmit('token'); });
       expect(result.current.errors.title).toBe('Title too long');
-      expect(result.current.errors.startDateTime).toBe('Invalid');
+      expect(result.current.errors.startDate).toBe('Invalid');
     });
   });
 

--- a/mobile/src/viewmodels/event/useCreateEventViewModel.ts
+++ b/mobile/src/viewmodels/event/useCreateEventViewModel.ts
@@ -83,8 +83,10 @@ export interface CreateEventFormErrors {
   description?: string | null;
   categoryId?: string | null;
   location?: string | null;
-  startDateTime?: string | null;
-  endDateTime?: string | null;
+  startDate?: string | null;
+  startTime?: string | null;
+  endDate?: string | null;
+  endTime?: string | null;
   tags?: string | null;
   constraints?: string | null;
 }
@@ -174,11 +176,50 @@ export function formatDateInput(current: string, previous: string): string {
   return formatDigitsToDate(digits.slice(0, 8));
 }
 
+/** Returns an error message if the date string (dd.mm.yyyy) is invalid, or null if valid. */
+export function validateDateFormat(date: string): string | null {
+  const parts = date.split('.');
+  if (parts.length !== 3) return 'Invalid date format';
+  const [dayStr, monthStr, yearStr] = parts;
+  if (yearStr.length < 4) return 'Invalid date format';
+  const day = parseInt(dayStr, 10);
+  const month = parseInt(monthStr, 10);
+  const year = parseInt(yearStr, 10);
+  if (isNaN(day) || isNaN(month) || isNaN(year)) return 'Invalid date';
+  if (month < 1 || month > 12) return 'Invalid date: month must be 1–12';
+  if (day < 1 || day > 31) return 'Invalid date: day must be 1–31';
+  // Guard against JS Date silently normalizing overflow (e.g. 30.02.2030 → March)
+  const iso = `${year}-${monthStr.padStart(2, '0')}-${dayStr.padStart(2, '0')}T00:00:00`;
+  const parsed = new Date(iso);
+  if (
+    isNaN(parsed.getTime()) ||
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() + 1 !== month ||
+    parsed.getDate() !== day
+  ) {
+    return 'Invalid date';
+  }
+  return null;
+}
+
+/** Returns an error message if the time string (HH:mm) is invalid, or null if valid. */
+export function validateTimeFormat(time: string): string | null {
+  const parts = time.split(':');
+  if (parts.length !== 2) return 'Invalid time format';
+  const [hourStr, minuteStr] = parts;
+  const hour = parseInt(hourStr, 10);
+  const minute = parseInt(minuteStr, 10);
+  if (isNaN(hour) || isNaN(minute)) return 'Invalid time';
+  if (hour < 0 || hour > 23) return 'Invalid time: hour must be 0–23';
+  if (minute < 0 || minute > 59) return 'Invalid time: minute must be 0–59';
+  return null;
+}
+
 function parseDateTime(date: string, time: string): string | null {
   if (!date || !time) return null;
-  const [day, month, year] = date.split('.');
-  if (!day || !month || !year) return null;
-  const iso = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T${time}:00`;
+  const [dayStr, monthStr, yearStr] = date.split('.');
+  if (!dayStr || !monthStr || !yearStr) return null;
+  const iso = `${yearStr}-${monthStr.padStart(2, '0')}-${dayStr.padStart(2, '0')}T${time}:00`;
   const parsed = new Date(iso);
   if (isNaN(parsed.getTime())) return null;
   return parsed.toISOString();
@@ -219,27 +260,51 @@ function validateForm(formData: CreateEventFormData): CreateEventFormErrors {
     errors.location = 'Please select a location';
   }
 
-  if (!formData.startDate || !formData.startTime) {
-    errors.startDateTime = 'Start date and time are required';
+  if (!formData.startDate) {
+    errors.startDate = 'Start date is required';
   } else {
+    const dateErr = validateDateFormat(formData.startDate);
+    if (dateErr) errors.startDate = dateErr;
+  }
+
+  if (!formData.startTime) {
+    errors.startTime = 'Start time is required';
+  } else {
+    const timeErr = validateTimeFormat(formData.startTime);
+    if (timeErr) errors.startTime = timeErr;
+  }
+
+  if (!errors.startDate && !errors.startTime && formData.startDate && formData.startTime) {
     const parsed = parseDateTime(formData.startDate, formData.startTime);
     if (!parsed) {
-      errors.startDateTime = 'Invalid start date/time format';
+      errors.startDate = 'Invalid start date';
     } else if (new Date(parsed) <= new Date()) {
-      errors.startDateTime = 'Start date must be in the future';
+      errors.startDate = 'Start date must be in the future';
     }
   }
 
   if (formData.endDate || formData.endTime) {
-    if (!formData.endDate || !formData.endTime) {
-      errors.endDateTime = 'Both end date and time are required';
+    if (!formData.endDate) {
+      errors.endDate = 'End date is required';
     } else {
+      const dateErr = validateDateFormat(formData.endDate);
+      if (dateErr) errors.endDate = dateErr;
+    }
+
+    if (!formData.endTime) {
+      errors.endTime = 'End time is required';
+    } else {
+      const timeErr = validateTimeFormat(formData.endTime);
+      if (timeErr) errors.endTime = timeErr;
+    }
+
+    if (!errors.endDate && !errors.endTime && formData.endDate && formData.endTime) {
       const parsedEnd = parseDateTime(formData.endDate, formData.endTime);
       const parsedStart = parseDateTime(formData.startDate, formData.startTime);
       if (!parsedEnd) {
-        errors.endDateTime = 'Invalid end date/time format';
+        errors.endDate = 'Invalid end date';
       } else if (parsedStart && new Date(parsedEnd) <= new Date(parsedStart)) {
-        errors.endDateTime = 'End must be after start';
+        errors.endDate = 'End must be after start';
       }
     }
   }
@@ -272,14 +337,16 @@ export function useCreateEventViewModel(): CreateEventViewModel {
       setFormData((prev) => ({ ...prev, [field]: value }));
       // Map form fields to their corresponding error keys
       const errorKeyMap: Partial<Record<keyof CreateEventFormData, keyof CreateEventFormErrors>> = {
-        startDate: 'startDateTime',
-        startTime: 'startDateTime',
-        endDate: 'endDateTime',
-        endTime: 'endDateTime',
         locationQuery: 'location',
       };
-      const errorKey = errorKeyMap[field] ?? field;
-      setErrors((prev) => ({ ...prev, [errorKey]: null }));
+      const errorKey = (errorKeyMap[field] ?? field) as keyof CreateEventFormErrors;
+      setErrors((prev) => {
+        const next = { ...prev, [errorKey]: null };
+        // Time changes also clear the associated date error (cross-field "must be after" constraint)
+        if (field === 'startTime') next.startDate = null;
+        if (field === 'endTime') next.endDate = null;
+        return next;
+      });
       setApiError(null);
       setSuccessMessage(null);
     },
@@ -553,8 +620,8 @@ export function useCreateEventViewModel(): CreateEventViewModel {
               else if (key === 'category_id') fieldErrors.categoryId = msg;
               else if (key === 'lat' || key === 'lon' || key === 'address')
                 fieldErrors.location = msg;
-              else if (key === 'start_time') fieldErrors.startDateTime = msg;
-              else if (key === 'end_time') fieldErrors.endDateTime = msg;
+              else if (key === 'start_time') fieldErrors.startDate = msg;
+              else if (key === 'end_time') fieldErrors.endDate = msg;
               else if (key === 'tags') fieldErrors.tags = msg;
               else if (key.startsWith('constraints')) fieldErrors.constraints = msg;
             }

--- a/mobile/src/views/event/CreateEventView.tsx
+++ b/mobile/src/views/event/CreateEventView.tsx
@@ -275,7 +275,7 @@ export default function CreateEventView() {
               <TextInput
                 style={[
                   styles.input,
-                  vm.errors.startDateTime && styles.inputError,
+                  vm.errors.startDate && styles.inputError,
                 ]}
                 placeholder="dd.mm.yyyy"
                 placeholderTextColor="#9CA3AF"
@@ -286,13 +286,16 @@ export default function CreateEventView() {
                 keyboardType="numbers-and-punctuation"
                 editable={!vm.isLoading}
               />
+              {vm.errors.startDate && (
+                <Text style={styles.fieldError}>{vm.errors.startDate}</Text>
+              )}
             </View>
             <View style={styles.dateTimeColSmall}>
               <Text style={styles.label}>{' '}</Text>
               <TextInput
                 style={[
                   styles.input,
-                  vm.errors.startDateTime && styles.inputError,
+                  vm.errors.startTime && styles.inputError,
                 ]}
                 placeholder="HH:mm"
                 placeholderTextColor="#9CA3AF"
@@ -302,11 +305,11 @@ export default function CreateEventView() {
                 maxLength={5}
                 editable={!vm.isLoading}
               />
+              {vm.errors.startTime && (
+                <Text style={styles.fieldError}>{vm.errors.startTime}</Text>
+              )}
             </View>
           </View>
-          {vm.errors.startDateTime && (
-            <Text style={styles.fieldError}>{vm.errors.startDateTime}</Text>
-          )}
         </View>
 
         {/* End Date/Time */}
@@ -317,7 +320,7 @@ export default function CreateEventView() {
               <TextInput
                 style={[
                   styles.input,
-                  vm.errors.endDateTime && styles.inputError,
+                  vm.errors.endDate && styles.inputError,
                 ]}
                 placeholder="dd.mm.yyyy"
                 placeholderTextColor="#9CA3AF"
@@ -328,13 +331,16 @@ export default function CreateEventView() {
                 keyboardType="numbers-and-punctuation"
                 editable={!vm.isLoading}
               />
+              {vm.errors.endDate && (
+                <Text style={styles.fieldError}>{vm.errors.endDate}</Text>
+              )}
             </View>
             <View style={styles.dateTimeColSmall}>
               <Text style={styles.label}>{' '}</Text>
               <TextInput
                 style={[
                   styles.input,
-                  vm.errors.endDateTime && styles.inputError,
+                  vm.errors.endTime && styles.inputError,
                 ]}
                 placeholder="HH:mm"
                 placeholderTextColor="#9CA3AF"
@@ -344,11 +350,11 @@ export default function CreateEventView() {
                 maxLength={5}
                 editable={!vm.isLoading}
               />
+              {vm.errors.endTime && (
+                <Text style={styles.fieldError}>{vm.errors.endTime}</Text>
+              )}
             </View>
           </View>
-          {vm.errors.endDateTime && (
-            <Text style={styles.fieldError}>{vm.errors.endDateTime}</Text>
-          )}
         </View>
 
         {/* Privacy Level */}


### PR DESCRIPTION
## 📋 Summary
The event creation form accepted impossible dates like `35.21.2030` and invalid times like `28:00` without any error. This was caused by JavaScript's `Date` constructor silently normalizing overflow values instead of returning `NaN`, bypassing the existing `isNaN` check.

## 🔄 Changes
- Added `validateDateFormat` helper with explicit range checks (day 1–31, month 1–12) and a JS Date cross-check to catch impossible calendar dates (e.g. `30.02.2030`)
- Added `validateTimeFormat` helper with explicit range checks (hour 0–23, minute 0–59)
- Updated `validateForm` to set errors per field: invalid date shows only the date box in red, invalid time shows only the time box in red, both if both are invalid
- Updated `CreateEventView` to bind each input to its own error field and display error messages beneath each respective input
- Added test coverage for all invalid input cases from the issue

## 🧪 Testing
1. Open the Create Event screen
2. Enter `35.21.2030` as date and `28:00` as time — both fields should turn red with individual error messages
3. Enter `35.06.2030` as date with a valid time — only the date box should be red
4. Enter a valid date with `28:00` as time — only the time box should be red
5. Enter `30.02.2030` (impossible calendar date) — only the date box should be red
6. Form should not submit in any of the above cases

## 🔗 Related
Closes #220