### PR TITLE
feat(backend): add favorites and personal event listing endpoints

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -1479,3 +1479,121 @@ func (r *EventRepository) TransitionEventStatuses(ctx context.Context) error {
 	return err
 }
 
+// AddFavorite inserts a row into favorite_event. If the row already exists the
+// operation is silently ignored (idempotent).
+func (r *EventRepository) AddFavorite(ctx context.Context, userID, eventID uuid.UUID) error {
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO favorite_event (user_id, event_id)
+		VALUES ($1, $2)
+		ON CONFLICT (user_id, event_id) DO NOTHING
+	`, userID, eventID)
+	if err != nil {
+		return fmt.Errorf("add favorite: %w", err)
+	}
+	return nil
+}
+
+// RemoveFavorite deletes a row from favorite_event. If no row exists the
+// operation is silently ignored (idempotent).
+func (r *EventRepository) RemoveFavorite(ctx context.Context, userID, eventID uuid.UUID) error {
+	_, err := r.pool.Exec(ctx, `
+		DELETE FROM favorite_event
+		WHERE user_id = $1 AND event_id = $2
+	`, userID, eventID)
+	if err != nil {
+		return fmt.Errorf("remove favorite: %w", err)
+	}
+	return nil
+}
+
+// ListFavoriteEvents returns all events the user has favorited, ordered by most
+// recently favorited first.
+func (r *EventRepository) ListFavoriteEvents(ctx context.Context, userID uuid.UUID) ([]eventapp.FavoriteEventRecord, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT e.id, e.title, ec.name, e.image_url, e.status,
+		       e.start_time, e.end_time, fav.created_at
+		FROM favorite_event fav
+		JOIN event e ON e.id = fav.event_id
+		LEFT JOIN event_category ec ON ec.id = e.category_id
+		WHERE fav.user_id = $1
+		ORDER BY fav.created_at DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list favorite events: %w", err)
+	}
+	defer rows.Close()
+
+	var records []eventapp.FavoriteEventRecord
+	for rows.Next() {
+		var (
+			r       eventapp.FavoriteEventRecord
+			status  string
+			catName *string
+			endTime pgtype.Timestamptz
+		)
+		if err := rows.Scan(&r.ID, &r.Title, &catName, &r.ImageURL, &status,
+			&r.StartTime, &endTime, &r.FavoritedAt); err != nil {
+			return nil, fmt.Errorf("scan favorite event: %w", err)
+		}
+		r.Status = domain.EventStatus(status)
+		r.CategoryName = catName
+		if endTime.Valid {
+			r.EndTime = &endTime.Time
+		}
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}
+
+// ListMyEvents returns events where the user is either the host or an approved
+// participant, filtered by the given statuses. Each record indicates whether the
+// user is the host. Results are ordered by start_time descending.
+func (r *EventRepository) ListMyEvents(ctx context.Context, userID uuid.UUID, statuses []domain.EventStatus) ([]eventapp.MyEventRecord, error) {
+	statusStrings := make([]string, len(statuses))
+	for i, s := range statuses {
+		statusStrings[i] = string(s)
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT e.id, e.title, ec.name, e.image_url, e.status,
+		       e.start_time, e.end_time,
+		       (e.host_id = $1) AS is_host
+		FROM event e
+		LEFT JOIN event_category ec ON ec.id = e.category_id
+		WHERE e.status = ANY($2::text[])
+		  AND (
+		      e.host_id = $1
+		      OR EXISTS (
+		          SELECT 1 FROM participation p
+		          WHERE p.event_id = e.id AND p.user_id = $1 AND p.status = 'APPROVED'
+		      )
+		  )
+		ORDER BY e.start_time DESC
+	`, userID, statusStrings)
+	if err != nil {
+		return nil, fmt.Errorf("list my events: %w", err)
+	}
+	defer rows.Close()
+
+	var records []eventapp.MyEventRecord
+	for rows.Next() {
+		var (
+			rec     eventapp.MyEventRecord
+			status  string
+			catName *string
+			endTime pgtype.Timestamptz
+		)
+		if err := rows.Scan(&rec.ID, &rec.Title, &catName, &rec.ImageURL, &status,
+			&rec.StartTime, &endTime, &rec.IsHost); err != nil {
+			return nil, fmt.Errorf("scan my event: %w", err)
+		}
+		rec.Status = domain.EventStatus(status)
+		rec.CategoryName = catName
+		if endTime.Valid {
+			rec.EndTime = &endTime.Time
+		}
+		records = append(records, rec)
+	}
+	return records, rows.Err()
+}
+

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
@@ -36,6 +36,14 @@ func RegisterEventRoutes(router fiber.Router, handler *EventHandler, auth fiber.
 	group.Post("/:id/join-requests/:joinRequestId/approve", auth, handler.ApproveJoinRequest)
 	group.Post("/:id/join-requests/:joinRequestId/reject", auth, handler.RejectJoinRequest)
 	group.Patch("/:id/cancel", auth, handler.CancelEvent)
+	group.Post("/:id/favorite", auth, handler.AddFavorite)
+	group.Delete("/:id/favorite", auth, handler.RemoveFavorite)
+
+	me := router.Group("/me")
+	me.Get("/favorites", auth, handler.ListFavoriteEvents)
+	me.Get("/events/upcoming", auth, handler.ListMyUpcomingEvents)
+	me.Get("/events/completed", auth, handler.ListMyCompletedEvents)
+	me.Get("/events/canceled", auth, handler.ListMyCanceledEvents)
 }
 
 // DiscoverEvents handles GET /events.
@@ -278,6 +286,80 @@ func (h *EventHandler) CancelEvent(c *fiber.Ctx) error {
 	}
 
 	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// AddFavorite handles POST /events/:id/favorite.
+func (h *EventHandler) AddFavorite(c *fiber.Ctx) error {
+	eventID, err := parseEventIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	if err := h.service.AddFavorite(c.UserContext(), claims.UserID, eventID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// RemoveFavorite handles DELETE /events/:id/favorite.
+func (h *EventHandler) RemoveFavorite(c *fiber.Ctx) error {
+	eventID, err := parseEventIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	if err := h.service.RemoveFavorite(c.UserContext(), claims.UserID, eventID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// ListFavoriteEvents handles GET /me/favorites.
+func (h *EventHandler) ListFavoriteEvents(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ListFavoriteEvents(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.JSON(result)
+}
+
+// ListMyUpcomingEvents handles GET /me/events/upcoming.
+func (h *EventHandler) ListMyUpcomingEvents(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ListMyUpcomingEvents(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.JSON(result)
+}
+
+// ListMyCompletedEvents handles GET /me/events/completed.
+func (h *EventHandler) ListMyCompletedEvents(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ListMyCompletedEvents(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.JSON(result)
+}
+
+// ListMyCanceledEvents handles GET /me/events/canceled.
+func (h *EventHandler) ListMyCanceledEvents(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ListMyCanceledEvents(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.JSON(result)
 }
 
 func parseEventIDParam(c *fiber.Ctx) (uuid.UUID, error) {

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -174,6 +174,30 @@ func (s *stubEventService) CancelEvent(_ context.Context, _, eventID uuid.UUID) 
 	return s.err
 }
 
+func (s *stubEventService) AddFavorite(_ context.Context, _, _ uuid.UUID) error {
+	return s.err
+}
+
+func (s *stubEventService) RemoveFavorite(_ context.Context, _, _ uuid.UUID) error {
+	return s.err
+}
+
+func (s *stubEventService) ListFavoriteEvents(_ context.Context, _ uuid.UUID) (*event.FavoriteEventsResult, error) {
+	return &event.FavoriteEventsResult{Items: []event.FavoriteEventItem{}}, s.err
+}
+
+func (s *stubEventService) ListMyUpcomingEvents(_ context.Context, _ uuid.UUID) (*event.MyEventsResult, error) {
+	return &event.MyEventsResult{Items: []event.MyEventItem{}}, s.err
+}
+
+func (s *stubEventService) ListMyCompletedEvents(_ context.Context, _ uuid.UUID) (*event.MyEventsResult, error) {
+	return &event.MyEventsResult{Items: []event.MyEventItem{}}, s.err
+}
+
+func (s *stubEventService) ListMyCanceledEvents(_ context.Context, _ uuid.UUID) (*event.MyEventsResult, error) {
+	return &event.MyEventsResult{Items: []event.MyEventItem{}}, s.err
+}
+
 // fakeVerifier implements domain.TokenVerifier for tests in this package.
 type fakeVerifier struct {
 	claims *domain.AuthClaims

--- a/backend/internal/application/event/repository.go
+++ b/backend/internal/application/event/repository.go
@@ -19,4 +19,8 @@ type Repository interface {
 	GetEventByID(ctx context.Context, eventID uuid.UUID) (*domain.Event, error)
 	TransitionEventStatuses(ctx context.Context) error
 	CancelEvent(ctx context.Context, eventID uuid.UUID) error
+	AddFavorite(ctx context.Context, userID, eventID uuid.UUID) error
+	RemoveFavorite(ctx context.Context, userID, eventID uuid.UUID) error
+	ListFavoriteEvents(ctx context.Context, userID uuid.UUID) ([]FavoriteEventRecord, error)
+	ListMyEvents(ctx context.Context, userID uuid.UUID, statuses []domain.EventStatus) ([]MyEventRecord, error)
 }

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -81,6 +81,30 @@ type DiscoverEventsCursor struct {
 	RelevanceScore    *float64                  `json:"relevance_score,omitempty"`
 }
 
+// MyEventRecord is the repository-level projection for personal event listings.
+type MyEventRecord struct {
+	ID           uuid.UUID
+	Title        string
+	CategoryName *string
+	ImageURL     *string
+	Status       domain.EventStatus
+	StartTime    time.Time
+	EndTime      *time.Time
+	IsHost       bool
+}
+
+// FavoriteEventRecord is the repository-level projection for favorite event listings.
+type FavoriteEventRecord struct {
+	ID           uuid.UUID
+	Title        string
+	CategoryName *string
+	ImageURL     *string
+	Status       domain.EventStatus
+	StartTime    time.Time
+	EndTime      *time.Time
+	FavoritedAt  time.Time
+}
+
 // EventDetailRecord is the repository-level projection used for event detail responses.
 type EventDetailRecord struct {
 	ID                       uuid.UUID

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -282,3 +282,75 @@ func (s *Service) CancelEvent(ctx context.Context, userID, eventID uuid.UUID) er
 
 	return nil
 }
+
+// AddFavorite saves an event to the user's favorites list.
+func (s *Service) AddFavorite(ctx context.Context, userID, eventID uuid.UUID) error {
+	return s.eventRepo.AddFavorite(ctx, userID, eventID)
+}
+
+// RemoveFavorite removes an event from the user's favorites list.
+func (s *Service) RemoveFavorite(ctx context.Context, userID, eventID uuid.UUID) error {
+	return s.eventRepo.RemoveFavorite(ctx, userID, eventID)
+}
+
+// ListFavoriteEvents returns events the user has favorited, ordered by most recent.
+func (s *Service) ListFavoriteEvents(ctx context.Context, userID uuid.UUID) (*FavoriteEventsResult, error) {
+	records, err := s.eventRepo.ListFavoriteEvents(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]FavoriteEventItem, len(records))
+	for i, r := range records {
+		items[i] = FavoriteEventItem{
+			ID:          r.ID.String(),
+			Title:       r.Title,
+			Category:    r.CategoryName,
+			ImageURL:    r.ImageURL,
+			Status:      string(r.Status),
+			StartTime:   r.StartTime,
+			EndTime:     r.EndTime,
+			FavoritedAt: r.FavoritedAt,
+		}
+	}
+
+	return &FavoriteEventsResult{Items: items}, nil
+}
+
+// ListMyUpcomingEvents returns the user's upcoming events (ACTIVE or IN_PROGRESS).
+func (s *Service) ListMyUpcomingEvents(ctx context.Context, userID uuid.UUID) (*MyEventsResult, error) {
+	return s.listMyEvents(ctx, userID, []domain.EventStatus{domain.EventStatusActive, domain.EventStatusInProgress})
+}
+
+// ListMyCompletedEvents returns the user's completed events.
+func (s *Service) ListMyCompletedEvents(ctx context.Context, userID uuid.UUID) (*MyEventsResult, error) {
+	return s.listMyEvents(ctx, userID, []domain.EventStatus{domain.EventStatusCompleted})
+}
+
+// ListMyCanceledEvents returns the user's canceled events.
+func (s *Service) ListMyCanceledEvents(ctx context.Context, userID uuid.UUID) (*MyEventsResult, error) {
+	return s.listMyEvents(ctx, userID, []domain.EventStatus{domain.EventStatusCanceled})
+}
+
+func (s *Service) listMyEvents(ctx context.Context, userID uuid.UUID, statuses []domain.EventStatus) (*MyEventsResult, error) {
+	records, err := s.eventRepo.ListMyEvents(ctx, userID, statuses)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]MyEventItem, len(records))
+	for i, r := range records {
+		items[i] = MyEventItem{
+			ID:        r.ID.String(),
+			Title:     r.Title,
+			Category:  r.CategoryName,
+			ImageURL:  r.ImageURL,
+			Status:    string(r.Status),
+			StartTime: r.StartTime,
+			EndTime:   r.EndTime,
+			IsHost:    r.IsHost,
+		}
+	}
+
+	return &MyEventsResult{Items: items}, nil
+}

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -235,6 +235,40 @@ type EventDetailInvitation struct {
 	User         EventDetailHostContextUser `json:"user"`
 }
 
+// MyEventItem is a compact event summary returned by the my-events endpoints.
+type MyEventItem struct {
+	ID        string     `json:"id"`
+	Title     string     `json:"title"`
+	Category  *string    `json:"category"`
+	ImageURL  *string    `json:"image_url"`
+	Status    string     `json:"status"`
+	StartTime time.Time  `json:"start_time"`
+	EndTime   *time.Time `json:"end_time"`
+	IsHost    bool       `json:"is_host"`
+}
+
+// MyEventsResult wraps a list of personal event items.
+type MyEventsResult struct {
+	Items []MyEventItem `json:"items"`
+}
+
+// FavoriteEventItem is the compact event summary returned by the favorites list.
+type FavoriteEventItem struct {
+	ID          string     `json:"id"`
+	Title       string     `json:"title"`
+	Category    *string    `json:"category"`
+	ImageURL    *string    `json:"image_url"`
+	Status      string     `json:"status"`
+	StartTime   time.Time  `json:"start_time"`
+	EndTime     *time.Time `json:"end_time"`
+	FavoritedAt time.Time  `json:"favorited_at"`
+}
+
+// FavoriteEventsResult wraps a list of favorite event items.
+type FavoriteEventsResult struct {
+	Items []FavoriteEventItem `json:"items"`
+}
+
 // JoinEventResult is returned after a user successfully joins a public event.
 type JoinEventResult struct {
 	ParticipationID string    `json:"participation_id"`

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -81,6 +81,22 @@ func (r *fakeEventRepo) CancelEvent(_ context.Context, eventID uuid.UUID) error 
 	return nil
 }
 
+func (r *fakeEventRepo) AddFavorite(_ context.Context, _, _ uuid.UUID) error {
+	return r.err
+}
+
+func (r *fakeEventRepo) RemoveFavorite(_ context.Context, _, _ uuid.UUID) error {
+	return r.err
+}
+
+func (r *fakeEventRepo) ListFavoriteEvents(_ context.Context, _ uuid.UUID) ([]FavoriteEventRecord, error) {
+	return nil, r.err
+}
+
+func (r *fakeEventRepo) ListMyEvents(_ context.Context, _ uuid.UUID, _ []domain.EventStatus) ([]MyEventRecord, error) {
+	return nil, r.err
+}
+
 func (r *fakeEventRepo) ListDiscoverableEvents(_ context.Context, userID uuid.UUID, params DiscoverEventsParams) ([]DiscoverableEventRecord, error) {
 	r.discoverCallCount++
 	r.lastDiscoverUserID = userID

--- a/backend/internal/application/event/usecase.go
+++ b/backend/internal/application/event/usecase.go
@@ -14,4 +14,10 @@ type UseCase interface {
 	ApproveJoinRequest(ctx context.Context, hostUserID, eventID, joinRequestID uuid.UUID) (*ApproveJoinRequestResult, error)
 	RejectJoinRequest(ctx context.Context, hostUserID, eventID, joinRequestID uuid.UUID) (*RejectJoinRequestResult, error)
 	CancelEvent(ctx context.Context, userID, eventID uuid.UUID) error
+	AddFavorite(ctx context.Context, userID, eventID uuid.UUID) error
+	RemoveFavorite(ctx context.Context, userID, eventID uuid.UUID) error
+	ListFavoriteEvents(ctx context.Context, userID uuid.UUID) (*FavoriteEventsResult, error)
+	ListMyUpcomingEvents(ctx context.Context, userID uuid.UUID) (*MyEventsResult, error)
+	ListMyCompletedEvents(ctx context.Context, userID uuid.UUID) (*MyEventsResult, error)
+	ListMyCanceledEvents(ctx context.Context, userID uuid.UUID) (*MyEventsResult, error)
 }

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -2408,3 +2408,99 @@ func TestCancelEventReturnsConflictForNonActiveEvent(t *testing.T) {
 		t.Fatalf("expected 409 AppError, got %v", err)
 	}
 }
+
+func TestAddAndRemoveFavorite(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	user := common.GivenUser(t, harness.AuthRepo)
+	ref := common.GivenPublicEvent(t, harness.Service, host.ID)
+
+	// when: add favorite
+	err := harness.EventRepo.AddFavorite(context.Background(), user.ID, ref.ID)
+	if err != nil {
+		t.Fatalf("AddFavorite() error = %v", err)
+	}
+
+	// then: appears in favorites list
+	favs, err := harness.EventRepo.ListFavoriteEvents(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("ListFavoriteEvents() error = %v", err)
+	}
+	if len(favs) != 1 || favs[0].ID != ref.ID {
+		t.Fatalf("expected 1 favorite with ID %s, got %d items", ref.ID, len(favs))
+	}
+
+	// when: add again (idempotent)
+	err = harness.EventRepo.AddFavorite(context.Background(), user.ID, ref.ID)
+	if err != nil {
+		t.Fatalf("AddFavorite() duplicate error = %v", err)
+	}
+
+	// when: remove favorite
+	err = harness.EventRepo.RemoveFavorite(context.Background(), user.ID, ref.ID)
+	if err != nil {
+		t.Fatalf("RemoveFavorite() error = %v", err)
+	}
+
+	// then: no longer in favorites
+	favs, err = harness.EventRepo.ListFavoriteEvents(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("ListFavoriteEvents() after remove error = %v", err)
+	}
+	if len(favs) != 0 {
+		t.Fatalf("expected 0 favorites after remove, got %d", len(favs))
+	}
+}
+
+func TestListMyEventsUpcomingAndCompleted(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	activeRef := common.GivenPublicEvent(t, harness.Service, host.ID)
+
+	// cancel one event to test canceled listing
+	cancelRef := common.GivenPublicEvent(t, harness.Service, host.ID)
+	_ = harness.Service.CancelEvent(context.Background(), host.ID, cancelRef.ID)
+
+	// when: list upcoming (ACTIVE events)
+	upcoming, err := harness.Service.ListMyUpcomingEvents(context.Background(), host.ID)
+	if err != nil {
+		t.Fatalf("ListMyUpcomingEvents() error = %v", err)
+	}
+
+	// then: active event should be in upcoming
+	found := false
+	for _, item := range upcoming.Items {
+		if item.ID == activeRef.ID.String() {
+			found = true
+			if !item.IsHost {
+				t.Fatal("expected is_host = true for host's own event")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected active event %s in upcoming list", activeRef.ID)
+	}
+
+	// when: list canceled
+	canceled, err := harness.Service.ListMyCanceledEvents(context.Background(), host.ID)
+	if err != nil {
+		t.Fatalf("ListMyCanceledEvents() error = %v", err)
+	}
+
+	// then: canceled event should be in list
+	found = false
+	for _, item := range canceled.Items {
+		if item.ID == cancelRef.ID.String() {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected canceled event %s in canceled list", cancelRef.ID)
+	}
+}

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -1511,6 +1511,118 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
+  /events/{id}/favorite:
+    post:
+      tags: [Events]
+      summary: Add event to favorites
+      description: Saves the event to the authenticated user's favorites. Idempotent — calling twice has no additional effect.
+      operationId: addFavorite
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Event added to favorites (or already favorited).
+        '401':
+          description: Missing or invalid access token.
+    delete:
+      tags: [Events]
+      summary: Remove event from favorites
+      description: Removes the event from the authenticated user's favorites. Idempotent — calling when not favorited has no effect.
+      operationId: removeFavorite
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Event removed from favorites (or was not favorited).
+        '401':
+          description: Missing or invalid access token.
+
+  /me/favorites:
+    get:
+      tags: [Events]
+      summary: List favorite events
+      description: Returns the authenticated user's favorite events ordered by most recently favorited first.
+      operationId: listFavoriteEvents
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Favorite events listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FavoriteEventsResponse'
+        '401':
+          description: Missing or invalid access token.
+
+  /me/events/upcoming:
+    get:
+      tags: [Events]
+      summary: List upcoming events
+      description: Returns events where the user is host or approved participant with status ACTIVE or IN_PROGRESS, ordered by start_time descending.
+      operationId: listMyUpcomingEvents
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Upcoming events listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MyEventsResponse'
+        '401':
+          description: Missing or invalid access token.
+
+  /me/events/completed:
+    get:
+      tags: [Events]
+      summary: List completed events
+      description: Returns events where the user is host or approved participant with status COMPLETED, ordered by start_time descending.
+      operationId: listMyCompletedEvents
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Completed events listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MyEventsResponse'
+        '401':
+          description: Missing or invalid access token.
+
+  /me/events/canceled:
+    get:
+      tags: [Events]
+      summary: List canceled events
+      description: Returns events where the user is host or approved participant with status CANCELED, ordered by start_time descending.
+      operationId: listMyCanceledEvents
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Canceled events listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MyEventsResponse'
+        '401':
+          description: Missing or invalid access token.
+
 components:
   securitySchemes:
     bearerAuth:
@@ -2479,3 +2591,91 @@ components:
         cooldown_ends_at:
           type: string
           format: date-time
+
+    FavoriteEventsResponse:
+      type: object
+      additionalProperties: false
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/FavoriteEventItem'
+
+    FavoriteEventItem:
+      type: object
+      additionalProperties: false
+      required: [id, title, status, start_time, favorited_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        category:
+          type:
+            - string
+            - "null"
+        image_url:
+          type:
+            - string
+            - "null"
+        status:
+          type: string
+          description: Event status, for example `ACTIVE`, `IN_PROGRESS`, `CANCELED`, or `COMPLETED`.
+          example: ACTIVE
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type:
+            - string
+            - "null"
+          format: date-time
+        favorited_at:
+          type: string
+          format: date-time
+
+    MyEventsResponse:
+      type: object
+      additionalProperties: false
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MyEventItem'
+
+    MyEventItem:
+      type: object
+      additionalProperties: false
+      required: [id, title, status, start_time, is_host]
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        category:
+          type:
+            - string
+            - "null"
+        image_url:
+          type:
+            - string
+            - "null"
+        status:
+          type: string
+          description: Event status, for example `ACTIVE`, `IN_PROGRESS`, `CANCELED`, or `COMPLETED`.
+          example: ACTIVE
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type:
+            - string
+            - "null"
+          format: date-time
+        is_host:
+          type: boolean
+          description: Whether the authenticated user is the host of this event.


### PR DESCRIPTION
  ## 📋 Summary
  Added 6 new authenticated endpoints for managing favorites and listing personal events. Users can  
  add/remove events from favorites, list their favorited events, and view their upcoming, completed, 
  and canceled events with host indication.

  ## 🔄 Changes
  - `POST /events/:id/favorite` — add event to favorites (idempotent)
  - `DELETE /events/:id/favorite` — remove event from favorites (idempotent)
  - `GET /me/favorites` — list favorite events ordered by most recently favorited
  - `GET /me/events/upcoming` — list ACTIVE/IN_PROGRESS events (hosted or participating)
  - `GET /me/events/completed` — list COMPLETED events
  - `GET /me/events/canceled` — list CANCELED events
  - My-events responses include `is_host` field per item
  - OpenAPI documentation added for all 6 endpoints

  ## 🧪 Testing
  - `go build ./...` passes
  - `go test ./...` passes (all unit tests)
  - `go test -tags=integration ./tests_integration/` passes (all integration tests)
  - New integration tests: `TestAddAndRemoveFavorite`, `TestListMyEventsUpcomingAndCompleted`        

  ## 🔗 Related
  Closes #147

  Base branch: main