### PR TITLE
feat(backend): add IN_PROGRESS event status with two-phase transitions

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -606,7 +606,12 @@ func (r *EventRepository) loadEventDetailCore(
 			e.description,
 			e.image_url,
 			e.privacy_level,
-			CASE WHEN e.status = 'ACTIVE' AND e.end_time < NOW() THEN 'COMPLETED' ELSE e.status END AS status,
+			CASE
+				WHEN e.status = 'ACTIVE' AND e.end_time < NOW() THEN 'COMPLETED'
+				WHEN e.status = 'ACTIVE' AND e.start_time < NOW() THEN 'IN_PROGRESS'
+				WHEN e.status = 'IN_PROGRESS' AND e.end_time < NOW() THEN 'COMPLETED'
+				ELSE e.status
+			END AS status,
 			e.start_time,
 			e.end_time,
 			e.capacity,
@@ -1425,12 +1430,18 @@ func (r *EventRepository) SetEventImageIfVersion(
 
 var _ imageuploadapp.EventRepository = (*EventRepository)(nil)
 
-// ExpireActiveEvents sets status to COMPLETED for all ACTIVE events whose end_time has passed.
-func (r *EventRepository) ExpireActiveEvents(ctx context.Context) error {
+// TransitionEventStatuses moves ACTIVE events to IN_PROGRESS when their
+// start_time has passed and IN_PROGRESS (or ACTIVE) events to COMPLETED when
+// their end_time has passed.
+func (r *EventRepository) TransitionEventStatuses(ctx context.Context) error {
 	_, err := r.pool.Exec(ctx, `
 		UPDATE event
-		SET status = 'COMPLETED'
-		WHERE status = 'ACTIVE' AND end_time < NOW()
+		SET status = CASE
+			WHEN end_time < NOW() THEN 'COMPLETED'
+			ELSE 'IN_PROGRESS'
+		END
+		WHERE (status = 'ACTIVE' AND start_time < NOW())
+		   OR (status = 'IN_PROGRESS' AND end_time < NOW())
 	`)
 	return err
 }

--- a/backend/internal/application/event/repository.go
+++ b/backend/internal/application/event/repository.go
@@ -13,5 +13,5 @@ type Repository interface {
 	ListDiscoverableEvents(ctx context.Context, userID uuid.UUID, params DiscoverEventsParams) ([]DiscoverableEventRecord, error)
 	GetEventDetail(ctx context.Context, userID, eventID uuid.UUID) (*EventDetailRecord, error)
 	GetEventByID(ctx context.Context, eventID uuid.UUID) (*domain.Event, error)
-	ExpireActiveEvents(ctx context.Context) error
+	TransitionEventStatuses(ctx context.Context) error
 }

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -65,7 +65,7 @@ func (r *fakeEventRepo) GetEventDetail(_ context.Context, userID, eventID uuid.U
 	return nil, domain.ErrNotFound
 }
 
-func (r *fakeEventRepo) ExpireActiveEvents(_ context.Context) error {
+func (r *fakeEventRepo) TransitionEventStatuses(_ context.Context) error {
 	return r.err
 }
 

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -100,12 +100,13 @@ func New(ctx context.Context) (*Container, error) {
 	return container, nil
 }
 
-// StartEventExpiryJob immediately expires all past ACTIVE events, then repeats
-// every interval until ctx is cancelled.
+// StartEventExpiryJob immediately transitions event statuses
+// (ACTIVE → IN_PROGRESS → COMPLETED), then repeats every interval until ctx
+// is cancelled.
 func (c *Container) StartEventExpiryJob(ctx context.Context, interval time.Duration) {
 	expire := func() {
-		if err := c.eventRepo.ExpireActiveEvents(ctx); err != nil {
-			log.Printf("event expiry job: %v", err)
+		if err := c.eventRepo.TransitionEventStatuses(ctx); err != nil {
+			log.Printf("event status transition job: %v", err)
 		}
 	}
 	expire()

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -44,9 +44,10 @@ const (
 	GenderFemale EventParticipantGender = "FEMALE"
 	GenderOther  EventParticipantGender = "OTHER"
 
-	EventStatusActive    EventStatus = "ACTIVE"
-	EventStatusCanceled  EventStatus = "CANCELED"
-	EventStatusCompleted EventStatus = "COMPLETED"
+	EventStatusActive     EventStatus = "ACTIVE"
+	EventStatusInProgress EventStatus = "IN_PROGRESS"
+	EventStatusCanceled   EventStatus = "CANCELED"
+	EventStatusCompleted  EventStatus = "COMPLETED"
 
 	EventDiscoverySortStartTime EventDiscoverySort = "START_TIME"
 	EventDiscoverySortDistance  EventDiscoverySort = "DISTANCE"

--- a/backend/tests_integration/common/fixtures.go
+++ b/backend/tests_integration/common/fixtures.go
@@ -239,6 +239,33 @@ func GivenExpiredEvent(t *testing.T, hostID uuid.UUID) uuid.UUID {
 	return id
 }
 
+// GivenStartedEvent inserts an ACTIVE event whose start_time is in the past
+// but end_time is still in the future.
+func GivenStartedEvent(t *testing.T, hostID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	pool := RequirePool(t)
+	categoryID := GivenEventCategory(t)
+	now := time.Now().UTC()
+
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO event (host_id, title, privacy_level, status, location_type, start_time, end_time, category_id)
+		VALUES ($1, $2, 'PUBLIC', 'ACTIVE', 'POINT', $3, $4, $5)
+		RETURNING id`,
+		hostID,
+		"started_event_"+uuid.NewString()[:8],
+		now.Add(-1*time.Hour),
+		now.Add(2*time.Hour),
+		categoryID,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("GivenStartedEvent() insert error = %v", err)
+	}
+
+	return id
+}
+
 func StringPtr(value string) *string {
 	return &value
 }

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -2286,20 +2286,20 @@ func assertDiscoverEventIDsInOrder(t *testing.T, items []eventapp.DiscoverableEv
 	}
 }
 
-func TestExpireActiveEvents(t *testing.T) {
+func TestTransitionEventStatuses_ExpiredToCompleted(t *testing.T) {
 	t.Parallel()
 
-	// given
+	// given — an ACTIVE event whose end_time is in the past
 	harness := common.NewEventHarness(t)
 	host := common.GivenUser(t, harness.AuthRepo)
 	expiredEventID := common.GivenExpiredEvent(t, host.ID)
 
 	// when
-	err := harness.EventRepo.ExpireActiveEvents(context.Background())
+	err := harness.EventRepo.TransitionEventStatuses(context.Background())
 
 	// then
 	if err != nil {
-		t.Fatalf("ExpireActiveEvents() error = %v", err)
+		t.Fatalf("TransitionEventStatuses() error = %v", err)
 	}
 
 	event, err := harness.EventRepo.GetEventByID(context.Background(), expiredEventID)
@@ -2308,5 +2308,30 @@ func TestExpireActiveEvents(t *testing.T) {
 	}
 	if event.Status != domain.EventStatusCompleted {
 		t.Fatalf("expected status %q, got %q", domain.EventStatusCompleted, event.Status)
+	}
+}
+
+func TestTransitionEventStatuses_StartedToInProgress(t *testing.T) {
+	t.Parallel()
+
+	// given — an ACTIVE event whose start_time has passed but end_time is in the future
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	startedEventID := common.GivenStartedEvent(t, host.ID)
+
+	// when
+	err := harness.EventRepo.TransitionEventStatuses(context.Background())
+
+	// then
+	if err != nil {
+		t.Fatalf("TransitionEventStatuses() error = %v", err)
+	}
+
+	event, err := harness.EventRepo.GetEventByID(context.Background(), startedEventID)
+	if err != nil {
+		t.Fatalf("GetEventByID() error = %v", err)
+	}
+	if event.Status != domain.EventStatusInProgress {
+		t.Fatalf("expected status %q, got %q", domain.EventStatusInProgress, event.Status)
 	}
 }

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -1795,7 +1795,7 @@ components:
           enum: [PUBLIC, PROTECTED, PRIVATE]
         status:
           type: string
-          description: Current event status as stored in the database, for example `ACTIVE`, `CANCELED`, or `COMPLETED`.
+          description: Current event status as stored in the database, for example `ACTIVE`, `IN_PROGRESS`, `CANCELED`, or `COMPLETED`.
           example: ACTIVE
         start_time:
           type: string


### PR DESCRIPTION
  ## 📋 Summary
  Added `IN_PROGRESS` as a new event status. Events now transition from `ACTIVE` → `IN_PROGRESS` when
   `start_time` passes, and from `IN_PROGRESS` → `COMPLETED` when `end_time` passes.

  ## 🔄 Changes
  - Added `EventStatusInProgress` domain constant
  - Renamed `ExpireActiveEvents` to `TransitionEventStatuses` with two-phase SQL logic
  - Updated event detail query CASE to reflect IN_PROGRESS status in real-time
  - Added `GivenStartedEvent` test fixture
  - Added integration test for ACTIVE → IN_PROGRESS transition
  - Updated OpenAPI docs to include IN_PROGRESS status

  ## 🧪 Testing
  - `go build ./...` passes
  - `go test ./...` passes (all unit tests)
  - `go test -tags=integration ./tests_integration/` passes (all integration tests)

  ## 🔗 Related
  Closes #281

  Base branch: main