### PR TITLE
feat(backend): auto-complete stale and max-duration events in background job (#314)

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -1490,17 +1490,28 @@ func (r *EventRepository) CompleteEvent(ctx context.Context, eventID uuid.UUID) 
 }
 
 // TransitionEventStatuses moves ACTIVE events to IN_PROGRESS when their
-// start_time has passed and IN_PROGRESS (or ACTIVE) events to COMPLETED when
-// their end_time has passed.
+// start_time has passed, and transitions ACTIVE/IN_PROGRESS events to COMPLETED
+// when any of the following conditions apply:
+//   - end_time has passed
+//   - start_time is older than 60 days (max duration, unconditional)
+//   - start_time is older than 30 days AND updated_at is older than 7 days (stale/zombie)
+//
+// updated_at reflects event-level mutations (title, description, cancel, etc.).
+// Participation activity does not advance updated_at.
 func (r *EventRepository) TransitionEventStatuses(ctx context.Context) error {
 	_, err := r.pool.Exec(ctx, `
 		UPDATE event
 		SET status = CASE
-			WHEN end_time < NOW() THEN 'COMPLETED'
+			WHEN end_time IS NOT NULL AND end_time < NOW()                                                         THEN 'COMPLETED'
+			WHEN start_time < NOW() - INTERVAL '60 days'                                                          THEN 'COMPLETED'
+			WHEN start_time < NOW() - INTERVAL '30 days' AND updated_at < NOW() - INTERVAL '7 days'               THEN 'COMPLETED'
 			ELSE 'IN_PROGRESS'
 		END
-		WHERE (status = 'ACTIVE' AND start_time < NOW())
-		   OR (status = 'IN_PROGRESS' AND end_time < NOW())
+		WHERE status IN ('ACTIVE', 'IN_PROGRESS')
+		  AND (
+		    start_time < NOW()
+		    OR (end_time IS NOT NULL AND end_time < NOW())
+		  )
 	`)
 	return err
 }

--- a/backend/tests_integration/common/fixtures.go
+++ b/backend/tests_integration/common/fixtures.go
@@ -266,6 +266,86 @@ func GivenStartedEvent(t *testing.T, hostID uuid.UUID) uuid.UUID {
 	return id
 }
 
+// GivenStaleEvent inserts an ACTIVE event whose start_time is >30 days ago
+// and updated_at is >7 days ago, making it eligible for stale auto-completion.
+func GivenStaleEvent(t *testing.T, hostID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	pool := RequirePool(t)
+	categoryID := GivenEventCategory(t)
+	now := time.Now().UTC()
+
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO event (host_id, title, privacy_level, status, location_type, start_time, updated_at, category_id)
+		VALUES ($1, $2, 'PUBLIC', 'ACTIVE', 'POINT', $3, $4, $5)
+		RETURNING id`,
+		hostID,
+		"stale_event_"+uuid.NewString()[:8],
+		now.Add(-31*24*time.Hour),
+		now.Add(-8*24*time.Hour),
+		categoryID,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("GivenStaleEvent() insert error = %v", err)
+	}
+
+	return id
+}
+
+// GivenVeryOldEvent inserts an ACTIVE event whose start_time is >60 days ago,
+// making it eligible for unconditional auto-completion.
+func GivenVeryOldEvent(t *testing.T, hostID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	pool := RequirePool(t)
+	categoryID := GivenEventCategory(t)
+	now := time.Now().UTC()
+
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO event (host_id, title, privacy_level, status, location_type, start_time, category_id)
+		VALUES ($1, $2, 'PUBLIC', 'ACTIVE', 'POINT', $3, $4)
+		RETURNING id`,
+		hostID,
+		"old_event_"+uuid.NewString()[:8],
+		now.Add(-61*24*time.Hour),
+		categoryID,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("GivenVeryOldEvent() insert error = %v", err)
+	}
+
+	return id
+}
+
+// GivenRecentlyUpdatedOldEvent inserts an ACTIVE event whose start_time is >30 days ago
+// but updated_at is within the last 7 days — it should NOT be auto-completed by the stale rule.
+func GivenRecentlyUpdatedOldEvent(t *testing.T, hostID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	pool := RequirePool(t)
+	categoryID := GivenEventCategory(t)
+	now := time.Now().UTC()
+
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO event (host_id, title, privacy_level, status, location_type, start_time, updated_at, category_id)
+		VALUES ($1, $2, 'PUBLIC', 'ACTIVE', 'POINT', $3, $4, $5)
+		RETURNING id`,
+		hostID,
+		"recent_updated_event_"+uuid.NewString()[:8],
+		now.Add(-31*24*time.Hour),
+		now.Add(-1*24*time.Hour),
+		categoryID,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("GivenRecentlyUpdatedOldEvent() insert error = %v", err)
+	}
+
+	return id
+}
+
 func StringPtr(value string) *string {
 	return &value
 }

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -2705,6 +2705,75 @@ func TestTransitionEventStatuses_StartedToInProgress(t *testing.T) {
 	}
 }
 
+func TestTransitionEventStatuses_StaleEventAutoCompletes(t *testing.T) {
+	t.Parallel()
+
+	// given — ACTIVE event started >30d ago, not updated in >7d
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	eventID := common.GivenStaleEvent(t, host.ID)
+
+	// when
+	if err := harness.EventRepo.TransitionEventStatuses(context.Background()); err != nil {
+		t.Fatalf("TransitionEventStatuses() error = %v", err)
+	}
+
+	// then
+	event, err := harness.EventRepo.GetEventByID(context.Background(), eventID)
+	if err != nil {
+		t.Fatalf("GetEventByID() error = %v", err)
+	}
+	if event.Status != domain.EventStatusCompleted {
+		t.Fatalf("expected status %q, got %q", domain.EventStatusCompleted, event.Status)
+	}
+}
+
+func TestTransitionEventStatuses_VeryOldEventAutoCompletes(t *testing.T) {
+	t.Parallel()
+
+	// given — ACTIVE event started >60d ago (unconditional)
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	eventID := common.GivenVeryOldEvent(t, host.ID)
+
+	// when
+	if err := harness.EventRepo.TransitionEventStatuses(context.Background()); err != nil {
+		t.Fatalf("TransitionEventStatuses() error = %v", err)
+	}
+
+	// then
+	event, err := harness.EventRepo.GetEventByID(context.Background(), eventID)
+	if err != nil {
+		t.Fatalf("GetEventByID() error = %v", err)
+	}
+	if event.Status != domain.EventStatusCompleted {
+		t.Fatalf("expected status %q, got %q", domain.EventStatusCompleted, event.Status)
+	}
+}
+
+func TestTransitionEventStatuses_RecentlyUpdatedOldEventStaysActive(t *testing.T) {
+	t.Parallel()
+
+	// given — ACTIVE event started >30d ago but updated within 7d — should NOT be auto-completed
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	eventID := common.GivenRecentlyUpdatedOldEvent(t, host.ID)
+
+	// when
+	if err := harness.EventRepo.TransitionEventStatuses(context.Background()); err != nil {
+		t.Fatalf("TransitionEventStatuses() error = %v", err)
+	}
+
+	// then — should have transitioned to IN_PROGRESS (start_time passed) but not COMPLETED
+	event, err := harness.EventRepo.GetEventByID(context.Background(), eventID)
+	if err != nil {
+		t.Fatalf("GetEventByID() error = %v", err)
+	}
+	if event.Status == domain.EventStatusCompleted {
+		t.Fatalf("expected event to stay active/in-progress, got COMPLETED")
+	}
+}
+
 func TestCancelEventSuccessPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION

📋 Summary

  Extends the background job to auto-complete long-running open-ended events that would otherwise stay
  ACTIVE/IN_PROGRESS forever. Two new rules are applied on each job tick: a stale rule (30d old + no
  activity in 7d) and a hard cap (60d unconditional).

  🔄 Changes

  - event_repo.go: Extended TransitionEventStatuses SQL with two additional CASE branches:
    - start_time < NOW() - 30 days AND updated_at < NOW() - 7 days → COMPLETED (stale/zombie)
    - start_time < NOW() - 60 days → COMPLETED (max duration, unconditional)
  - tests_integration/common/fixtures.go: Added GivenStaleEvent, GivenVeryOldEvent,
  GivenRecentlyUpdatedOldEvent test helpers
  - tests_integration/event_test.go: Added 3 integration tests covering stale auto-complete, old event
  auto-complete, and recently-updated event staying alive

  🧪 Testing

  go test -tags integration ./tests_integration/... -count=1 -run TestTransitionEventStatuses

  🔗 Related

  Closes #314