### PR TITLE
fix(backend): include favorite_count in discovery response

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -346,6 +346,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 				el.address AS location_address,
 				e.privacy_level,
 				e.approved_participant_count,
+				e.favorite_count,
 				(fav.event_id IS NOT NULL) AS is_favorited,
 				us.final_score AS host_final_score,
 				COALESCE(us.hosted_event_rating_count, 0) AS host_rating_count,
@@ -367,6 +368,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			location_address,
 			privacy_level,
 			approved_participant_count,
+			favorite_count,
 			is_favorited,
 			host_final_score,
 			host_rating_count,
@@ -395,6 +397,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			locationAddress          pgtype.Text
 			privacyLevel             string
 			approvedParticipantCount int
+			favoriteCount            int
 			isFavorited              bool
 			hostFinalScore           pgtype.Float8
 			hostRatingCount          int
@@ -411,6 +414,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			&locationAddress,
 			&privacyLevel,
 			&approvedParticipantCount,
+			&favoriteCount,
 			&isFavorited,
 			&hostFinalScore,
 			&hostRatingCount,
@@ -427,6 +431,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			StartTime:                startTime,
 			PrivacyLevel:             domain.EventPrivacyLevel(privacyLevel),
 			ApprovedParticipantCount: approvedParticipantCount,
+			FavoriteCount:            favoriteCount,
 			IsFavorited:              isFavorited,
 			HostScore: eventapp.EventHostScoreSummaryRecord{
 				HostedEventRatingCount: hostRatingCount,

--- a/backend/internal/application/event/helpers.go
+++ b/backend/internal/application/event/helpers.go
@@ -74,6 +74,7 @@ func toDiscoverableEventItem(record DiscoverableEventRecord) DiscoverableEventIt
 		LocationAddress:          record.LocationAddress,
 		PrivacyLevel:             string(record.PrivacyLevel),
 		ApprovedParticipantCount: record.ApprovedParticipantCount,
+		FavoriteCount:            record.FavoriteCount,
 		IsFavorited:              record.IsFavorited,
 		HostScore:                toEventHostScoreSummary(record.HostScore),
 	}

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -65,6 +65,7 @@ type DiscoverableEventRecord struct {
 	LocationAddress          *string
 	PrivacyLevel             domain.EventPrivacyLevel
 	ApprovedParticipantCount int
+	FavoriteCount            int
 	IsFavorited              bool
 	HostScore                EventHostScoreSummaryRecord
 	DistanceMeters           float64

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -83,6 +83,7 @@ type DiscoverableEventItem struct {
 	LocationAddress          *string               `json:"location_address"`
 	PrivacyLevel             string                `json:"privacy_level"`
 	ApprovedParticipantCount int                   `json:"approved_participant_count"`
+	FavoriteCount            int                   `json:"favorite_count"`
 	IsFavorited              bool                  `json:"is_favorited"`
 	HostScore                EventHostScoreSummary `json:"host_score"`
 }

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -1297,6 +1297,7 @@ paths:
                         location_address: Belgrad Forest, Istanbul
                         privacy_level: PUBLIC
                         approved_participant_count: 42
+                        favorite_count: 8
                         is_favorited: true
                         host_score:
                           final_score: 4.18
@@ -1309,6 +1310,7 @@ paths:
                         location_address: Besiktas, Istanbul
                         privacy_level: PROTECTED
                         approved_participant_count: 18
+                        favorite_count: 3
                         is_favorited: false
                         host_score:
                           final_score: null
@@ -1796,6 +1798,7 @@ components:
         - start_time
         - privacy_level
         - approved_participant_count
+        - favorite_count
         - is_favorited
         - host_score
       properties:
@@ -1839,6 +1842,11 @@ components:
           minimum: 0
           description: Current count of approved participants.
           example: 42
+        favorite_count:
+          type: integer
+          minimum: 0
+          description: Total number of users who have favorited this event.
+          example: 8
         is_favorited:
           type: boolean
           description: Whether the authenticated user has favorited the event.


### PR DESCRIPTION
## 📋 Summary
  Added `favorite_count` to the `GET /events` discovery response items. Previously only available in 
  `GET /events/{id}` detail, causing mobile event cards to display `0` saves.

  ## 🔄 Changes
  - Added `favorite_count` to discovery SQL SELECT (`e.favorite_count`)
  - Added `FavoriteCount int` to `DiscoverableEventRecord` and `DiscoverableEventItem`
  - Updated mapping in `toDiscoverableEventItem`
  - Updated `DiscoverEventItem` schema and examples in OpenAPI docs

  ## 🧪 Testing
  - `go build ./...` passes
  - `go test ./...` passes (all unit tests)
  - `go test -tags=integration ./tests_integration/` passes (all integration tests)

  ## 🔗 Related
  Closes #298

  Base: main