### PR TITLE
feat(backend): expose event status in discovery and exclude IN_PROGRESS

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -235,7 +235,7 @@ func buildRouteWKT(points []domain.GeoPoint) string {
 	return "SRID=4326;LINESTRING(" + strings.Join(segments, ", ") + ")"
 }
 
-// ListDiscoverableEvents returns nearby ACTIVE PUBLIC/PROTECTED events using
+// ListDiscoverableEvents returns nearby ACTIVE (not IN_PROGRESS) PUBLIC/PROTECTED events using
 // combined full-text search, structured filters, and keyset pagination.
 func (r *EventRepository) ListDiscoverableEvents(
 	ctx context.Context,
@@ -251,7 +251,8 @@ func (r *EventRepository) ListDiscoverableEvents(
 	lonPlaceholder := addArg(params.Origin.Lon)
 	latPlaceholder := addArg(params.Origin.Lat)
 	userPlaceholder := addArg(userID)
-	statusPlaceholder := addArg([]string{string(domain.EventStatusActive), string(domain.EventStatusInProgress)})
+	// Discovery lists joinable upcoming events only (ACTIVE), not IN_PROGRESS.
+	statusPlaceholder := addArg([]string{string(domain.EventStatusActive)})
 	privacyPlaceholder := addArg(toPrivacyLevelStringSlice(params.PrivacyLevels))
 	radiusPlaceholder := addArg(params.RadiusMeters)
 
@@ -337,6 +338,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 				COALESCE(ec.name, '') AS category_name,
 				e.image_url,
 				e.start_time,
+				e.status,
 				el.address AS location_address,
 				e.privacy_level,
 				e.approved_participant_count,
@@ -359,6 +361,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			category_name,
 			image_url,
 			start_time,
+			status,
 			location_address,
 			privacy_level,
 			approved_participant_count,
@@ -388,6 +391,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			categoryName             string
 			imageURL                 pgtype.Text
 			startTime                time.Time
+			eventStatus              string
 			locationAddress          pgtype.Text
 			privacyLevel             string
 			approvedParticipantCount int
@@ -405,6 +409,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			&categoryName,
 			&imageURL,
 			&startTime,
+			&eventStatus,
 			&locationAddress,
 			&privacyLevel,
 			&approvedParticipantCount,
@@ -423,6 +428,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			Title:                    title,
 			CategoryName:             categoryName,
 			StartTime:                startTime,
+			Status:                   domain.EventStatus(eventStatus),
 			PrivacyLevel:             domain.EventPrivacyLevel(privacyLevel),
 			ApprovedParticipantCount: approvedParticipantCount,
 			FavoriteCount:            favoriteCount,

--- a/backend/internal/application/event/helpers.go
+++ b/backend/internal/application/event/helpers.go
@@ -71,6 +71,7 @@ func toDiscoverableEventItem(record DiscoverableEventRecord) DiscoverableEventIt
 		CategoryName:             record.CategoryName,
 		ImageURL:                 record.ImageURL,
 		StartTime:                record.StartTime,
+		Status:                   string(record.Status),
 		LocationAddress:          record.LocationAddress,
 		PrivacyLevel:             string(record.PrivacyLevel),
 		ApprovedParticipantCount: record.ApprovedParticipantCount,

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -62,6 +62,7 @@ type DiscoverableEventRecord struct {
 	CategoryName             string
 	ImageURL                 *string
 	StartTime                time.Time
+	Status                   domain.EventStatus
 	LocationAddress          *string
 	PrivacyLevel             domain.EventPrivacyLevel
 	ApprovedParticipantCount int

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -80,6 +80,7 @@ type DiscoverableEventItem struct {
 	CategoryName             string                `json:"category_name"`
 	ImageURL                 *string               `json:"image_url"`
 	StartTime                time.Time             `json:"start_time"`
+	Status                   string                `json:"status"`
 	LocationAddress          *string               `json:"location_address"`
 	PrivacyLevel             string                `json:"privacy_level"`
 	ApprovedParticipantCount int                   `json:"approved_participant_count"`

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -907,6 +907,7 @@ func TestDiscoverEventsAppliesDefaultsAndMapsResults(t *testing.T) {
 			CategoryName:             "Sports",
 			ImageURL:                 &imageURL,
 			StartTime:                startTime,
+			Status:                   domain.EventStatusActive,
 			LocationAddress:          &address,
 			PrivacyLevel:             domain.PrivacyPublic,
 			ApprovedParticipantCount: 7,
@@ -956,6 +957,9 @@ func TestDiscoverEventsAppliesDefaultsAndMapsResults(t *testing.T) {
 	}
 	if result.Items[0].CategoryName != "Sports" {
 		t.Fatalf("expected category name %q, got %q", "Sports", result.Items[0].CategoryName)
+	}
+	if result.Items[0].Status != string(domain.EventStatusActive) {
+		t.Fatalf("expected status %q, got %q", domain.EventStatusActive, result.Items[0].Status)
 	}
 	if !result.Items[0].IsFavorited {
 		t.Fatal("expected event to be favorited")
@@ -1105,6 +1109,7 @@ func TestDiscoverEventsBuildsNextCursorFromLastReturnedItem(t *testing.T) {
 		Title:                    "First Event",
 		CategoryName:             "Sports",
 		StartTime:                time.Date(2030, time.January, 1, 18, 0, 0, 0, time.UTC),
+		Status:                   domain.EventStatusActive,
 		PrivacyLevel:             domain.PrivacyPublic,
 		ApprovedParticipantCount: 5,
 		DistanceMeters:           100,
@@ -1114,6 +1119,7 @@ func TestDiscoverEventsBuildsNextCursorFromLastReturnedItem(t *testing.T) {
 		Title:                    "Second Event",
 		CategoryName:             "Sports",
 		StartTime:                time.Date(2030, time.January, 2, 18, 0, 0, 0, time.UTC),
+		Status:                   domain.EventStatusActive,
 		PrivacyLevel:             domain.PrivacyPublic,
 		ApprovedParticipantCount: 6,
 		DistanceMeters:           200,

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -1978,6 +1978,7 @@ components:
         - title
         - category_name
         - start_time
+        - status
         - privacy_level
         - approved_participant_count
         - favorite_count
@@ -2008,6 +2009,11 @@ components:
           format: date-time
           description: Event start time.
           example: "2026-05-01T08:00:00+03:00"
+        status:
+          type: string
+          description: Event lifecycle state. The discovery endpoint returns only ACTIVE events (not IN_PROGRESS).
+          enum: [ACTIVE]
+          example: ACTIVE
         location_address:
           type:
             - string


### PR DESCRIPTION
## 📋 Summary

Exposes `status` on each item returned by `GET /events` (discovery) so clients can rely on the API instead of inferring lifecycle from timestamps. Discovery results are restricted to **ACTIVE** events only, so **IN_PROGRESS** events no longer appear in the default discovery list (aligns with mobile filtering in #327).

## 🔄 Changes

- Add `status` to `DiscoverableEventRecord`, `DiscoverableEventItem`, and the discovery SQL projection.
- Restrict the discovery query to `ACTIVE` events only (exclude `IN_PROGRESS` from discovery).
- Map `status` in `toDiscoverableEventItem` and extend unit tests.
- Update `docs/openapi/event.yaml` for `DiscoverEventItem.status` and discovery behavior.

## 🧪 Testing

- `go test ./internal/application/event/... ./internal/adapter/in/postgres/... ./internal/adapter/out/httpapi/event_handler/...`

## 🔗 Related

Closes #352