### PR TITLE
feat(backend): add leave-event endpoint

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -658,21 +658,28 @@ func (r *EventRepository) loadEventDetailCore(
 					FROM participation p
 					WHERE p.event_id = e.id
 					  AND p.user_id = $2
-					  AND p.status = $12
-				) THEN $13
+					  AND p.status = $6
+				) THEN $7
+				WHEN EXISTS (
+					SELECT 1
+					FROM participation p
+					WHERE p.event_id = e.id
+					  AND p.user_id = $2
+					  AND p.status = $14
+				) THEN $15
 				WHEN EXISTS (
 					SELECT 1
 					FROM join_request jr
 					WHERE jr.event_id = e.id
 					  AND jr.user_id = $2
-					  AND jr.status = $6
-				) THEN $7
+					  AND jr.status = $8
+				) THEN $9
 				WHEN EXISTS (
 					SELECT 1
 					FROM invitation inv
 					WHERE inv.event_id = e.id
 					  AND inv.invited_user_id = $2
-				) THEN $8
+				) THEN $10
 				ELSE $3
 			END AS participation_status
 		FROM event e
@@ -683,21 +690,21 @@ func (r *EventRepository) loadEventDetailCore(
 		LEFT JOIN user_score us ON us.user_id = host.id
 		WHERE e.id = $1
 		  AND (
-			e.privacy_level IN ($9, $10)
+			e.privacy_level IN ($11, $12)
 			OR e.host_id = $2
 			OR EXISTS (
 				SELECT 1
 				FROM participation p
 				WHERE p.event_id = e.id
 				  AND p.user_id = $2
-				  AND p.status IN ($4, $12)
+				  AND p.status IN ($4, $6, $14)
 			)
 			OR EXISTS (
 				SELECT 1
 				FROM invitation inv
 				WHERE inv.event_id = e.id
 				  AND inv.invited_user_id = $2
-				  AND inv.status = $11
+				  AND inv.status = $13
 			)
 		  )
 	`,
@@ -706,6 +713,8 @@ func (r *EventRepository) loadEventDetailCore(
 		string(domain.EventDetailParticipationStatusNone),
 		domain.ParticipationStatusApproved,
 		string(domain.EventDetailParticipationStatusJoined),
+		domain.ParticipationStatusLeaved,
+		string(domain.EventDetailParticipationStatusLeaved),
 		string(domain.JoinRequestStatusPending),
 		string(domain.EventDetailParticipationStatusPending),
 		string(domain.EventDetailParticipationStatusInvited),
@@ -1087,9 +1096,14 @@ func (r *EventRepository) loadApprovedParticipants(
 			return nil, fmt.Errorf("scan approved participant: %w", err)
 		}
 
+		participationStatus, ok := domain.ParseParticipationStatus(status)
+		if !ok {
+			return nil, fmt.Errorf("scan approved participant: unknown participation status %q", status)
+		}
+
 		participant := eventapp.EventDetailApprovedParticipantRecord{
 			ParticipationID: participationID,
-			Status:          status,
+			Status:          participationStatus,
 			CreatedAt:       createdAt,
 			UpdatedAt:       updatedAt,
 			User: eventapp.EventDetailHostContextUserRecord{
@@ -1444,7 +1458,8 @@ func (r *EventRepository) SetEventImageIfVersion(
 
 var _ imageuploadapp.EventRepository = (*EventRepository)(nil)
 
-// CancelEvent sets the event status to CANCELED and cancels all its participations atomically.
+// CancelEvent sets the event status to CANCELED and transitions active
+// participations to CANCELED atomically while preserving historical LEAVED rows.
 // Returns ErrEventNotCancelable if the event is not in ACTIVE status.
 func (r *EventRepository) CancelEvent(ctx context.Context, eventID uuid.UUID) error {
 	tx, err := r.pool.Begin(ctx)
@@ -1483,7 +1498,8 @@ func (r *EventRepository) CancelEvent(ctx context.Context, eventID uuid.UUID) er
 		UPDATE participation
 		SET status = $1, updated_at = NOW()
 		WHERE event_id = $2
-	`, domain.ParticipationStatusCanceled, eventID)
+		  AND status <> $3
+	`, domain.ParticipationStatusCanceled, eventID, domain.ParticipationStatusLeaved)
 	if err != nil {
 		return fmt.Errorf("cancel event participations: %w", err)
 	}

--- a/backend/internal/adapter/in/postgres/join_request_repo.go
+++ b/backend/internal/adapter/in/postgres/join_request_repo.go
@@ -407,11 +407,16 @@ func (r *JoinRequestRepository) insertApprovedParticipation(
 		return nil, fmt.Errorf("insert participation: %w", err)
 	}
 
+	parsedStatus, ok := domain.ParseParticipationStatus(status)
+	if !ok {
+		return nil, fmt.Errorf("insert participation: unknown participation status %q", status)
+	}
+
 	return &domain.Participation{
 		ID:        id,
 		EventID:   eventID,
 		UserID:    userID,
-		Status:    status,
+		Status:    parsedStatus,
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
 	}, nil

--- a/backend/internal/adapter/in/postgres/participation_repo.go
+++ b/backend/internal/adapter/in/postgres/participation_repo.go
@@ -56,11 +56,56 @@ func (r *ParticipationRepository) CreateParticipation(ctx context.Context, event
 		return nil, mapParticipationInsertError(err)
 	}
 
+	parsedStatus, ok := domain.ParseParticipationStatus(status)
+	if !ok {
+		return nil, fmt.Errorf("insert participation: unknown participation status %q", status)
+	}
+
 	return &domain.Participation{
 		ID:        id,
 		EventID:   eventID,
 		UserID:    userID,
-		Status:    status,
+		Status:    parsedStatus,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}, nil
+}
+
+// LeaveParticipation transitions an APPROVED participation to LEAVED.
+func (r *ParticipationRepository) LeaveParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
+	var (
+		id        uuid.UUID
+		status    string
+		createdAt time.Time
+		updatedAt time.Time
+	)
+
+	err := r.pool.QueryRow(ctx, `
+		UPDATE participation
+		SET status = $3,
+		    updated_at = NOW()
+		WHERE event_id = $1
+		  AND user_id = $2
+		  AND status = $4
+		RETURNING id, status, created_at, updated_at
+	`, eventID, userID, domain.ParticipationStatusLeaved, domain.ParticipationStatusApproved).Scan(&id, &status, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, r.mapLeaveParticipationNoRow(ctx, eventID)
+		}
+		return nil, fmt.Errorf("leave participation: %w", err)
+	}
+
+	parsedStatus, ok := domain.ParseParticipationStatus(status)
+	if !ok {
+		return nil, fmt.Errorf("leave participation: unknown participation status %q", status)
+	}
+
+	return &domain.Participation{
+		ID:        id,
+		EventID:   eventID,
+		UserID:    userID,
+		Status:    parsedStatus,
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
 	}, nil
@@ -94,6 +139,18 @@ func (r *ParticipationRepository) mapCreateParticipationNoRow(ctx context.Contex
 	}
 
 	return fmt.Errorf("insert participation: join preconditions changed during insert")
+}
+
+func (r *ParticipationRepository) mapLeaveParticipationNoRow(ctx context.Context, eventID uuid.UUID) error {
+	event, err := r.loadEventJoinState(ctx, eventID)
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		return domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+	}
+
+	return domain.ConflictError(domain.ErrorCodeEventLeaveNotAllowed, "Only approved participants can leave this event.")
 }
 
 func (r *ParticipationRepository) loadEventJoinState(ctx context.Context, eventID uuid.UUID) (*domain.Event, error) {

--- a/backend/internal/adapter/in/postgres/profile_repo.go
+++ b/backend/internal/adapter/in/postgres/profile_repo.go
@@ -143,10 +143,10 @@ func (r *ProfileRepository) GetUpcomingEvents(ctx context.Context, userID uuid.U
 		JOIN participation p ON p.event_id = e.id
 		LEFT JOIN event_category ec ON ec.id = e.category_id
 		WHERE p.user_id = $1
-		  AND p.status = 'APPROVED'
-		  AND e.status IN ('ACTIVE', 'IN_PROGRESS')
+		  AND p.status = $2
+		  AND e.status IN ($3, $4)
 		ORDER BY e.start_time ASC
-	`, userID)
+	`, userID, domain.ParticipationStatusApproved, domain.EventStatusActive, domain.EventStatusInProgress)
 	if err != nil {
 		return nil, fmt.Errorf("get upcoming events: %w", err)
 	}
@@ -154,8 +154,8 @@ func (r *ProfileRepository) GetUpcomingEvents(ctx context.Context, userID uuid.U
 	return scanEventSummaries(rows)
 }
 
-// GetCompletedEvents returns events the user had an APPROVED participation in
-// that are now COMPLETED.
+// GetCompletedEvents returns events the user either completed as an APPROVED
+// participant or left after the event had already started.
 func (r *ProfileRepository) GetCompletedEvents(ctx context.Context, userID uuid.UUID) ([]domain.EventSummary, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT
@@ -170,10 +170,13 @@ func (r *ProfileRepository) GetCompletedEvents(ctx context.Context, userID uuid.
 		JOIN participation p ON p.event_id = e.id
 		LEFT JOIN event_category ec ON ec.id = e.category_id
 		WHERE p.user_id = $1
-		  AND p.status = 'APPROVED'
-		  AND e.status = 'COMPLETED'
+		  AND (
+			p.status = $2
+			OR (p.status = $3 AND p.updated_at >= e.start_time)
+		  )
+		  AND e.status = $4
 		ORDER BY e.start_time DESC
-	`, userID)
+	`, userID, domain.ParticipationStatusApproved, domain.ParticipationStatusLeaved, domain.EventStatusCompleted)
 	if err != nil {
 		return nil, fmt.Errorf("get completed events: %w", err)
 	}
@@ -197,10 +200,10 @@ func (r *ProfileRepository) GetCanceledEvents(ctx context.Context, userID uuid.U
 		JOIN participation p ON p.event_id = e.id
 		LEFT JOIN event_category ec ON ec.id = e.category_id
 		WHERE p.user_id = $1
-		  AND p.status = 'CANCELED'
-		  AND e.status = 'CANCELED'
+		  AND p.status = $2
+		  AND e.status = $3
 		ORDER BY e.start_time DESC
-	`, userID)
+	`, userID, domain.ParticipationStatusCanceled, domain.EventStatusCanceled)
 	if err != nil {
 		return nil, fmt.Errorf("get canceled events: %w", err)
 	}

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
@@ -32,6 +32,7 @@ func RegisterEventRoutes(router fiber.Router, handler *EventHandler, auth fiber.
 	group.Get("/:id", auth, handler.GetEventDetail)
 	group.Post("/", auth, handler.CreateEvent)
 	group.Post("/:id/join", auth, handler.JoinEvent)
+	group.Patch("/:id/leave", auth, handler.LeaveEvent)
 	group.Post("/:id/join-request", auth, handler.RequestJoin)
 	group.Post("/:id/join-requests/:joinRequestId/approve", auth, handler.ApproveJoinRequest)
 	group.Post("/:id/join-requests/:joinRequestId/reject", auth, handler.RejectJoinRequest)
@@ -195,6 +196,23 @@ func (h *EventHandler) JoinEvent(c *fiber.Ctx) error {
 	}
 
 	return c.Status(fiber.StatusCreated).JSON(result)
+}
+
+// LeaveEvent handles PATCH /events/:id/leave.
+// Allows the authenticated user to leave an event they previously joined.
+func (h *EventHandler) LeaveEvent(c *fiber.Ctx) error {
+	eventID, err := parseEventIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.LeaveEvent(c.UserContext(), claims.UserID, eventID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.JSON(result)
 }
 
 // RequestJoin handles POST /events/:id/join-request.

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -24,12 +24,14 @@ type stubEventService struct {
 	callCount                int
 	discoverCallCount        int
 	detailCallCount          int
+	leaveCallCount           int
 	requestJoinCallCount     int
 	approveJoinCallCount     int
 	rejectJoinCallCount      int
 	lastInput                event.CreateEventInput
 	lastDiscoverInput        event.DiscoverEventsInput
 	lastDetailEventID        uuid.UUID
+	lastLeaveEventID         uuid.UUID
 	lastRequestJoinInput     event.RequestJoinInput
 	lastApproveJoinEventID   uuid.UUID
 	lastApproveJoinRequestID uuid.UUID
@@ -119,6 +121,20 @@ func (s *stubEventService) JoinEvent(_ context.Context, _, eventID uuid.UUID) (*
 		EventID:         eventID.String(),
 		Status:          domain.ParticipationStatusApproved,
 		CreatedAt:       time.Now().UTC(),
+	}, nil
+}
+
+func (s *stubEventService) LeaveEvent(_ context.Context, _, eventID uuid.UUID) (*event.LeaveEventResult, error) {
+	s.leaveCallCount++
+	s.lastLeaveEventID = eventID
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &event.LeaveEventResult{
+		ParticipationID: uuid.New().String(),
+		EventID:         eventID.String(),
+		Status:          domain.ParticipationStatusLeaved,
+		UpdatedAt:       time.Now().UTC(),
 	}, nil
 }
 
@@ -777,6 +793,54 @@ func TestJoinEventInvalidIDReturns400(t *testing.T) {
 	// then
 	if resp.StatusCode != fiber.StatusBadRequest {
 		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+}
+
+func TestLeaveEventInvalidIDReturns400(t *testing.T) {
+	// given
+	app := newEventTestApp(&stubEventService{}, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodPatch, "/events/not-a-uuid/leave", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+}
+
+func TestLeaveEventParsesIDBeforeCallingService(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodPatch, "/events/"+eventID.String()+"/leave", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.leaveCallCount != 1 {
+		t.Fatalf("expected leave service to be called once, got %d", svc.leaveCallCount)
+	}
+	if svc.lastLeaveEventID != eventID {
+		t.Fatalf("expected parsed event %s, got %s", eventID, svc.lastLeaveEventID)
 	}
 }
 

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -194,7 +194,7 @@ type EventDetailHostContextRecord struct {
 // EventDetailApprovedParticipantRecord is a host-visible approved participation projection.
 type EventDetailApprovedParticipantRecord struct {
 	ParticipationID uuid.UUID
-	Status          string
+	Status          domain.ParticipationStatus
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 	HostRating      *EventDetailRatingRecord

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -182,6 +182,38 @@ func (s *Service) JoinEvent(ctx context.Context, userID, eventID uuid.UUID) (*Jo
 	}, nil
 }
 
+// LeaveEvent allows an approved participant to leave an event before it ends.
+// The event host cannot leave their own event.
+func (s *Service) LeaveEvent(ctx context.Context, userID, eventID uuid.UUID) (*LeaveEventResult, error) {
+	event, err := s.eventRepo.GetEventByID(ctx, eventID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+		return nil, err
+	}
+
+	if event.HostID == userID {
+		return nil, domain.ForbiddenError(domain.ErrorCodeHostCannotLeave, "The event host cannot leave their own event.")
+	}
+
+	if !canLeaveEvent(event, s.now().UTC()) {
+		return nil, domain.ConflictError(domain.ErrorCodeEventNotLeaveable, "This event can no longer be left.")
+	}
+
+	p, err := s.participationService.LeaveParticipation(ctx, eventID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LeaveEventResult{
+		ParticipationID: p.ID.String(),
+		EventID:         p.EventID.String(),
+		Status:          p.Status,
+		UpdatedAt:       p.UpdatedAt,
+	}, nil
+}
+
 // RequestJoin creates a join request for a PROTECTED event.
 // The host must approve the request before the user becomes a participant.
 //
@@ -358,4 +390,14 @@ func (s *Service) ListFavoriteEvents(ctx context.Context, userID uuid.UUID) (*Fa
 	}
 
 	return &FavoriteEventsResult{Items: items}, nil
+}
+
+func canLeaveEvent(event *domain.Event, now time.Time) bool {
+	if event.Status == domain.EventStatusCanceled || event.Status == domain.EventStatusCompleted {
+		return false
+	}
+	if event.EndTime != nil && !now.Before(*event.EndTime) {
+		return false
+	}
+	return true
 }

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -208,7 +208,7 @@ type EventDetailHostContext struct {
 // EventDetailApprovedParticipant is returned only to the host.
 type EventDetailApprovedParticipant struct {
 	ParticipationID string                     `json:"participation_id"`
-	Status          string                     `json:"status"`
+	Status          domain.ParticipationStatus `json:"status"`
 	CreatedAt       time.Time                  `json:"created_at"`
 	UpdatedAt       time.Time                  `json:"updated_at"`
 	HostRating      *EventDetailRating         `json:"host_rating"`
@@ -255,10 +255,18 @@ type FavoriteEventsResult struct {
 
 // JoinEventResult is returned after a user successfully joins a public event.
 type JoinEventResult struct {
-	ParticipationID string    `json:"participation_id"`
-	EventID         string    `json:"event_id"`
-	Status          string    `json:"status"`
-	CreatedAt       time.Time `json:"created_at"`
+	ParticipationID string                     `json:"participation_id"`
+	EventID         string                     `json:"event_id"`
+	Status          domain.ParticipationStatus `json:"status"`
+	CreatedAt       time.Time                  `json:"created_at"`
+}
+
+// LeaveEventResult is returned after a user successfully leaves an event.
+type LeaveEventResult struct {
+	ParticipationID string                     `json:"participation_id"`
+	EventID         string                     `json:"event_id"`
+	Status          domain.ParticipationStatus `json:"status"`
+	UpdatedAt       time.Time                  `json:"updated_at"`
 }
 
 // RequestJoinInput is the validated input for creating a protected-event join request.
@@ -277,12 +285,12 @@ type RequestJoinResult struct {
 
 // ApproveJoinRequestResult is returned after a host approves a join request.
 type ApproveJoinRequestResult struct {
-	JoinRequestID       string    `json:"join_request_id"`
-	EventID             string    `json:"event_id"`
-	JoinRequestStatus   string    `json:"join_request_status"`
-	ParticipationID     string    `json:"participation_id"`
-	ParticipationStatus string    `json:"participation_status"`
-	UpdatedAt           time.Time `json:"updated_at"`
+	JoinRequestID       string                     `json:"join_request_id"`
+	EventID             string                     `json:"event_id"`
+	JoinRequestStatus   string                     `json:"join_request_status"`
+	ParticipationID     string                     `json:"participation_id"`
+	ParticipationStatus domain.ParticipationStatus `json:"participation_status"`
+	UpdatedAt           time.Time                  `json:"updated_at"`
 }
 
 // RejectJoinRequestResult is returned after a host rejects a join request.

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -119,10 +119,13 @@ func (r *fakeEventRepo) ListDiscoverableEvents(_ context.Context, userID uuid.UU
 
 // fakeParticipationService is an in-memory implementation of ParticipationService.
 type fakeParticipationService struct {
-	err         error
-	callCount   int
-	lastEventID uuid.UUID
-	lastUserID  uuid.UUID
+	err              error
+	callCount        int
+	leaveCallCount   int
+	lastEventID      uuid.UUID
+	lastUserID       uuid.UUID
+	lastLeaveEventID uuid.UUID
+	lastLeaveUserID  uuid.UUID
 }
 
 func (s *fakeParticipationService) CreateApprovedParticipation(_ context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
@@ -140,6 +143,25 @@ func (s *fakeParticipationService) CreateApprovedParticipation(_ context.Context
 		UserID:    userID,
 		Status:    domain.ParticipationStatusApproved,
 		CreatedAt: now,
+		UpdatedAt: now,
+	}, nil
+}
+
+func (s *fakeParticipationService) LeaveParticipation(_ context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
+	s.leaveCallCount++
+	s.lastLeaveEventID = eventID
+	s.lastLeaveUserID = userID
+
+	if s.err != nil {
+		return nil, s.err
+	}
+	now := time.Now().UTC()
+	return &domain.Participation{
+		ID:        uuid.New(),
+		EventID:   eventID,
+		UserID:    userID,
+		Status:    domain.ParticipationStatusLeaved,
+		CreatedAt: now.Add(-time.Hour),
 		UpdatedAt: now,
 	}, nil
 }
@@ -1190,6 +1212,19 @@ func TestCompleteEventConflictWhenTerminal(t *testing.T) {
 	}
 }
 
+func leaveableEvent(hostID uuid.UUID) *domain.Event {
+	start := time.Now().UTC().Add(time.Hour)
+	end := start.Add(2 * time.Hour)
+	return &domain.Event{
+		ID:           uuid.New(),
+		HostID:       hostID,
+		PrivacyLevel: domain.PrivacyPublic,
+		Status:       domain.EventStatusActive,
+		StartTime:    start,
+		EndTime:      &end,
+	}
+}
+
 func TestJoinEventSuccessReturnsApproved(t *testing.T) {
 	hostID := uuid.New()
 	joinerID := uuid.New()
@@ -1282,6 +1317,67 @@ func TestJoinEventAllowsWhenUnderCapacity(t *testing.T) {
 	}
 	if result.Status != domain.ParticipationStatusApproved {
 		t.Fatalf("expected status APPROVED, got %q", result.Status)
+	}
+}
+
+func TestLeaveEventSuccessReturnsLeaved(t *testing.T) {
+	hostID := uuid.New()
+	participantID := uuid.New()
+	ev := leaveableEvent(hostID)
+	svc, _, participationService, _ := newTestEventServiceWithEvent(ev)
+
+	result, err := svc.LeaveEvent(context.Background(), participantID, ev.ID)
+
+	if err != nil {
+		t.Fatalf("LeaveEvent() error = %v", err)
+	}
+	if result.Status != domain.ParticipationStatusLeaved {
+		t.Fatalf("expected status %q, got %q", domain.ParticipationStatusLeaved, result.Status)
+	}
+	if participationService.leaveCallCount != 1 {
+		t.Fatalf("expected leave participation service to be called once")
+	}
+	if participationService.lastLeaveEventID != ev.ID || participationService.lastLeaveUserID != participantID {
+		t.Fatalf("expected leave participation service to receive event %s and user %s", ev.ID, participantID)
+	}
+}
+
+func TestLeaveEventRejectsHost(t *testing.T) {
+	hostID := uuid.New()
+	ev := leaveableEvent(hostID)
+	svc, _, _, _ := newTestEventServiceWithEvent(ev)
+
+	_, err := svc.LeaveEvent(context.Background(), hostID, ev.ID)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if appErr, ok := errors.AsType[*domain.AppError](err); !ok || appErr.Code != domain.ErrorCodeHostCannotLeave {
+		t.Fatalf("expected host_cannot_leave, got %v", err)
+	}
+}
+
+func TestLeaveEventRejectsEndedEvent(t *testing.T) {
+	hostID := uuid.New()
+	participantID := uuid.New()
+	end := time.Now().UTC().Add(-time.Minute)
+	ev := &domain.Event{
+		ID:           uuid.New(),
+		HostID:       hostID,
+		PrivacyLevel: domain.PrivacyPublic,
+		Status:       domain.EventStatusActive,
+		StartTime:    end.Add(-2 * time.Hour),
+		EndTime:      &end,
+	}
+	svc, _, _, _ := newTestEventServiceWithEvent(ev)
+
+	_, err := svc.LeaveEvent(context.Background(), participantID, ev.ID)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if appErr, ok := errors.AsType[*domain.AppError](err); !ok || appErr.Code != domain.ErrorCodeEventNotLeaveable {
+		t.Fatalf("expected event_not_leaveable, got %v", err)
 	}
 }
 

--- a/backend/internal/application/event/usecase.go
+++ b/backend/internal/application/event/usecase.go
@@ -10,6 +10,7 @@ type UseCase interface {
 	DiscoverEvents(ctx context.Context, userID uuid.UUID, input DiscoverEventsInput) (*DiscoverEventsResult, error)
 	GetEventDetail(ctx context.Context, userID, eventID uuid.UUID) (*GetEventDetailResult, error)
 	JoinEvent(ctx context.Context, userID, eventID uuid.UUID) (*JoinEventResult, error)
+	LeaveEvent(ctx context.Context, userID, eventID uuid.UUID) (*LeaveEventResult, error)
 	RequestJoin(ctx context.Context, userID, eventID uuid.UUID, input RequestJoinInput) (*RequestJoinResult, error)
 	ApproveJoinRequest(ctx context.Context, hostUserID, eventID, joinRequestID uuid.UUID) (*ApproveJoinRequestResult, error)
 	RejectJoinRequest(ctx context.Context, hostUserID, eventID, joinRequestID uuid.UUID) (*RejectJoinRequestResult, error)

--- a/backend/internal/application/participation/repository.go
+++ b/backend/internal/application/participation/repository.go
@@ -10,4 +10,5 @@ import (
 // Repository is the application-layer persistence port for participations.
 type Repository interface {
 	CreateParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error)
+	LeaveParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error)
 }

--- a/backend/internal/application/participation/service.go
+++ b/backend/internal/application/participation/service.go
@@ -24,3 +24,9 @@ func NewService(repo Repository) *Service {
 func (s *Service) CreateApprovedParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
 	return s.repo.CreateParticipation(ctx, eventID, userID)
 }
+
+// LeaveParticipation marks an APPROVED participation as LEAVED for the given
+// event and user.
+func (s *Service) LeaveParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
+	return s.repo.LeaveParticipation(ctx, eventID, userID)
+}

--- a/backend/internal/application/participation/service_test.go
+++ b/backend/internal/application/participation/service_test.go
@@ -11,11 +11,14 @@ import (
 )
 
 type fakeParticipationRepo struct {
-	err         error
-	callCount   int
-	lastEventID uuid.UUID
-	lastUserID  uuid.UUID
-	result      *domain.Participation
+	err              error
+	callCount        int
+	leaveCallCount   int
+	lastEventID      uuid.UUID
+	lastUserID       uuid.UUID
+	lastLeaveEventID uuid.UUID
+	lastLeaveUserID  uuid.UUID
+	result           *domain.Participation
 }
 
 func (r *fakeParticipationRepo) CreateParticipation(_ context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
@@ -37,6 +40,29 @@ func (r *fakeParticipationRepo) CreateParticipation(_ context.Context, eventID, 
 		UserID:    userID,
 		Status:    domain.ParticipationStatusApproved,
 		CreatedAt: now,
+		UpdatedAt: now,
+	}, nil
+}
+
+func (r *fakeParticipationRepo) LeaveParticipation(_ context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
+	r.leaveCallCount++
+	r.lastLeaveEventID = eventID
+	r.lastLeaveUserID = userID
+
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.result != nil {
+		return r.result, nil
+	}
+
+	now := time.Now().UTC()
+	return &domain.Participation{
+		ID:        uuid.New(),
+		EventID:   eventID,
+		UserID:    userID,
+		Status:    domain.ParticipationStatusLeaved,
+		CreatedAt: now.Add(-time.Hour),
 		UpdatedAt: now,
 	}, nil
 }
@@ -78,5 +104,33 @@ func TestCreateApprovedParticipationPropagatesRepoError(t *testing.T) {
 	// then
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+}
+
+func TestLeaveParticipationDelegatesToRepo(t *testing.T) {
+	// given
+	repo := &fakeParticipationRepo{}
+	service := NewService(repo)
+	eventID := uuid.New()
+	userID := uuid.New()
+
+	// when
+	result, err := service.LeaveParticipation(context.Background(), eventID, userID)
+
+	// then
+	if err != nil {
+		t.Fatalf("LeaveParticipation() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected participation result, got nil")
+	}
+	if repo.leaveCallCount != 1 {
+		t.Fatalf("expected leave repo to be called once, got %d", repo.leaveCallCount)
+	}
+	if repo.lastLeaveEventID != eventID || repo.lastLeaveUserID != userID {
+		t.Fatalf("expected leave repo to receive event %s and user %s", eventID, userID)
+	}
+	if result.Status != domain.ParticipationStatusLeaved {
+		t.Fatalf("expected status %q, got %q", domain.ParticipationStatusLeaved, result.Status)
 	}
 }

--- a/backend/internal/application/participation/usecase.go
+++ b/backend/internal/application/participation/usecase.go
@@ -10,4 +10,5 @@ import (
 // UseCase is the inbound application port for participation flows.
 type UseCase interface {
 	CreateApprovedParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error)
+	LeaveParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error)
 }

--- a/backend/internal/application/profile/service.go
+++ b/backend/internal/application/profile/service.go
@@ -59,8 +59,8 @@ func (s *Service) GetMyHostedEvents(ctx context.Context, userID uuid.UUID) ([]Ev
 	return toEventSummaries(events), nil
 }
 
-// GetMyUpcomingEvents returns events the user has an approved participation in
-// that are still ACTIVE or IN_PROGRESS.
+// GetMyUpcomingEvents returns events the user is still actively participating
+// in with an APPROVED participation.
 func (s *Service) GetMyUpcomingEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error) {
 	events, err := s.repo.GetUpcomingEvents(ctx, userID)
 	if err != nil {
@@ -69,7 +69,8 @@ func (s *Service) GetMyUpcomingEvents(ctx context.Context, userID uuid.UUID) ([]
 	return toEventSummaries(events), nil
 }
 
-// GetMyCompletedEvents returns events the user participated in that have COMPLETED.
+// GetMyCompletedEvents returns completed events the user either finished as an
+// APPROVED participant or left after the event had already started.
 func (s *Service) GetMyCompletedEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error) {
 	events, err := s.repo.GetCompletedEvents(ctx, userID)
 	if err != nil {

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -37,6 +37,7 @@ const (
 	ErrorCodeAlreadyRequested                = "already_requested"
 	ErrorCodeEventJoinNotAllowed             = "event_join_not_allowed"
 	ErrorCodeHostCannotJoin                  = "host_cannot_join"
+	ErrorCodeHostCannotLeave                 = "host_cannot_leave"
 	ErrorCodeCapacityExceeded                = "capacity_exceeded"
 	ErrorCodeJoinRequestNotFound             = "join_request_not_found"
 	ErrorCodeJoinRequestModerationNotAllowed = "join_request_moderation_not_allowed"
@@ -48,6 +49,8 @@ const (
 	ErrorCodeEventNotCompletable             = "event_not_completable"
 	ErrorCodeEventCanceled                   = "event_canceled"
 	ErrorCodeEventNotJoinable                = "event_not_joinable"
+	ErrorCodeEventLeaveNotAllowed            = "event_leave_not_allowed"
+	ErrorCodeEventNotLeaveable               = "event_not_leaveable"
 	ErrorCodeFavoriteLocationNotFound        = "favorite_location_not_found"
 	ErrorCodeFavoriteLocationLimitExceeded   = "favorite_location_limit_exceeded"
 

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -54,6 +54,7 @@ const (
 	EventDiscoverySortRelevance EventDiscoverySort = "RELEVANCE"
 
 	EventDetailParticipationStatusJoined   EventDetailParticipationStatus = "JOINED"
+	EventDetailParticipationStatusLeaved   EventDetailParticipationStatus = "LEAVED"
 	EventDetailParticipationStatusPending  EventDetailParticipationStatus = "PENDING"
 	EventDetailParticipationStatusInvited  EventDetailParticipationStatus = "INVITED"
 	EventDetailParticipationStatusNone     EventDetailParticipationStatus = "NONE"

--- a/backend/internal/domain/participation.go
+++ b/backend/internal/domain/participation.go
@@ -6,18 +6,44 @@ import (
 	"github.com/google/uuid"
 )
 
+// ParticipationStatus defines the lifecycle state of an event participation row.
+type ParticipationStatus string
+
 const (
-	ParticipationStatusApproved = "APPROVED"
-	ParticipationStatusPending  = "PENDING"
-	ParticipationStatusCanceled = "CANCELED"
+	// ParticipationStatusApproved means the user is currently participating in the event.
+	ParticipationStatusApproved ParticipationStatus = "APPROVED"
+	// ParticipationStatusPending is reserved for flows that keep pending participation rows.
+	ParticipationStatusPending ParticipationStatus = "PENDING"
+	// ParticipationStatusCanceled marks a participation canceled because the event was canceled.
+	ParticipationStatusCanceled ParticipationStatus = "CANCELED"
+	// ParticipationStatusLeaved marks a participant who explicitly left the event.
+	ParticipationStatusLeaved ParticipationStatus = "LEAVED"
 )
+
+var participationStatuses = map[string]ParticipationStatus{
+	string(ParticipationStatusApproved): ParticipationStatusApproved,
+	string(ParticipationStatusPending):  ParticipationStatusPending,
+	string(ParticipationStatusCanceled): ParticipationStatusCanceled,
+	string(ParticipationStatusLeaved):   ParticipationStatusLeaved,
+}
+
+// ParseParticipationStatus converts a wire or persistence string into a domain status.
+func ParseParticipationStatus(value string) (ParticipationStatus, bool) {
+	status, ok := participationStatuses[value]
+	return status, ok
+}
+
+// String returns the serialized wire value of the participation status.
+func (s ParticipationStatus) String() string {
+	return string(s)
+}
 
 // Participation records a user's membership status in an event.
 type Participation struct {
 	ID        uuid.UUID
 	EventID   uuid.UUID
 	UserID    uuid.UUID
-	Status    string
+	Status    ParticipationStatus
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/backend/migrations/000019_participation_status_constraint.down.sql
+++ b/backend/migrations/000019_participation_status_constraint.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE participation
+    DROP CONSTRAINT IF EXISTS chk_participation_status;

--- a/backend/migrations/000019_participation_status_constraint.up.sql
+++ b/backend/migrations/000019_participation_status_constraint.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE participation
+    ADD CONSTRAINT chk_participation_status
+        CHECK (status IN ('APPROVED', 'PENDING', 'CANCELED', 'LEAVED'));

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -119,7 +119,7 @@ func TestCreateEventPersistsInternalHostParticipationWithoutChangingVisibleCount
 	}
 
 	// then
-	if participationStatus != domain.ParticipationStatusApproved {
+	if participationStatus != string(domain.ParticipationStatusApproved) {
 		t.Fatalf("expected host participation status %q, got %q", domain.ParticipationStatusApproved, participationStatus)
 	}
 	if detail.ApprovedParticipantCount != 0 {
@@ -1499,6 +1499,105 @@ func TestJoinEventRejectsNonExistentEvent(t *testing.T) {
 	common.RequireAppErrorCode(t, err, domain.ErrorCodeEventNotFound)
 }
 
+func TestLeaveEventSuccessPathBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	ref := common.GivenPublicEvent(t, harness.Service, host.ID)
+
+	if _, err := harness.Service.JoinEvent(context.Background(), participant.ID, ref.ID); err != nil {
+		t.Fatalf("JoinEvent() error = %v", err)
+	}
+
+	result, err := harness.Service.LeaveEvent(context.Background(), participant.ID, ref.ID)
+	if err != nil {
+		t.Fatalf("LeaveEvent() error = %v", err)
+	}
+
+	if result.ParticipationID == "" {
+		t.Fatal("expected non-empty participation_id")
+	}
+	if result.Status != domain.ParticipationStatusLeaved {
+		t.Fatalf("expected status %q, got %q", domain.ParticipationStatusLeaved, result.Status)
+	}
+
+	var storedStatus string
+	if err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`SELECT status FROM participation WHERE event_id = $1 AND user_id = $2`,
+		ref.ID,
+		participant.ID,
+	).Scan(&storedStatus); err != nil {
+		t.Fatalf("load participation status error = %v", err)
+	}
+	if storedStatus != string(domain.ParticipationStatusLeaved) {
+		t.Fatalf("expected stored participation status %q, got %q", domain.ParticipationStatusLeaved, storedStatus)
+	}
+
+	detail, err := harness.Service.GetEventDetail(context.Background(), participant.ID, ref.ID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if detail.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusLeaved) {
+		t.Fatalf("expected participation_status %q, got %q", domain.EventDetailParticipationStatusLeaved, detail.ViewerContext.ParticipationStatus)
+	}
+
+	upcomingEvents, err := harness.ProfileService.GetMyUpcomingEvents(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("GetMyUpcomingEvents() error = %v", err)
+	}
+	for _, e := range upcomingEvents {
+		if e.ID == ref.ID.String() {
+			t.Fatalf("left event %s should not appear in upcoming events", ref.ID)
+		}
+	}
+}
+
+func TestLeaveEventRejectsHost(t *testing.T) {
+	t.Parallel()
+
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	ref := common.GivenPublicEvent(t, harness.Service, host.ID)
+
+	_, err := harness.Service.LeaveEvent(context.Background(), host.ID, ref.ID)
+
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeHostCannotLeave)
+}
+
+func TestLeaveEventRejectsPendingJoinRequester(t *testing.T) {
+	t.Parallel()
+
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	requester := common.GivenUser(t, harness.AuthRepo)
+	ref := common.GivenProtectedEvent(t, harness.Service, host.ID)
+
+	if _, err := harness.Service.RequestJoin(context.Background(), requester.ID, ref.ID, eventapp.RequestJoinInput{}); err != nil {
+		t.Fatalf("RequestJoin() error = %v", err)
+	}
+
+	_, err := harness.Service.LeaveEvent(context.Background(), requester.ID, ref.ID)
+
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeEventLeaveNotAllowed)
+}
+
+func TestLeaveEventRejectsEndedEvent(t *testing.T) {
+	t.Parallel()
+
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventID := common.GivenExpiredEvent(t, host.ID)
+	insertParticipation(t, eventID, participant.ID, domain.ParticipationStatusApproved)
+
+	_, err := harness.Service.LeaveEvent(context.Background(), participant.ID, eventID)
+
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeEventNotLeaveable)
+}
+
 // ---------------------------------------------------------
 // RequestJoin tests
 // ---------------------------------------------------------
@@ -2127,7 +2226,7 @@ func insertEventConstraint(t *testing.T, eventID uuid.UUID, constraintType, info
 	}
 }
 
-func insertParticipation(t *testing.T, eventID, userID uuid.UUID, status string) uuid.UUID {
+func insertParticipation(t *testing.T, eventID, userID uuid.UUID, status domain.ParticipationStatus) uuid.UUID {
 	t.Helper()
 
 	var participationID uuid.UUID
@@ -2143,6 +2242,48 @@ func insertParticipation(t *testing.T, eventID, userID uuid.UUID, status string)
 	}
 
 	return participationID
+}
+
+func insertParticipationWithTimes(
+	t *testing.T,
+	eventID, userID uuid.UUID,
+	status domain.ParticipationStatus,
+	createdAt, updatedAt time.Time,
+) uuid.UUID {
+	t.Helper()
+
+	var participationID uuid.UUID
+	err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`INSERT INTO participation (event_id, user_id, status, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 RETURNING id`,
+		eventID,
+		userID,
+		status,
+		createdAt,
+		updatedAt,
+	).Scan(&participationID)
+	if err != nil {
+		t.Fatalf("insert timed participation error = %v", err)
+	}
+
+	return participationID
+}
+
+func loadEventStartTime(t *testing.T, eventID uuid.UUID) time.Time {
+	t.Helper()
+
+	var startTime time.Time
+	if err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`SELECT start_time FROM event WHERE id = $1`,
+		eventID,
+	).Scan(&startTime); err != nil {
+		t.Fatalf("load event start_time error = %v", err)
+	}
+
+	return startTime
 }
 
 func insertUserScore(
@@ -2743,6 +2884,70 @@ func TestGetMyUpcomingEventsExcludesCanceledEvent(t *testing.T) {
 	for _, e := range events {
 		if e.ID == ref.ID.String() {
 			t.Fatalf("canceled event %s should not appear in upcoming events", ref.ID)
+		}
+	}
+}
+
+func TestGetMyCompletedEventsIncludesLeavedParticipationAfterStart(t *testing.T) {
+	t.Parallel()
+
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventID := common.GivenStartedEvent(t, host.ID)
+
+	if _, err := harness.Service.JoinEvent(context.Background(), participant.ID, eventID); err != nil {
+		t.Fatalf("JoinEvent() error = %v", err)
+	}
+	if _, err := harness.Service.LeaveEvent(context.Background(), participant.ID, eventID); err != nil {
+		t.Fatalf("LeaveEvent() error = %v", err)
+	}
+	updateEventStatus(t, eventID, string(domain.EventStatusCompleted))
+
+	events, err := harness.ProfileService.GetMyCompletedEvents(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("GetMyCompletedEvents() error = %v", err)
+	}
+
+	var found bool
+	for _, e := range events {
+		if e.ID == eventID.String() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("completed event %s not found for participant who left after start", eventID)
+	}
+}
+
+func TestGetMyCompletedEventsExcludesLeavedParticipationBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventID := common.GivenExpiredEvent(t, host.ID)
+	updateEventStatus(t, eventID, string(domain.EventStatusCompleted))
+
+	startTime := loadEventStartTime(t, eventID)
+	insertParticipationWithTimes(
+		t,
+		eventID,
+		participant.ID,
+		domain.ParticipationStatusLeaved,
+		startTime.Add(-2*time.Hour),
+		startTime.Add(-30*time.Minute),
+	)
+
+	events, err := harness.ProfileService.GetMyCompletedEvents(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("GetMyCompletedEvents() error = %v", err)
+	}
+
+	for _, e := range events {
+		if e.ID == eventID.String() {
+			t.Fatalf("completed event %s should be excluded after leaving before start", eventID)
 		}
 	}
 }

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -733,6 +733,118 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
 
+  /events/{id}/leave:
+    patch:
+      tags: [Events]
+      summary: Leave an event
+      description: |
+        Marks the authenticated user's participation as `LEAVED`.
+
+        Rules:
+        - The event must exist.
+        - The authenticated user must currently have an `APPROVED` participation.
+        - The event host cannot leave their own event.
+        - A pending join request does not qualify; only approved participants may leave.
+        - Leaving is allowed before `start_time` and while the event is still active.
+        - Leaving is no longer allowed after the event has ended or once the event is already `CANCELED` or `COMPLETED`.
+        - If the user leaves before `start_time`, the event is excluded from completed/past participation lists.
+        - If the user leaves after `start_time`, completed/past participation lists may still include the event after it finishes.
+      operationId: leaveEvent
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: UUID of the event to leave.
+          example: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+      responses:
+        '200':
+          description: Successfully left the event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaveEventResponse'
+              examples:
+                left:
+                  value:
+                    participation_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                    event_id: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+                    status: LEAVED
+                    updated_at: "2026-03-26T11:30:00+03:00"
+        '400':
+          description: Invalid event ID format.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                invalid_id:
+                  value:
+                    error:
+                      code: validation_error
+                      message: The request body contains invalid fields. See error.details for field-specific messages.
+                      details:
+                        id: must be a valid UUID
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: The event host cannot leave their own event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                host_cannot_leave:
+                  value:
+                    error:
+                      code: host_cannot_leave
+                      message: The event host cannot leave their own event.
+        '404':
+          description: Event not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                not_found:
+                  value:
+                    error:
+                      code: event_not_found
+                      message: The requested event does not exist.
+        '409':
+          description: |
+            Conflict. Either the caller is not an approved participant (`event_leave_not_allowed`)
+            or the event can no longer be left in its current timing/state (`event_not_leaveable`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                event_leave_not_allowed:
+                  value:
+                    error:
+                      code: event_leave_not_allowed
+                      message: Only approved participants can leave this event.
+                event_not_leaveable:
+                  value:
+                    error:
+                      code: event_not_leaveable
+                      message: This event can no longer be left.
+        '500':
+          description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
   /events/{id}/cancel:
     patch:
       tags: [Events]
@@ -2166,10 +2278,11 @@ components:
           type: boolean
         participation_status:
           type: string
-          enum: [JOINED, PENDING, INVITED, NONE]
+          enum: [JOINED, LEAVED, PENDING, INVITED, CANCELED, NONE]
           description: |
             Resolved for the authenticated user with the following precedence:
-            approved participation -> `JOINED`, pending join request -> `PENDING`,
+            approved participation -> `JOINED`, leaved participation -> `LEAVED`,
+            canceled participation -> `CANCELED`, pending join request -> `PENDING`,
             invitation row -> `INVITED`, otherwise `NONE`.
 
     EventHostScoreSummary:
@@ -2521,6 +2634,31 @@ components:
           format: date-time
           example: "2026-03-26T11:00:00+03:00"
 
+    LeaveEventResponse:
+      type: object
+      additionalProperties: false
+      required: [participation_id, event_id, status, updated_at]
+      properties:
+        participation_id:
+          type: string
+          format: uuid
+          description: UUID of the updated participation record.
+          example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+        event_id:
+          type: string
+          format: uuid
+          description: UUID of the event that was left.
+          example: 5f81d6de-8cb4-4639-8f60-7c9f55456121
+        status:
+          type: string
+          enum: [LEAVED]
+          description: Participation status after leaving. Always `LEAVED`.
+          example: LEAVED
+        updated_at:
+          type: string
+          format: date-time
+          example: "2026-03-26T11:30:00+03:00"
+
     RequestJoinRequest:
       type: object
       additionalProperties: false
@@ -2645,4 +2783,3 @@ components:
         favorited_at:
           type: string
           format: date-time
-


### PR DESCRIPTION
## 📋 Summary
Adds a dedicated authenticated leave-event flow and introduces `LEAVED` as a first-class participation status across the backend. This lets approved participants leave before or during an active event while preserving the agreed profile/history behavior: pre-start leaves do not count as past participation, post-start leaves do.

## 🔄 Changes
- Added `LEAVED` to participation domain/status handling and enforced allowed participation values with a new DB constraint migration.
- Implemented `PATCH /events/{id}/leave` for authenticated users.
- Defined leave rules:
  - only `APPROVED` participants can leave
  - hosts cannot leave their own events
  - pending join request users cannot leave
  - leaving is allowed before start and while the event is active
  - leaving is denied after the event has ended or when the event is already canceled/completed
- Updated participation persistence to transition `APPROVED -> LEAVED`.
- Updated event detail viewer participation mapping to return `LEAVED` where relevant.
- Updated profile/history queries so:
  - pre-start `LEAVED` participations are excluded from completed/past participation lists
  - post-start `LEAVED` participations are included in completed/past participation lists after the event completes
- Preserved historical `LEAVED` rows when an event is later canceled.
- Updated OpenAPI docs in `docs/openapi/event.yaml` for the new endpoint and participation enum behavior.
- Added/updated unit, handler, and integration tests for success and denial paths.

## 🧪 Testing
- Ran targeted unit and integration tests for leave flow and profile/history behavior.
- Ran full backend verification with:
  - `cd backend`
  - `./shipcheck.sh`

## 🔗 Related
- Closes #315 
