### PR TITLE
feat(mobile): add warning message in event details for auto-completion

### DIFF
--- a/mobile/src/utils/eventDate.test.ts
+++ b/mobile/src/utils/eventDate.test.ts
@@ -1,0 +1,57 @@
+import { getAutoCompletionDaysLeft } from './eventDate';
+
+function daysAgo(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString();
+}
+
+describe('getAutoCompletionDaysLeft', () => {
+  it('returns null for ACTIVE events', () => {
+    expect(getAutoCompletionDaysLeft('ACTIVE', daysAgo(55))).toBeNull();
+  });
+
+  it('returns null for COMPLETED events', () => {
+    expect(getAutoCompletionDaysLeft('COMPLETED', daysAgo(55))).toBeNull();
+  });
+
+  it('returns null for CANCELED events', () => {
+    expect(getAutoCompletionDaysLeft('CANCELED', daysAgo(55))).toBeNull();
+  });
+
+  it('returns null for IN_PROGRESS events that have an end_time', () => {
+    const endTime = new Date(Date.now() + 86400000).toISOString();
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', daysAgo(55), endTime)).toBeNull();
+  });
+
+  it('returns null when event started less than 53 days ago', () => {
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', daysAgo(52))).toBeNull();
+  });
+
+  it('returns null when event started 60 or more days ago', () => {
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', daysAgo(60))).toBeNull();
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', daysAgo(65))).toBeNull();
+  });
+
+  it('returns 7 when event started exactly 53 days ago', () => {
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', daysAgo(53))).toBe(7);
+  });
+
+  it('returns 1 when event started exactly 59 days ago', () => {
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', daysAgo(59))).toBe(1);
+  });
+
+  it('returns correct days left for day 55', () => {
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', daysAgo(55))).toBe(5);
+  });
+
+  it('treats null end_time the same as undefined', () => {
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', daysAgo(55), null)).toBe(5);
+  });
+
+  it('accepts a custom now parameter', () => {
+    const startTime = '2026-01-01T00:00:00Z';
+    const now = new Date('2026-02-24T00:00:00Z'); // 54 days later
+    expect(getAutoCompletionDaysLeft('IN_PROGRESS', startTime, null, now)).toBe(6);
+  });
+});

--- a/mobile/src/utils/eventDate.ts
+++ b/mobile/src/utils/eventDate.ts
@@ -53,3 +53,30 @@ export function formatEventDateLabel(
 
   return `${startDatePart} • ${startTimePart} - ${endDatePart} • ${endTimePart}`;
 }
+
+/**
+ * Returns the number of days remaining before an in-progress event without an
+ * end date is auto-completed (at the 60-day mark), or `null` when no warning
+ * should be displayed.
+ *
+ * A warning is shown between day 53 and day 59 (inclusive) since the event
+ * started.
+ */
+export function getAutoCompletionDaysLeft(
+  status: string,
+  startTime: string,
+  endTime?: string | null,
+  now: Date = new Date(),
+): number | null {
+  if (status !== 'IN_PROGRESS' || endTime) return null;
+
+  const daysSinceStart = Math.floor(
+    (now.getTime() - new Date(startTime).getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (daysSinceStart >= 53 && daysSinceStart < 60) {
+    return 60 - daysSinceStart;
+  }
+
+  return null;
+}

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -16,7 +16,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Feather, Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { useEventDetailViewModel } from '@/viewmodels/event/useEventDetailViewModel';
-import { formatEventDateLabel } from '@/utils/eventDate';
+import { formatEventDateLabel, getAutoCompletionDaysLeft } from '@/utils/eventDate';
 import { formatEventLocation } from '@/utils/eventLocation';
 import { EventDetail } from '@/models/event';
 import JoinRequestsModal from '@/components/events/JoinRequestsModal';
@@ -295,22 +295,17 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
         </View>
 
         {/* Auto-completion warning for in-progress events without an end date */}
-        {event.status === 'IN_PROGRESS' && !event.end_time && (() => {
-          const daysSinceStart = Math.floor(
-            (Date.now() - new Date(event.start_time).getTime()) / (1000 * 60 * 60 * 24)
+        {(() => {
+          const daysLeft = getAutoCompletionDaysLeft(event.status, event.start_time, event.end_time);
+          if (daysLeft == null) return null;
+          return (
+            <View style={styles.warningBanner}>
+              <Feather name="alert-triangle" size={16} color="#D97706" />
+              <Text style={styles.warningBannerText}>
+                This event will be automatically completed in {daysLeft} day{daysLeft !== 1 ? 's' : ''} due to inactivity.
+              </Text>
+            </View>
           );
-          if (daysSinceStart >= 53 && daysSinceStart < 60) {
-            const daysLeft = 60 - daysSinceStart;
-            return (
-              <View style={styles.warningBanner}>
-                <Feather name="alert-triangle" size={16} color="#D97706" />
-                <Text style={styles.warningBannerText}>
-                  This event will be automatically completed in {daysLeft} day{daysLeft !== 1 ? 's' : ''} due to inactivity.
-                </Text>
-              </View>
-            );
-          }
-          return null;
         })()}
 
         {/* Core info */}


### PR DESCRIPTION
## 📋 Summary
- Show an amber warning banner on the event detail page for in-progress events without an end date, between day 53 and day 60 since start, informing users the event will be automatically completed due to inactivity.
- Extract `getAutoCompletionDaysLeft` utility for testability.

## 🔄 Changes
- **`mobile/src/utils/eventDate.ts`** — Added `getAutoCompletionDaysLeft(status, startTime, endTime, now?)` utility that returns the number of days remaining before auto-completion, or `null` when no warning should be shown.
- **`mobile/src/views/event/EventDetailView.tsx`** — Added an amber warning banner (with `alert-triangle` icon) rendered between the hero image and core info sections when the utility returns a non-null value. Added `warningBanner` and `warningBannerText` styles.
- **`mobile/src/utils/eventDate.test.ts`** — Added 11 unit tests covering status filtering, end_time presence, boundary conditions (days 52, 53, 59, 60), and custom `now` parameter.

## 🧪 Testing
```bash
cd mobile
npx jest src/utils/eventDate.test.ts
```
Verify on the app:
- Temporarily hardcode a mock `now` date (e.g. 55 days after an event's `start_time`) in `getAutoCompletionDaysLeft` call inside `EventDetailView.tsx` and confirm the amber warning banner appears on an in-progress event without an end date
- Confirm the banner does not appear for events with an end date, non in-progress events, or events started less than 53 days ago

## 🔗 Related
Closes #312