### PR TITLE
fix(mobile): exclude active events from profile lists and add status …

### DIFF
--- a/mobile/src/components/events/MyEventCard.tsx
+++ b/mobile/src/components/events/MyEventCard.tsx
@@ -4,43 +4,14 @@ import { Feather } from '@expo/vector-icons';
 import { MyEventBadge, MyEventSummary } from '@/models/event';
 import { formatEventDateLabel } from '@/utils/eventDate';
 import { formatEventLocation } from '@/utils/eventLocation';
+import {
+  formatEventStatusLabel,
+  getEventStatusBadgeColors,
+} from '@/utils/eventStatus';
 
 interface MyEventCardProps {
   event: MyEventSummary;
   onPress?: (eventId: string) => void;
-}
-
-function formatStatusLabel(status: MyEventSummary['status']) {
-  if (status === 'IN_PROGRESS') return 'In Progress';
-  return status.charAt(0) + status.slice(1).toLowerCase();
-}
-
-function getStatusStyle(status: MyEventSummary['status']) {
-  if (status === 'ACTIVE') {
-    return {
-      container: styles.statusBadgeActive,
-      text: styles.statusTextActive,
-    };
-  }
-
-  if (status === 'IN_PROGRESS') {
-    return {
-      container: styles.statusBadgeInProgress,
-      text: styles.statusTextInProgress,
-    };
-  }
-
-  if (status === 'COMPLETED') {
-    return {
-      container: styles.statusBadgeCompleted,
-      text: styles.statusTextCompleted,
-    };
-  }
-
-  return {
-    container: styles.statusBadgeCanceled,
-    text: styles.statusTextCanceled,
-  };
 }
 
 function getBadgeStyle(type: MyEventBadge['type']) {
@@ -81,7 +52,7 @@ function getLocationLabel(address?: string | null) {
 }
 
 export default function MyEventCard({ event, onPress }: MyEventCardProps) {
-  const statusStyle = getStatusStyle(event.status);
+  const statusColors = getEventStatusBadgeColors(event.status);
 
   return (
     <TouchableOpacity
@@ -105,9 +76,19 @@ export default function MyEventCard({ event, onPress }: MyEventCardProps) {
 
       <View style={styles.content}>
         <View style={styles.topRow}>
-          <View style={[styles.statusBadge, statusStyle.container]}>
-            <Text style={[styles.statusBadgeText, statusStyle.text]}>
-              {formatStatusLabel(event.status)}
+          <View
+            style={[
+              styles.statusBadge,
+              { backgroundColor: statusColors.backgroundColor },
+            ]}
+          >
+            <Text
+              style={[
+                styles.statusBadgeText,
+                { color: statusColors.textColor },
+              ]}
+            >
+              {formatEventStatusLabel(event.status)}
             </Text>
           </View>
 
@@ -208,33 +189,9 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     borderRadius: 999,
   },
-  statusBadgeActive: {
-    backgroundColor: '#DCFCE7',
-  },
-  statusBadgeInProgress: {
-    backgroundColor: '#DBEAFE',
-  },
-  statusBadgeCompleted: {
-    backgroundColor: '#E2E8F0',
-  },
-  statusBadgeCanceled: {
-    backgroundColor: '#FEE2E2',
-  },
   statusBadgeText: {
     fontSize: 12,
     fontWeight: '700',
-  },
-  statusTextActive: {
-    color: '#166534',
-  },
-  statusTextInProgress: {
-    color: '#1D4ED8',
-  },
-  statusTextCompleted: {
-    color: '#334155',
-  },
-  statusTextCanceled: {
-    color: '#B91C1C',
   },
   attendeePill: {
     flexDirection: 'row',

--- a/mobile/src/components/profile/ProfileEventCard.tsx
+++ b/mobile/src/components/profile/ProfileEventCard.tsx
@@ -8,6 +8,10 @@ import {
   View,
 } from 'react-native';
 import { formatEventDateLabel } from '@/utils/eventDate';
+import {
+  formatEventStatusLabel,
+  getEventStatusBadgeColors,
+} from '@/utils/eventStatus';
 
 interface ProfileEventCardProps {
   title: string;
@@ -23,14 +27,6 @@ function formatPrivacyLabel(value: NonNullable<ProfileEventCardProps['privacyLev
   return value.charAt(0) + value.slice(1).toLowerCase();
 }
 
-function formatStatusLabel(value: string) {
-  return value
-    .toLowerCase()
-    .split('_')
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ');
-}
-
 export default function ProfileEventCard({
   title,
   imageUrl,
@@ -40,6 +36,8 @@ export default function ProfileEventCard({
   privacyLevel,
   onPress,
 }: ProfileEventCardProps) {
+  const statusColors = getEventStatusBadgeColors(status);
+
   return (
     <TouchableOpacity
       activeOpacity={0.92}
@@ -106,8 +104,20 @@ export default function ProfileEventCard({
               <Text style={styles.categoryBadgeText}>{categoryLabel}</Text>
             </View>
 
-            <View style={styles.statusBadge}>
-              <Text style={styles.statusBadgeText}>{formatStatusLabel(status)}</Text>
+            <View
+              style={[
+                styles.statusBadge,
+                { backgroundColor: statusColors.backgroundColor },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.statusBadgeText,
+                  { color: statusColors.textColor },
+                ]}
+              >
+                {formatEventStatusLabel(status)}
+              </Text>
             </View>
           </View>
         </View>
@@ -215,13 +225,11 @@ const styles = StyleSheet.create({
     color: '#7C2D12',
   },
   statusBadge: {
-    backgroundColor: 'rgba(255, 255, 255, 0.92)',
     paddingHorizontal: 12,
     paddingVertical: 7,
     borderRadius: 999,
   },
   statusBadgeText: {
-    color: '#111827',
     fontSize: 12,
     fontWeight: '700',
   },

--- a/mobile/src/services/profileService.ts
+++ b/mobile/src/services/profileService.ts
@@ -22,6 +22,10 @@ export function getMyCompletedEvents(token: string): Promise<ProfileEventsRespon
   return apiGetAuth<ProfileEventsResponse>('/me/events/completed', token);
 }
 
+export function getMyCanceledEvents(token: string): Promise<ProfileEventsResponse> {
+  return apiGetAuth<ProfileEventsResponse>('/me/events/canceled', token);
+}
+
 export function getProfileAvatarUploadUrl(
   token: string,
 ): Promise<ImageUploadInitResponse> {

--- a/mobile/src/utils/eventStatus.test.ts
+++ b/mobile/src/utils/eventStatus.test.ts
@@ -1,0 +1,39 @@
+import {
+  formatEventStatusLabel,
+  getEventStatusBadgeColors,
+  shouldShowProfileEvent,
+} from './eventStatus';
+
+describe('eventStatus', () => {
+  it('formats known and unknown backend statuses for display', () => {
+    expect(formatEventStatusLabel('IN_PROGRESS')).toBe('In Progress');
+    expect(formatEventStatusLabel('CANCELED')).toBe('Canceled');
+    expect(formatEventStatusLabel('WAITING_REVIEW')).toBe('Waiting Review');
+    expect(formatEventStatusLabel('')).toBe('Unknown');
+  });
+
+  it('returns distinct colors for supported statuses with a safe fallback', () => {
+    expect(getEventStatusBadgeColors('IN_PROGRESS')).toEqual({
+      backgroundColor: '#DBEAFE',
+      textColor: '#1D4ED8',
+    });
+    expect(getEventStatusBadgeColors('COMPLETED')).toEqual({
+      backgroundColor: '#E2E8F0',
+      textColor: '#334155',
+    });
+    expect(getEventStatusBadgeColors('CANCELED')).toEqual({
+      backgroundColor: '#FEE2E2',
+      textColor: '#B91C1C',
+    });
+    expect(getEventStatusBadgeColors('WAITING_REVIEW')).toEqual({
+      backgroundColor: 'rgba(255, 255, 255, 0.92)',
+      textColor: '#111827',
+    });
+  });
+
+  it('hides only ACTIVE events from profile lists', () => {
+    expect(shouldShowProfileEvent('ACTIVE')).toBe(false);
+    expect(shouldShowProfileEvent('IN_PROGRESS')).toBe(true);
+    expect(shouldShowProfileEvent('WAITING_REVIEW')).toBe(true);
+  });
+});

--- a/mobile/src/utils/eventStatus.ts
+++ b/mobile/src/utils/eventStatus.ts
@@ -1,0 +1,62 @@
+import type { MyEventStatus } from '@/models/event';
+
+export interface EventStatusBadgeColors {
+  backgroundColor: string;
+  textColor: string;
+}
+
+const STATUS_LABELS: Record<MyEventStatus, string> = {
+  ACTIVE: 'Active',
+  IN_PROGRESS: 'In Progress',
+  COMPLETED: 'Completed',
+  CANCELED: 'Canceled',
+};
+
+const STATUS_BADGE_COLORS: Record<MyEventStatus, EventStatusBadgeColors> = {
+  ACTIVE: {
+    backgroundColor: '#DCFCE7',
+    textColor: '#166534',
+  },
+  IN_PROGRESS: {
+    backgroundColor: '#DBEAFE',
+    textColor: '#1D4ED8',
+  },
+  COMPLETED: {
+    backgroundColor: '#E2E8F0',
+    textColor: '#334155',
+  },
+  CANCELED: {
+    backgroundColor: '#FEE2E2',
+    textColor: '#B91C1C',
+  },
+};
+
+const DEFAULT_STATUS_BADGE_COLORS: EventStatusBadgeColors = {
+  backgroundColor: 'rgba(255, 255, 255, 0.92)',
+  textColor: '#111827',
+};
+
+export function formatEventStatusLabel(status: string): string {
+  const normalized = status.trim();
+  if (!normalized) return 'Unknown';
+
+  const knownLabel = STATUS_LABELS[normalized as MyEventStatus];
+  if (knownLabel) return knownLabel;
+
+  const formatted = normalized
+    .toLowerCase()
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+  return formatted || 'Unknown';
+}
+
+export function getEventStatusBadgeColors(status: string): EventStatusBadgeColors {
+  return STATUS_BADGE_COLORS[status as MyEventStatus] ?? DEFAULT_STATUS_BADGE_COLORS;
+}
+
+export function shouldShowProfileEvent(status: string): boolean {
+  return status !== 'ACTIVE';
+}

--- a/mobile/src/viewmodels/profile/useProfileViewModel.test.tsx
+++ b/mobile/src/viewmodels/profile/useProfileViewModel.test.tsx
@@ -21,6 +21,7 @@ const mockGetMyProfile = jest.mocked(profileService.getMyProfile);
 const mockGetMyHostedEvents = jest.mocked(profileService.getMyHostedEvents);
 const mockGetMyUpcomingEvents = jest.mocked(profileService.getMyUpcomingEvents);
 const mockGetMyCompletedEvents = jest.mocked(profileService.getMyCompletedEvents);
+const mockGetMyCanceledEvents = jest.mocked(profileService.getMyCanceledEvents);
 const mockUseAuth = jest.mocked(useAuth);
 
 function createDeferred<T>() {
@@ -47,7 +48,7 @@ const attendedUpcomingFixture: ProfileEventSummary = {
   image_url: 'https://example.com/events/attended.jpg',
   start_time: '2026-04-15T18:30:00Z',
   end_time: '2026-04-15T21:00:00Z',
-  status: 'PUBLISHED',
+  status: 'IN_PROGRESS',
   category: 'Social',
 };
 
@@ -61,13 +62,23 @@ const attendedCompletedFixture: ProfileEventSummary = {
   category: 'Culture',
 };
 
+const attendedCanceledFixture: ProfileEventSummary = {
+  id: 'attended-event-3',
+  title: 'Open Air Cinema',
+  image_url: 'https://example.com/events/canceled.jpg',
+  start_time: '2026-03-18T19:00:00Z',
+  end_time: '2026-03-18T22:00:00Z',
+  status: 'CANCELED',
+  category: 'Entertainment',
+};
+
 const hostedEventFixture: ProfileEventSummary = {
   id: 'hosted-event-1',
   title: 'Sunrise Hike',
   image_url: 'https://example.com/events/hosted.jpg',
   start_time: '2026-04-12T08:00:00Z',
   end_time: '2026-04-12T10:00:00Z',
-  status: 'PUBLISHED',
+  status: 'IN_PROGRESS',
   category: 'Outdoors',
 };
 
@@ -112,6 +123,9 @@ describe('useProfileViewModel', () => {
     mockGetMyCompletedEvents.mockResolvedValue({
       events: [{ ...attendedCompletedFixture, privacy_level: 'PUBLIC' }],
     });
+    mockGetMyCanceledEvents.mockResolvedValue({
+      events: [{ ...attendedCanceledFixture, privacy_level: 'PUBLIC' }],
+    });
   });
 
   it('starts in loading state', () => {
@@ -119,10 +133,12 @@ describe('useProfileViewModel', () => {
     const deferredHosted = createDeferred<{ events: ProfileEventSummary[] }>();
     const deferredUpcoming = createDeferred<{ events: ProfileEventSummary[] }>();
     const deferredCompleted = createDeferred<{ events: ProfileEventSummary[] }>();
+    const deferredCanceled = createDeferred<{ events: ProfileEventSummary[] }>();
     mockGetMyProfile.mockReturnValue(deferredProfile.promise);
     mockGetMyHostedEvents.mockReturnValue(deferredHosted.promise);
     mockGetMyUpcomingEvents.mockReturnValue(deferredUpcoming.promise);
     mockGetMyCompletedEvents.mockReturnValue(deferredCompleted.promise);
+    mockGetMyCanceledEvents.mockReturnValue(deferredCanceled.promise);
 
     const { result } = renderHook(() => useProfileViewModel());
     expect(result.current.isLoading).toBe(true);
@@ -137,6 +153,7 @@ describe('useProfileViewModel', () => {
     expect(mockGetMyHostedEvents).toHaveBeenCalledWith('test-token');
     expect(mockGetMyUpcomingEvents).toHaveBeenCalledWith('test-token');
     expect(mockGetMyCompletedEvents).toHaveBeenCalledWith('test-token');
+    expect(mockGetMyCanceledEvents).toHaveBeenCalledWith('test-token');
     expect(result.current.profile).toEqual(profileFixture);
     expect(result.current.apiError).toBeNull();
   });
@@ -175,7 +192,7 @@ describe('useProfileViewModel', () => {
         end_time: '2026-04-12T10:00:00Z',
         image_url: 'https://example.com/events/hosted.jpg',
         category_label: 'Outdoors',
-        status: 'PUBLISHED',
+        status: 'IN_PROGRESS',
         privacy_level: 'PUBLIC',
       },
     ]);
@@ -187,7 +204,7 @@ describe('useProfileViewModel', () => {
         end_time: '2026-04-15T21:00:00Z',
         image_url: 'https://example.com/events/attended.jpg',
         category_label: 'Social',
-        status: 'PUBLISHED',
+        status: 'IN_PROGRESS',
         privacy_level: 'PROTECTED',
       },
       {
@@ -200,9 +217,19 @@ describe('useProfileViewModel', () => {
         status: 'COMPLETED',
         privacy_level: 'PUBLIC',
       },
+      {
+        id: 'attended-event-3',
+        title: 'Open Air Cinema',
+        start_time: '2026-03-18T19:00:00Z',
+        end_time: '2026-03-18T22:00:00Z',
+        image_url: 'https://example.com/events/canceled.jpg',
+        category_label: 'Entertainment',
+        status: 'CANCELED',
+        privacy_level: 'PUBLIC',
+      },
     ]);
     expect(result.current.hostedCount).toBe(1);
-    expect(result.current.attendedCount).toBe(2);
+    expect(result.current.attendedCount).toBe(3);
   });
 
   it('deduplicates attended events returned by multiple endpoints', async () => {
@@ -216,6 +243,7 @@ describe('useProfileViewModel', () => {
     expect(result.current.attendedEvents.map((event) => event.id)).toEqual([
       'attended-event-1',
       'attended-event-2',
+      'attended-event-3',
     ]);
   });
 
@@ -235,6 +263,33 @@ describe('useProfileViewModel', () => {
     expect(result.current.attendedEvents.map((event) => event.id)).toEqual([
       'attended-event-1',
       'attended-event-2',
+      'attended-event-3',
+    ]);
+  });
+
+  it('filters ACTIVE events out of the hosted and attended tabs', async () => {
+    mockGetMyHostedEvents.mockResolvedValue({
+      events: [
+        { ...hostedEventFixture, status: 'ACTIVE' },
+        { ...hostedEventFixture, id: 'hosted-event-2', status: 'CANCELED' },
+      ],
+    });
+    mockGetMyUpcomingEvents.mockResolvedValue({
+      events: [
+        { ...attendedUpcomingFixture, id: 'attended-event-active', status: 'ACTIVE' },
+        attendedUpcomingFixture,
+      ],
+    });
+
+    const { result } = await renderProfileViewModel();
+
+    expect(result.current.hostedEvents.map((event) => event.status)).toEqual([
+      'CANCELED',
+    ]);
+    expect(result.current.attendedEvents.map((event) => event.status)).toEqual([
+      'IN_PROGRESS',
+      'COMPLETED',
+      'CANCELED',
     ]);
   });
 
@@ -299,6 +354,7 @@ describe('useProfileViewModel', () => {
     expect(mockGetMyHostedEvents).not.toHaveBeenCalled();
     expect(mockGetMyUpcomingEvents).not.toHaveBeenCalled();
     expect(mockGetMyCompletedEvents).not.toHaveBeenCalled();
+    expect(mockGetMyCanceledEvents).not.toHaveBeenCalled();
   });
 
   it('can refresh profile data', async () => {
@@ -312,6 +368,7 @@ describe('useProfileViewModel', () => {
     mockGetMyHostedEvents.mockResolvedValue({ events: [hostedEventFixture] });
     mockGetMyUpcomingEvents.mockResolvedValue({ events: [attendedUpcomingFixture] });
     mockGetMyCompletedEvents.mockResolvedValue({ events: [attendedCompletedFixture] });
+    mockGetMyCanceledEvents.mockResolvedValue({ events: [attendedCanceledFixture] });
 
     await act(async () => {
       await result.current.refresh();

--- a/mobile/src/viewmodels/profile/useProfileViewModel.ts
+++ b/mobile/src/viewmodels/profile/useProfileViewModel.ts
@@ -7,6 +7,7 @@ import type { ProfileEventSummary } from '@/models/profile';
 import type { PrivacyLevel } from '@/models/event';
 import {
   confirmProfileAvatarUpload,
+  getMyCanceledEvents,
   getMyCompletedEvents,
   getMyHostedEvents,
   getMyProfile,
@@ -16,6 +17,7 @@ import {
 import { ApiError } from '@/services/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { uploadFileToPresignedUrl } from '@/services/eventService';
+import { shouldShowProfileEvent } from '@/utils/eventStatus';
 
 export interface ProfileEventItem {
   id: string;
@@ -114,19 +116,6 @@ function normalizeEndTime(value?: string | null): string | null {
   return trimmed;
 }
 
-function mapHostedEvent(event: ProfileEventSummary): ProfileEventItem {
-  return {
-    id: event.id,
-    title: event.title,
-    start_time: event.start_time,
-    end_time: normalizeEndTime(event.end_time),
-    image_url: event.image_url ?? null,
-    category_label: event.category ?? 'Event',
-    status: event.status,
-    privacy_level: event.privacy_level ?? null,
-  };
-}
-
 function mapProfileEvent(event: ProfileEventSummary): ProfileEventItem {
   return {
     id: event.id,
@@ -191,19 +180,33 @@ export function useProfileViewModel(): ProfileViewModel {
       setApiError(null);
 
       try {
-        const [profileResult, hostedResult, upcomingResult, completedResult] = await Promise.all([
+        const [
+          profileResult,
+          hostedResult,
+          upcomingResult,
+          completedResult,
+          canceledResult,
+        ] = await Promise.all([
           getMyProfile(token),
           getMyHostedEvents(token),
           getMyUpcomingEvents(token),
           getMyCompletedEvents(token),
+          getMyCanceledEvents(token),
         ]);
         setProfile(profileResult);
-        const mappedHostedEvents = hostedResult.events.map(mapHostedEvent);
-        const mergedAttendedEvents = excludeHostedEvents(
-          mergeEventsById(upcomingResult.events, completedResult.events),
-          mappedHostedEvents,
+        const allHostedEvents = hostedResult.events.map(mapProfileEvent);
+        const visibleHostedEvents = allHostedEvents.filter((event) =>
+          shouldShowProfileEvent(event.status),
         );
-        setHostedEvents(mappedHostedEvents);
+        const mergedAttendedEvents = excludeHostedEvents(
+          mergeEventsById(
+            upcomingResult.events,
+            completedResult.events,
+            canceledResult.events,
+          ),
+          allHostedEvents,
+        ).filter((event) => shouldShowProfileEvent(event.status));
+        setHostedEvents(visibleHostedEvents);
         setAttendedEvents(mergedAttendedEvents);
         setRatingLabel(
           profileResult.host_score?.final_score != null


### PR DESCRIPTION
## 📋 Summary

This PR updates the mobile Profile event lists and event status badges so the Profile screen matches the expected product behavior.

**ACTIVE** events are now excluded from the Profile **Hosted** and **Attended** tabs, while visible statuses use distinct badge backgrounds for **IN_PROGRESS**, **COMPLETED**, and **CANCELED**. The status UI is handled through shared mobile logic so both tabs stay consistent and unknown backend statuses fall back gracefully without breaking the UI.

## 🔄 Changes

- Added `/me/events/canceled` to the mobile profile flow so canceled attended events can appear in Profile
- Filtered **ACTIVE** events out of Profile hosted/attended lists before rendering
- Centralized status label/color mapping in a shared helper
- Applied shared status badge styling to `ProfileEventCard`
- Reused the same status helper in `MyEventCard` to keep event status presentation consistent across mobile
- Added test coverage for:
  - excluding **ACTIVE** events from Profile lists
  - including canceled attended events
  - graceful fallback for unknown statuses
  - shared status label/color behavior

## 🧪 Testing

**Automated**
```bash
cd mobile
npm test
```

**Manual**

Suggested manual verification:

1. Log in to the mobile app with a user who has hosted and attended events in **ACTIVE**, **IN_PROGRESS**, **COMPLETED**, and **CANCELED** states
2. Open **Profile > Hosted** and confirm **ACTIVE** events do not appear
3. Verify visible hosted events show distinct badge backgrounds for **IN_PROGRESS**, **COMPLETED**, and **CANCELED**
4. Switch to **Profile > Attended** and confirm **ACTIVE** events do not appear there either
5. Verify visible attended events use the same status badge styling as Hosted
6. Tap a visible event card from both tabs and confirm navigation to event detail still works
7. If test data allows, verify an unknown/unexpected status renders a readable fallback label and does not break the UI

## 🔗 Related

- Closes #355