### PR TITLE
feat(mobile): improve black and white theme consistency

### DIFF
--- a/mobile/src/components/home/FiltersBottomSheet.tsx
+++ b/mobile/src/components/home/FiltersBottomSheet.tsx
@@ -625,7 +625,7 @@ const styles = StyleSheet.create({
   showMoreText: {
     fontSize: 15,
     fontWeight: '600',
-    color: '#2563EB',
+    color: '#111827',
   },
   row: {
     flexDirection: 'row',

--- a/mobile/src/views/auth/ForgotPasswordView.tsx
+++ b/mobile/src/views/auth/ForgotPasswordView.tsx
@@ -214,7 +214,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#E5E7EB',
   },
   stepDotActive: {
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
   },
   successBanner: {
     backgroundColor: '#ECFDF5',
@@ -269,7 +269,7 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   button: {
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
     borderRadius: 10,
     paddingVertical: 14,
     alignItems: 'center',
@@ -299,7 +299,7 @@ const styles = StyleSheet.create({
   },
   footerLink: {
     fontSize: 15,
-    color: '#2563EB',
+    color: '#111827',
     fontWeight: '600',
   },
 });

--- a/mobile/src/views/auth/LoginView.tsx
+++ b/mobile/src/views/auth/LoginView.tsx
@@ -181,7 +181,7 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   button: {
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
     borderRadius: 10,
     paddingVertical: 14,
     alignItems: 'center',
@@ -206,7 +206,7 @@ const styles = StyleSheet.create({
   },
   footerLink: {
     fontSize: 15,
-    color: '#2563EB',
+    color: '#111827',
     fontWeight: '600',
   },
 });

--- a/mobile/src/views/auth/RegisterView.tsx
+++ b/mobile/src/views/auth/RegisterView.tsx
@@ -303,7 +303,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#E5E7EB',
   },
   stepDotActive: {
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
   },
   errorBanner: {
     backgroundColor: '#FEF2F2',
@@ -363,8 +363,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9FAFB',
   },
   genderOptionSelected: {
-    backgroundColor: '#2563EB',
-    borderColor: '#2563EB',
+    backgroundColor: '#111827',
+    borderColor: '#111827',
   },
   genderOptionText: {
     fontSize: 14,
@@ -374,7 +374,7 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
   },
   button: {
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
     borderRadius: 10,
     paddingVertical: 14,
     alignItems: 'center',
@@ -408,7 +408,7 @@ const styles = StyleSheet.create({
   },
   footerLink: {
     fontSize: 15,
-    color: '#2563EB',
+    color: '#111827',
     fontWeight: '600',
   },
 });

--- a/mobile/src/views/event/CreateEventView.tsx
+++ b/mobile/src/views/event/CreateEventView.tsx
@@ -387,7 +387,7 @@ export default function CreateEventView() {
             )}
           </View>
           {vm.isSearchingLocation && (
-            <ActivityIndicator size="small" color="#2563EB" style={styles.searchSpinner} />
+            <ActivityIndicator size="small" color="#111827" style={styles.searchSpinner} />
           )}
           {vm.locationSuggestions.length > 0 && (
             <View style={styles.suggestionsContainer}>
@@ -988,7 +988,7 @@ const styles = StyleSheet.create({
   inlineActionText: {
     fontSize: 13,
     fontWeight: '600',
-    color: '#2563EB',
+    color: '#111827',
   },
   required: {
     color: '#EF4444',
@@ -1092,12 +1092,12 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9FAFB',
   },
   chipSelected: {
-    backgroundColor: '#2563EB',
-    borderColor: '#2563EB',
+    backgroundColor: '#111827',
+    borderColor: '#111827',
   },
   chipUsed: {
-    backgroundColor: '#E0E7FF',
-    borderColor: '#A5B4FC',
+    backgroundColor: '#F3F4F6',
+    borderColor: '#D1D5DB',
     opacity: 0.6,
   },
   chipText: {
@@ -1108,7 +1108,7 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
   },
   chipTextUsed: {
-    color: '#4338CA',
+    color: '#6B7280',
   },
   showMoreBtn: {
     marginTop: 8,
@@ -1116,8 +1116,8 @@ const styles = StyleSheet.create({
   },
   showMoreText: {
     fontSize: 13,
-    color: '#2563EB',
-    fontWeight: '500',
+    color: '#111827',
+    fontWeight: '600',
   },
   locationInputRow: {
     flexDirection: 'row',
@@ -1207,7 +1207,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9FAFB',
   },
   privacyOptionSelected: {
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
   },
   privacyOptionText: {
     fontSize: 14,
@@ -1230,7 +1230,7 @@ const styles = StyleSheet.create({
     width: 44,
     height: 44,
     borderRadius: 10,
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -1246,14 +1246,14 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 16,
-    backgroundColor: '#EFF6FF',
+    backgroundColor: '#F3F4F6',
     borderWidth: 1,
-    borderColor: '#BFDBFE',
+    borderColor: '#D1D5DB',
     marginTop: 8,
   },
   tagChipText: {
     fontSize: 13,
-    color: '#2563EB',
+    color: '#111827',
   },
   constraintInputSection: {
     marginTop: 10,
@@ -1287,7 +1287,7 @@ const styles = StyleSheet.create({
     padding: 6,
   },
   submitButton: {
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
     borderRadius: 10,
     paddingVertical: 14,
     alignItems: 'center',

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -17,6 +17,10 @@ import { router } from 'expo-router';
 import { Feather, Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { useEventDetailViewModel } from '@/viewmodels/event/useEventDetailViewModel';
 import { formatEventDateLabel, getAutoCompletionDaysLeft } from '@/utils/eventDate';
+import {
+  formatEventStatusLabel,
+  getEventStatusBadgeColors,
+} from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
 import { EventDetail } from '@/models/event';
 import JoinRequestsModal from '@/components/events/JoinRequestsModal';
@@ -45,23 +49,22 @@ function PrivacyBadge({ level }: { level: EventDetail['privacy_level'] }) {
 
 function StatusBadge({ status }: { status: string }) {
   if (status === 'ACTIVE') return null;
-  const isCanceled = status === 'CANCELED';
-  const isInProgress = status === 'IN_PROGRESS';
-  
-  if (isInProgress) {
-    return (
-      <View style={[styles.badge, styles.badgeInProgress]}>
-        <Text style={[styles.badgeText, styles.badgeTextInProgress]}>
-          In Progress
-        </Text>
-      </View>
-    );
-  }
+  const statusColors = getEventStatusBadgeColors(status);
 
   return (
-    <View style={[styles.badge, isCanceled ? styles.badgeCanceled : styles.badgeCompleted]}>
-      <Text style={[styles.badgeText, isCanceled ? styles.badgeTextCanceled : styles.badgeTextCompleted]}>
-        {isCanceled ? 'Canceled' : 'Completed'}
+    <View
+      style={[
+        styles.badge,
+        { backgroundColor: statusColors.backgroundColor },
+      ]}
+    >
+      <Text
+        style={[
+          styles.badgeText,
+          { color: statusColors.textColor },
+        ]}
+      >
+        {formatEventStatusLabel(status)}
       </Text>
     </View>
   );
@@ -149,7 +152,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
     if (status_ === 'INVITED') {
       return (
         <View style={styles.statusChip}>
-          <Feather name="mail" size={16} color="#2563EB" />
+          <Feather name="mail" size={16} color="#111827" />
           <Text style={styles.statusChipTextBlue}>You&apos;re invited</Text>
         </View>
       );
@@ -215,7 +218,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
   if (vm.isLoading) {
     return (
       <SafeAreaView style={styles.centeredScreen}>
-        <ActivityIndicator size="large" color="#2563EB" />
+        <ActivityIndicator size="large" color="#111827" />
       </SafeAreaView>
     );
   }
@@ -691,15 +694,6 @@ const styles = StyleSheet.create({
   badgeProtected: {
     backgroundColor: '#FEF3C7',
   },
-  badgeCanceled: {
-    backgroundColor: '#FEE2E2',
-  },
-  badgeCompleted: {
-    backgroundColor: '#F3F4F6',
-  },
-  badgeInProgress: {
-    backgroundColor: '#FEF3C7',
-  },
   badgeText: {
     fontSize: 12,
     fontWeight: '700',
@@ -709,15 +703,6 @@ const styles = StyleSheet.create({
   },
   badgeTextProtected: {
     color: '#92400E',
-  },
-  badgeTextCanceled: {
-    color: '#991B1B',
-  },
-  badgeTextCompleted: {
-    color: '#374151',
-  },
-  badgeTextInProgress: {
-    color: '#B45309',
   },
 
   /* Section */
@@ -742,7 +727,7 @@ const styles = StyleSheet.create({
   /* Category chip */
   categoryChip: {
     alignSelf: 'flex-start',
-    backgroundColor: '#EFF6FF',
+    backgroundColor: 'rgba(15, 23, 42, 0.72)',
     paddingHorizontal: 12,
     paddingVertical: 4,
     borderRadius: 999,
@@ -751,7 +736,7 @@ const styles = StyleSheet.create({
   categoryChipText: {
     fontSize: 12,
     fontWeight: '700',
-    color: '#2563EB',
+    color: '#FFFFFF',
   },
 
   /* Event title */
@@ -884,7 +869,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: 8,
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
     borderRadius: 14,
     paddingVertical: 15,
   },
@@ -988,7 +973,7 @@ const styles = StyleSheet.create({
     lineHeight: 20,
   },
   retryButton: {
-    backgroundColor: '#2563EB',
+    backgroundColor: '#111827',
     paddingHorizontal: 28,
     paddingVertical: 12,
     borderRadius: 10,
@@ -1003,7 +988,7 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   backLinkText: {
-    color: '#2563EB',
+    color: '#111827',
     fontSize: 15,
     fontWeight: '600',
   },
@@ -1126,8 +1111,8 @@ const styles = StyleSheet.create({
     borderColor: '#E5E7EB',
   },
   hostActionBtnPrimary: {
-    backgroundColor: '#3B82F6',
-    borderColor: '#2563EB',
+    backgroundColor: '#111827',
+    borderColor: '#111827',
   },
   hostActionBtnDanger: {
     backgroundColor: '#FEF2F2',

--- a/mobile/src/views/events/MyEventsView.tsx
+++ b/mobile/src/views/events/MyEventsView.tsx
@@ -32,7 +32,7 @@ function StatePanel({
   return (
     <View style={styles.statePanel}>
       <View style={styles.stateIcon}>
-        <Feather name={icon} size={24} color="#2563EB" />
+        <Feather name={icon} size={24} color="#111827" />
       </View>
       <Text style={styles.stateTitle}>{title}</Text>
       <Text style={styles.stateSubtitle}>{subtitle}</Text>
@@ -99,7 +99,7 @@ export default function MyEventsView() {
         <View style={styles.content}>
           {vm.isLoading ? (
             <View style={styles.loadingPanel}>
-              <ActivityIndicator size="large" color="#2563EB" />
+              <ActivityIndicator size="large" color="#111827" />
               <Text style={styles.loadingText}>Loading your events...</Text>
             </View>
           ) : vm.errorMessage ? (
@@ -225,7 +225,7 @@ const styles = StyleSheet.create({
     color: '#94A3B8',
   },
   tabCountActive: {
-    color: '#2563EB',
+    color: '#111827',
   },
   content: {
     flex: 1,

--- a/mobile/src/views/favorites/FavoriteEventsTab.tsx
+++ b/mobile/src/views/favorites/FavoriteEventsTab.tsx
@@ -58,7 +58,7 @@ export default function FavoriteEventsTab() {
         ListFooterComponent={
           vm.isLoadingMore ? (
             <View style={styles.footerLoader}>
-              <ActivityIndicator size="small" color="#2563EB" />
+              <ActivityIndicator size="small" color="#111827" />
             </View>
           ) : null
         }

--- a/mobile/src/views/favorites/FavoriteLocationsTab.test.tsx
+++ b/mobile/src/views/favorites/FavoriteLocationsTab.test.tsx
@@ -9,14 +9,42 @@ import { useFavoriteLocationsViewModel } from '@/viewmodels/favorites/useFavorit
 
 jest.mock('react-native', () => {
   const ReactLocal = require('react');
+  const reactNativeOnlyProps = new Set([
+    'accessibilityLabel',
+    'activeOpacity',
+    'contentContainerStyle',
+    'hitSlop',
+    'keyboardShouldPersistTaps',
+    'numberOfLines',
+    'placeholderTextColor',
+  ]);
+
+  const stripReactNativeOnlyProps = (props: Record<string, unknown>) => {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(props)) {
+      if (!reactNativeOnlyProps.has(key)) {
+        out[key] = props[key];
+      }
+    }
+    return out;
+  };
+
   const createDiv =
     (displayName: string) =>
       ({ children, ...props }: { children?: React.ReactNode }) =>
-        ReactLocal.createElement('div', { ...props, 'data-testid': displayName }, children);
+        ReactLocal.createElement(
+          'div',
+          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          children,
+        );
   const createSpan =
     (displayName: string) =>
       ({ children, ...props }: { children?: React.ReactNode }) =>
-        ReactLocal.createElement('span', { ...props, 'data-testid': displayName }, children);
+        ReactLocal.createElement(
+          'span',
+          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          children,
+        );
 
   return {
     ActivityIndicator: createDiv('ActivityIndicator'),
@@ -33,7 +61,7 @@ jest.mock('react-native', () => {
       onChangeText?: (value: string) => void;
     }) =>
       ReactLocal.createElement('input', {
-        ...props,
+        ...stripReactNativeOnlyProps(props),
         value,
         onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
           onChangeText?.(event.target.value),
@@ -51,7 +79,7 @@ jest.mock('react-native', () => {
       ReactLocal.createElement(
         'button',
         {
-          ...props,
+          ...stripReactNativeOnlyProps(props),
           type: 'button',
           disabled,
           onClick: onPress,

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -96,7 +96,7 @@ export default function HomeView() {
               ListFooterComponent={
                 vm.isLoadingMore ? (
                   <View style={styles.footerLoader}>
-                    <ActivityIndicator size="small" color="#2563EB" />
+                    <ActivityIndicator size="small" color="#111827" />
                   </View>
                 ) : null
               }

--- a/mobile/src/views/profile/EditProfileView.tsx
+++ b/mobile/src/views/profile/EditProfileView.tsx
@@ -215,7 +215,7 @@ export default function EditProfileView() {
               {vm.isSearchingLocation ? (
                 <ActivityIndicator
                   size="small"
-                  color="#2563EB"
+                  color="#111827"
                   style={styles.searchSpinner}
                 />
               ) : null}


### PR DESCRIPTION
## 📋 Summary

Aligns the mobile app’s remaining accent colors with the established black/white theme so the experience feels visually consistent across auth, create event, home, filters, profile-related, and event detail flows, while preserving semantic colors for privacy, status, success, warning, and destructive actions.

## 🔄 Changes

- Updated `LoginView`, `RegisterView`, and `ForgotPasswordView` to replace blue buttons, links, and step accents with black/white theme equivalents.
- Updated `CreateEventView` to replace blue action, selection, helper, and loading accents with black/white theme colors.
- Updated `FiltersBottomSheet` and related “Show more” actions to match the same black/white accent direction.
- Updated the home loading spinner to use the shared dark accent instead of blue.
- Updated non-semantic blue accents in `EventDetailView` to match the black/white theme while preserving privacy and status colors.
- Aligned the event detail status badge presentation with the shared mobile status helper so event status colors are consistent with the profile flow.
- Cleaned up the `FavoriteLocationsTab` test-only React Native mock so jsdom warnings from RN-only props no longer appear, without changing app behavior.

## 🧪 Testing

**Automated**
```bash
cd mobile
npm test

```

**Manual**
- Open Login, Register, and Forgot Password screens and confirm buttons/links use the black/white theme.
- Open Create Event and confirm buttons, chips, helper actions, and loading indicators no longer use blue accents.
- Open Home and verify the loading spinner uses the updated dark accent.
- Open filter bottom sheet and confirm “Show more” and related accent text match the black/white theme.
- Open Event Detail and verify non-status/non-privacy blue accents are removed while privacy/status badge colors remain semantic and consistent.
- Verify no interaction or navigation behavior changed during these style updates.

🔗 Related
Closes #354
