### PR TITLE
feat(backend): add privacy_level and location_address to favorite events endpoint

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -1554,9 +1554,10 @@ func (r *EventRepository) RemoveFavorite(ctx context.Context, userID, eventID uu
 func (r *EventRepository) ListFavoriteEvents(ctx context.Context, userID uuid.UUID) ([]eventapp.FavoriteEventRecord, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT e.id, e.title, ec.name, e.image_url, e.status,
-		       e.start_time, e.end_time, fav.created_at
+		       e.privacy_level, el.address, e.start_time, e.end_time, fav.created_at
 		FROM favorite_event fav
 		JOIN event e ON e.id = fav.event_id
+		JOIN event_location el ON el.event_id = e.id
 		LEFT JOIN event_category ec ON ec.id = e.category_id
 		WHERE fav.user_id = $1
 		ORDER BY fav.created_at DESC
@@ -1569,17 +1570,23 @@ func (r *EventRepository) ListFavoriteEvents(ctx context.Context, userID uuid.UU
 	var records []eventapp.FavoriteEventRecord
 	for rows.Next() {
 		var (
-			r       eventapp.FavoriteEventRecord
-			status  string
-			catName *string
-			endTime pgtype.Timestamptz
+			r               eventapp.FavoriteEventRecord
+			status          string
+			privacyLevel    string
+			catName         *string
+			locationAddress pgtype.Text
+			endTime         pgtype.Timestamptz
 		)
 		if err := rows.Scan(&r.ID, &r.Title, &catName, &r.ImageURL, &status,
-			&r.StartTime, &endTime, &r.FavoritedAt); err != nil {
+			&privacyLevel, &locationAddress, &r.StartTime, &endTime, &r.FavoritedAt); err != nil {
 			return nil, fmt.Errorf("scan favorite event: %w", err)
 		}
 		r.Status = domain.EventStatus(status)
+		r.PrivacyLevel = domain.EventPrivacyLevel(privacyLevel)
 		r.CategoryName = catName
+		if locationAddress.Valid {
+			r.LocationAddress = &locationAddress.String
+		}
 		if endTime.Valid {
 			r.EndTime = &endTime.Time
 		}

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -85,14 +85,16 @@ type DiscoverEventsCursor struct {
 
 // FavoriteEventRecord is the repository-level projection for favorite event listings.
 type FavoriteEventRecord struct {
-	ID           uuid.UUID
-	Title        string
-	CategoryName *string
-	ImageURL     *string
-	Status       domain.EventStatus
-	StartTime    time.Time
-	EndTime      *time.Time
-	FavoritedAt  time.Time
+	ID              uuid.UUID
+	Title           string
+	CategoryName    *string
+	ImageURL        *string
+	Status          domain.EventStatus
+	PrivacyLevel    domain.EventPrivacyLevel
+	LocationAddress *string
+	StartTime       time.Time
+	EndTime         *time.Time
+	FavoritedAt     time.Time
 }
 
 // EventDetailRecord is the repository-level projection used for event detail responses.

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -393,14 +393,16 @@ func (s *Service) ListFavoriteEvents(ctx context.Context, userID uuid.UUID) (*Fa
 	items := make([]FavoriteEventItem, len(records))
 	for i, r := range records {
 		items[i] = FavoriteEventItem{
-			ID:          r.ID.String(),
-			Title:       r.Title,
-			Category:    r.CategoryName,
-			ImageURL:    r.ImageURL,
-			Status:      string(r.Status),
-			StartTime:   r.StartTime,
-			EndTime:     r.EndTime,
-			FavoritedAt: r.FavoritedAt,
+			ID:              r.ID.String(),
+			Title:           r.Title,
+			Category:        r.CategoryName,
+			ImageURL:        r.ImageURL,
+			Status:          string(r.Status),
+			PrivacyLevel:    string(r.PrivacyLevel),
+			LocationAddress: r.LocationAddress,
+			StartTime:       r.StartTime,
+			EndTime:         r.EndTime,
+			FavoritedAt:     r.FavoritedAt,
 		}
 	}
 

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -239,14 +239,16 @@ type EventDetailInvitation struct {
 
 // FavoriteEventItem is the compact event summary returned by the favorites list.
 type FavoriteEventItem struct {
-	ID          string     `json:"id"`
-	Title       string     `json:"title"`
-	Category    *string    `json:"category"`
-	ImageURL    *string    `json:"image_url"`
-	Status      string     `json:"status"`
-	StartTime   time.Time  `json:"start_time"`
-	EndTime     *time.Time `json:"end_time"`
-	FavoritedAt time.Time  `json:"favorited_at"`
+	ID              string     `json:"id"`
+	Title           string     `json:"title"`
+	Category        *string    `json:"category"`
+	ImageURL        *string    `json:"image_url"`
+	Status          string     `json:"status"`
+	PrivacyLevel    string     `json:"privacy_level"`
+	LocationAddress *string    `json:"location_address"`
+	StartTime       time.Time  `json:"start_time"`
+	EndTime         *time.Time `json:"end_time"`
+	FavoritedAt     time.Time  `json:"favorited_at"`
 }
 
 // FavoriteEventsResult wraps a list of favorite event items.

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -37,6 +37,7 @@ type fakeEventRepo struct {
 	discoverErr        error
 	detailErr          error
 	events             map[uuid.UUID]*domain.Event
+	favoriteRecords    []FavoriteEventRecord
 	discoverRecords    []DiscoverableEventRecord
 	detailRecord       *EventDetailRecord
 	discoverCallCount  int
@@ -126,7 +127,10 @@ func (r *fakeEventRepo) RemoveFavorite(_ context.Context, _, _ uuid.UUID) error 
 }
 
 func (r *fakeEventRepo) ListFavoriteEvents(_ context.Context, _ uuid.UUID) ([]FavoriteEventRecord, error) {
-	return nil, r.err
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.favoriteRecords, nil
 }
 
 func (r *fakeEventRepo) ListDiscoverableEvents(_ context.Context, userID uuid.UUID, params DiscoverEventsParams) ([]DiscoverableEventRecord, error) {
@@ -969,6 +973,55 @@ func TestDiscoverEventsAppliesDefaultsAndMapsResults(t *testing.T) {
 	}
 	if result.PageInfo.NextCursor != nil {
 		t.Fatalf("expected nil next_cursor, got %v", result.PageInfo.NextCursor)
+	}
+}
+
+func TestListFavoriteEventsMapsPrivacyLevelAndLocationAddress(t *testing.T) {
+	// given
+	svc, eventRepo, _, _ := newTestEventService()
+	category := "Music"
+	imageURL := "https://example.com/favorite.jpg"
+	locationAddress := "Kadikoy, Istanbul"
+	startTime := time.Date(2030, time.January, 2, 18, 0, 0, 0, time.UTC)
+	endTime := time.Date(2030, time.January, 2, 21, 0, 0, 0, time.UTC)
+	favoritedAt := time.Date(2030, time.January, 1, 12, 0, 0, 0, time.UTC)
+	eventID := uuid.New()
+
+	eventRepo.favoriteRecords = []FavoriteEventRecord{
+		{
+			ID:              eventID,
+			Title:           "Sunset Concert",
+			CategoryName:    &category,
+			ImageURL:        &imageURL,
+			Status:          domain.EventStatusActive,
+			PrivacyLevel:    domain.PrivacyProtected,
+			LocationAddress: &locationAddress,
+			StartTime:       startTime,
+			EndTime:         &endTime,
+			FavoritedAt:     favoritedAt,
+		},
+	}
+
+	// when
+	result, err := svc.ListFavoriteEvents(context.Background(), uuid.New())
+
+	// then
+	if err != nil {
+		t.Fatalf("ListFavoriteEvents() error = %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result.Items))
+	}
+
+	item := result.Items[0]
+	if item.ID != eventID.String() {
+		t.Fatalf("expected id %s, got %s", eventID, item.ID)
+	}
+	if item.PrivacyLevel != string(domain.PrivacyProtected) {
+		t.Fatalf("expected privacy_level %q, got %q", domain.PrivacyProtected, item.PrivacyLevel)
+	}
+	if item.LocationAddress == nil || *item.LocationAddress != locationAddress {
+		t.Fatalf("expected location_address %q, got %v", locationAddress, item.LocationAddress)
 	}
 }
 

--- a/backend/internal/application/profile/service.go
+++ b/backend/internal/application/profile/service.go
@@ -45,7 +45,7 @@ func (s *Service) GetMyProfile(ctx context.Context, userID uuid.UUID) (*GetProfi
 		DisplayName:            p.DisplayName,
 		Bio:                    p.Bio,
 		AvatarURL:              p.AvatarURL,
-		FinalScore: p.FinalScore,
+		FinalScore:             p.FinalScore,
 		HostScore: &HostScore{
 			Score:       p.HostScore.Score,
 			RatingCount: p.HostScore.RatingCount,

--- a/backend/internal/application/profile/service_dto.go
+++ b/backend/internal/application/profile/service_dto.go
@@ -30,17 +30,17 @@ type ParticipantScore struct {
 
 // GetProfileResult is the output of the GetMyProfile use case.
 type GetProfileResult struct {
-	ID                     string     `json:"id"`
-	Username               string     `json:"username"`
-	Email                  string     `json:"email"`
-	PhoneNumber            *string    `json:"phone_number"`
-	Gender                 *string    `json:"gender"`
-	BirthDate              *string    `json:"birth_date"`
-	EmailVerified          bool       `json:"email_verified"`
-	Status                 string     `json:"status"`
-	DefaultLocationAddress *string    `json:"default_location_address"`
-	DefaultLocationLat     *float64   `json:"default_location_lat"`
-	DefaultLocationLon     *float64   `json:"default_location_lon"`
+	ID                     string            `json:"id"`
+	Username               string            `json:"username"`
+	Email                  string            `json:"email"`
+	PhoneNumber            *string           `json:"phone_number"`
+	Gender                 *string           `json:"gender"`
+	BirthDate              *string           `json:"birth_date"`
+	EmailVerified          bool              `json:"email_verified"`
+	Status                 string            `json:"status"`
+	DefaultLocationAddress *string           `json:"default_location_address"`
+	DefaultLocationLat     *float64          `json:"default_location_lat"`
+	DefaultLocationLon     *float64          `json:"default_location_lon"`
 	DisplayName            *string           `json:"display_name"`
 	Bio                    *string           `json:"bio"`
 	AvatarURL              *string           `json:"avatar_url"`

--- a/backend/internal/application/profile/service_test.go
+++ b/backend/internal/application/profile/service_test.go
@@ -19,13 +19,13 @@ func (u *fakeUnitOfWork) RunInTx(ctx context.Context, fn func(ctx context.Contex
 }
 
 type fakeProfileRepo struct {
-	profile       *domain.UserProfile
-	profileErr    error
-	hostedEvents  []domain.EventSummary
-	upcomingEvents []domain.EventSummary
+	profile         *domain.UserProfile
+	profileErr      error
+	hostedEvents    []domain.EventSummary
+	upcomingEvents  []domain.EventSummary
 	completedEvents []domain.EventSummary
 	canceledEvents  []domain.EventSummary
-	eventsErr      error
+	eventsErr       error
 }
 
 func (r *fakeProfileRepo) GetProfile(_ context.Context, _ uuid.UUID) (*domain.UserProfile, error) {
@@ -62,10 +62,10 @@ func TestGetMyProfileMapsHostScore(t *testing.T) {
 	score := 4.5
 	repo := &fakeProfileRepo{
 		profile: &domain.UserProfile{
-			ID:       uuid.New(),
-			Username: "testuser",
-			Email:    "test@example.com",
-			Status:   domain.UserStatusActive,
+			ID:         uuid.New(),
+			Username:   "testuser",
+			Email:      "test@example.com",
+			Status:     domain.UserStatusActive,
 			FinalScore: &score,
 			HostScore: domain.HostScore{
 				Score:       &score,

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -33,8 +33,8 @@ type EventSummary struct {
 
 // HostScore holds the cached rating summary for a user acting as an event host.
 type HostScore struct {
-	Score                  *float64
-	RatingCount            int
+	Score       *float64
+	RatingCount int
 }
 
 // ParticipantScore holds the cached rating summary for a user acting as a participant.

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -3332,42 +3332,72 @@ func TestAddAndRemoveFavorite(t *testing.T) {
 	harness := common.NewEventHarness(t)
 	user := common.GivenUser(t, harness.AuthRepo)
 	host := common.GivenUser(t, harness.AuthRepo)
-	ref := common.GivenPublicEvent(t, harness.Service, host.ID)
+	categoryID := common.GivenEventCategory(t)
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	lat := 41.0082
+	lon := 28.9784
+	locationAddress := "Kadikoy, Istanbul"
+
+	result, err := harness.Service.CreateEvent(context.Background(), host.ID, eventapp.CreateEventInput{
+		Title:        "Favorite Event Metadata",
+		Description:  common.StringPtr("A favorited event with metadata"),
+		CategoryID:   &categoryID,
+		LocationType: domain.LocationPoint,
+		Address:      common.StringPtr(locationAddress),
+		Lat:          &lat,
+		Lon:          &lon,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyProtected,
+	})
+	if err != nil {
+		t.Fatalf("CreateEvent() error = %v", err)
+	}
+
+	eventID, err := uuid.Parse(result.ID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() error = %v", err)
+	}
 
 	// when: add favorite
-	err := harness.EventRepo.AddFavorite(context.Background(), user.ID, ref.ID)
+	err = harness.EventRepo.AddFavorite(context.Background(), user.ID, eventID)
 	if err != nil {
 		t.Fatalf("AddFavorite() error = %v", err)
 	}
 
-	// then: appears in favorites list
-	favs, err := harness.EventRepo.ListFavoriteEvents(context.Background(), user.ID)
+	// then: appears in favorites list with the required event metadata
+	favs, err := harness.Service.ListFavoriteEvents(context.Background(), user.ID)
 	if err != nil {
 		t.Fatalf("ListFavoriteEvents() error = %v", err)
 	}
-	if len(favs) != 1 || favs[0].ID != ref.ID {
-		t.Fatalf("expected 1 favorite with ID %s, got %d items", ref.ID, len(favs))
+	if len(favs.Items) != 1 || favs.Items[0].ID != eventID.String() {
+		t.Fatalf("expected 1 favorite with ID %s, got %d items", eventID, len(favs.Items))
+	}
+	if favs.Items[0].PrivacyLevel != string(domain.PrivacyProtected) {
+		t.Fatalf("expected privacy_level %q, got %q", domain.PrivacyProtected, favs.Items[0].PrivacyLevel)
+	}
+	if favs.Items[0].LocationAddress == nil || *favs.Items[0].LocationAddress != locationAddress {
+		t.Fatalf("expected location_address %q, got %v", locationAddress, favs.Items[0].LocationAddress)
 	}
 
 	// when: add again (idempotent)
-	err = harness.EventRepo.AddFavorite(context.Background(), user.ID, ref.ID)
+	err = harness.EventRepo.AddFavorite(context.Background(), user.ID, eventID)
 	if err != nil {
 		t.Fatalf("AddFavorite() duplicate error = %v", err)
 	}
 
 	// when: remove favorite
-	err = harness.EventRepo.RemoveFavorite(context.Background(), user.ID, ref.ID)
+	err = harness.EventRepo.RemoveFavorite(context.Background(), user.ID, eventID)
 	if err != nil {
 		t.Fatalf("RemoveFavorite() error = %v", err)
 	}
 
 	// then: no longer in favorites
-	favs, err = harness.EventRepo.ListFavoriteEvents(context.Background(), user.ID)
+	favs, err = harness.Service.ListFavoriteEvents(context.Background(), user.ID)
 	if err != nil {
 		t.Fatalf("ListFavoriteEvents() after remove error = %v", err)
 	}
-	if len(favs) != 0 {
-		t.Fatalf("expected 0 favorites after remove, got %d", len(favs))
+	if len(favs.Items) != 0 {
+		t.Fatalf("expected 0 favorites after remove, got %d", len(favs.Items))
 	}
 }
 

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -2775,7 +2775,7 @@ components:
     FavoriteEventItem:
       type: object
       additionalProperties: false
-      required: [id, title, status, start_time, favorited_at]
+      required: [id, title, status, privacy_level, location_address, start_time, favorited_at]
       properties:
         id:
           type: string
@@ -2794,6 +2794,17 @@ components:
           type: string
           description: Event status, for example `ACTIVE`, `IN_PROGRESS`, `CANCELED`, or `COMPLETED`.
           example: ACTIVE
+        privacy_level:
+          type: string
+          enum: [PUBLIC, PROTECTED, PRIVATE]
+          description: Current stored event visibility level.
+          example: PUBLIC
+        location_address:
+          type:
+            - string
+            - "null"
+          description: Optional human-readable location address stored for the event.
+          example: Kadikoy, Istanbul
         start_time:
           type: string
           format: date-time


### PR DESCRIPTION
## 📋 Summary
`GET /api/me/favorites` response now includes `privacy_level` and `location_address`. This allows the mobile client to render favorite event cards correctly without making additional detail requests.

## 🔄 Changes
- Updated favorites listing query to include `privacy_level` and `location_address` in the response projection.
- Updated backend service/DTO layer; `GET /api/me/favorites` now returns for each item:
  - `privacy_level`
  - `location_address`
- Updated favorites response schema in `docs/openapi/event.yaml`.
- Added unit test: validates `privacy_level` and `location_address` in favorites mapping.
- Updated integration test: verifies new fields are correctly returned for a favorited event.
- Applied `gofmt` formatting only (per `shipcheck`) to some unrelated profile files.

## 🧪 Testing
- `cd backend && go test ./internal/application/event`
- `cd backend && go test -tags=integration ./tests_integration -run TestAddAndRemoveFavorite`
- `cd backend && ./shipcheck.sh`

## 🔗 Related
Closes #369