### PR TITLE
fix(mobile): use dedicated favorites endpoint for favorite events

### DIFF
--- a/mobile/src/components/profile/ProfileEventCard.tsx
+++ b/mobile/src/components/profile/ProfileEventCard.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from 'react-native';
 import { formatEventDateLabel } from '@/utils/eventDate';
+import { formatEventLocation } from '@/utils/eventLocation';
 import {
   formatEventStatusLabel,
   getEventStatusBadgeColors,
@@ -18,6 +19,7 @@ interface ProfileEventCardProps {
   imageUrl?: string | null;
   categoryLabel: string;
   startTime: string;
+  locationAddress?: string | null;
   status: string;
   privacyLevel: 'PUBLIC' | 'PROTECTED' | 'PRIVATE' | null;
   onPress: () => void;
@@ -32,6 +34,7 @@ export default function ProfileEventCard({
   imageUrl,
   categoryLabel,
   startTime,
+  locationAddress,
   status,
   privacyLevel,
   onPress,
@@ -128,11 +131,22 @@ export default function ProfileEventCard({
           {title}
         </Text>
 
-        <View style={styles.metaRow}>
-          <Feather name="clock" size={16} color="#6B7280" />
-          <Text style={styles.metaText}>
-            {formatEventDateLabel(startTime)}
-          </Text>
+        <View style={styles.metaGroup}>
+          {locationAddress ? (
+            <View style={styles.metaRow}>
+              <Feather name="map-pin" size={16} color="#6B7280" />
+              <Text style={styles.metaText}>
+                {formatEventLocation(locationAddress)}
+              </Text>
+            </View>
+          ) : null}
+
+          <View style={styles.metaRow}>
+            <Feather name="clock" size={16} color="#6B7280" />
+            <Text style={styles.metaText}>
+              {formatEventDateLabel(startTime)}
+            </Text>
+          </View>
         </View>
       </View>
     </TouchableOpacity>
@@ -244,6 +258,9 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: '#111827',
     marginBottom: 10,
+  },
+  metaGroup: {
+    gap: 8,
   },
   metaRow: {
     flexDirection: 'row',

--- a/mobile/src/env.d.ts
+++ b/mobile/src/env.d.ts
@@ -39,3 +39,9 @@ declare module 'expo-image-manipulator' {
     saveOptions: { compress?: number; format?: string },
   ): Promise<{ uri: string }>;
 }
+
+declare module 'expo-secure-store' {
+  export function getItemAsync(key: string): Promise<string | null>;
+  export function setItemAsync(key: string, value: string): Promise<void>;
+  export function deleteItemAsync(key: string): Promise<void>;
+}

--- a/mobile/src/models/favorite.ts
+++ b/mobile/src/models/favorite.ts
@@ -1,8 +1,12 @@
+import type { PrivacyLevel } from '@/models/event';
+
 export interface FavoriteEventItem {
   id: string;
   title: string;
   category?: string | null;
   image_url?: string | null;
+  location_address?: string | null;
+  privacy_level?: PrivacyLevel | null;
   status: string;
   start_time: string;
   end_time?: string | null;

--- a/mobile/src/viewmodels/favorites/useFavoriteEventsViewModel.test.tsx
+++ b/mobile/src/viewmodels/favorites/useFavoriteEventsViewModel.test.tsx
@@ -1,13 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook, act, waitFor } from '@testing-library/react';
-import * as eventService from '@/services/eventService';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { ApiError } from '@/services/api';
 import * as favoriteService from '@/services/favoriteService';
-import type { EventSummary, PaginatedEventsResponse } from '@/models/event';
+import type { FavoriteEventItem, FavoriteEventsResponse } from '@/models/favorite';
 import { useFavoriteEventsViewModel } from './useFavoriteEventsViewModel';
 
-jest.mock('@/services/eventService');
 jest.mock('@/services/favoriteService');
 jest.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -18,103 +17,76 @@ jest.mock('@/contexts/AuthContext', () => ({
   }),
 }));
 
-const mockListEvents = jest.mocked(eventService.listEvents);
+const mockListFavoriteEvents = jest.mocked(favoriteService.listFavoriteEvents);
 const mockRemoveFavorite = jest.mocked(favoriteService.removeFavorite);
 
-function makeEvent(id: string, isFavorited = true): EventSummary {
+function makeEvent(id: string): FavoriteEventItem {
   return {
     id,
     title: `Event ${id}`,
-    category_name: 'Outdoors',
+    category: 'Outdoors',
+    image_url: `https://example.com/${id}.jpg`,
+    status: 'CANCELED',
     start_time: '2026-04-09T14:00:00+03:00',
-    privacy_level: 'PUBLIC',
-    approved_participant_count: 1,
-    is_favorited: isFavorited,
-    host_score: { final_score: null, hosted_event_rating_count: 0 },
-    favorite_count: 3,
+    end_time: '2026-04-09T16:00:00+03:00',
+    favorited_at: '2026-04-06T10:00:00+03:00',
   };
 }
 
-const page1: PaginatedEventsResponse = {
+const favoritesResponse: FavoriteEventsResponse = {
   items: [makeEvent('e1'), makeEvent('e2')],
-  page_info: {
-    has_next: true,
-    next_cursor: 'cursor-2',
-  },
-};
-
-const page2: PaginatedEventsResponse = {
-  items: [makeEvent('e3')],
-  page_info: {
-    has_next: false,
-    next_cursor: null,
-  },
 };
 
 describe('useFavoriteEventsViewModel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockListEvents.mockResolvedValue(page1);
+    mockListFavoriteEvents.mockResolvedValue(favoritesResponse);
     mockRemoveFavorite.mockResolvedValue(undefined);
   });
 
-  it('loads favorite events on mount using only_favorited query', async () => {
+  it('loads favorite events on mount from the dedicated favorites endpoint', async () => {
     const { result } = renderHook(() => useFavoriteEventsViewModel());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(mockListEvents).toHaveBeenCalledWith(
-      {
-        lat: 41.0082,
-        lon: 28.9784,
-        only_favorited: true,
-        limit: 20,
-        cursor: undefined,
-      },
-      'mock-token',
-    );
-    expect(result.current.events).toEqual(page1.items);
-    expect(result.current.hasMore).toBe(true);
+    expect(mockListFavoriteEvents).toHaveBeenCalledWith('mock-token');
+    expect(result.current.events).toEqual(favoritesResponse.items);
+    expect(result.current.hasMore).toBe(false);
   });
 
-  it('refresh reloads first page', async () => {
+  it('refresh reloads the favorite events list from the favorites endpoint', async () => {
     const { result } = renderHook(() => useFavoriteEventsViewModel());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    mockListEvents.mockResolvedValueOnce({
+    mockListFavoriteEvents.mockResolvedValueOnce({
       items: [makeEvent('e9')],
-      page_info: { has_next: false, next_cursor: null },
     });
 
     await act(async () => {
       await result.current.refresh();
     });
 
-    expect(result.current.events.map((e) => e.id)).toEqual(['e9']);
+    expect(mockListFavoriteEvents).toHaveBeenCalledTimes(2);
+    expect(result.current.events.map((event) => event.id)).toEqual(['e9']);
     expect(result.current.hasMore).toBe(false);
   });
 
-  it('loadMore appends next page', async () => {
+  it('loadMore is a no-op because the favorites endpoint is not paginated', async () => {
     const { result } = renderHook(() => useFavoriteEventsViewModel());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    mockListEvents.mockResolvedValueOnce(page2);
 
     await act(async () => {
       await result.current.loadMore();
     });
 
-    expect(mockListEvents).toHaveBeenLastCalledWith(
-      expect.objectContaining({ cursor: 'cursor-2' }),
-      'mock-token',
-    );
-    expect(result.current.events.map((e) => e.id)).toEqual(['e1', 'e2', 'e3']);
-    expect(result.current.hasMore).toBe(false);
+    expect(mockListFavoriteEvents).toHaveBeenCalledTimes(1);
+    expect(result.current.events.map((event) => event.id)).toEqual(['e1', 'e2']);
+    expect(result.current.isLoadingMore).toBe(false);
   });
 
-  it('remove favorite calls API and removes item locally', async () => {
+  it('remove favorite calls the API and removes the event locally', async () => {
     const { result } = renderHook(() => useFavoriteEventsViewModel());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -124,16 +96,23 @@ describe('useFavoriteEventsViewModel', () => {
     });
 
     expect(mockRemoveFavorite).toHaveBeenCalledWith('e1', 'mock-token');
-    expect(result.current.events.map((e) => e.id)).toEqual(['e2']);
+    expect(result.current.events.map((event) => event.id)).toEqual(['e2']);
   });
 
-  it('sets apiError when loading fails', async () => {
-    mockListEvents.mockRejectedValueOnce(new Error('network'));
+  it('surfaces a helpful apiError when loading fails', async () => {
+    mockListFavoriteEvents.mockRejectedValueOnce(
+      new ApiError(500, {
+        error: {
+          code: 'favorites_failed',
+          message: 'Favorites are temporarily unavailable.',
+        },
+      }),
+    );
 
     const { result } = renderHook(() => useFavoriteEventsViewModel());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.apiError).toBe('Failed to load favorite events. Please try again.');
+    expect(result.current.apiError).toBe('Favorites are temporarily unavailable.');
   });
 });

--- a/mobile/src/viewmodels/favorites/useFavoriteEventsViewModel.ts
+++ b/mobile/src/viewmodels/favorites/useFavoriteEventsViewModel.ts
@@ -1,18 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
-import { EventSummary } from '@/models/event';
-import { listEvents } from '@/services/eventService';
-import { removeFavorite } from '@/services/favoriteService';
 import { useAuth } from '@/contexts/AuthContext';
-
-const DEFAULT_LOCATION = {
-  lat: 41.0082,
-  lon: 28.9784,
-};
-
-const PAGE_SIZE = 20;
+import { FavoriteEventItem } from '@/models/favorite';
+import { ApiError } from '@/services/api';
+import {
+  listFavoriteEvents,
+  removeFavorite,
+} from '@/services/favoriteService';
 
 export interface FavoriteEventsViewModel {
-  events: EventSummary[];
+  events: FavoriteEventItem[];
   isLoading: boolean;
   isRefreshing: boolean;
   isLoadingMore: boolean;
@@ -23,82 +19,81 @@ export interface FavoriteEventsViewModel {
   loadMore: () => Promise<void>;
 }
 
+function getLoadErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 401) {
+    return 'You must be logged in to view favorites.';
+  }
+
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return 'Failed to load favorite events. Please try again.';
+}
+
+function getRemoveErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 401) {
+    return 'You must be logged in to manage favorites.';
+  }
+
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return 'Failed to remove favorite. Please try again.';
+}
+
 export function useFavoriteEventsViewModel(): FavoriteEventsViewModel {
   const { token } = useAuth();
 
-  const [events, setEvents] = useState<EventSummary[]>([]);
+  const [events, setEvents] = useState<FavoriteEventItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
 
   const fetchEvents = useCallback(
-    async (mode: 'initial' | 'refresh' | 'loadMore') => {
+    async (mode: 'initial' | 'refresh') => {
       if (!token) {
         setEvents([]);
         setApiError('You must be logged in to view favorites.');
         setIsLoading(false);
+        setIsRefreshing(false);
         return;
       }
 
       if (mode === 'initial') setIsLoading(true);
       if (mode === 'refresh') setIsRefreshing(true);
-      if (mode === 'loadMore') setIsLoadingMore(true);
-
-      if (mode !== 'loadMore') {
-        setNextCursor(null);
-        setHasMore(false);
-      }
 
       setApiError(null);
 
       try {
-        const response = await listEvents(
-          {
-            lat: DEFAULT_LOCATION.lat,
-            lon: DEFAULT_LOCATION.lon,
-            only_favorited: true,
-            limit: PAGE_SIZE,
-            cursor: mode === 'loadMore' ? nextCursor ?? undefined : undefined,
-          },
-          token,
-        );
-
-        setHasMore(response.page_info.has_next);
-        setNextCursor(response.page_info.next_cursor);
-
-        if (mode === 'loadMore') {
-          setEvents((prev) => [...prev, ...response.items]);
-        } else {
-          setEvents(response.items);
+        const response = await listFavoriteEvents(token);
+        setEvents(response.items);
+      } catch (error) {
+        if (mode === 'initial') {
+          setEvents([]);
         }
-      } catch {
-        setApiError('Failed to load favorite events. Please try again.');
+
+        setApiError(getLoadErrorMessage(error));
       } finally {
         if (mode === 'initial') setIsLoading(false);
         if (mode === 'refresh') setIsRefreshing(false);
-        if (mode === 'loadMore') setIsLoadingMore(false);
       }
     },
-    [token, nextCursor],
+    [token],
   );
 
   useEffect(() => {
     void fetchEvents('initial');
-  }, [token]);
+  }, [fetchEvents]);
 
   const refresh = useCallback(async () => {
     await fetchEvents('refresh');
   }, [fetchEvents]);
 
   const loadMore = useCallback(async () => {
-    if (isLoading || isLoadingMore || isRefreshing || !hasMore || !nextCursor) {
-      return;
-    }
-    await fetchEvents('loadMore');
-  }, [isLoading, isLoadingMore, isRefreshing, hasMore, nextCursor, fetchEvents]);
+    // The favorites endpoint currently returns the full list without cursor pagination.
+  }, []);
 
   const handleRemoveFavorite = useCallback(
     async (eventId: string) => {
@@ -106,9 +101,9 @@ export function useFavoriteEventsViewModel(): FavoriteEventsViewModel {
 
       try {
         await removeFavorite(eventId, token);
-        setEvents((prev) => prev.filter((e) => e.id !== eventId));
-      } catch {
-        setApiError('Failed to remove favorite. Please try again.');
+        setEvents((prev) => prev.filter((event) => event.id !== eventId));
+      } catch (error) {
+        setApiError(getRemoveErrorMessage(error));
       }
     },
     [token],
@@ -118,8 +113,8 @@ export function useFavoriteEventsViewModel(): FavoriteEventsViewModel {
     events,
     isLoading,
     isRefreshing,
-    isLoadingMore,
-    hasMore,
+    isLoadingMore: false,
+    hasMore: false,
     apiError,
     handleRemoveFavorite,
     refresh,

--- a/mobile/src/views/favorites/FavoriteEventsTab.test.tsx
+++ b/mobile/src/views/favorites/FavoriteEventsTab.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import FavoriteEventsTab from './FavoriteEventsTab';
+import type { FavoriteEventsViewModel } from '@/viewmodels/favorites/useFavoriteEventsViewModel';
+import { useFavoriteEventsViewModel } from '@/viewmodels/favorites/useFavoriteEventsViewModel';
+import { router } from 'expo-router';
+
+jest.mock('react-native', () => {
+  const ReactLocal = require('react');
+  const reactNativeOnlyProps = new Set([
+    'accessibilityLabel',
+    'activeOpacity',
+    'contentContainerStyle',
+    'hitSlop',
+    'numberOfLines',
+    'showsVerticalScrollIndicator',
+  ]);
+
+  const stripReactNativeOnlyProps = (props: Record<string, unknown>) => {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(props)) {
+      if (!reactNativeOnlyProps.has(key)) {
+        out[key] = props[key];
+      }
+    }
+    return out;
+  };
+
+  const createDiv =
+    (displayName: string) =>
+      ({ children, ...props }: { children?: React.ReactNode }) =>
+        ReactLocal.createElement(
+          'div',
+          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          children,
+        );
+  const createSpan =
+    (displayName: string) =>
+      ({ children, ...props }: { children?: React.ReactNode }) =>
+        ReactLocal.createElement(
+          'span',
+          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          children,
+        );
+
+  return {
+    ActivityIndicator: createDiv('ActivityIndicator'),
+    View: createDiv('View'),
+    Text: createSpan('Text'),
+    TouchableOpacity: ({
+      children,
+      onPress,
+      disabled,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      disabled?: boolean;
+    }) =>
+      ReactLocal.createElement(
+        'button',
+        {
+          ...stripReactNativeOnlyProps(props),
+          type: 'button',
+          disabled,
+          onClick: onPress,
+        },
+        children,
+      ),
+    FlatList: ({
+      data,
+      renderItem,
+      keyExtractor,
+      ListEmptyComponent,
+      ListFooterComponent,
+    }: {
+      data: Array<unknown>;
+      renderItem: (item: { item: any; index: number }) => React.ReactNode;
+      keyExtractor?: (item: any, index: number) => string;
+      ListEmptyComponent?: React.ReactNode;
+      ListFooterComponent?: React.ReactNode;
+    }) =>
+      ReactLocal.createElement(
+        'div',
+        { 'data-testid': 'FlatList' },
+        data.length > 0
+          ? data.map((item, index) =>
+            ReactLocal.createElement(
+              ReactLocal.Fragment,
+              {
+                key: keyExtractor ? keyExtractor(item, index) : String(index),
+              },
+              renderItem({ item, index }),
+            ))
+          : ListEmptyComponent,
+        ListFooterComponent ?? null,
+      ),
+    StyleSheet: {
+      create: <T,>(styles: T) => styles,
+    },
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const ReactLocal = require('react');
+
+  function createIconComponent(library: string) {
+    return ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', {
+        'data-icon-library': library,
+        'data-icon': name,
+      });
+  }
+
+  return {
+    Ionicons: createIconComponent('ionicons'),
+  };
+});
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/profile/ProfileEventCard', () => {
+  const ReactLocal = require('react');
+
+  return {
+    __esModule: true,
+    default: ({
+      title,
+      categoryLabel,
+      status,
+      privacyLevel,
+      locationAddress,
+      onPress,
+    }: {
+      title: string;
+      categoryLabel: string;
+      status: string;
+      privacyLevel: 'PUBLIC' | 'PROTECTED' | 'PRIVATE' | null;
+      locationAddress?: string | null;
+      onPress: () => void;
+    }) =>
+      ReactLocal.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: onPress,
+        },
+        `${title} | ${categoryLabel} | ${status} | ${privacyLevel ?? 'NO_PRIVACY'} | ${locationAddress ?? 'NO_LOCATION'}`,
+      ),
+  };
+});
+
+jest.mock('@/viewmodels/favorites/useFavoriteEventsViewModel', () => ({
+  useFavoriteEventsViewModel: jest.fn(),
+}));
+
+const mockUseFavoriteEventsViewModel = jest.mocked(useFavoriteEventsViewModel);
+const mockRouterPush = jest.mocked(router.push);
+
+function buildViewModel(
+  overrides: Partial<FavoriteEventsViewModel> = {},
+): FavoriteEventsViewModel {
+  return {
+    events: [],
+    isLoading: false,
+    isRefreshing: false,
+    isLoadingMore: false,
+    hasMore: false,
+    apiError: null,
+    handleRemoveFavorite: jest
+      .fn<(eventId: string) => Promise<void>>()
+      .mockResolvedValue(undefined),
+    refresh: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    loadMore: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('FavoriteEventsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the loading state while favorite events are being fetched', () => {
+    mockUseFavoriteEventsViewModel.mockReturnValue(
+      buildViewModel({ isLoading: true }),
+    );
+
+    render(<FavoriteEventsTab />);
+
+    expect(screen.getByText('Loading favorites...')).toBeTruthy();
+  });
+
+  it('renders the empty state when the user has no favorite events', () => {
+    mockUseFavoriteEventsViewModel.mockReturnValue(buildViewModel());
+
+    render(<FavoriteEventsTab />);
+
+    expect(screen.getByText('No favorite events yet')).toBeTruthy();
+    expect(screen.getByText('Tap the heart icon on an event to save it here.')).toBeTruthy();
+  });
+
+  it('renders an error banner without the empty state when loading fails', () => {
+    mockUseFavoriteEventsViewModel.mockReturnValue(
+      buildViewModel({
+        apiError: 'Favorites are temporarily unavailable.',
+      }),
+    );
+
+    render(<FavoriteEventsTab />);
+
+    expect(screen.getByText('Favorites are temporarily unavailable.')).toBeTruthy();
+    expect(screen.queryByText('No favorite events yet')).toBeNull();
+  });
+
+  it('renders favorite events from the dedicated favorites payload and navigates on press', () => {
+    mockUseFavoriteEventsViewModel.mockReturnValue(
+      buildViewModel({
+        events: [
+          {
+            id: 'event-1',
+            title: 'Forest Walk',
+            category: 'Outdoors',
+            image_url: null,
+            status: 'COMPLETED',
+            start_time: '2026-04-09T14:00:00+03:00',
+            end_time: null,
+            favorited_at: '2026-04-06T10:00:00+03:00',
+          },
+        ],
+      }),
+    );
+
+    render(<FavoriteEventsTab />);
+
+    const eventButton = screen.getByText('Forest Walk | Outdoors | COMPLETED | NO_PRIVACY | NO_LOCATION');
+    expect(eventButton).toBeTruthy();
+
+    fireEvent.click(eventButton);
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/event/event-1');
+  });
+
+  it('passes the optional privacy level through when the favorites response includes it', () => {
+    mockUseFavoriteEventsViewModel.mockReturnValue(
+      buildViewModel({
+        events: [
+          {
+            id: 'event-2',
+            title: 'City Ride',
+            category: 'Sports',
+            image_url: null,
+            privacy_level: 'PROTECTED',
+            status: 'ACTIVE',
+            start_time: '2026-04-12T09:00:00+03:00',
+            end_time: null,
+            favorited_at: '2026-04-06T12:00:00+03:00',
+          },
+        ],
+      }),
+    );
+
+    render(<FavoriteEventsTab />);
+
+    expect(screen.getByText('City Ride | Sports | ACTIVE | PROTECTED | NO_LOCATION')).toBeTruthy();
+  });
+
+  it('passes the optional location address through when the favorites response includes it', () => {
+    mockUseFavoriteEventsViewModel.mockReturnValue(
+      buildViewModel({
+        events: [
+          {
+            id: 'event-3',
+            title: 'Sunrise Meetup',
+            category: 'Wellness',
+            image_url: null,
+            location_address: 'Bebek Sahili, Besiktas, Istanbul, Turkiye',
+            status: 'ACTIVE',
+            start_time: '2026-04-13T07:00:00+03:00',
+            end_time: null,
+            favorited_at: '2026-04-06T13:00:00+03:00',
+          },
+        ],
+      }),
+    );
+
+    render(<FavoriteEventsTab />);
+
+    expect(
+      screen.getByText(
+        'Sunrise Meetup | Wellness | ACTIVE | NO_PRIVACY | Bebek Sahili, Besiktas, Istanbul, Turkiye',
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/mobile/src/views/favorites/FavoriteEventsTab.tsx
+++ b/mobile/src/views/favorites/FavoriteEventsTab.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { router, type Href } from 'expo-router';
-import EventCard from '@/components/events/EventCard';
+import ProfileEventCard from '@/components/profile/ProfileEventCard';
 import { useFavoriteEventsViewModel } from '@/viewmodels/favorites/useFavoriteEventsViewModel';
 
 export default function FavoriteEventsTab() {
@@ -35,9 +35,15 @@ export default function FavoriteEventsTab() {
         data={vm.events}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <EventCard
-            event={item}
-            onPress={(id) => router.push(`/event/${id}` as Href)}
+          <ProfileEventCard
+            title={item.title}
+            imageUrl={item.image_url}
+            categoryLabel={item.category ?? 'Event'}
+            startTime={item.start_time}
+            locationAddress={item.location_address ?? null}
+            status={item.status}
+            privacyLevel={item.privacy_level ?? null}
+            onPress={() => router.push(`/event/${item.id}` as Href)}
           />
         )}
         contentContainerStyle={styles.listContent}
@@ -46,7 +52,7 @@ export default function FavoriteEventsTab() {
         refreshing={vm.isRefreshing}
         onEndReachedThreshold={0.35}
         onEndReached={vm.loadMore}
-        ListEmptyComponent={
+        ListEmptyComponent={vm.apiError ? null : (
           <View style={styles.center}>
             <Ionicons name="heart-outline" size={40} color="#D1D5DB" />
             <Text style={styles.emptyTitle}>No favorite events yet</Text>
@@ -54,7 +60,7 @@ export default function FavoriteEventsTab() {
               Tap the heart icon on an event to save it here.
             </Text>
           </View>
-        }
+        )}
         ListFooterComponent={
           vm.isLoadingMore ? (
             <View style={styles.footerLoader}>


### PR DESCRIPTION
## 📋 Summary
This PR updates the mobile Favorites flow to use the dedicated favorites endpoint and render saved events with richer, more consistent event cards.

Instead of fetching favorited events through the discovery listing, the mobile app now reads favorites from `/me/favorites`, which removes the old location-based and paginated loading assumptions. Favorite event cards now reuse shared profile-style UI so status, privacy level, and location details are displayed consistently, while the view model surfaces clearer API errors for load and remove actions.

## 🔄 Changes
- Switched the mobile Favorites flow from `listEvents(... only_favorited=true)` to the dedicated `/me/favorites` endpoint
- Removed default-location and cursor-pagination logic from the Favorites view model because the favorites endpoint returns the saved list directly
- Added clearer API error handling for unauthorized and general failures when loading or removing favorites
- Extended the mobile favorite event model to support `privacy_level` and `location_address`
- Replaced the Favorites tab’s generic event card with `ProfileEventCard`
- Passed status, privacy level, and location address into favorite event cards so saved events match the richer mobile event presentation
- Added test coverage for loading favorites from the dedicated endpoint
- Added test coverage for refreshing favorites from the dedicated endpoint
- Added test coverage for `loadMore` being a no-op for the non-paginated favorites response
- Added test coverage for removing a favorite and updating local state
- Added test coverage for Favorites tab loading, empty, and error states
- Added test coverage for forwarding `privacy_level` and `location_address` to the card UI
- Added test coverage for navigating from a favorite event card to event detail

## 🧪 Testing

### Automated
```bash
cd mobile
npm test -- --runInBand src/viewmodels/favorites/useFavoriteEventsViewModel.test.tsx src/views/favorites/FavoriteEventsTab.test.tsx
```

### Manual
Suggested manual verification:

- Log in to the mobile app with a user who has one or more favorited events
- Open the Favorites screen and confirm saved events are listed correctly
- Verify event cards show status badges and, when available, privacy level and location information
- Tap a favorite event card and confirm navigation to the event detail screen still works
- Remove a favorite and confirm it disappears from the list immediately
- Pull to refresh and confirm the list reloads successfully
- Verify the empty state appears when the user has no favorite events
- If test data allows, verify API failure cases show an error banner without breaking the screen

## 🔗 Related
Closes #368