### PR TITLE
feat(frontend): Add Leave Event button to My Events #378

### DIFF
--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -88,6 +88,13 @@ export function joinEvent(
   return apiPostAuth<JoinEventResponse>(`/events/${eventId}/join`, {}, token);
 }
 
+export function leaveEvent(
+  eventId: string,
+  token: string,
+): Promise<void> {
+  return apiPatchAuth<void>(`/events/${eventId}/leave`, {}, token);
+}
+
 export function requestJoinEvent(
   eventId: string,
   token: string,

--- a/frontend/src/styles/my-events.css
+++ b/frontend/src/styles/my-events.css
@@ -210,6 +210,31 @@
   color: #6b7280;
 }
 
+/* Leave Event button */
+.me-leave-btn {
+  margin-top: 8px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #dc2626;
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  align-self: flex-start;
+}
+
+.me-leave-btn:hover:not(:disabled) {
+  background-color: #fee2e2;
+  border-color: #fca5a5;
+}
+
+.me-leave-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Responsive */
 @media (max-width: 600px) {
   .me-title {

--- a/frontend/src/viewmodels/event/useMyEventsViewModel.ts
+++ b/frontend/src/viewmodels/event/useMyEventsViewModel.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { profileService } from '@/services/profileService';
+import { leaveEvent } from '@/services/eventService';
 import type { EventSummary } from '@/models/profile';
 import { ApiError } from '@/services/api';
 
@@ -14,6 +15,7 @@ export function useMyEventsViewModel(token: string | null) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<MyEventsTab>('active');
+  const [leavingEventId, setLeavingEventId] = useState<string | null>(null);
 
   const fetchEvents = useCallback(async () => {
     if (!token) return;
@@ -48,6 +50,23 @@ export function useMyEventsViewModel(token: string | null) {
     fetchEvents();
   }, [fetchEvents]);
 
+  const handleLeaveEvent = async (eventId: string) => {
+    if (!token) return;
+    setLeavingEventId(eventId);
+    try {
+      await leaveEvent(eventId, token);
+      await fetchEvents();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        window.alert(`Failed to leave event: ${err.message}`);
+      } else {
+        window.alert('Failed to leave event. Please try again.');
+      }
+    } finally {
+      setLeavingEventId(null);
+    }
+  };
+
   return {
     organized,
     upcoming,
@@ -58,6 +77,8 @@ export function useMyEventsViewModel(token: string | null) {
     error,
     activeTab,
     setActiveTab,
+    leavingEventId,
+    handleLeaveEvent,
     retry: fetchEvents,
   };
 }

--- a/frontend/src/views/events/MyEventsPage.tsx
+++ b/frontend/src/views/events/MyEventsPage.tsx
@@ -36,7 +36,22 @@ function StatusBadge({ status }: { status: string }) {
   return <span className={`me-status-badge ${cls}`}>{presentation.label}</span>;
 }
 
-function EventCard({ event }: { event: EventSummary }) {
+function EventCard({ 
+  event, 
+  onLeave, 
+  isLeaving 
+}: { 
+  event: EventSummary; 
+  onLeave?: (eventId: string) => void; 
+  isLeaving?: boolean; 
+}) {
+  const handleLeaveClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (window.confirm('Are you sure to leave?')) {
+      onLeave?.(event.id);
+    }
+  };
+
   return (
     <Link to={`/events/${event.id}`} className="me-card">
       <div className="me-card-image-wrapper">
@@ -56,12 +71,34 @@ function EventCard({ event }: { event: EventSummary }) {
         <p className="me-card-date">
           {formatDate(event.start_time)} &middot; {formatTime(event.start_time)}
         </p>
+        {onLeave && (
+          <button
+            type="button"
+            className="me-leave-btn"
+            onClick={handleLeaveClick}
+            disabled={isLeaving}
+          >
+            {isLeaving ? 'Leaving...' : 'Leave Event'}
+          </button>
+        )}
       </div>
     </Link>
   );
 }
 
-function EventList({ events, emptyMessage }: { events: EventSummary[]; emptyMessage: string }) {
+function EventList({ 
+  events, 
+  emptyMessage,
+  onLeave,
+  leavingEventId,
+  hostedEventIds
+}: { 
+  events: EventSummary[]; 
+  emptyMessage: string;
+  onLeave?: (eventId: string) => void;
+  leavingEventId?: string | null;
+  hostedEventIds?: string[];
+}) {
   if (events.length === 0) {
     return (
       <div className="me-empty">
@@ -73,7 +110,12 @@ function EventList({ events, emptyMessage }: { events: EventSummary[]; emptyMess
   return (
     <div className="me-grid">
       {events.map((event) => (
-        <EventCard key={event.id} event={event} />
+        <EventCard 
+          key={event.id} 
+          event={event} 
+          onLeave={hostedEventIds?.includes(event.id) ? undefined : onLeave}
+          isLeaving={leavingEventId === event.id}
+        />
       ))}
     </div>
   );
@@ -98,6 +140,8 @@ export default function MyEventsPage() {
     past: vm.past.length,
     canceled: vm.canceled.length,
   };
+
+  const hostedEventIds = vm.organized.map(e => e.id);
 
   return (
     <div className="me-page">
@@ -146,12 +190,18 @@ export default function MyEventsPage() {
             <EventList
               events={vm.active}
               emptyMessage="No events in progress right now."
+              onLeave={vm.handleLeaveEvent}
+              leavingEventId={vm.leavingEventId}
+              hostedEventIds={hostedEventIds}
             />
           )}
           {vm.activeTab === 'upcoming' && (
             <EventList
               events={vm.upcoming}
               emptyMessage="No upcoming events. Discover events to join!"
+              onLeave={vm.handleLeaveEvent}
+              leavingEventId={vm.leavingEventId}
+              hostedEventIds={hostedEventIds}
             />
           )}
           {vm.activeTab === 'organized' && (


### PR DESCRIPTION
## Description

Resolves #378 

This PR implements the "Leave Event" functionality on the frontend for the **My Events** page, enabling users to effortlessly withdraw their participation from events they are currently attending without requiring any backend modifications (as the `PATCH /events/:id/leave` endpoint already existed).

### Key Changes
- **API Service Entegration**: Added `leaveEvent` function directly calling the verified backend endpoint.
- **ViewModel Updates**: Updated `useMyEventsViewModel.ts` to seamlessly handle leaving state (`leavingEventId`). On success, the event lists automatically update without a hard page reload.
- **UI Enhancements**: 
  - Injected a "Leave Event" button strictly into the `Upcoming` and `In Progress` event cards.
  - Added native `window.confirm('Are you sure to leave?')` dialog to intercept accidental clicks.
  - **Host Verification:** Specifically configured the event card lists to strictly hide the "Leave Event" button for events where the active user is the **host/organizer**.

## Affected Area
- Frontend / My Events Page (`MyEventsPage.tsx`)
- Frontend / Event API Service (`eventService.ts`)

## Visual & Testing Checklist
- [x] Verified user receives confirmation dialog before leaving.
- [x] Verified "Leave Event" button is hidden for hosted/organized events.
- [x] Verified graceful loading state while the API handles the request.
- [x] Verified no console errors or UI breakages post-operation.
