### PR TITLE
chore: optimize event detail and favorite flows

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
@@ -532,38 +533,91 @@ func (r *EventRepository) GetEventDetail(
 		return nil, err
 	}
 
-	location, err := r.loadEventDetailLocation(ctx, eventID, record.Location.Type)
-	if err != nil {
-		return nil, err
-	}
-	location.Address = record.Location.Address
-	record.Location = location
+	groupCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
 
-	tags, err := r.loadEventTags(ctx, eventID)
-	if err != nil {
-		return nil, err
-	}
-	record.Tags = tags
+	var (
+		location          eventapp.EventDetailLocationRecord
+		tags              []string
+		constraints       []eventapp.EventDetailConstraintRecord
+		viewerEventRating *eventapp.EventDetailRatingRecord
+		hostContext       *eventapp.EventDetailHostContextRecord
+		wg                sync.WaitGroup
+		firstErr          error
+		errOnce           sync.Once
+	)
 
-	constraints, err := r.loadEventConstraints(ctx, eventID)
-	if err != nil {
-		return nil, err
+	runConcurrentLoad := func(load func(context.Context) error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := load(groupCtx); err != nil {
+				errOnce.Do(func() {
+					firstErr = err
+					cancel(err)
+				})
+			}
+		}()
 	}
-	record.Constraints = constraints
 
-	viewerEventRating, err := r.loadViewerEventRating(ctx, eventID, userID)
-	if err != nil {
-		return nil, err
-	}
-	record.ViewerEventRating = viewerEventRating
+	runConcurrentLoad(func(ctx context.Context) error {
+		loadedLocation, err := r.loadEventDetailLocation(groupCtx, eventID, record.Location.Type)
+		if err != nil {
+			return err
+		}
+		location = loadedLocation
+		return nil
+	})
+
+	runConcurrentLoad(func(ctx context.Context) error {
+		loadedTags, err := r.loadEventTags(groupCtx, eventID)
+		if err != nil {
+			return err
+		}
+		tags = loadedTags
+		return nil
+	})
+
+	runConcurrentLoad(func(ctx context.Context) error {
+		loadedConstraints, err := r.loadEventConstraints(groupCtx, eventID)
+		if err != nil {
+			return err
+		}
+		constraints = loadedConstraints
+		return nil
+	})
+
+	runConcurrentLoad(func(ctx context.Context) error {
+		loadedViewerEventRating, err := r.loadViewerEventRating(groupCtx, eventID, userID)
+		if err != nil {
+			return err
+		}
+		viewerEventRating = loadedViewerEventRating
+		return nil
+	})
 
 	if record.ViewerContext.IsHost {
-		hostContext, err := r.loadEventHostContext(ctx, eventID)
-		if err != nil {
-			return nil, err
-		}
-		record.HostContext = hostContext
+		runConcurrentLoad(func(ctx context.Context) error {
+			loadedHostContext, err := r.loadEventHostContext(groupCtx, eventID)
+			if err != nil {
+				return err
+			}
+			hostContext = loadedHostContext
+			return nil
+		})
 	}
+
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	location.Address = record.Location.Address
+	record.Location = location
+	record.Tags = tags
+	record.Constraints = constraints
+	record.ViewerEventRating = viewerEventRating
+	record.HostContext = hostContext
 
 	return record, nil
 }
@@ -963,19 +1017,61 @@ func (r *EventRepository) loadEventHostContext(
 	ctx context.Context,
 	eventID uuid.UUID,
 ) (*eventapp.EventDetailHostContextRecord, error) {
-	approvedParticipants, err := r.loadApprovedParticipants(ctx, eventID)
-	if err != nil {
-		return nil, err
+	groupCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	var (
+		approvedParticipants []eventapp.EventDetailApprovedParticipantRecord
+		pendingJoinRequests  []eventapp.EventDetailPendingJoinRequestRecord
+		invitations          []eventapp.EventDetailInvitationRecord
+		wg                   sync.WaitGroup
+		firstErr             error
+		errOnce              sync.Once
+	)
+
+	runConcurrentLoad := func(load func(context.Context) error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := load(groupCtx); err != nil {
+				errOnce.Do(func() {
+					firstErr = err
+					cancel(err)
+				})
+			}
+		}()
 	}
 
-	pendingJoinRequests, err := r.loadPendingJoinRequests(ctx, eventID)
-	if err != nil {
-		return nil, err
-	}
+	runConcurrentLoad(func(ctx context.Context) error {
+		loadedApprovedParticipants, err := r.loadApprovedParticipants(groupCtx, eventID)
+		if err != nil {
+			return err
+		}
+		approvedParticipants = loadedApprovedParticipants
+		return nil
+	})
 
-	invitations, err := r.loadInvitations(ctx, eventID)
-	if err != nil {
-		return nil, err
+	runConcurrentLoad(func(ctx context.Context) error {
+		loadedPendingJoinRequests, err := r.loadPendingJoinRequests(groupCtx, eventID)
+		if err != nil {
+			return err
+		}
+		pendingJoinRequests = loadedPendingJoinRequests
+		return nil
+	})
+
+	runConcurrentLoad(func(ctx context.Context) error {
+		loadedInvitations, err := r.loadInvitations(groupCtx, eventID)
+		if err != nil {
+			return err
+		}
+		invitations = loadedInvitations
+		return nil
+	})
+
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
 	}
 
 	return &eventapp.EventDetailHostContextRecord{

--- a/backend/migrations/000020_event_detail_and_favorite_perf.down.sql
+++ b/backend/migrations/000020_event_detail_and_favorite_perf.down.sql
@@ -1,0 +1,37 @@
+DROP INDEX IF EXISTS idx_invitation_event_created;
+DROP INDEX IF EXISTS idx_join_request_event_status_created;
+DROP INDEX IF EXISTS idx_participation_event_status_created;
+DROP INDEX IF EXISTS idx_event_constraint_event_id;
+
+CREATE OR REPLACE FUNCTION sync_favorite_count() RETURNS trigger AS
+$$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE event
+        SET favorite_count = (SELECT COUNT(*)
+                              FROM favorite_event
+                              WHERE event_id = OLD.event_id)
+        WHERE id = OLD.event_id;
+    ELSIF TG_OP = 'INSERT' THEN
+        UPDATE event
+        SET favorite_count = (SELECT COUNT(*)
+                              FROM favorite_event
+                              WHERE event_id = NEW.event_id)
+        WHERE id = NEW.event_id;
+    ELSIF TG_OP = 'UPDATE' AND OLD.event_id IS DISTINCT FROM NEW.event_id THEN
+        UPDATE event
+        SET favorite_count = (SELECT COUNT(*)
+                              FROM favorite_event
+                              WHERE event_id = OLD.event_id)
+        WHERE id = OLD.event_id;
+
+        UPDATE event
+        SET favorite_count = (SELECT COUNT(*)
+                              FROM favorite_event
+                              WHERE event_id = NEW.event_id)
+        WHERE id = NEW.event_id;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;

--- a/backend/migrations/000020_event_detail_and_favorite_perf.up.sql
+++ b/backend/migrations/000020_event_detail_and_favorite_perf.up.sql
@@ -1,0 +1,35 @@
+CREATE INDEX IF NOT EXISTS idx_event_constraint_event_id ON event_constraint (event_id);
+
+CREATE INDEX IF NOT EXISTS idx_participation_event_status_created
+    ON participation (event_id, status, created_at, id);
+
+CREATE INDEX IF NOT EXISTS idx_join_request_event_status_created
+    ON join_request (event_id, status, created_at, id);
+
+CREATE INDEX IF NOT EXISTS idx_invitation_event_created
+    ON invitation (event_id, created_at, id);
+
+CREATE OR REPLACE FUNCTION sync_favorite_count() RETURNS trigger AS
+$$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        UPDATE event
+        SET favorite_count = favorite_count + 1
+        WHERE id = NEW.event_id;
+    ELSIF TG_OP = 'DELETE' THEN
+        UPDATE event
+        SET favorite_count = GREATEST(favorite_count - 1, 0)
+        WHERE id = OLD.event_id;
+    ELSIF TG_OP = 'UPDATE' AND OLD.event_id IS DISTINCT FROM NEW.event_id THEN
+        UPDATE event
+        SET favorite_count = GREATEST(favorite_count - 1, 0)
+        WHERE id = OLD.event_id;
+
+        UPDATE event
+        SET favorite_count = favorite_count + 1
+        WHERE id = NEW.event_id;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EventDetailResponse } from '@/models/event';
+import { useEventDetailViewModel } from './useEventDetailViewModel';
+
+const mockGetEventDetail = vi.fn();
+const mockAddFavorite = vi.fn();
+const mockRemoveFavorite = vi.fn();
+
+vi.mock('@/services/eventService', () => ({
+  getEventDetail: (...args: unknown[]) => mockGetEventDetail(...args),
+  getEventImageUploadUrl: vi.fn(),
+  confirmEventImageUpload: vi.fn(),
+  joinEvent: vi.fn(),
+  requestJoinEvent: vi.fn(),
+  approveJoinRequest: vi.fn(),
+  rejectJoinRequest: vi.fn(),
+  cancelEvent: vi.fn(),
+  addFavorite: (...args: unknown[]) => mockAddFavorite(...args),
+  removeFavorite: (...args: unknown[]) => mockRemoveFavorite(...args),
+  upsertEventRating: vi.fn(),
+  upsertParticipantRating: vi.fn(),
+}));
+
+vi.mock('@/utils/imageResize', () => ({
+  prepareAvatarBlobs: vi.fn(),
+}));
+
+function makeEvent(overrides: Partial<EventDetailResponse> = {}): EventDetailResponse {
+  return {
+    id: 'event-1',
+    title: 'Sunset Walk',
+    description: 'A relaxed walk by the coast.',
+    image_url: null,
+    privacy_level: 'PUBLIC',
+    status: 'COMPLETED',
+    start_time: '2026-04-01T17:00:00Z',
+    end_time: '2026-04-01T19:00:00Z',
+    capacity: 20,
+    minimum_age: null,
+    preferred_gender: null,
+    approved_participant_count: 8,
+    pending_participant_count: 0,
+    favorite_count: 3,
+    created_at: '2026-03-20T10:00:00Z',
+    updated_at: '2026-04-02T10:00:00Z',
+    category: { id: 1, name: 'Outdoors' },
+    host: {
+      id: 'host-1',
+      username: 'hostuser',
+      display_name: 'Host User',
+      avatar_url: null,
+    },
+    host_score: {
+      final_score: 4.7,
+      hosted_event_rating_count: 12,
+    },
+    location: {
+      type: 'POINT',
+      address: 'Moda Coast',
+      point: { lat: 40.98, lon: 29.03 },
+      route_points: [],
+    },
+    tags: ['walk'],
+    constraints: [],
+    rating_window: {
+      opens_at: '2026-04-01T19:00:00Z',
+      closes_at: '2026-04-08T19:00:00Z',
+      is_active: true,
+    },
+    viewer_event_rating: null,
+    viewer_context: {
+      is_host: false,
+      is_favorited: false,
+      participation_status: 'JOINED',
+    },
+    host_context: null,
+    ...overrides,
+  };
+}
+
+describe('useEventDetailViewModel favorites', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAddFavorite.mockResolvedValue(undefined);
+    mockRemoveFavorite.mockResolvedValue(undefined);
+  });
+
+  it('adds favorite locally without refetching event detail', async () => {
+    mockGetEventDetail.mockResolvedValue(makeEvent());
+
+    const { result } = renderHook(() => useEventDetailViewModel('event-1', 'token'));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      await result.current.handleFavoriteToggle();
+    });
+
+    expect(mockAddFavorite).toHaveBeenCalledWith('event-1', 'token');
+    expect(mockGetEventDetail).toHaveBeenCalledTimes(1);
+    expect(result.current.event?.viewer_context.is_favorited).toBe(true);
+    expect(result.current.event?.favorite_count).toBe(4);
+  });
+
+  it('removes favorite locally without refetching event detail', async () => {
+    mockGetEventDetail.mockResolvedValue(
+      makeEvent({
+        favorite_count: 4,
+        viewer_context: {
+          is_host: false,
+          is_favorited: true,
+          participation_status: 'JOINED',
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => useEventDetailViewModel('event-1', 'token'));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      await result.current.handleFavoriteToggle();
+    });
+
+    expect(mockRemoveFavorite).toHaveBeenCalledWith('event-1', 'token');
+    expect(mockGetEventDetail).toHaveBeenCalledTimes(1);
+    expect(result.current.event?.viewer_context.is_favorited).toBe(false);
+    expect(result.current.event?.favorite_count).toBe(3);
+  });
+
+  it('rolls back the local favorite state when the request fails', async () => {
+    mockGetEventDetail.mockResolvedValue(makeEvent());
+    mockAddFavorite.mockRejectedValue(new Error('request failed'));
+
+    const { result } = renderHook(() => useEventDetailViewModel('event-1', 'token'));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      await result.current.handleFavoriteToggle();
+    });
+
+    expect(mockGetEventDetail).toHaveBeenCalledTimes(1);
+    expect(result.current.event?.viewer_context.is_favorited).toBe(false);
+    expect(result.current.event?.favorite_count).toBe(3);
+  });
+});

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -197,20 +197,50 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
 
   const handleFavoriteToggle = useCallback(async () => {
     if (!eventId || !token || !event) return;
+
+    const wasFavorited = event.viewer_context.is_favorited;
+    const previousCount = event.favorite_count;
+    const nextCount = wasFavorited
+      ? Math.max(0, previousCount - 1)
+      : previousCount + 1;
+
     setFavoriteLoading(true);
+    setEvent((prev) =>
+      prev
+        ? {
+            ...prev,
+            favorite_count: nextCount,
+            viewer_context: {
+              ...prev.viewer_context,
+              is_favorited: !wasFavorited,
+            },
+          }
+        : prev,
+    );
+
     try {
-      if (event.viewer_context.is_favorited) {
+      if (wasFavorited) {
         await removeFavorite(eventId, token);
       } else {
         await addFavorite(eventId, token);
       }
-      await refreshEventDetail();
     } catch {
-      // silently fail — UI will stay in previous state
+      setEvent((prev) =>
+        prev
+          ? {
+              ...prev,
+              favorite_count: previousCount,
+              viewer_context: {
+                ...prev.viewer_context,
+                is_favorited: wasFavorited,
+              },
+            }
+          : prev,
+      );
     } finally {
       setFavoriteLoading(false);
     }
-  }, [eventId, token, event, refreshEventDetail]);
+  }, [eventId, token, event]);
 
   const [cancelLoading, setCancelLoading] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Improves event detail and favorite flows on the backend (fewer sequential DB round-trips, cheaper favorite counter updates, supporting indexes) and removes the redundant full event-detail refetch on the web after toggling favorites by applying optimistic local updates to `favorite_count` and `is_favorited`.

## Changes

- **Backend (`internal/adapter/in/postgres/event_repo.go`)**: Parallelize independent loads in `GetEventDetail` and `loadEventHostContext` (same response shape; lower wall-clock latency). Uses `context.WithCancelCause` + `sync.WaitGroup` to cancel sibling work on first error.
- **Backend (migration `000020_event_detail_and_favorite_perf`)**: Replace `sync_favorite_count` trigger implementation from per-row `COUNT(*)` over `favorite_event` to `+1`/`-1` updates on `event.favorite_count` (with `GREATEST` on decrement). Add indexes: `event_constraint(event_id)`, composite indexes aligned with detail queries on `participation`, `join_request`, and `invitation`.
- **Frontend (`frontend/src/viewmodels/event/useEventDetailViewModel.ts`)**: On favorite toggle, update `viewer_context.is_favorited` and `favorite_count` locally; no `getEventDetail` after `addFavorite`/`removeFavorite`; rollback on API failure.
- **Frontend tests (`frontend/src/viewmodels/event/useEventDetailViewModel.test.ts`)**: Cover add/remove without extra detail fetch and rollback on failure.

## Testing

- Backend: `./shipcheck.sh` from `backend/` (passed).
- Frontend: `npm --prefix frontend test -- --run src/viewmodels/event/useEventDetailViewModel.test.ts src/views/events/EventDetailPage.test.tsx` (passed).
