### PR TITLE
feat(frontend): change color palette

### DIFF
--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -8,7 +8,7 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
   if (isLoading) {
     return (
       <div className="auth-page">
-        <div className="spinner" style={{ borderTopColor: '#2563eb', borderColor: 'rgba(37,99,235,0.2)' }} />
+        <div className="spinner" style={{ borderTopColor: '#111827', borderColor: 'rgba(17,24,39,0.2)' }} />
       </div>
     );
   }

--- a/frontend/src/components/UserAvatar.css
+++ b/frontend/src/components/UserAvatar.css
@@ -18,7 +18,7 @@
 }
 
 .user-avatar--accent {
-  background-color: #2563eb;
+  background-color: #111827;
 }
 
 .user-avatar--muted {

--- a/frontend/src/styles/auth.css
+++ b/frontend/src/styles/auth.css
@@ -72,8 +72,8 @@
 }
 
 .field-input:focus {
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  border-color: #111827;
+  box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.1);
 }
 
 .field-input.has-error {
@@ -110,19 +110,19 @@
 }
 
 .gender-option:hover {
-  border-color: #2563eb;
+  border-color: #111827;
 }
 
 .gender-option.selected {
-  background-color: #2563eb;
-  border-color: #2563eb;
+  background-color: #111827;
+  border-color: #111827;
   color: #ffffff;
 }
 
 /* Buttons */
 .btn-primary {
   width: 100%;
-  background-color: #2563eb;
+  background-color: #111827;
   color: #ffffff;
   border: none;
   border-radius: 10px;
@@ -135,7 +135,7 @@
 }
 
 .btn-primary:hover:not(:disabled) {
-  background-color: #1d4ed8;
+  background-color: #0F172A;
 }
 
 .btn-primary:disabled {
@@ -173,7 +173,7 @@
 
 .auth-footer a,
 .link {
-  color: #2563eb;
+  color: #111827;
   font-weight: 600;
   text-decoration: none;
   cursor: pointer;
@@ -199,7 +199,7 @@
 }
 
 .step-dot.active {
-  background-color: #2563eb;
+  background-color: #111827;
 }
 
 /* Forgot password link */
@@ -227,18 +227,18 @@
 .btn-outline {
   width: 100%;
   background: none;
-  border: 2px solid #2563eb;
+  border: 2px solid #111827;
   border-radius: 10px;
   padding: 14px;
   font-size: 16px;
   font-weight: 600;
-  color: #2563eb;
+  color: #111827;
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .btn-outline:hover {
-  background-color: #eff6ff;
+  background-color: #F3F4F6;
 }
 
 /* Spinner */

--- a/frontend/src/styles/create-event.css
+++ b/frontend/src/styles/create-event.css
@@ -122,9 +122,9 @@
 }
 
 .ce-image-upload-btn:hover:not(:disabled) {
-  border-color: #2563eb;
-  color: #2563eb;
-  background-color: #eff6ff;
+  border-color: #111827;
+  color: #111827;
+  background-color: #F3F4F6;
 }
 
 .ce-image-preview-wrapper {
@@ -207,8 +207,8 @@
 }
 
 .ce-tp-tab.active {
-  background-color: #2563eb;
-  border-color: #2563eb;
+  background-color: #111827;
+  border-color: #111827;
   color: #ffffff;
 }
 
@@ -244,12 +244,12 @@
 }
 
 .ce-tp-cell:hover {
-  background-color: #eff6ff;
-  color: #2563eb;
+  background-color: #F3F4F6;
+  color: #111827;
 }
 
 .ce-tp-cell.selected {
-  background-color: #2563eb;
+  background-color: #111827;
   color: #ffffff;
   font-weight: 600;
 }
@@ -274,12 +274,12 @@
 }
 
 .ce-age-preset-chip:hover {
-  border-color: #2563eb;
+  border-color: #111827;
 }
 
 .ce-age-preset-chip.selected {
-  background-color: #2563eb;
-  border-color: #2563eb;
+  background-color: #111827;
+  border-color: #111827;
   color: #ffffff;
 }
 
@@ -302,12 +302,12 @@
 }
 
 .ce-category-chip:hover {
-  border-color: #2563eb;
+  border-color: #111827;
 }
 
 .ce-category-chip.selected {
-  background-color: #2563eb;
-  border-color: #2563eb;
+  background-color: #111827;
+  border-color: #111827;
   color: #ffffff;
 }
 
@@ -329,12 +329,12 @@
 }
 
 .ce-privacy-chip:hover {
-  border-color: #2563eb;
+  border-color: #111827;
 }
 
 .ce-privacy-chip.selected {
-  background-color: #2563eb;
-  border-color: #2563eb;
+  background-color: #111827;
+  border-color: #111827;
   color: #ffffff;
 }
 
@@ -401,8 +401,8 @@
 .ce-tag-add-btn {
   padding: 10px 18px;
   border-radius: 10px;
-  border: 1px solid #2563eb;
-  background-color: #2563eb;
+  border: 1px solid #111827;
+  background-color: #111827;
   color: #ffffff;
   font-size: 14px;
   font-weight: 600;
@@ -412,7 +412,7 @@
 }
 
 .ce-tag-add-btn:hover:not(:disabled) {
-  background-color: #1d4ed8;
+  background-color: #0F172A;
 }
 
 .ce-tag-add-btn:disabled {
@@ -433,8 +433,8 @@
   gap: 6px;
   padding: 5px 12px;
   border-radius: 20px;
-  background-color: #eff6ff;
-  color: #2563eb;
+  background-color: #F3F4F6;
+  color: #111827;
   font-size: 13px;
   font-weight: 500;
 }
@@ -442,7 +442,7 @@
 .ce-tag-remove {
   background: none;
   border: none;
-  color: #2563eb;
+  color: #111827;
   font-size: 16px;
   line-height: 1;
   cursor: pointer;

--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -62,14 +62,14 @@
 
 .dc-filter-toggle:hover,
 .dc-filter-toggle.active {
-  border-color: #2563eb;
-  color: #2563eb;
+  border-color: #111827;
+  color: #111827;
 }
 
 .dc-filter-toggle.has-filters {
-  background-color: #eff6ff;
-  border-color: #2563eb;
-  color: #2563eb;
+  background-color: #F3F4F6;
+  border-color: #111827;
+  color: #111827;
   font-weight: 600;
 }
 
@@ -115,12 +115,12 @@
 }
 
 .dc-filter-chip:hover {
-  border-color: #2563eb;
+  border-color: #111827;
 }
 
 .dc-filter-chip.selected {
-  background-color: #2563eb;
-  border-color: #2563eb;
+  background-color: #111827;
+  border-color: #111827;
   color: #ffffff;
 }
 
@@ -184,16 +184,16 @@
 .dc-use-my-loc {
   padding: 2px 10px;
   border-radius: 12px;
-  border: 1px solid #2563eb;
+  border: 1px solid #111827;
   background: none;
-  color: #2563eb;
+  color: #111827;
   font-size: 12px;
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .dc-use-my-loc:hover {
-  background-color: #eff6ff;
+  background-color: #F3F4F6;
 }
 
 .dc-location-wrapper {
@@ -264,12 +264,12 @@
 }
 
 .dc-sort-chip:hover {
-  border-color: #2563eb;
+  border-color: #111827;
 }
 
 .dc-sort-chip.selected {
-  background-color: #2563eb;
-  border-color: #2563eb;
+  background-color: #111827;
+  border-color: #111827;
   color: #ffffff;
 }
 
@@ -292,14 +292,14 @@
 }
 
 .dc-category-chip:hover {
-  border-color: #2563eb;
-  color: #2563eb;
+  border-color: #111827;
+  color: #111827;
 }
 
 .dc-category-chip.selected {
-  background-color: #eff6ff;
-  border-color: #2563eb;
-  color: #2563eb;
+  background-color: #F3F4F6;
+  border-color: #111827;
+  color: #111827;
   font-weight: 600;
 }
 
@@ -453,7 +453,7 @@
 }
 
 .dc-card-category {
-  color: #2563eb;
+  color: #111827;
   font-weight: 600;
 }
 
@@ -525,8 +525,8 @@
 }
 
 .dc-load-more-btn:hover:not(:disabled) {
-  border-color: #2563eb;
-  color: #2563eb;
+  border-color: #111827;
+  color: #111827;
 }
 
 .dc-load-more-btn:disabled {

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -19,8 +19,8 @@
 }
 
 .ed-back-btn:hover {
-  border-color: #2563eb;
-  color: #2563eb;
+  border-color: #111827;
+  color: #111827;
 }
 
 /* Hero image */
@@ -261,8 +261,8 @@
   display: inline-block;
   padding: 4px 12px;
   border-radius: 14px;
-  background-color: #eff6ff;
-  color: #2563eb;
+  background-color: #F3F4F6;
+  color: #111827;
   font-size: 13px;
   font-weight: 600;
 }
@@ -431,8 +431,8 @@
 .ed-tag {
   padding: 5px 14px;
   border-radius: 16px;
-  background-color: #eff6ff;
-  color: #2563eb;
+  background-color: #F3F4F6;
+  color: #111827;
   font-size: 13px;
   font-weight: 500;
 }
@@ -498,9 +498,9 @@
 }
 
 .ed-participation-invited {
-  background-color: #eff6ff;
-  color: #2563eb;
-  border: 1px solid #bfdbfe;
+  background-color: #F3F4F6;
+  color: #111827;
+  border: 1px solid #D1D5DB;
 }
 
 .ed-leave-action {
@@ -541,12 +541,12 @@
 .ed-rating-banner {
   padding: 12px 16px;
   border-radius: 10px;
-  background-color: #eff6ff;
-  color: #2563eb;
+  background-color: #F3F4F6;
+  color: #111827;
   font-size: 14px;
   font-weight: 500;
   text-align: center;
-  border: 1px solid #bfdbfe;
+  border: 1px solid #D1D5DB;
   margin-bottom: 10px;
 }
 
@@ -556,11 +556,11 @@
   gap: 16px;
   padding: 24px;
   border-radius: 20px;
-  border: 1px solid #bfdbfe;
+  border: 1px solid #D1D5DB;
   background:
-    radial-gradient(circle at top right, rgba(37, 99, 235, 0.16), transparent 36%),
-    linear-gradient(135deg, #f8fbff 0%, #eef4ff 100%);
-  box-shadow: 0 16px 40px rgba(37, 99, 235, 0.08);
+    radial-gradient(circle at top right, rgba(17, 24, 39, 0.06), transparent 36%),
+    linear-gradient(135deg, #FAFAFA 0%, #F3F4F6 100%);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.06);
 }
 
 .ed-participant-rating-section {
@@ -580,8 +580,8 @@
   align-items: center;
   padding: 6px 10px;
   border-radius: 999px;
-  background-color: #dbeafe;
-  color: #1d4ed8;
+  background-color: #E2E8F0;
+  color: #111827;
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -606,8 +606,8 @@
   padding: 8px 12px;
   border-radius: 999px;
   background-color: rgba(255, 255, 255, 0.85);
-  border: 1px solid rgba(37, 99, 235, 0.18);
-  color: #1e40af;
+  border: 1px solid rgba(17, 24, 39, 0.15);
+  color: #111827;
   font-size: 13px;
   font-weight: 600;
 }
@@ -811,9 +811,9 @@
   margin-left: auto;
   padding: 9px 14px;
   border-radius: 10px;
-  border: 1px solid #2563eb;
+  border: 1px solid #111827;
   background-color: #ffffff;
-  color: #2563eb;
+  color: #111827;
   font-size: 13px;
   font-weight: 700;
   cursor: pointer;
@@ -821,7 +821,7 @@
 }
 
 .ed-rate-participant-btn:hover:not(:disabled) {
-  background-color: #eff6ff;
+  background-color: #F3F4F6;
 }
 
 .ed-rate-participant-btn:disabled {
@@ -834,7 +834,7 @@
   margin-left: 48px;
   padding: 18px;
   border-radius: 16px;
-  border: 1px solid #dbeafe;
+  border: 1px solid #E5E7EB;
   background-color: #ffffff;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
   display: flex;
@@ -1209,7 +1209,7 @@
 }
 
 .ed-join-auth-link {
-  color: #2563eb;
+  color: #111827;
   font-weight: 600;
   text-decoration: none;
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -16,7 +16,7 @@ body {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     sans-serif;
   color: #111827;
-  background-color: #ffffff;
+  background-color: #F8FAFC;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -39,7 +39,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(ellipse at 30% 40%, #1a1a2e 0%, #0f0f14 70%);
+  background: radial-gradient(ellipse at 30% 40%, #1a1a22 0%, #0f0f14 70%);
 }
 
 .dot-canvas {
@@ -80,7 +80,7 @@
 
 .logo-icon {
   font-size: 32px;
-  color: #a78bfa;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .landing-tagline {
@@ -110,17 +110,17 @@
   letter-spacing: 0.2px;
 }
 
-/* Primary — solid purple */
+/* Primary — solid white */
 .landing-btn--primary {
-  background: #7c3aed;
-  color: #ffffff;
-  box-shadow: 0 4px 20px rgba(124, 58, 237, 0.4);
+  background: #ffffff;
+  color: #0F172A;
+  box-shadow: 0 4px 20px rgba(255, 255, 255, 0.25);
 }
 
 .landing-btn--primary:hover {
-  background: #6d28d9;
+  background: #F3F4F6;
   transform: translateY(-2px);
-  box-shadow: 0 6px 28px rgba(109, 40, 217, 0.45);
+  box-shadow: 0 6px 28px rgba(255, 255, 255, 0.3);
 }
 
 /* Outline */
@@ -132,8 +132,8 @@
 }
 
 .landing-btn--outline:hover {
-  border-color: rgba(139, 92, 246, 0.6);
-  background: rgba(139, 92, 246, 0.08);
+  border-color: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.08);
   transform: translateY(-2px);
 }
 

--- a/frontend/src/styles/my-events.css
+++ b/frontend/src/styles/my-events.css
@@ -45,8 +45,8 @@
 }
 
 .me-tab.active {
-  color: #2563eb;
-  border-bottom-color: #2563eb;
+  color: #111827;
+  border-bottom-color: #111827;
   font-weight: 600;
 }
 
@@ -60,8 +60,8 @@
 }
 
 .me-tab.active .me-tab-count {
-  background-color: #eff6ff;
-  color: #2563eb;
+  background-color: #F3F4F6;
+  color: #111827;
 }
 
 /* Loading */
@@ -163,7 +163,7 @@
 .me-card-category {
   font-size: 12px;
   font-weight: 600;
-  color: #2563eb;
+  color: #111827;
 }
 
 .me-card-title {

--- a/frontend/src/styles/profile.css
+++ b/frontend/src/styles/profile.css
@@ -25,8 +25,8 @@
 
 .edit-toggle-btn {
   background-color: transparent;
-  color: #2563eb;
-  border: 1px solid #2563eb;
+  color: #111827;
+  border: 1px solid #111827;
   padding: 0.5rem 1rem;
   border-radius: 6px;
   cursor: pointer;
@@ -35,7 +35,7 @@
 }
 
 .edit-toggle-btn:hover {
-  background-color: #2563eb;
+  background-color: #111827;
   color: white;
 }
 
@@ -51,7 +51,7 @@
   height: 120px;
   border-radius: 50%;
   object-fit: cover;
-  border: 3px solid #2563eb;
+  border: 3px solid #111827;
   background-color: #e5e7eb;
 }
 
@@ -130,7 +130,7 @@
 .form-group input:focus,
 .form-group textarea:focus {
   outline: none;
-  border-color: #2563eb;
+  border-color: #111827;
 }
 
 .form-group textarea {
@@ -146,7 +146,7 @@
 
 .save-btn {
   flex: 1;
-  background-color: #2563eb;
+  background-color: #111827;
   color: #ffffff;
   border: none;
   padding: 0.75rem;

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -28,7 +28,7 @@
 .shell-logo {
   font-size: 18px;
   font-weight: 700;
-  color: #2563eb;
+  color: #111827;
   text-decoration: none;
   white-space: nowrap;
 }
@@ -58,8 +58,8 @@
 }
 
 .shell-nav-link.active {
-  color: #2563eb;
-  background-color: #eff6ff;
+  color: #111827;
+  background-color: #F3F4F6;
   font-weight: 600;
 }
 
@@ -76,7 +76,7 @@
   font-size: 14px;
   font-weight: 600;
   color: #ffffff;
-  background-color: #2563eb;
+  background-color: #111827;
   text-decoration: none;
   border-radius: 8px;
   white-space: nowrap;
@@ -84,7 +84,7 @@
 }
 
 .shell-create-btn:hover {
-  background-color: #1d4ed8;
+  background-color: #0F172A;
 }
 
 /* User menu */
@@ -175,15 +175,15 @@
   padding: 7px 16px;
   font-size: 14px;
   font-weight: 600;
-  color: #2563eb;
+  color: #111827;
   text-decoration: none;
-  border: 1px solid #2563eb;
+  border: 1px solid #111827;
   border-radius: 8px;
   transition: all 0.15s;
 }
 
 .shell-signin-btn:hover {
-  background-color: #eff6ff;
+  background-color: #F3F4F6;
 }
 
 .shell-signup-btn {
@@ -191,14 +191,14 @@
   font-size: 14px;
   font-weight: 600;
   color: #ffffff;
-  background-color: #2563eb;
+  background-color: #111827;
   text-decoration: none;
   border-radius: 8px;
   transition: background-color 0.15s;
 }
 
 .shell-signup-btn:hover {
-  background-color: #1d4ed8;
+  background-color: #0F172A;
 }
 
 /* Hamburger (hidden on desktop) */
@@ -330,21 +330,21 @@
     height: 56px;
     border-radius: 50%;
     border: none;
-    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    background: linear-gradient(135deg, #111827, #0F172A);
     color: #ffffff;
     font-size: 28px;
     font-weight: 300;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    box-shadow: 0 4px 16px rgba(37, 99, 235, 0.4);
+    box-shadow: 0 4px 16px rgba(15, 23, 42, 0.3);
     transition: transform 0.15s, box-shadow 0.15s;
     text-decoration: none;
   }
 
   .shell-fab:hover {
     transform: scale(1.08);
-    box-shadow: 0 6px 24px rgba(37, 99, 235, 0.5);
+    box-shadow: 0 6px 24px rgba(15, 23, 42, 0.4);
   }
 
   .shell-fab:active {

--- a/frontend/src/views/auth/LandingPage.tsx
+++ b/frontend/src/views/auth/LandingPage.tsx
@@ -11,10 +11,10 @@ function DotCanvas() {
   const raf = useRef(0);
 
   const COLORS = [
-    'rgba(59,130,246,.50)',   // blue
-    'rgba(99,102,241,.55)',   // indigo
-    'rgba(139,92,246,.50)',   // violet
-    'rgba(168,85,247,.45)',   // purple
+    'rgba(255,255,255,.30)',
+    'rgba(200,200,210,.35)',
+    'rgba(160,165,175,.30)',
+    'rgba(130,135,145,.25)',
   ];
 
   const initDots = useCallback((w: number, h: number) => {


### PR DESCRIPTION
## 📋 Summary

Aligns the web frontend with the mobile app’s neutral **black/white** visual language: primary actions and chrome use near-black (`#111827` / `#0F172A`) instead of blue, page background matches mobile slate (`#F8FAFC`), and the landing page drops purple CTAs for monochrome styling. Semantic colors (status badges, errors, success, ratings) are unchanged to stay consistent with mobile.

## 🔄 Changes

- **`frontend/src/styles/global.css`** — Default page background set to `#F8FAFC`.
- **`frontend/src/styles/shell.css`** — Logo, nav active state, auth buttons, create button, mobile FAB: blue → neutral dark; FAB gradient and shadows updated.
- **`frontend/src/styles/auth.css`** — Focus rings, pills, primary/outline buttons, links, step dots: blue → neutral palette.
- **`frontend/src/styles/landing.css`** — Primary/outline/ghost buttons and logo accent: purple/blue → white/neutral on dark panel; right-panel gradient slightly neutralized.
- **`frontend/src/styles/discover.css`**, **`create-event.css`**, **`event-detail.css`**, **`my-events.css`**, **`profile.css`** — Filters, chips, tags, category accents, rating UI, tabs, profile controls: brand blue → `#111827` / gray surfaces where appropriate.
- **`frontend/src/components/UserAvatar.css`** — Accent fill from blue to `#111827`.
- **`frontend/src/components/ProtectedRoute.tsx`** — Loading spinner colors aligned with neutral theme.
- **`frontend/src/views/auth/LandingPage.tsx`** — Dot-canvas palette from blue/violet to neutral grays/whites.

**Behavior:** No API or routing changes; visual/styling only.

## 🧪 Testing

- Run the frontend (`npm run dev` in `frontend/`) and spot-check: landing, login/register, shell nav (desktop + mobile menu + FAB), Discover filters/chips, create event, event detail, my events/favorites, profile, 404/fallback if touched.
- Confirm primary buttons and links are dark/neutral, not blue; landing “Sign In” reads clearly on dark panel.
- Optional: `npm test` in `frontend/` if you want automated coverage on unchanged logic.

## 🔗 Related
Closes #348 