### PR TITLE
feat(frontend): add cancel event flow

### DIFF
--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -1,4 +1,4 @@
-import { apiPostAuth, apiGet, apiGetAuth } from './api';
+import { apiPostAuth, apiPatchAuth, apiGet, apiGetAuth } from './api';
 import {
   CreateEventRequest,
   CreateEventResponse,
@@ -95,6 +95,13 @@ export function rejectJoinRequest(
     {},
     token,
   );
+}
+
+export function cancelEvent(
+  eventId: string,
+  token: string,
+): Promise<void> {
+  return apiPatchAuth<void>(`/events/${eventId}/cancel`, {}, token);
 }
 
 export async function searchLocation(

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -562,6 +562,116 @@
   cursor: not-allowed;
 }
 
+/* Cancel event button */
+.ed-cancel-event-btn {
+  width: 100%;
+  padding: 12px 24px;
+  border-radius: 10px;
+  border: 1px solid #dc2626;
+  background: none;
+  color: #dc2626;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ed-cancel-event-btn:hover:not(:disabled) {
+  background-color: #fef2f2;
+}
+
+.ed-cancel-event-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Confirmation modal */
+.ed-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 20px;
+}
+
+.ed-modal {
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 28px;
+  max-width: 420px;
+  width: 100%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+}
+
+.ed-modal-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 10px 0;
+}
+
+.ed-modal-text {
+  font-size: 14px;
+  color: #6b7280;
+  line-height: 1.6;
+  margin: 0 0 24px 0;
+}
+
+.ed-modal-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.ed-modal-cancel-btn {
+  flex: 1;
+  padding: 10px 20px;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background: none;
+  color: #374151;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ed-modal-cancel-btn:hover:not(:disabled) {
+  border-color: #9ca3af;
+}
+
+.ed-modal-confirm-btn {
+  flex: 1;
+  padding: 10px 20px;
+  border-radius: 10px;
+  border: 1px solid #dc2626;
+  background-color: #dc2626;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ed-modal-confirm-btn:hover:not(:disabled) {
+  background-color: #b91c1c;
+  border-color: #b91c1c;
+}
+
+.ed-modal-confirm-btn:disabled,
+.ed-modal-cancel-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Invitation status */
 .ed-invitation-status {
   padding: 3px 10px;

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getEventDetail, joinEvent, requestJoinEvent, approveJoinRequest, rejectJoinRequest } from '@/services/eventService';
+import { getEventDetail, joinEvent, requestJoinEvent, approveJoinRequest, rejectJoinRequest, cancelEvent } from '@/services/eventService';
 import type { EventDetailResponse } from '@/models/event';
 import { ApiError } from '@/services/api';
 
@@ -155,8 +155,36 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     }
   }, [eventId, token]);
 
+  const [cancelLoading, setCancelLoading] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
+  const handleCancel = useCallback(async () => {
+    if (!eventId || !token) return;
+    setCancelLoading(true);
+    setCancelError(null);
+
+    try {
+      await cancelEvent(eventId, token);
+      const updated = await getEventDetail(eventId, token);
+      setEvent(updated);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const errorMap: Record<string, string> = {
+          event_cancel_not_allowed: 'Only the event host can cancel this event.',
+          event_not_cancelable: 'Only active events can be canceled.',
+        };
+        setCancelError(errorMap[err.code] ?? err.message);
+      } else {
+        setCancelError('Failed to cancel event. Please try again.');
+      }
+    } finally {
+      setCancelLoading(false);
+    }
+  }, [eventId, token]);
+
   const dismissJoinError = useCallback(() => setJoinError(null), []);
   const dismissModerateError = useCallback(() => setModerateError(null), []);
+  const dismissCancelError = useCallback(() => setCancelError(null), []);
 
   return {
     event,
@@ -166,12 +194,16 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     joinError,
     moderatingId,
     moderateError,
+    cancelLoading,
+    cancelError,
     retry: fetchDetail,
     handleJoin,
     handleRequestJoin,
     handleApprove,
     handleReject,
+    handleCancel,
     dismissJoinError,
     dismissModerateError,
+    dismissCancelError,
   };
 }

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -198,6 +198,46 @@ function JoinActionSection({
   );
 }
 
+function CancelConfirmModal({
+  onConfirm,
+  onClose,
+  loading,
+}: {
+  onConfirm: () => void;
+  onClose: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="ed-modal-overlay" onClick={onClose}>
+      <div className="ed-modal" onClick={(e) => e.stopPropagation()}>
+        <h3 className="ed-modal-title">Cancel Event</h3>
+        <p className="ed-modal-text">
+          Are you sure you want to cancel this event? This action cannot be undone.
+          All participants will be notified.
+        </p>
+        <div className="ed-modal-actions">
+          <button
+            type="button"
+            className="ed-modal-cancel-btn"
+            onClick={onClose}
+            disabled={loading}
+          >
+            Go Back
+          </button>
+          <button
+            type="button"
+            className="ed-modal-confirm-btn"
+            onClick={onConfirm}
+            disabled={loading}
+          >
+            {loading ? <span className="spinner" /> : 'Yes, Cancel Event'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function EventContent({
   event,
   joinLoading,
@@ -210,6 +250,10 @@ function EventContent({
   onApprove,
   onReject,
   onDismissModerateError,
+  cancelLoading,
+  cancelError,
+  onCancel,
+  onDismissCancelError,
 }: {
   event: EventDetailResponse;
   joinLoading: boolean;
@@ -222,8 +266,13 @@ function EventContent({
   onApprove: (joinRequestId: string) => void;
   onReject: (joinRequestId: string) => void;
   onDismissModerateError: () => void;
+  cancelLoading: boolean;
+  cancelError: string | null;
+  onCancel: () => void;
+  onDismissCancelError: () => void;
 }) {
   const navigate = useNavigate();
+  const [showCancelModal, setShowCancelModal] = useState(false);
 
   return (
     <div className="ed-page">
@@ -420,6 +469,26 @@ function EventContent({
           <div className="ed-section">
             <h2 className="ed-section-title">Management</h2>
 
+            {/* Cancel event button */}
+            {event.status === 'ACTIVE' && (
+              <div className="ed-mgmt-group">
+                {cancelError && (
+                  <div className="ed-join-error" style={{ marginBottom: 10 }}>
+                    <span>{cancelError}</span>
+                    <button type="button" className="ed-join-error-dismiss" onClick={onDismissCancelError}>&times;</button>
+                  </div>
+                )}
+                <button
+                  type="button"
+                  className="ed-cancel-event-btn"
+                  onClick={() => setShowCancelModal(true)}
+                  disabled={cancelLoading}
+                >
+                  Cancel Event
+                </button>
+              </div>
+            )}
+
             {/* Approved participants */}
             <div className="ed-mgmt-group">
               <h3 className="ed-mgmt-title">
@@ -545,6 +614,18 @@ function EventContent({
           </div>
         )}
       </div>
+
+      {/* Cancel confirmation modal */}
+      {showCancelModal && (
+        <CancelConfirmModal
+          loading={cancelLoading}
+          onConfirm={() => {
+            onCancel();
+            setShowCancelModal(false);
+          }}
+          onClose={() => setShowCancelModal(false)}
+        />
+      )}
     </div>
   );
 }
@@ -607,6 +688,10 @@ export default function EventDetailPage() {
       onApprove={vm.handleApprove}
       onReject={vm.handleReject}
       onDismissModerateError={vm.dismissModerateError}
+      cancelLoading={vm.cancelLoading}
+      cancelError={vm.cancelError}
+      onCancel={vm.handleCancel}
+      onDismissCancelError={vm.dismissCancelError}
     />
   );
 }


### PR DESCRIPTION
## 📋 Summary
Adds the ability for event hosts to cancel their active events directly from the event detail page, with a confirmation modal to prevent accidental cancellations.

## 🔄 Changes
- `eventService.ts` — Added `cancelEvent()` function calling `PATCH /events/:id/cancel`
- `useEventDetailViewModel.ts` — Added `handleCancel`, `cancelLoading`, `cancelError`, and `dismissCancelError` state/handlers
- `EventDetailPage.tsx` — Added `CancelConfirmModal` component and "Cancel Event" button in the management section (only shown for ACTIVE events)
- `event-detail.css` — Added styles for cancel button and confirmation modal (overlay, card, action buttons)

## 🧪 Testing
1. Log in as an event host and navigate to an active event's detail page
2. Scroll to the Management section — "Cancel Event" button should be visible
3. Click "Cancel Event" — a confirmation modal should appear
4. Click "Go Back" — modal should close without any action
5. Click "Yes, Cancel Event" — event should be canceled and status should update on the page
6. Verify the "Cancel Event" button no longer appears for non-ACTIVE events
7. Log in as a non-host participant — "Cancel Event" button should not be visible

## 🔗 Related
Link issues with: #174 
