### PR TITLE
feat(backend): add participants_count and location_address to event summaries

### DIFF
--- a/backend/internal/adapter/in/postgres/profile_repo.go
+++ b/backend/internal/adapter/in/postgres/profile_repo.go
@@ -118,9 +118,12 @@ func (r *ProfileRepository) GetHostedEvents(ctx context.Context, userID uuid.UUI
 			e.end_time,
 			e.status,
 			ec.name AS category,
-			e.image_url
+			e.image_url,
+			e.approved_participant_count,
+			el.address
 		FROM event e
 		LEFT JOIN event_category ec ON ec.id = e.category_id
+		LEFT JOIN event_location el ON el.event_id = e.id
 		WHERE e.host_id = $1
 		ORDER BY e.start_time DESC
 	`, userID)
@@ -142,10 +145,13 @@ func (r *ProfileRepository) GetUpcomingEvents(ctx context.Context, userID uuid.U
 			e.end_time,
 			e.status,
 			ec.name AS category,
-			e.image_url
+			e.image_url,
+			e.approved_participant_count,
+			el.address
 		FROM event e
 		JOIN participation p ON p.event_id = e.id
 		LEFT JOIN event_category ec ON ec.id = e.category_id
+		LEFT JOIN event_location el ON el.event_id = e.id
 		WHERE p.user_id = $1
 		  AND p.status = $2
 		  AND e.status IN ($3, $4)
@@ -169,10 +175,13 @@ func (r *ProfileRepository) GetCompletedEvents(ctx context.Context, userID uuid.
 			e.end_time,
 			e.status,
 			ec.name AS category,
-			e.image_url
+			e.image_url,
+			e.approved_participant_count,
+			el.address
 		FROM event e
 		JOIN participation p ON p.event_id = e.id
 		LEFT JOIN event_category ec ON ec.id = e.category_id
+		LEFT JOIN event_location el ON el.event_id = e.id
 		WHERE p.user_id = $1
 		  AND (
 			p.status = $2
@@ -199,10 +208,13 @@ func (r *ProfileRepository) GetCanceledEvents(ctx context.Context, userID uuid.U
 			e.end_time,
 			e.status,
 			ec.name AS category,
-			e.image_url
+			e.image_url,
+			e.approved_participant_count,
+			el.address
 		FROM event e
 		JOIN participation p ON p.event_id = e.id
 		LEFT JOIN event_category ec ON ec.id = e.category_id
+		LEFT JOIN event_location el ON el.event_id = e.id
 		WHERE p.user_id = $1
 		  AND p.status = $2
 		  AND e.status = $3
@@ -223,12 +235,14 @@ func scanEventSummaries(rows interface {
 	var events []domain.EventSummary
 	for rows.Next() {
 		var (
-			e        domain.EventSummary
-			endTime  pgtype.Timestamptz
-			category pgtype.Text
-			imageURL pgtype.Text
+			e               domain.EventSummary
+			endTime         pgtype.Timestamptz
+			category        pgtype.Text
+			imageURL        pgtype.Text
+			locationAddress pgtype.Text
 		)
-		if err := rows.Scan(&e.ID, &e.Title, &e.StartTime, &endTime, &e.Status, &category, &imageURL); err != nil {
+		if err := rows.Scan(&e.ID, &e.Title, &e.StartTime, &endTime, &e.Status, &category, &imageURL,
+			&e.ApprovedParticipantCount, &locationAddress); err != nil {
 			return nil, fmt.Errorf("scan event summary: %w", err)
 		}
 		if endTime.Valid {
@@ -236,6 +250,7 @@ func scanEventSummaries(rows interface {
 		}
 		e.Category = textPtr(category)
 		e.ImageURL = textPtr(imageURL)
+		e.LocationAddress = textPtr(locationAddress)
 		events = append(events, e)
 	}
 	if err := rows.Err(); err != nil {

--- a/backend/internal/application/profile/service.go
+++ b/backend/internal/application/profile/service.go
@@ -98,13 +98,15 @@ func toEventSummaries(events []domain.EventSummary) []EventSummary {
 	result := make([]EventSummary, len(events))
 	for i, e := range events {
 		result[i] = EventSummary{
-			ID:        e.ID.String(),
-			Title:     e.Title,
-			StartTime: e.StartTime.Format("2006-01-02T15:04:05Z07:00"),
-			EndTime:   e.EndTime.Format("2006-01-02T15:04:05Z07:00"),
-			Status:    e.Status,
-			Category:  e.Category,
-			ImageURL:  e.ImageURL,
+			ID:                e.ID.String(),
+			Title:             e.Title,
+			StartTime:         e.StartTime.Format("2006-01-02T15:04:05Z07:00"),
+			EndTime:           e.EndTime.Format("2006-01-02T15:04:05Z07:00"),
+			Status:            e.Status,
+			Category:          e.Category,
+			ImageURL:          e.ImageURL,
+			ParticipantsCount: e.ApprovedParticipantCount,
+			LocationAddress:   e.LocationAddress,
 		}
 	}
 	return result

--- a/backend/internal/application/profile/service_dto.go
+++ b/backend/internal/application/profile/service_dto.go
@@ -4,13 +4,15 @@ import "github.com/google/uuid"
 
 // EventSummary is a lightweight event representation used in profile responses.
 type EventSummary struct {
-	ID        string  `json:"id"`
-	Title     string  `json:"title"`
-	StartTime string  `json:"start_time"`
-	EndTime   string  `json:"end_time"`
-	Status    string  `json:"status"`
-	Category  *string `json:"category"`
-	ImageURL  *string `json:"image_url"`
+	ID                string  `json:"id"`
+	Title             string  `json:"title"`
+	StartTime         string  `json:"start_time"`
+	EndTime           string  `json:"end_time"`
+	Status            string  `json:"status"`
+	Category          *string `json:"category"`
+	ImageURL          *string `json:"image_url"`
+	ParticipantsCount int     `json:"participants_count"`
+	LocationAddress   *string `json:"location_address"`
 }
 
 // GetProfileResult is the output of the GetMyProfile use case.

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -19,13 +19,15 @@ type Profile struct {
 
 // EventSummary is a lightweight event projection used in profile responses.
 type EventSummary struct {
-	ID        uuid.UUID
-	Title     string
-	StartTime time.Time
-	EndTime   time.Time
-	Status    string
-	Category  *string
-	ImageURL  *string
+	ID                       uuid.UUID
+	Title                    string
+	StartTime                time.Time
+	EndTime                  time.Time
+	Status                   string
+	Category                 *string
+	ImageURL                 *string
+	ApprovedParticipantCount int
+	LocationAddress          *string
 }
 
 // UserProfile is the combined projection of app_user and profile returned by

--- a/docs/openapi/profile.yaml
+++ b/docs/openapi/profile.yaml
@@ -396,6 +396,17 @@ components:
             - string
             - "null"
           example: "https://example.com/images/yoga.jpg"
+        participants_count:
+          type: integer
+          minimum: 0
+          description: Current count of approved participants.
+          example: 24
+        location_address:
+          type:
+            - string
+            - "null"
+          description: Event location address text.
+          example: "Maçka Democracy Park, Istanbul"
 
     ErrorEnvelope:
       type: object


### PR DESCRIPTION
## 📋 Summary
  Added `participants_count` and `location_address` to the event summaries returned by the four      
  my-events endpoints, so mobile clients can render participant counts and location on event cards   
  without extra detail requests.

  ## 🔄 Changes
  - Extended `EventSummary` domain struct and DTO with `participants_count` (int) and
  `location_address` (nullable string)
  - Updated 4 profile repo SQL queries (hosted, upcoming, completed, canceled) to SELECT
  `e.approved_participant_count` and JOIN `event_location` for address
  - Updated `scanEventSummaries` to scan the new columns
  - Updated OpenAPI `EventSummary` schema in profile.yaml

  ## 🧪 Testing
  - `go build ./...` passes
  - `go test ./...` passes (all unit tests)
  - `go test -tags=integration ./tests_integration/` passes (all integration tests)

  ## 🔗 Related
  Closes #328

  Base: main