### PR TITLE
fix(frontend): upcoming event card badge styling

### DIFF
--- a/frontend/src/styles/my-events.css
+++ b/frontend/src/styles/my-events.css
@@ -195,6 +195,18 @@
   flex-shrink: 0;
 }
 
+.me-status-upcoming {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+  border: 1px solid #93c5fd;
+}
+
+.me-status-in-progress {
+  background-color: #fef9c3;
+  color: #a16207;
+  border: 1px solid #fde047;
+}
+
 .me-status-active {
   background-color: #dcfce7;
   color: #16a34a;

--- a/frontend/src/views/events/MyEventsPage.tsx
+++ b/frontend/src/views/events/MyEventsPage.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useMyEventsViewModel, type MyEventsTab } from '@/viewmodels/event/useMyEventsViewModel';
 import type { EventSummary } from '@/models/profile';
 import { EventCoverImage } from '@/components/EventCoverImage';
-import { getEventStatusPresentation } from '@/utils/eventStatus';
+import { getEventLifecyclePresentation, getEventStatusPresentation } from '@/utils/eventStatus';
 import '@/styles/my-events.css';
 
 function formatDate(iso: string): string {
@@ -26,6 +26,15 @@ function formatTime(iso: string): string {
 }
 
 function StatusBadge({ status }: { status: string }) {
+  const lifecycle = getEventLifecyclePresentation(status);
+  if (lifecycle) {
+    const cls = lifecycle.variant === 'upcoming'
+      ? 'me-status-upcoming'
+      : 'me-status-in-progress';
+
+    return <span className={`me-status-badge ${cls}`}>{lifecycle.label}</span>;
+  }
+
   const presentation = getEventStatusPresentation(status);
   const cls = presentation.tone === 'active'
     ? 'me-status-active'

--- a/frontend/src/views/favorites/FavoritesPage.tsx
+++ b/frontend/src/views/favorites/FavoritesPage.tsx
@@ -5,7 +5,7 @@ import { useFavoritesViewModel } from '@/viewmodels/favorites/useFavoritesViewMo
 import FavoriteLocationsTab from './FavoriteLocationsTab';
 import type { FavoriteEventItem } from '@/models/event';
 import { EventCoverImage } from '@/components/EventCoverImage';
-import { getEventStatusPresentation } from '@/utils/eventStatus';
+import { getEventLifecyclePresentation, getEventStatusPresentation } from '@/utils/eventStatus';
 import '@/styles/my-events.css';
 import '@/styles/favorites.css';
 
@@ -31,6 +31,15 @@ function formatTime(iso: string): string {
 }
 
 function StatusBadge({ status }: { status: string }) {
+  const lifecycle = getEventLifecyclePresentation(status);
+  if (lifecycle) {
+    const cls = lifecycle.variant === 'upcoming'
+      ? 'me-status-upcoming'
+      : 'me-status-in-progress';
+
+    return <span className={`me-status-badge ${cls}`}>{lifecycle.label}</span>;
+  }
+
   const presentation = getEventStatusPresentation(status);
   const cls = presentation.tone === 'active'
     ? 'me-status-active'


### PR DESCRIPTION
## 📋 Summary
Updates web event cards so upcoming events no longer appear with a green `Active` badge. Events with backend status `ACTIVE` now render as a blue `UPCOMING` badge, matching the intended lifecycle wording and improving clarity for users.

## 🔄 Changes
- Updated event card badge rendering in `frontend/src/views/events/MyEventsPage.tsx`
- Updated favorite event card badge rendering in `frontend/src/views/favorites/FavoritesPage.tsx`
- Reused lifecycle-based presentation for `ACTIVE` and `IN_PROGRESS` statuses before falling back to generic status labels
- Added shared badge styles for upcoming and in-progress states in `frontend/src/styles/my-events.css`
- Preserved existing completed and canceled badge behavior

## 🧪 Testing
- Run `cd frontend`
- Run `npm exec tsc -b`
- Open the web app and go to My Events and Favorites
- Verify that upcoming events show a blue `UPCOMING` badge
- Verify that in-progress events still show `IN PROGRESS`
- Verify that completed and canceled events still render their existing badges

## 🔗 Related
Link issues with:  #393 
