### PR TITLE
fix(backend): allow rejoin after pre-start leave

### DIFF
--- a/backend/internal/adapter/in/postgres/join_request_repo.go
+++ b/backend/internal/adapter/in/postgres/join_request_repo.go
@@ -77,12 +77,17 @@ func (r *JoinRequestRepository) CreateJoinRequest(ctx context.Context, params jo
 			return domain.ConflictError(domain.ErrorCodeEventJoinNotAllowed, "Only PROTECTED events accept join requests.")
 		}
 
-		participating, err := repo.participationExists(ctx, params.EventID, params.UserID)
+		participation, err := loadParticipation(ctx, repo.db, params.EventID, params.UserID, false)
 		if err != nil {
 			return err
 		}
-		if participating {
-			return domain.ConflictError(domain.ErrorCodeAlreadyParticipating, "You are already participating in this event.")
+		if participation != nil && !canReactivateLeavedParticipation(participation, event.StartTime) {
+			return mapJoinParticipationConflict(
+				participation,
+				event.StartTime,
+				"You are already participating in this event.",
+				"You cannot request to join again after leaving once the event has started.",
+			)
 		}
 
 		existing, err := repo.loadJoinRequestByEventAndUser(ctx, params.EventID, params.UserID, true)
@@ -108,7 +113,7 @@ func (r *JoinRequestRepository) CreateJoinRequest(ctx context.Context, params jo
 			}
 		}
 
-		created, err = repo.handleExistingJoinRequestForCreate(ctx, existing, params)
+		created, err = repo.handleExistingJoinRequestForCreate(ctx, existing, participation, event.StartTime, params)
 		return err
 	})
 	if err != nil {
@@ -149,18 +154,11 @@ func (r *JoinRequestRepository) ApproveJoinRequest(
 			return domain.ConflictError(domain.ErrorCodeJoinRequestStateInvalid, "Only PENDING join requests can be approved.")
 		}
 
-		participating, err := repo.participationExists(ctx, params.EventID, request.UserID)
-		if err != nil {
-			return err
-		}
-		if participating {
-			return domain.ConflictError(domain.ErrorCodeAlreadyParticipating, "The requester is already participating in this event.")
-		}
 		if event.Capacity != nil && event.ApprovedParticipantCount >= *event.Capacity {
 			return domain.ConflictError(domain.ErrorCodeCapacityExceeded, "This event has reached its maximum capacity.")
 		}
 
-		participation, err := repo.insertApprovedParticipation(ctx, params.EventID, request.UserID)
+		participation, err := repo.insertOrReactivateApprovedParticipation(ctx, event, request.UserID)
 		if err != nil {
 			return err
 		}
@@ -234,12 +232,17 @@ func (r *JoinRequestRepository) RejectJoinRequest(
 func (r *JoinRequestRepository) handleExistingJoinRequestForCreate(
 	ctx context.Context,
 	existing *domain.JoinRequest,
+	participation *domain.Participation,
+	eventStart time.Time,
 	params joinrequestapp.CreateJoinRequestParams,
 ) (*domain.JoinRequest, error) {
 	switch existing.Status {
 	case domain.JoinRequestStatusPending:
 		return nil, domain.ConflictError(domain.ErrorCodeAlreadyRequested, "You already have a pending join request for this event.")
 	case domain.JoinRequestStatusApproved:
+		if canReactivateLeavedParticipation(participation, eventStart) {
+			return r.reactivateJoinRequest(ctx, existing.ID, params.HostUserID, params.Message)
+		}
 		return nil, domain.ConflictError(domain.ErrorCodeAlreadyParticipating, "You are already participating in this event.")
 	case domain.JoinRequestStatusRejected:
 		if time.Now().UTC().Before(existing.UpdatedAt.Add(domain.JoinRequestCooldown)) {
@@ -253,7 +256,7 @@ func (r *JoinRequestRepository) handleExistingJoinRequestForCreate(
 
 func (r *JoinRequestRepository) loadEventState(ctx context.Context, eventID uuid.UUID, forUpdate bool) (*domain.Event, error) {
 	query := `
-		SELECT host_id, privacy_level, capacity, approved_participant_count
+		SELECT host_id, privacy_level, capacity, approved_participant_count, start_time
 		FROM event
 		WHERE id = $1
 	`
@@ -266,9 +269,10 @@ func (r *JoinRequestRepository) loadEventState(ctx context.Context, eventID uuid
 		privacyLevel  string
 		capacity      pgtype.Int4
 		approvedCount int
+		startTime     time.Time
 	)
 
-	err := r.db.QueryRow(ctx, query, eventID).Scan(&hostID, &privacyLevel, &capacity, &approvedCount)
+	err := r.db.QueryRow(ctx, query, eventID).Scan(&hostID, &privacyLevel, &capacity, &approvedCount, &startTime)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -281,6 +285,7 @@ func (r *JoinRequestRepository) loadEventState(ctx context.Context, eventID uuid
 		HostID:                   hostID,
 		PrivacyLevel:             domain.EventPrivacyLevel(privacyLevel),
 		ApprovedParticipantCount: approvedCount,
+		StartTime:                startTime,
 	}
 	if capacity.Valid {
 		value := int(capacity.Int32)
@@ -326,21 +331,6 @@ func (r *JoinRequestRepository) loadJoinRequestByID(
 	return scanJoinRequest(r.db.QueryRow(ctx, query, eventID, joinRequestID))
 }
 
-func (r *JoinRequestRepository) participationExists(ctx context.Context, eventID, userID uuid.UUID) (bool, error) {
-	var exists bool
-	err := r.db.QueryRow(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM participation
-			WHERE event_id = $1 AND user_id = $2
-		)
-	`, eventID, userID).Scan(&exists)
-	if err != nil {
-		return false, fmt.Errorf("check participation existence: %w", err)
-	}
-	return exists, nil
-}
-
 func (r *JoinRequestRepository) insertJoinRequest(
 	ctx context.Context,
 	params joinrequestapp.CreateJoinRequestParams,
@@ -384,42 +374,59 @@ func (r *JoinRequestRepository) reactivateJoinRequest(
 	return request, nil
 }
 
-func (r *JoinRequestRepository) insertApprovedParticipation(
+func (r *JoinRequestRepository) insertOrReactivateApprovedParticipation(
 	ctx context.Context,
-	eventID, userID uuid.UUID,
+	event *domain.Event,
+	userID uuid.UUID,
 ) (*domain.Participation, error) {
-	var (
-		id        uuid.UUID
-		status    string
-		createdAt time.Time
-		updatedAt time.Time
-	)
-
-	err := r.db.QueryRow(ctx, `
-		INSERT INTO participation (event_id, user_id, status)
-		VALUES ($1, $2, $3)
-		RETURNING id, status, created_at, updated_at
-	`, eventID, userID, domain.ParticipationStatusApproved).Scan(&id, &status, &createdAt, &updatedAt)
+	participation, err := scanParticipation(r.db.QueryRow(ctx, `
+		WITH reactivated AS (
+			UPDATE participation
+			SET status = $3,
+			    created_at = NOW(),
+			    updated_at = NOW()
+			WHERE event_id = $1
+			  AND user_id = $2
+			  AND status = $4
+			  AND updated_at < $5
+			RETURNING id, status, created_at, updated_at
+		),
+		inserted AS (
+			INSERT INTO participation (event_id, user_id, status)
+			SELECT $1, $2, $3
+			WHERE NOT EXISTS (SELECT 1 FROM reactivated)
+			ON CONFLICT ON CONSTRAINT uq_event_user DO NOTHING
+			RETURNING id, status, created_at, updated_at
+		)
+		SELECT id, status, created_at, updated_at
+		FROM reactivated
+		UNION ALL
+		SELECT id, status, created_at, updated_at
+		FROM inserted
+		LIMIT 1
+	`, event.ID, userID, domain.ParticipationStatusApproved, domain.ParticipationStatusLeaved, event.StartTime), event.ID, userID, "approve join request participation")
 	if err != nil {
-		if isConstraintError(err, "uq_event_user") {
-			return nil, domain.ConflictError(domain.ErrorCodeAlreadyParticipating, "The requester is already participating in this event.")
-		}
-		return nil, fmt.Errorf("insert participation: %w", err)
+		return nil, err
 	}
 
-	parsedStatus, ok := domain.ParseParticipationStatus(status)
-	if !ok {
-		return nil, fmt.Errorf("insert participation: unknown participation status %q", status)
+	if participation != nil {
+		return participation, nil
 	}
 
-	return &domain.Participation{
-		ID:        id,
-		EventID:   eventID,
-		UserID:    userID,
-		Status:    parsedStatus,
-		CreatedAt: createdAt,
-		UpdatedAt: updatedAt,
-	}, nil
+	existing, err := loadParticipation(ctx, r.db, event.ID, userID, true)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return nil, mapJoinParticipationConflict(
+			existing,
+			event.StartTime,
+			"The requester is already participating in this event.",
+			"The requester cannot rejoin this event after leaving once it has started.",
+		)
+	}
+
+	return nil, fmt.Errorf("approve join request participation: no row returned and no existing participation found")
 }
 
 func (r *JoinRequestRepository) updateJoinRequestStatus(

--- a/backend/internal/adapter/in/postgres/participation_record.go
+++ b/backend/internal/adapter/in/postgres/participation_record.go
@@ -1,0 +1,92 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+func loadParticipation(
+	ctx context.Context,
+	db execer,
+	eventID, userID uuid.UUID,
+	forUpdate bool,
+) (*domain.Participation, error) {
+	query := `
+		SELECT id, status, created_at, updated_at
+		FROM participation
+		WHERE event_id = $1 AND user_id = $2
+	`
+	if forUpdate {
+		query += ` FOR UPDATE`
+	}
+
+	return scanParticipation(db.QueryRow(ctx, query, eventID, userID), eventID, userID, "load participation")
+}
+
+func scanParticipation(
+	row pgx.Row,
+	eventID, userID uuid.UUID,
+	operation string,
+) (*domain.Participation, error) {
+	var (
+		id        uuid.UUID
+		status    string
+		createdAt time.Time
+		updatedAt time.Time
+	)
+
+	err := row.Scan(&id, &status, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s: %w", operation, err)
+	}
+
+	parsedStatus, ok := domain.ParseParticipationStatus(status)
+	if !ok {
+		return nil, fmt.Errorf("%s: unknown participation status %q", operation, status)
+	}
+
+	return &domain.Participation{
+		ID:        id,
+		EventID:   eventID,
+		UserID:    userID,
+		Status:    parsedStatus,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}, nil
+}
+
+func canReactivateLeavedParticipation(participation *domain.Participation, eventStart time.Time) bool {
+	return participation != nil &&
+		participation.Status == domain.ParticipationStatusLeaved &&
+		participation.UpdatedAt.Before(eventStart)
+}
+
+func mapJoinParticipationConflict(
+	participation *domain.Participation,
+	eventStart time.Time,
+	activeMessage string,
+	leftAfterStartMessage string,
+) error {
+	if participation == nil {
+		return fmt.Errorf("map join participation conflict: missing participation")
+	}
+
+	if participation.Status == domain.ParticipationStatusLeaved {
+		if canReactivateLeavedParticipation(participation, eventStart) {
+			return fmt.Errorf("map join participation conflict: expected pre-start LEAVED participation to be reactivated")
+		}
+
+		return domain.ConflictError(domain.ErrorCodeAlreadyParticipating, leftAfterStartMessage)
+	}
+
+	return domain.ConflictError(domain.ErrorCodeAlreadyParticipating, activeMessage)
+}

--- a/backend/internal/adapter/in/postgres/participation_repo.go
+++ b/backend/internal/adapter/in/postgres/participation_repo.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -25,62 +24,57 @@ func NewParticipationRepository(pool *pgxpool.Pool) *ParticipationRepository {
 }
 
 // CreateParticipation inserts an APPROVED participation row.
-// Returns a ConflictError with code already_participating on duplicate (event_id, user_id).
+// Rejoins before start reactivate the existing row instead of inserting a duplicate.
 func (r *ParticipationRepository) CreateParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
-	var (
-		id        uuid.UUID
-		status    string
-		createdAt time.Time
-		updatedAt time.Time
-	)
-
-	err := r.pool.QueryRow(ctx, `
+	participation, err := scanParticipation(r.pool.QueryRow(ctx, `
 		WITH joinable_event AS (
-			SELECT id
+			SELECT id, start_time
 			FROM event
 			WHERE id = $1
 			  AND host_id <> $2
 			  AND privacy_level = $3
 			  AND (capacity IS NULL OR approved_participant_count < capacity)
+		),
+		reactivated AS (
+			UPDATE participation
+			SET status = $4,
+			    created_at = NOW(),
+			    updated_at = NOW()
+			WHERE event_id = $1
+			  AND user_id = $2
+			  AND status = $5
+			  AND updated_at < (SELECT start_time FROM joinable_event)
+			RETURNING id, status, created_at, updated_at
+		),
+		inserted AS (
+			INSERT INTO participation (event_id, user_id, status)
+			SELECT id, $2, $4
+			FROM joinable_event
+			WHERE NOT EXISTS (SELECT 1 FROM reactivated)
+			ON CONFLICT ON CONSTRAINT uq_event_user DO NOTHING
+			RETURNING id, status, created_at, updated_at
 		)
-		INSERT INTO participation (event_id, user_id, status)
-		SELECT id, $2, $4
-		FROM joinable_event
-		ON CONFLICT ON CONSTRAINT uq_event_user DO NOTHING
-		RETURNING id, status, created_at, updated_at
-	`, eventID, userID, domain.PrivacyPublic, domain.ParticipationStatusApproved).Scan(&id, &status, &createdAt, &updatedAt)
+		SELECT id, status, created_at, updated_at
+		FROM reactivated
+		UNION ALL
+		SELECT id, status, created_at, updated_at
+		FROM inserted
+		LIMIT 1
+	`, eventID, userID, domain.PrivacyPublic, domain.ParticipationStatusApproved, domain.ParticipationStatusLeaved), eventID, userID, "create participation")
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, r.mapCreateParticipationNoRow(ctx, eventID, userID)
-		}
-		return nil, mapParticipationInsertError(err)
+		return nil, err
 	}
 
-	parsedStatus, ok := domain.ParseParticipationStatus(status)
-	if !ok {
-		return nil, fmt.Errorf("insert participation: unknown participation status %q", status)
+	if participation == nil {
+		return nil, r.mapCreateParticipationNoRow(ctx, eventID, userID)
 	}
 
-	return &domain.Participation{
-		ID:        id,
-		EventID:   eventID,
-		UserID:    userID,
-		Status:    parsedStatus,
-		CreatedAt: createdAt,
-		UpdatedAt: updatedAt,
-	}, nil
+	return participation, nil
 }
 
 // LeaveParticipation transitions an APPROVED participation to LEAVED.
 func (r *ParticipationRepository) LeaveParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
-	var (
-		id        uuid.UUID
-		status    string
-		createdAt time.Time
-		updatedAt time.Time
-	)
-
-	err := r.pool.QueryRow(ctx, `
+	participation, err := scanParticipation(r.pool.QueryRow(ctx, `
 		UPDATE participation
 		SET status = $3,
 		    updated_at = NOW()
@@ -88,27 +82,16 @@ func (r *ParticipationRepository) LeaveParticipation(ctx context.Context, eventI
 		  AND user_id = $2
 		  AND status = $4
 		RETURNING id, status, created_at, updated_at
-	`, eventID, userID, domain.ParticipationStatusLeaved, domain.ParticipationStatusApproved).Scan(&id, &status, &createdAt, &updatedAt)
+	`, eventID, userID, domain.ParticipationStatusLeaved, domain.ParticipationStatusApproved), eventID, userID, "leave participation")
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, r.mapLeaveParticipationNoRow(ctx, eventID)
-		}
-		return nil, fmt.Errorf("leave participation: %w", err)
+		return nil, err
 	}
 
-	parsedStatus, ok := domain.ParseParticipationStatus(status)
-	if !ok {
-		return nil, fmt.Errorf("leave participation: unknown participation status %q", status)
+	if participation == nil {
+		return nil, r.mapLeaveParticipationNoRow(ctx, eventID)
 	}
 
-	return &domain.Participation{
-		ID:        id,
-		EventID:   eventID,
-		UserID:    userID,
-		Status:    parsedStatus,
-		CreatedAt: createdAt,
-		UpdatedAt: updatedAt,
-	}, nil
+	return participation, nil
 }
 
 func (r *ParticipationRepository) mapCreateParticipationNoRow(ctx context.Context, eventID, userID uuid.UUID) error {
@@ -130,15 +113,20 @@ func (r *ParticipationRepository) mapCreateParticipationNoRow(ctx context.Contex
 		return domain.ConflictError(domain.ErrorCodeCapacityExceeded, "This event has reached its maximum capacity.")
 	}
 
-	exists, err := r.participationExists(ctx, eventID, userID)
+	participation, err := loadParticipation(ctx, r.pool, eventID, userID, false)
 	if err != nil {
 		return err
 	}
-	if exists {
-		return domain.ConflictError(domain.ErrorCodeAlreadyParticipating, "You are already participating in this event.")
+	if participation != nil {
+		return mapJoinParticipationConflict(
+			participation,
+			event.StartTime,
+			"You are already participating in this event.",
+			"You cannot rejoin an event after leaving once it has started.",
+		)
 	}
 
-	return fmt.Errorf("insert participation: join preconditions changed during insert")
+	return fmt.Errorf("create participation: join preconditions changed during insert")
 }
 
 func (r *ParticipationRepository) mapLeaveParticipationNoRow(ctx context.Context, eventID uuid.UUID) error {
@@ -159,13 +147,14 @@ func (r *ParticipationRepository) loadEventJoinState(ctx context.Context, eventI
 		privacyLevel  string
 		capacity      pgtype.Int4
 		approvedCount int
+		startTime     time.Time
 	)
 
 	err := r.pool.QueryRow(ctx, `
-		SELECT host_id, privacy_level, capacity, approved_participant_count
+		SELECT host_id, privacy_level, capacity, approved_participant_count, start_time
 		FROM event
 		WHERE id = $1
-	`, eventID).Scan(&hostID, &privacyLevel, &capacity, &approvedCount)
+	`, eventID).Scan(&hostID, &privacyLevel, &capacity, &approvedCount, &startTime)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -178,34 +167,11 @@ func (r *ParticipationRepository) loadEventJoinState(ctx context.Context, eventI
 		HostID:                   hostID,
 		PrivacyLevel:             domain.EventPrivacyLevel(privacyLevel),
 		ApprovedParticipantCount: approvedCount,
+		StartTime:                startTime,
 	}
 	if capacity.Valid {
 		event.Capacity = new(int(capacity.Int32))
 	}
 
 	return event, nil
-}
-
-func (r *ParticipationRepository) participationExists(ctx context.Context, eventID, userID uuid.UUID) (bool, error) {
-	var exists bool
-	err := r.pool.QueryRow(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM participation
-			WHERE event_id = $1 AND user_id = $2
-		)
-	`, eventID, userID).Scan(&exists)
-	if err != nil {
-		return false, fmt.Errorf("check participation existence: %w", err)
-	}
-	return exists, nil
-}
-
-// mapParticipationInsertError converts a UNIQUE constraint violation on the
-// participation table into a domain ConflictError.
-func mapParticipationInsertError(err error) error {
-	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "uq_event_user" {
-		return domain.ConflictError(domain.ErrorCodeAlreadyParticipating, "You are already participating in this event.")
-	}
-	return fmt.Errorf("insert participation: %w", err)
 }

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -1457,6 +1457,89 @@ func TestJoinEventRejectsDuplicate(t *testing.T) {
 	common.RequireAppErrorCode(t, err, domain.ErrorCodeAlreadyParticipating)
 }
 
+func TestJoinEventAllowsRejoinAfterLeavingBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	event := common.GivenPublicEvent(t, harness.Service, host.ID)
+
+	firstJoin, err := harness.Service.JoinEvent(context.Background(), participant.ID, event.ID)
+	if err != nil {
+		t.Fatalf("JoinEvent() first call error = %v", err)
+	}
+	if _, err := harness.Service.LeaveEvent(context.Background(), participant.ID, event.ID); err != nil {
+		t.Fatalf("LeaveEvent() error = %v", err)
+	}
+
+	// when
+	secondJoin, err := harness.Service.JoinEvent(context.Background(), participant.ID, event.ID)
+
+	// then
+	if err != nil {
+		t.Fatalf("JoinEvent() second call error = %v", err)
+	}
+	if secondJoin.ParticipationID != firstJoin.ParticipationID {
+		t.Fatalf("expected reactivated participation_id %q, got %q", firstJoin.ParticipationID, secondJoin.ParticipationID)
+	}
+	if secondJoin.Status != domain.ParticipationStatusApproved {
+		t.Fatalf("expected status %q, got %q", domain.ParticipationStatusApproved, secondJoin.Status)
+	}
+
+	var storedStatus string
+	if err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`SELECT status FROM participation WHERE event_id = $1 AND user_id = $2`,
+		event.ID,
+		participant.ID,
+	).Scan(&storedStatus); err != nil {
+		t.Fatalf("load participation status error = %v", err)
+	}
+	if storedStatus != string(domain.ParticipationStatusApproved) {
+		t.Fatalf("expected stored participation status %q, got %q", domain.ParticipationStatusApproved, storedStatus)
+	}
+
+	detail, err := harness.Service.GetEventDetail(context.Background(), participant.ID, event.ID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+	if detail.ViewerContext.ParticipationStatus != string(domain.EventDetailParticipationStatusJoined) {
+		t.Fatalf("expected participation_status %q, got %q", domain.EventDetailParticipationStatusJoined, detail.ViewerContext.ParticipationStatus)
+	}
+}
+
+func TestJoinEventRejectsRejoinAfterLeavingStartedEvent(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventID := common.GivenStartedEvent(t, host.ID)
+
+	if _, err := harness.Service.JoinEvent(context.Background(), participant.ID, eventID); err != nil {
+		t.Fatalf("JoinEvent() first call error = %v", err)
+	}
+	if _, err := harness.Service.LeaveEvent(context.Background(), participant.ID, eventID); err != nil {
+		t.Fatalf("LeaveEvent() error = %v", err)
+	}
+
+	// when
+	_, err := harness.Service.JoinEvent(context.Background(), participant.ID, eventID)
+
+	// then
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeAlreadyParticipating)
+	appErr, ok := errors.AsType[*domain.AppError](err)
+	if !ok {
+		t.Fatalf("expected AppError, got %v", err)
+	}
+	if appErr.Message != "You cannot rejoin an event after leaving once it has started." {
+		t.Fatalf("expected post-start leave message, got %q", appErr.Message)
+	}
+}
+
 func TestJoinEventRejectsHostJoiningOwnEvent(t *testing.T) {
 	t.Parallel()
 
@@ -1664,6 +1747,135 @@ func TestRequestJoinRejectsDuplicate(t *testing.T) {
 
 	// then
 	common.RequireAppErrorCode(t, err, domain.ErrorCodeAlreadyRequested)
+}
+
+func TestRequestJoinAllowsReapplyAfterApprovedParticipationLeavesBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	requester := common.GivenUser(t, harness.AuthRepo)
+	event := common.GivenProtectedEvent(t, harness.Service, host.ID)
+	initialMessage := "First request"
+	retryMessage := "Retry request"
+
+	firstRequest, err := harness.Service.RequestJoin(context.Background(), requester.ID, event.ID, eventapp.RequestJoinInput{
+		Message: &initialMessage,
+	})
+	if err != nil {
+		t.Fatalf("RequestJoin() first call error = %v", err)
+	}
+
+	firstJoinRequestID, err := uuid.Parse(firstRequest.JoinRequestID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() first join_request_id error = %v", err)
+	}
+
+	firstApproval, err := harness.Service.ApproveJoinRequest(context.Background(), host.ID, event.ID, firstJoinRequestID)
+	if err != nil {
+		t.Fatalf("ApproveJoinRequest() first approval error = %v", err)
+	}
+
+	if _, err := harness.Service.LeaveEvent(context.Background(), requester.ID, event.ID); err != nil {
+		t.Fatalf("LeaveEvent() error = %v", err)
+	}
+
+	// when
+	retryRequest, err := harness.Service.RequestJoin(context.Background(), requester.ID, event.ID, eventapp.RequestJoinInput{
+		Message: &retryMessage,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("RequestJoin() retry error = %v", err)
+	}
+	if retryRequest.JoinRequestID != firstRequest.JoinRequestID {
+		t.Fatalf("expected reactivated join_request_id %q, got %q", firstRequest.JoinRequestID, retryRequest.JoinRequestID)
+	}
+	if retryRequest.Status != string(domain.JoinRequestStatusPending) {
+		t.Fatalf("expected status %q, got %q", domain.JoinRequestStatusPending, retryRequest.Status)
+	}
+
+	var (
+		storedStatus       string
+		storedMessage      *string
+		hasNoParticipation bool
+	)
+	if err := common.RequirePool(t).QueryRow(
+		context.Background(),
+		`SELECT status, message, participation_id IS NULL
+		 FROM join_request
+		 WHERE id = $1`,
+		retryRequest.JoinRequestID,
+	).Scan(&storedStatus, &storedMessage, &hasNoParticipation); err != nil {
+		t.Fatalf("select reactivated join_request error = %v", err)
+	}
+	if storedStatus != string(domain.JoinRequestStatusPending) {
+		t.Fatalf("expected stored join request status %q, got %q", domain.JoinRequestStatusPending, storedStatus)
+	}
+	if storedMessage == nil || *storedMessage != retryMessage {
+		t.Fatalf("expected stored retry message %q, got %v", retryMessage, storedMessage)
+	}
+	if !hasNoParticipation {
+		t.Fatal("expected reactivated join request participation_id to be nil")
+	}
+
+	retryJoinRequestID, err := uuid.Parse(retryRequest.JoinRequestID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() retry join_request_id error = %v", err)
+	}
+
+	secondApproval, err := harness.Service.ApproveJoinRequest(context.Background(), host.ID, event.ID, retryJoinRequestID)
+	if err != nil {
+		t.Fatalf("ApproveJoinRequest() second approval error = %v", err)
+	}
+	if secondApproval.ParticipationID != firstApproval.ParticipationID {
+		t.Fatalf("expected reactivated participation_id %q, got %q", firstApproval.ParticipationID, secondApproval.ParticipationID)
+	}
+	if secondApproval.ParticipationStatus != domain.ParticipationStatusApproved {
+		t.Fatalf("expected participation status %q, got %q", domain.ParticipationStatusApproved, secondApproval.ParticipationStatus)
+	}
+}
+
+func TestRequestJoinRejectsReapplyAfterLeavingStartedEvent(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	requester := common.GivenUser(t, harness.AuthRepo)
+	eventID := givenStartedProtectedEvent(t, host.ID)
+
+	firstRequest, err := harness.Service.RequestJoin(context.Background(), requester.ID, eventID, eventapp.RequestJoinInput{})
+	if err != nil {
+		t.Fatalf("RequestJoin() first call error = %v", err)
+	}
+
+	firstJoinRequestID, err := uuid.Parse(firstRequest.JoinRequestID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() first join_request_id error = %v", err)
+	}
+
+	if _, err := harness.Service.ApproveJoinRequest(context.Background(), host.ID, eventID, firstJoinRequestID); err != nil {
+		t.Fatalf("ApproveJoinRequest() error = %v", err)
+	}
+	if _, err := harness.Service.LeaveEvent(context.Background(), requester.ID, eventID); err != nil {
+		t.Fatalf("LeaveEvent() error = %v", err)
+	}
+
+	// when
+	_, err = harness.Service.RequestJoin(context.Background(), requester.ID, eventID, eventapp.RequestJoinInput{})
+
+	// then
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeAlreadyParticipating)
+	appErr, ok := errors.AsType[*domain.AppError](err)
+	if !ok {
+		t.Fatalf("expected AppError, got %v", err)
+	}
+	if appErr.Message != "You cannot request to join again after leaving once the event has started." {
+		t.Fatalf("expected post-start leave message, got %q", appErr.Message)
+	}
 }
 
 func TestRequestJoinRejectsHostRequestingOwnEvent(t *testing.T) {
@@ -2377,6 +2589,22 @@ func createProtectedEventWithCapacity(t *testing.T, harness *common.EventHarness
 	eventID, err := uuid.Parse(result.ID)
 	if err != nil {
 		t.Fatalf("uuid.Parse() event id error = %v", err)
+	}
+
+	return eventID
+}
+
+func givenStartedProtectedEvent(t *testing.T, hostID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	eventID := common.GivenStartedEvent(t, hostID)
+	if _, err := common.RequirePool(t).Exec(
+		context.Background(),
+		`UPDATE event SET privacy_level = $2 WHERE id = $1`,
+		eventID,
+		domain.PrivacyProtected,
+	); err != nil {
+		t.Fatalf("update started event privacy error = %v", err)
 	}
 
 	return eventID

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -636,6 +636,8 @@ paths:
         - The event must exist and have `privacy_level: PUBLIC`.
         - The authenticated user must not be the event host.
         - A user can only join the same event once; a second attempt returns `409`.
+        - If the user previously left before `start_time`, the backend reactivates the same participation row as `APPROVED`.
+        - If the user left at or after `start_time`, later direct join attempts return `409 already_participating`.
         - Calling this endpoint on a `PROTECTED` event returns `409 event_join_not_allowed`.
       operationId: joinEvent
       security:
@@ -748,7 +750,9 @@ paths:
         - Leaving is allowed before `start_time` and while the event is still active.
         - Leaving is no longer allowed after the event has ended or once the event is already `CANCELED` or `COMPLETED`.
         - If the user leaves before `start_time`, the event is excluded from completed/past participation lists.
+        - If the user leaves before `start_time`, they can join again directly on `PUBLIC` events or submit a new join request on `PROTECTED` events.
         - If the user leaves after `start_time`, completed/past participation lists may still include the event after it finishes.
+        - If the user leaves at or after `start_time`, they cannot join the same event again.
       operationId: leaveEvent
       security:
         - bearerAuth: []
@@ -969,6 +973,8 @@ paths:
         - A user can only submit one pending request per event; a second attempt returns `409`.
         - After the host rejects a request, the same user must wait **3 days** before requesting again.
         - When the cooldown expires, the backend reactivates the same `join_request` row as `PENDING`.
+        - If the user previously had an approved participation but left before `start_time`, the backend reactivates the same `join_request` row as `PENDING` so the host can approve them again.
+        - If the user left at or after `start_time`, later request attempts return `409 already_participating`.
         - Calling this endpoint on a `PUBLIC` event returns `409 event_join_not_allowed`.
       operationId: requestJoinEvent
       security:
@@ -1095,7 +1101,9 @@ paths:
       description: |
         Allows the authenticated event host to approve a **PENDING** join request for a
         **PROTECTED** event. Approval updates the join request to `APPROVED` and creates an
-        `APPROVED` participation row atomically.
+        `APPROVED` participation row atomically. If the requester had left before
+        `start_time`, approval reactivates the same participation row instead of creating a
+        second one.
       operationId: approveJoinRequest
       security:
         - bearerAuth: []
@@ -2617,7 +2625,7 @@ components:
         participation_id:
           type: string
           format: uuid
-          description: UUID of the newly created participation record.
+          description: UUID of the created or reactivated participation record.
           example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
         event_id:
           type: string
@@ -2632,6 +2640,7 @@ components:
         created_at:
           type: string
           format: date-time
+          description: Timestamp of the join or rejoin activation.
           example: "2026-03-26T11:00:00+03:00"
 
     LeaveEventResponse:
@@ -2678,7 +2687,7 @@ components:
         join_request_id:
           type: string
           format: uuid
-          description: UUID of the newly created join request.
+          description: UUID of the created or reactivated join request.
           example: b2c3d4e5-f6a7-8901-bcde-f01234567890
         event_id:
           type: string
@@ -2693,6 +2702,7 @@ components:
         created_at:
           type: string
           format: date-time
+          description: Timestamp of the join request creation or reactivation.
           example: "2026-03-26T12:00:00+03:00"
 
     ApproveJoinRequestResponse:


### PR DESCRIPTION
## Summary
- allow users who left before event start to join again directly or submit a fresh join request
- keep post-start leaves non-rejoinable while preserving the existing rejected-request cooldown behavior
- update integration coverage and OpenAPI notes for the reactivation flow

## Root Cause
The backend treated any existing participation row as an active membership, so a `LEAVED` record blocked both direct joins and protected-event join requests even when the user had left before the event started.

## Changes
- added shared participation loading/conflict helpers in the Postgres adapter
- reactivated `LEAVED` participations when the leave happened before `start_time`
- reused approved join-request records and participation rows for protected-event rejoin flows
- added integration tests for pre-start rejoin success and post-start rejoin rejection
- updated `docs/openapi/event.yaml` to document the new behavior

## Validation
- `go test ./internal/application/event/...`
- `go test -tags=integration ./tests_integration -run 'TestJoinEvent|TestLeaveEvent|TestRequestJoin|TestApproveJoinRequest|TestRejectJoinRequest|TestGetMyCompletedEvents(IncludesLeavedParticipationAfterStart|ExcludesLeavedParticipationBeforeStart)'`
- `./shipcheck.sh`
