### PR TITLE
feat(mobile):  Home Location Flow & UX Improvements

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -7,7 +7,13 @@
     "scheme": "social-event-mapper",
     "userInterfaceStyle": "automatic",
     "plugins": [
-      "expo-router"
+      "expo-router",
+      [
+        "expo-location",
+        {
+          "locationWhenInUsePermission": "Allow Social Event Mapper to access your location so we can suggest nearby events and fill in your current location when you do not have a default location set."
+        }
+      ]
     ],
     "android": {
       "package": "com.bounswe2026group11.socialeventmapper",

--- a/mobile/jest.config.cjs
+++ b/mobile/jest.config.cjs
@@ -12,6 +12,7 @@ module.exports = {
     '^expo-file-system/legacy$': '<rootDir>/jest/mocks/expo-file-system-legacy.js',
     '^expo-image-picker$': '<rootDir>/jest/mocks/expo-image-picker.js',
     '^expo-image-manipulator$': '<rootDir>/jest/mocks/expo-image-manipulator.js',
+    '^expo-location$': '<rootDir>/jest/mocks/expo-location.js',
     '^expo-secure-store$': '<rootDir>/jest/mocks/expo-secure-store.js',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],

--- a/mobile/jest/mocks/expo-location.js
+++ b/mobile/jest/mocks/expo-location.js
@@ -1,0 +1,20 @@
+module.exports = {
+  PermissionStatus: {
+    GRANTED: 'granted',
+    DENIED: 'denied',
+    UNDETERMINED: 'undetermined',
+  },
+  Accuracy: {
+    Balanced: 3,
+  },
+  requestForegroundPermissionsAsync: jest.fn(async () => ({
+    status: 'denied',
+  })),
+  getCurrentPositionAsync: jest.fn(async () => ({
+    coords: {
+      latitude: 0,
+      longitude: 0,
+    },
+  })),
+  reverseGeocodeAsync: jest.fn(async () => []),
+};

--- a/mobile/jest/mocks/react-native.js
+++ b/mobile/jest/mocks/react-native.js
@@ -34,6 +34,7 @@ const REACT_NATIVE_ONLY_PROPS = new Set([
   'delayPressOut',
   'hitSlop',
   'horizontal',
+  'keyboardType',
   'nestedScrollEnabled',
   'overScrollMode',
   'pressRetentionOffset',
@@ -46,6 +47,7 @@ const REACT_NATIVE_ONLY_PROPS = new Set([
   'shouldRasterizeIOS',
   'snapToAlignment',
   'snapToInterval',
+  'textContentType',
   'tvParallaxProperties',
 ]);
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -14,6 +14,7 @@
         "expo-image-manipulator": "~55.0.13",
         "expo-image-picker": "~55.0.16",
         "expo-linking": "~55.0.8",
+        "expo-location": "~55.1.7",
         "expo-router": "~55.0.7",
         "expo-secure-store": "^55.0.11",
         "expo-splash-screen": "~55.0.12",
@@ -6144,6 +6145,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "55.1.7",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-55.1.7.tgz",
+      "integrity": "sha512-E8Qib2yAHTU7WZM/Qrmfx7G/OvMAnjeIyinyKK6x/sFxm+nBu/hKwGEp2BIW9ubM1tBjaId7S0WSAaZr3OPzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.12"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,6 +16,7 @@
     "expo-image-manipulator": "~55.0.13",
     "expo-image-picker": "~55.0.16",
     "expo-linking": "~55.0.8",
+    "expo-location": "~55.1.7",
     "expo-router": "~55.0.7",
     "expo-secure-store": "^55.0.11",
     "expo-splash-screen": "~55.0.12",

--- a/mobile/src/components/home/LocationPickerPanel.test.tsx
+++ b/mobile/src/components/home/LocationPickerPanel.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import LocationPickerPanel from './LocationPickerPanel';
+
+jest.mock('react-native', () => {
+  const ReactLocal = require('react');
+
+  const reactNativeOnlyProps = new Set([
+    'accessibilityLabel',
+    'accessibilityRole',
+    'activeOpacity',
+    'autoCorrect',
+    'contentContainerStyle',
+    'keyboardShouldPersistTaps',
+    'numberOfLines',
+    'placeholderTextColor',
+    'showsVerticalScrollIndicator',
+    'transparent',
+    'animationType',
+    'onRequestClose',
+  ]);
+
+  const stripReactNativeOnlyProps = (props: Record<string, unknown>) => {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(props)) {
+      if (!reactNativeOnlyProps.has(key)) {
+        out[key] = props[key];
+      }
+    }
+    return out;
+  };
+
+  const createDiv =
+    (displayName: string) =>
+      ({ children, ...props }: { children?: React.ReactNode }) =>
+        ReactLocal.createElement(
+          'div',
+          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          children,
+        );
+
+  const createSpan =
+    (displayName: string) =>
+      ({ children, ...props }: { children?: React.ReactNode }) =>
+        ReactLocal.createElement(
+          'span',
+          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          children,
+        );
+
+  const createButton =
+    (displayName: string) =>
+      ({
+        children,
+        onPress,
+        disabled,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        onPress?: () => void;
+        disabled?: boolean;
+      }) =>
+        ReactLocal.createElement(
+          'button',
+          {
+            ...stripReactNativeOnlyProps(props),
+            'data-testid': displayName,
+            type: 'button',
+            disabled,
+            onClick: disabled ? undefined : onPress,
+          },
+          children,
+        );
+
+  return {
+    ActivityIndicator: createDiv('ActivityIndicator'),
+    Modal: ({
+      children,
+      visible,
+    }: {
+      children?: React.ReactNode;
+      visible: boolean;
+    }) => (visible ? ReactLocal.createElement('div', null, children) : null),
+    View: createDiv('View'),
+    ScrollView: createDiv('ScrollView'),
+    Pressable: createButton('Pressable'),
+    Text: createSpan('Text'),
+    TextInput: ({
+      value,
+      onChangeText,
+      ...props
+    }: {
+      value?: string;
+      onChangeText?: (value: string) => void;
+    }) =>
+      ReactLocal.createElement('input', {
+        ...stripReactNativeOnlyProps(props),
+        value,
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+          onChangeText?.(event.target.value),
+      }),
+    TouchableOpacity: createButton('TouchableOpacity'),
+    StyleSheet: {
+      create: <T,>(styles: T) => styles,
+      absoluteFillObject: {},
+    },
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const ReactLocal = require('react');
+
+  return {
+    Feather: ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', {
+        'data-icon-library': 'feather',
+        'data-icon': name,
+      }),
+  };
+});
+
+function buildProps() {
+  return {
+    visible: true,
+    query: '',
+    suggestions: [],
+    isSearching: false,
+    selectedLocation: null,
+    anchorTop: 120,
+    defaultOption: {
+      title: 'Use Default Location',
+      subtitle: 'Kadikoy, Istanbul, Turkiye',
+      suggestion: {
+        display_name: 'Kadikoy, Istanbul, Turkiye',
+        lat: '40.9909',
+        lon: '29.0293',
+      },
+      isLoading: false,
+    },
+    favoriteOptions: [
+      {
+        id: 'favorite-1',
+        title: 'Home',
+        subtitle: 'Kadikoy, Istanbul, Turkiye',
+        suggestion: {
+          display_name: 'Kadikoy, Istanbul, Turkiye',
+          lat: '40.9909',
+          lon: '29.0293',
+        },
+      },
+      {
+        id: 'favorite-2',
+        title: 'Gym',
+        subtitle: 'Besiktas, Istanbul, Turkiye',
+        suggestion: {
+          display_name: 'Besiktas, Istanbul, Turkiye',
+          lat: '41.0422',
+          lon: '29.0083',
+        },
+      },
+    ],
+    isLoadingFavoriteLocations: false,
+    favoriteLocationsError: null,
+    onClose: jest.fn(),
+    onReset: jest.fn(),
+    onRetryFavoriteLocations: jest.fn(),
+    onChangeQuery: jest.fn(),
+    onSelectSavedLocation: jest.fn(),
+    onSelectSuggestion: jest.fn(),
+    onApply: jest.fn(),
+  };
+}
+
+describe('LocationPickerPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the default option and favorite locations as ready-to-use choices', () => {
+    const props = buildProps();
+
+    render(<LocationPickerPanel {...props} />);
+
+    expect(screen.getByPlaceholderText('Search for a location')).toBeTruthy();
+    expect(screen.getByText('Use Default Location')).toBeTruthy();
+    expect(screen.getByText('Favorite Locations')).toBeTruthy();
+    expect(screen.getByText('Home')).toBeTruthy();
+    expect(screen.getByText('Gym')).toBeTruthy();
+    expect(screen.getAllByText('Kadikoy, Istanbul, Turkiye').length).toBeGreaterThan(0);
+    expect(
+      (screen.getByText('Apply Location').closest('button') as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it('shows a loading state while favorite locations are being fetched', () => {
+    const props = buildProps();
+
+    render(
+      <LocationPickerPanel
+        {...props}
+        favoriteOptions={[]}
+        isLoadingFavoriteLocations
+      />,
+    );
+
+    expect(screen.getByText('Loading favorite locations...')).toBeTruthy();
+    expect(screen.queryByText('No favorite locations saved yet.')).toBeNull();
+  });
+
+  it('shows an empty state when the user has no favorite locations', () => {
+    const props = buildProps();
+
+    render(
+      <LocationPickerPanel
+        {...props}
+        favoriteOptions={[]}
+      />,
+    );
+
+    expect(screen.getByText('No favorite locations saved yet.')).toBeTruthy();
+  });
+
+  it('shows an error state with retry when favorite locations fail to load', () => {
+    const props = buildProps();
+
+    render(
+      <LocationPickerPanel
+        {...props}
+        favoriteOptions={[]}
+        favoriteLocationsError="Failed to load favorite locations. Please try again."
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Retry'));
+
+    expect(screen.getByText('Unable to load favorite locations')).toBeTruthy();
+    expect(props.onRetryFavoriteLocations).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows only search results while the user is searching', () => {
+    const props = buildProps();
+
+    render(
+      <LocationPickerPanel
+        {...props}
+        query="be"
+        suggestions={[
+          {
+            display_name: 'Besiktas, Istanbul, Turkiye',
+            lat: '41.0422',
+            lon: '29.0083',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Search Results')).toBeTruthy();
+    expect(screen.getByText('Besiktas, Istanbul')).toBeTruthy();
+    expect(screen.queryByText('Ready To Use')).toBeNull();
+    expect(screen.queryByText('Favorite Locations')).toBeNull();
+    expect(screen.queryByText('Use Default Location')).toBeNull();
+  });
+});

--- a/mobile/src/components/home/LocationPickerPanel.tsx
+++ b/mobile/src/components/home/LocationPickerPanel.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {
   ActivityIndicator,
-  FlatList,
   Modal,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -14,6 +14,13 @@ import { Feather } from '@expo/vector-icons';
 import { LocationSuggestion } from '@/models/event';
 import { formatEventLocation } from '@/utils/eventLocation';
 
+interface SavedLocationOption {
+  id: string;
+  title: string;
+  subtitle: string;
+  suggestion: LocationSuggestion;
+}
+
 interface LocationPickerPanelProps {
   visible: boolean;
   query: string;
@@ -21,11 +28,77 @@ interface LocationPickerPanelProps {
   isSearching: boolean;
   selectedLocation: LocationSuggestion | null;
   anchorTop: number;
+  defaultOption: {
+    title: string;
+    subtitle: string;
+    suggestion: LocationSuggestion | null;
+    isLoading: boolean;
+  };
+  favoriteOptions: SavedLocationOption[];
+  isLoadingFavoriteLocations: boolean;
+  favoriteLocationsError: string | null;
   onClose: () => void;
   onReset: () => void;
+  onRetryFavoriteLocations: () => void;
   onChangeQuery: (value: string) => void;
+  onSelectSavedLocation: (suggestion: LocationSuggestion) => void;
   onSelectSuggestion: (suggestion: LocationSuggestion) => void;
   onApply: () => void;
+}
+
+function isSelectedLocation(
+  selectedLocation: LocationSuggestion | null,
+  suggestion: LocationSuggestion | null,
+): boolean {
+  if (!selectedLocation || !suggestion) {
+    return false;
+  }
+
+  return (
+    selectedLocation.lat === suggestion.lat &&
+    selectedLocation.lon === suggestion.lon
+  );
+}
+
+function SavedLocationCard({
+  title,
+  subtitle,
+  iconName,
+  isSelected,
+  isDisabled = false,
+  onPress,
+}: {
+  title: string;
+  subtitle: string;
+  iconName: React.ComponentProps<typeof Feather>['name'];
+  isSelected: boolean;
+  isDisabled?: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <TouchableOpacity
+      style={[
+        styles.savedOptionCard,
+        isSelected && styles.savedOptionCardSelected,
+        isDisabled && styles.savedOptionCardDisabled,
+      ]}
+      onPress={onPress}
+      disabled={isDisabled}
+      activeOpacity={0.85}
+    >
+      <Feather
+        name={isSelected ? 'check-circle' : iconName}
+        size={18}
+        color={isSelected ? '#111827' : '#6B7280'}
+      />
+      <View style={styles.savedOptionContent}>
+        <Text style={styles.savedOptionTitle}>{title}</Text>
+        <Text style={styles.savedOptionSubtitle} numberOfLines={2}>
+          {subtitle}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
 }
 
 export default function LocationPickerPanel({
@@ -35,14 +108,26 @@ export default function LocationPickerPanel({
   isSearching,
   selectedLocation,
   anchorTop,
+  defaultOption,
+  favoriteOptions,
+  isLoadingFavoriteLocations,
+  favoriteLocationsError,
   onClose,
   onReset,
+  onRetryFavoriteLocations,
   onChangeQuery,
+  onSelectSavedLocation,
   onSelectSuggestion,
   onApply,
 }: LocationPickerPanelProps) {
-  const actionLabel =
-    query.trim().length === 0 ? 'Use Default Location' : 'Choose Location';
+  const trimmedQuery = query.trim();
+  const isSearchMode = trimmedQuery.length > 0;
+  const searchStateText =
+    trimmedQuery.length < 2
+      ? 'Type at least 2 characters.'
+      : 'No locations found.';
+
+  const canApply = Boolean(selectedLocation);
 
   return (
     <Modal
@@ -92,56 +177,128 @@ export default function LocationPickerPanel({
           </View>
 
           <View style={styles.listWrapper}>
-            {isSearching ? (
-              <View style={styles.centered}>
-                <ActivityIndicator size="small" color="#111827" />
-              </View>
-            ) : (
-              <FlatList
-                data={suggestions}
-                keyExtractor={(item, index) => `${item.lat}-${item.lon}-${index}`}
-                keyboardShouldPersistTaps="handled"
-                showsVerticalScrollIndicator={false}
-                renderItem={({ item }) => {
-                  const isSelected =
-                    selectedLocation?.lat === item.lat &&
-                    selectedLocation?.lon === item.lon;
+            <ScrollView
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={styles.listContent}
+            >
+              {isSearchMode ? (
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>Search Results</Text>
 
-                  return (
-                    <TouchableOpacity
-                      style={[styles.item, isSelected && styles.itemSelected]}
-                      onPress={() => onSelectSuggestion(item)}
-                      activeOpacity={0.85}
-                    >
-                      <Feather
-                        name={isSelected ? 'check-circle' : 'map-pin'}
-                        size={18}
-                        color={isSelected ? '#111827' : '#6B7280'}
-                      />
-                      <Text style={styles.itemText} numberOfLines={2}>
-                        {formatEventLocation(item.display_name)}
-                      </Text>
-                    </TouchableOpacity>
-                  );
-                }}
-                ListEmptyComponent={
-                  selectedLocation ? null : query.trim().length >= 2 ? (
-                    <Text style={styles.emptyText}>No locations found.</Text>
+                  {isSearching ? (
+                    <View style={styles.inlineStatusRow}>
+                      <ActivityIndicator size="small" color="#111827" />
+                      <Text style={styles.inlineStatusText}>Searching locations...</Text>
+                    </View>
+                  ) : suggestions.length > 0 ? (
+                    suggestions.map((item, index) => {
+                      const isSelected = isSelectedLocation(selectedLocation, item);
+
+                      return (
+                        <TouchableOpacity
+                          key={`${item.lat}-${item.lon}-${index}`}
+                          style={[styles.searchResultItem, isSelected && styles.savedOptionCardSelected]}
+                          onPress={() => onSelectSuggestion(item)}
+                          activeOpacity={0.85}
+                        >
+                          <Feather
+                            name={isSelected ? 'check-circle' : 'map-pin'}
+                            size={18}
+                            color={isSelected ? '#111827' : '#6B7280'}
+                          />
+                          <Text style={styles.searchResultText} numberOfLines={2}>
+                            {formatEventLocation(item.display_name)}
+                          </Text>
+                        </TouchableOpacity>
+                      );
+                    })
                   ) : (
-                    <Text style={styles.emptyText}>Type at least 2 characters.</Text>
-                  )
-                }
-                contentContainerStyle={styles.listContent}
-              />
-            )}
+                    <Text style={styles.emptyText}>{searchStateText}</Text>
+                  )}
+                </View>
+              ) : (
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>Ready To Use</Text>
+
+                  <SavedLocationCard
+                    title={defaultOption.title}
+                    subtitle={defaultOption.subtitle}
+                    iconName={defaultOption.isLoading ? 'loader' : 'home'}
+                    isSelected={isSelectedLocation(
+                      selectedLocation,
+                      defaultOption.suggestion,
+                    )}
+                    isDisabled={defaultOption.isLoading || !defaultOption.suggestion}
+                    onPress={() => {
+                      if (defaultOption.suggestion) {
+                        onSelectSavedLocation(defaultOption.suggestion);
+                      }
+                    }}
+                  />
+
+                  <View style={styles.favoriteHeaderRow}>
+                    <Text style={styles.favoriteSectionTitle}>Favorite Locations</Text>
+                    <Text style={styles.favoriteCountText}>
+                      {favoriteOptions.length} / 3
+                    </Text>
+                  </View>
+
+                  {isLoadingFavoriteLocations ? (
+                    <View style={styles.inlineStatusRow}>
+                      <ActivityIndicator size="small" color="#111827" />
+                      <Text style={styles.inlineStatusText}>
+                        Loading favorite locations...
+                      </Text>
+                    </View>
+                  ) : favoriteLocationsError ? (
+                    <View style={styles.messageCard}>
+                      <Text style={styles.messageTitle}>
+                        Unable to load favorite locations
+                      </Text>
+                      <Text style={styles.messageText}>{favoriteLocationsError}</Text>
+                      <TouchableOpacity
+                        style={styles.retryButton}
+                        onPress={onRetryFavoriteLocations}
+                        activeOpacity={0.85}
+                      >
+                        <Text style={styles.retryButtonText}>Retry</Text>
+                      </TouchableOpacity>
+                    </View>
+                  ) : favoriteOptions.length === 0 ? (
+                    <Text style={styles.emptyText}>
+                      No favorite locations saved yet.
+                    </Text>
+                  ) : (
+                    favoriteOptions.map((option) => (
+                      <SavedLocationCard
+                        key={option.id}
+                        title={option.title}
+                        subtitle={option.subtitle}
+                        iconName="star"
+                        isSelected={isSelectedLocation(
+                          selectedLocation,
+                          option.suggestion,
+                        )}
+                        onPress={() => onSelectSavedLocation(option.suggestion)}
+                      />
+                    ))
+                  )}
+                </View>
+              )}
+            </ScrollView>
           </View>
 
           <TouchableOpacity
-            style={styles.applyButton}
+            style={[
+              styles.applyButton,
+              !canApply && styles.applyButtonDisabled,
+            ]}
             onPress={onApply}
             activeOpacity={0.85}
+            disabled={!canApply}
           >
-            <Text style={styles.applyButtonText}>{actionLabel}</Text>
+            <Text style={styles.applyButtonText}>Apply Location</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -216,18 +373,24 @@ const styles = StyleSheet.create({
     color: '#111827',
   },
   listWrapper: {
-    maxHeight: 220,
-    minHeight: 80,
-  },
-  centered: {
-    minHeight: 80,
-    alignItems: 'center',
-    justifyContent: 'center',
+    maxHeight: 320,
+    minHeight: 180,
   },
   listContent: {
     paddingBottom: 4,
   },
-  item: {
+  section: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#6B7280',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    marginBottom: 10,
+  },
+  savedOptionCard: {
     backgroundColor: '#FFFFFF',
     borderRadius: 14,
     padding: 12,
@@ -238,11 +401,105 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#E5E7EB',
   },
-  itemSelected: {
+  savedOptionCardSelected: {
     borderColor: '#111827',
     backgroundColor: '#F9FAFB',
   },
-  itemText: {
+  savedOptionCardDisabled: {
+    opacity: 0.6,
+  },
+  savedOptionContent: {
+    flex: 1,
+  },
+  savedOptionTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  savedOptionSubtitle: {
+    fontSize: 13,
+    color: '#4B5563',
+    lineHeight: 18,
+  },
+  favoriteHeaderRow: {
+    marginTop: 6,
+    marginBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  favoriteSectionTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  favoriteCountText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  inlineStatusRow: {
+    minHeight: 56,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 12,
+  },
+  inlineStatusText: {
+    fontSize: 14,
+    color: '#4B5563',
+  },
+  messageCard: {
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#FECACA',
+    backgroundColor: '#FEF2F2',
+    padding: 12,
+  },
+  messageTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#991B1B',
+    marginBottom: 4,
+  },
+  messageText: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#B91C1C',
+  },
+  retryButton: {
+    marginTop: 10,
+    alignSelf: 'flex-start',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderWidth: 1,
+    borderColor: '#FCA5A5',
+  },
+  retryButtonText: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#991B1B',
+  },
+  searchResultItem: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 14,
+    padding: 12,
+    marginBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  searchResultText: {
     flex: 1,
     fontSize: 14,
     color: '#111827',
@@ -252,15 +509,18 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: '#6B7280',
     fontSize: 14,
-    marginTop: 20,
+    lineHeight: 20,
+    paddingVertical: 12,
   },
   applyButton: {
-    marginTop: 12,
     height: 52,
     borderRadius: 16,
     backgroundColor: '#111827',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  applyButtonDisabled: {
+    backgroundColor: '#9CA3AF',
   },
   applyButtonText: {
     fontSize: 15,

--- a/mobile/src/services/deviceLocationService.ts
+++ b/mobile/src/services/deviceLocationService.ts
@@ -1,0 +1,61 @@
+import * as ExpoLocation from 'expo-location';
+import type { LocationSuggestion } from '@/models/event';
+
+export const CURRENT_LOCATION_LABEL = 'Current location';
+
+function buildAddressLabel(
+  geocodedAddress?: ExpoLocation.LocationGeocodedAddress,
+): string {
+  if (!geocodedAddress) {
+    return CURRENT_LOCATION_LABEL;
+  }
+
+  if (geocodedAddress.formattedAddress) {
+    return geocodedAddress.formattedAddress;
+  }
+
+  const parts = [
+    geocodedAddress.name,
+    geocodedAddress.streetNumber && geocodedAddress.street
+      ? `${geocodedAddress.street} ${geocodedAddress.streetNumber}`
+      : geocodedAddress.street,
+    geocodedAddress.district,
+    geocodedAddress.city,
+    geocodedAddress.region,
+    geocodedAddress.country,
+  ].filter((value): value is string => Boolean(value?.trim()));
+
+  const uniqueParts = parts.filter(
+    (part, index) =>
+      index === parts.findIndex((candidate) => candidate.toLowerCase() === part.toLowerCase()),
+  );
+
+  return uniqueParts.join(', ') || CURRENT_LOCATION_LABEL;
+}
+
+export async function getCurrentLocationSuggestion(): Promise<LocationSuggestion | null> {
+  try {
+    const permission = await ExpoLocation.requestForegroundPermissionsAsync();
+
+    if (permission.status !== ExpoLocation.PermissionStatus.GRANTED) {
+      return null;
+    }
+
+    const position = await ExpoLocation.getCurrentPositionAsync({
+      accuracy: ExpoLocation.Accuracy.Balanced,
+    });
+
+    const addresses = await ExpoLocation.reverseGeocodeAsync({
+      latitude: position.coords.latitude,
+      longitude: position.coords.longitude,
+    });
+
+    return {
+      display_name: buildAddressLabel(addresses[0]),
+      lat: String(position.coords.latitude),
+      lon: String(position.coords.longitude),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/mobile/src/services/homeLocationSelectionStore.ts
+++ b/mobile/src/services/homeLocationSelectionStore.ts
@@ -1,0 +1,36 @@
+import type { LocationSuggestion } from '@/models/event';
+
+export type HomeLocationSelectionMode = 'DEFAULT' | 'CUSTOM';
+
+export interface HomeLocationSelectionState {
+  mode: HomeLocationSelectionMode;
+  location: LocationSuggestion | null;
+}
+
+const DEFAULT_SELECTION_STATE: HomeLocationSelectionState = {
+  mode: 'DEFAULT',
+  location: null,
+};
+
+const selectionsByScope = new Map<string, HomeLocationSelectionState>();
+
+export function getHomeLocationSelection(
+  scope: string,
+): HomeLocationSelectionState {
+  return selectionsByScope.get(scope) ?? DEFAULT_SELECTION_STATE;
+}
+
+export function setHomeLocationSelection(
+  scope: string,
+  selection: HomeLocationSelectionState,
+): void {
+  selectionsByScope.set(scope, selection);
+}
+
+export function clearHomeLocationSelection(scope: string): void {
+  selectionsByScope.delete(scope);
+}
+
+export function __resetHomeLocationSelectionStoreForTests(): void {
+  selectionsByScope.clear();
+}

--- a/mobile/src/viewmodels/home/useHomeViewModel.auth.test.tsx
+++ b/mobile/src/viewmodels/home/useHomeViewModel.auth.test.tsx
@@ -2,11 +2,16 @@
  * @jest-environment jsdom
  */
 import { renderHook, waitFor } from '@testing-library/react';
+import * as deviceLocationService from '@/services/deviceLocationService';
 import * as eventService from '@/services/eventService';
+import * as favoriteService from '@/services/favoriteService';
 import * as profileService from '@/services/profileService';
+import { __resetHomeLocationSelectionStoreForTests } from '@/services/homeLocationSelectionStore';
 import { useHomeViewModel } from './useHomeViewModel';
 
+jest.mock('@/services/deviceLocationService');
 jest.mock('@/services/eventService');
+jest.mock('@/services/favoriteService');
 jest.mock('@/services/profileService');
 jest.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -17,19 +22,26 @@ jest.mock('@/contexts/AuthContext', () => ({
   }),
 }));
 
+const mockGetCurrentLocationSuggestion = jest.mocked(
+  deviceLocationService.getCurrentLocationSuggestion,
+);
 const mockListEvents = jest.mocked(eventService.listEvents);
 const mockListCategories = jest.mocked(eventService.listCategories);
+const mockListFavoriteLocations = jest.mocked(favoriteService.listFavoriteLocations);
 const mockGetMyProfile = jest.mocked(profileService.getMyProfile);
 
 describe('useHomeViewModel auth behavior', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    __resetHomeLocationSelectionStoreForTests();
     mockListCategories.mockResolvedValue({
       items: [
         { id: 1, name: 'Sports' },
         { id: 2, name: 'Music' },
       ],
     });
+    mockGetCurrentLocationSuggestion.mockResolvedValue(null);
+    mockListFavoriteLocations.mockResolvedValue({ items: [] });
   });
 
   it('shows auth error and skips event loading when token is missing', async () => {

--- a/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
+++ b/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
@@ -2,15 +2,20 @@
  * @jest-environment jsdom
  */
 import { renderHook, act, waitFor } from '@testing-library/react';
+import * as deviceLocationService from '@/services/deviceLocationService';
 import * as eventService from '@/services/eventService';
+import * as favoriteService from '@/services/favoriteService';
 import * as profileService from '@/services/profileService';
 import type {
   ListCategoriesResponse,
   PaginatedEventsResponse,
 } from '@/models/event';
+import { __resetHomeLocationSelectionStoreForTests } from '@/services/homeLocationSelectionStore';
 import { useHomeViewModel } from './useHomeViewModel';
 
+jest.mock('@/services/deviceLocationService');
 jest.mock('@/services/eventService');
+jest.mock('@/services/favoriteService');
 jest.mock('@/services/profileService');
 jest.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -21,9 +26,13 @@ jest.mock('@/contexts/AuthContext', () => ({
   }),
 }));
 
+const mockGetCurrentLocationSuggestion = jest.mocked(
+  deviceLocationService.getCurrentLocationSuggestion,
+);
 const mockListEvents = jest.mocked(eventService.listEvents);
 const mockListCategories = jest.mocked(eventService.listCategories);
 const mockSearchLocation = jest.mocked(eventService.searchLocation);
+const mockListFavoriteLocations = jest.mocked(favoriteService.listFavoriteLocations);
 const mockGetMyProfile = jest.mocked(profileService.getMyProfile);
 
 const categoriesFixture: ListCategoriesResponse = {
@@ -106,8 +115,27 @@ const page2Fixture: PaginatedEventsResponse = {
 describe('useHomeViewModel', () => {
     beforeEach(() => {
     jest.clearAllMocks();
+    __resetHomeLocationSelectionStoreForTests();
     mockListCategories.mockResolvedValue(categoriesFixture);
     mockListEvents.mockResolvedValue(page1Fixture);
+    mockListFavoriteLocations.mockResolvedValue({
+      items: [
+        {
+          id: 'favorite-2',
+          name: 'Gym',
+          address: 'Besiktas, Istanbul, Turkiye',
+          lat: 41.0422,
+          lon: 29.0083,
+        },
+        {
+          id: 'favorite-1',
+          name: 'Home',
+          address: 'Kadikoy, Istanbul, Turkiye',
+          lat: 40.9909,
+          lon: 29.0293,
+        },
+      ],
+    });
     mockGetMyProfile.mockResolvedValue({
       id: 'user-1',
       username: 'mock',
@@ -124,6 +152,7 @@ describe('useHomeViewModel', () => {
       bio: null,
       avatar_url: null,
     });
+    mockGetCurrentLocationSuggestion.mockResolvedValue(null);
     mockSearchLocation.mockResolvedValue([
       {
         display_name: 'Kadikoy, Istanbul, Turkiye',
@@ -193,6 +222,10 @@ describe('useHomeViewModel', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
+    expect(result.current.defaultLocationOption.subtitle).toBe(
+      'Kadikoy, Istanbul, Turkiye',
+    );
+    expect(result.current.defaultLocationOption.isLoading).toBe(false);
     expect(mockListEvents).toHaveBeenCalledWith(
       expect.objectContaining({
         lat: 40.9909,
@@ -201,6 +234,118 @@ describe('useHomeViewModel', () => {
       'mock-token',
     );
     expect(result.current.locationLabel).toContain('Kadikoy');
+  });
+
+  it('keeps showing the resolved default location after silent refresh', async () => {
+    const profileDefault = {
+      id: 'user-1',
+      username: 'mock',
+      email: 'mock@example.com',
+      phone_number: null,
+      gender: null,
+      birth_date: null,
+      email_verified: true,
+      status: 'active',
+      default_location_address: 'Kadikoy, Istanbul, Turkiye',
+      default_location_lat: 40.9909,
+      default_location_lon: 29.0293,
+      display_name: null,
+      bio: null,
+      avatar_url: null,
+    };
+
+    mockGetMyProfile
+      .mockResolvedValueOnce(profileDefault)
+      .mockResolvedValue(profileDefault);
+
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.silentRefresh();
+    });
+
+    expect(result.current.defaultLocationOption.subtitle).toBe(
+      'Kadikoy, Istanbul, Turkiye',
+    );
+    expect(result.current.defaultLocationOption.isLoading).toBe(false);
+  });
+
+  it('requests the live location when no profile default exists and uses it when available', async () => {
+    mockGetCurrentLocationSuggestion.mockResolvedValueOnce({
+      display_name: 'Moda, Kadikoy, Istanbul, Turkiye',
+      lat: '40.9869',
+      lon: '29.0287',
+    });
+
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetCurrentLocationSuggestion).toHaveBeenCalledTimes(1);
+    expect(mockListEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lat: 40.9869,
+        lon: 29.0287,
+      }),
+      'mock-token',
+    );
+    expect(result.current.locationLabel).toBe('Moda, Kadikoy');
+    expect(result.current.defaultLocationOption.subtitle).toContain(
+      'Current location:',
+    );
+  });
+
+  it('loads favorite location options alphabetically and limits them to three items', async () => {
+    mockListFavoriteLocations.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'favorite-3',
+          name: 'Office',
+          address: 'Levent, Istanbul, Turkiye',
+          lat: 41.0827,
+          lon: 29.0112,
+        },
+        {
+          id: 'favorite-4',
+          name: 'Airport',
+          address: 'Arnavutkoy, Istanbul, Turkiye',
+          lat: 41.2753,
+          lon: 28.7519,
+        },
+        {
+          id: 'favorite-2',
+          name: 'Gym',
+          address: 'Besiktas, Istanbul, Turkiye',
+          lat: 41.0422,
+          lon: 29.0083,
+        },
+        {
+          id: 'favorite-1',
+          name: 'Home',
+          address: 'Kadikoy, Istanbul, Turkiye',
+          lat: 40.9909,
+          lon: 29.0293,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await waitFor(() => {
+      expect(result.current.isLoadingFavoriteLocations).toBe(false);
+    });
+
+    expect(result.current.favoriteLocationOptions.map((option) => option.title)).toEqual([
+      'Airport',
+      'Gym',
+      'Home',
+    ]);
   });
 
   it('updates search text', async () => {
@@ -752,6 +897,8 @@ describe('useHomeViewModel', () => {
       });
 
       expect(result.current.isLocationModalOpen).toBe(true);
+      expect(result.current.locationQuery).toBe('');
+      expect(result.current.pendingLocation).toBeNull();
 
       act(() => {
         result.current.closeLocationModal();
@@ -825,7 +972,7 @@ describe('useHomeViewModel', () => {
       expect(result.current.locationLabel).toBe('Kadikoy, Istanbul');
     });
 
-  it('resets location draft and keeps location modal open', async () => {
+    it('resets location draft and keeps location modal open', async () => {
       const { result } = renderHook(() => useHomeViewModel());
 
       await waitFor(() => {
@@ -853,12 +1000,14 @@ describe('useHomeViewModel', () => {
       expect(result.current.locationQuery).toBe('');
     });
 
-    it('applies system default location when no profile default exists', async () => {
+    it('applies the hardcoded fallback location only after the user explicitly selects it', async () => {
       const { result } = renderHook(() => useHomeViewModel());
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
       });
+
+      expect(mockGetCurrentLocationSuggestion).toHaveBeenCalledTimes(1);
 
       act(() => {
         result.current.openLocationModal();
@@ -885,7 +1034,9 @@ describe('useHomeViewModel', () => {
       });
 
       act(() => {
-        result.current.resetLocationDraft();
+        result.current.selectSavedLocationOption(
+          result.current.defaultLocationOption.suggestion!,
+        );
       });
 
       act(() => {
@@ -904,6 +1055,140 @@ describe('useHomeViewModel', () => {
 
       expect(result.current.isLocationModalOpen).toBe(false);
       expect(result.current.locationLabel).toBe('Istanbul');
+    });
+
+    it('applies a saved favorite location after it is selected', async () => {
+      const { result } = renderHook(() => useHomeViewModel());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await waitFor(() => {
+        expect(result.current.favoriteLocationOptions).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.openLocationModal();
+      });
+
+      act(() => {
+        result.current.selectSavedLocationOption(
+          result.current.favoriteLocationOptions[0].suggestion,
+        );
+      });
+
+      expect(result.current.pendingLocation?.display_name).toBe(
+        'Besiktas, Istanbul, Turkiye',
+      );
+
+      act(() => {
+        result.current.applySelectedLocation();
+      });
+
+      await waitFor(() => {
+        expect(mockListEvents).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            lat: 41.0422,
+            lon: 29.0083,
+          }),
+          'mock-token',
+        );
+      });
+
+      expect(result.current.locationLabel).toBe('Besiktas, Istanbul');
+    });
+
+    it('keeps the applied custom location after the hook remounts', async () => {
+      const firstRender = renderHook(() => useHomeViewModel());
+
+      await waitFor(() => {
+        expect(firstRender.result.current.isLoading).toBe(false);
+      });
+
+      await waitFor(() => {
+        expect(firstRender.result.current.favoriteLocationOptions).toHaveLength(2);
+      });
+
+      act(() => {
+        firstRender.result.current.openLocationModal();
+      });
+
+      act(() => {
+        firstRender.result.current.selectSavedLocationOption(
+          firstRender.result.current.favoriteLocationOptions[0].suggestion,
+        );
+      });
+
+      act(() => {
+        firstRender.result.current.applySelectedLocation();
+      });
+
+      await waitFor(() => {
+        expect(firstRender.result.current.locationLabel).toBe('Besiktas, Istanbul');
+      });
+
+      firstRender.unmount();
+
+      const secondRender = renderHook(() => useHomeViewModel());
+
+      await waitFor(() => {
+        expect(secondRender.result.current.isLoading).toBe(false);
+      });
+
+      expect(secondRender.result.current.locationLabel).toBe('Besiktas, Istanbul');
+      expect(mockListEvents).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          lat: 41.0422,
+          lon: 29.0083,
+        }),
+        'mock-token',
+      );
+    });
+
+    it('keeps the applied custom location during silent refresh', async () => {
+      const { result } = renderHook(() => useHomeViewModel());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await waitFor(() => {
+        expect(result.current.favoriteLocationOptions).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.openLocationModal();
+      });
+
+      act(() => {
+        result.current.selectSavedLocationOption(
+          result.current.favoriteLocationOptions[0].suggestion,
+        );
+      });
+
+      act(() => {
+        result.current.applySelectedLocation();
+      });
+
+      await waitFor(() => {
+        expect(result.current.locationLabel).toBe('Besiktas, Istanbul');
+      });
+
+      mockListEvents.mockResolvedValueOnce(page1Fixture);
+
+      await act(async () => {
+        await result.current.silentRefresh();
+      });
+
+      expect(result.current.locationLabel).toBe('Besiktas, Istanbul');
+      expect(mockListEvents).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          lat: 41.0422,
+          lon: 29.0083,
+        }),
+        'mock-token',
+      );
     });
 
     it('returns to the user profile default location after resetting a temporary location', async () => {
@@ -958,16 +1243,21 @@ describe('useHomeViewModel', () => {
         result.current.openLocationModal();
       });
 
-      expect(result.current.locationQuery).toBe('Besiktas, Istanbul, Turkiye');
+      expect(result.current.locationQuery).toBe('');
+      expect(result.current.pendingLocation).toBeNull();
 
       act(() => {
         result.current.resetLocationDraft();
       });
 
-      expect(result.current.pendingLocation?.display_name).toBe(
-        'Kadikoy, Istanbul, Turkiye',
-      );
+      expect(result.current.pendingLocation).toBeNull();
       expect(result.current.locationQuery).toBe('');
+
+      act(() => {
+        result.current.selectSavedLocationOption(
+          result.current.defaultLocationOption.suggestion!,
+        );
+      });
 
       act(() => {
         result.current.applySelectedLocation();

--- a/mobile/src/viewmodels/home/useHomeViewModel.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef,useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   EventCategory,
   EventSummary,
@@ -6,22 +6,32 @@ import {
   HomeFiltersDraft,
   LocationSuggestion,
 } from '@/models/event';
+import { FavoriteLocation } from '@/models/favorite';
+import { ApiError } from '@/services/api';
+import { getCurrentLocationSuggestion } from '@/services/deviceLocationService';
 import { listCategories, listEvents, searchLocation } from '@/services/eventService';
+import { listFavoriteLocations } from '@/services/favoriteService';
+import {
+  getHomeLocationSelection,
+  setHomeLocationSelection,
+} from '@/services/homeLocationSelectionStore';
 import { getMyProfile } from '@/services/profileService';
 import { formatEventLocation } from '@/utils/eventLocation';
 import { useAuth } from '@/contexts/AuthContext';
 
 const PAGE_SIZE = 2;
-
-function excludeInProgressEvents(items: EventSummary[]): EventSummary[] {
-  return items.filter((e) => e.status !== 'IN_PROGRESS');
-}
+const MAX_FAVORITE_LOCATION_OPTIONS = 3;
 
 const DEFAULT_LOCATION = {
   lat: 41.0082,
   lon: 28.9784,
 };
 const DEFAULT_LOCATION_LABEL = 'Istanbul';
+const FALLBACK_LOCATION: LocationSuggestion = {
+  display_name: DEFAULT_LOCATION_LABEL,
+  lat: String(DEFAULT_LOCATION.lat),
+  lon: String(DEFAULT_LOCATION.lon),
+};
 
 const DEFAULT_FILTERS: HomeFiltersDraft = {
   categoryIds: [],
@@ -30,6 +40,19 @@ const DEFAULT_FILTERS: HomeFiltersDraft = {
   endDate: '',
   radiusKm: 10,
 };
+
+type DefaultLocationSource = 'PROFILE' | 'LIVE' | 'FALLBACK';
+
+interface HomeLocationOption {
+  id: string;
+  title: string;
+  subtitle: string;
+  suggestion: LocationSuggestion;
+}
+
+function excludeInProgressEvents(items: EventSummary[]): EventSummary[] {
+  return items.filter((e) => e.status !== 'IN_PROGRESS');
+}
 
 function profileToSelectedLocation(profile: {
   default_location_address: string | null;
@@ -49,6 +72,60 @@ function profileToSelectedLocation(profile: {
     lat: String(profile.default_location_lat),
     lon: String(profile.default_location_lon),
   };
+}
+
+function favoriteLocationToSuggestion(location: FavoriteLocation): LocationSuggestion {
+  return {
+    display_name: location.address,
+    lat: String(location.lat),
+    lon: String(location.lon),
+  };
+}
+
+function sortFavoriteLocations(locations: FavoriteLocation[]): FavoriteLocation[] {
+  return [...locations].sort((left, right) => {
+    const nameComparison = left.name.localeCompare(
+      right.name,
+      undefined,
+      { sensitivity: 'base' },
+    );
+
+    if (nameComparison !== 0) {
+      return nameComparison;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function getFavoriteLocationsErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 401) {
+    return 'You must be logged in to view favorite locations.';
+  }
+
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return 'Failed to load favorite locations. Please try again.';
+}
+
+function getDefaultLocationSubtitle(
+  source: DefaultLocationSource,
+  location: LocationSuggestion | null,
+  isResolving: boolean,
+): string {
+  if (!location) {
+    return isResolving ? 'Resolving your location...' : 'Location unavailable.';
+  }
+
+  if (source === 'LIVE') {
+    return location.display_name === 'Current location'
+      ? 'Using your current live location.'
+      : `Current location: ${location.display_name}`;
+  }
+
+  return location.display_name;
 }
 
 function locationsMatch(
@@ -201,7 +278,6 @@ function validateFilterDatesLive(filters: HomeFiltersDraft): string | null {
       }
     }
 
-    // User is still typing the year; only partial day/month checks above should run
     if (value.length < 10) return null;
 
     const parsed = parseStrictDate(value);
@@ -234,8 +310,6 @@ function validateFilterDatesLive(filters: HomeFiltersDraft): string | null {
   return null;
 }
 
-
-
 export interface HomeViewModel {
   locationLabel: string;
   locationQuery: string;
@@ -243,6 +317,20 @@ export interface HomeViewModel {
   isSearchingLocation: boolean;
   isLocationModalOpen: boolean;
   pendingLocation: LocationSuggestion | null;
+  defaultLocationOption: {
+    title: string;
+    subtitle: string;
+    suggestion: LocationSuggestion | null;
+    isLoading: boolean;
+  };
+  favoriteLocationOptions: Array<{
+    id: string;
+    title: string;
+    subtitle: string;
+    suggestion: LocationSuggestion;
+  }>;
+  isLoadingFavoriteLocations: boolean;
+  favoriteLocationsError: string | null;
   categories: readonly EventCategory[];
   selectedCategoryId: number | null;
   searchText: string;
@@ -273,13 +361,17 @@ export interface HomeViewModel {
   openLocationModal: () => void;
   closeLocationModal: () => void;
   updateLocationQuery: (value: string) => void;
+  selectSavedLocationOption: (suggestion: LocationSuggestion) => void;
   selectLocationSuggestion: (suggestion: LocationSuggestion) => void;
   applySelectedLocation: () => void;
   resetLocationDraft: () => void;
+  retryFavoriteLocations: () => Promise<void>;
 }
 
 export function useHomeViewModel(): HomeViewModel {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
+  const locationSelectionScope = user?.id ?? token ?? 'anonymous';
+  const storedLocationSelection = getHomeLocationSelection(locationSelectionScope);
 
   const [categories, setCategories] = useState<EventCategory[]>([]);
   const [events, setEvents] = useState<EventSummary[]>([]);
@@ -288,17 +380,24 @@ export function useHomeViewModel(): HomeViewModel {
   const [locationSuggestions, setLocationSuggestions] = useState<LocationSuggestion[]>([]);
   const [isSearchingLocation, setIsSearchingLocation] = useState(false);
   const [isLocationModalOpen, setIsLocationModalOpen] = useState(false);
-  const [selectedLocation, setSelectedLocation] = useState<LocationSuggestion | null>(null);
-  const [defaultProfileLocation, setDefaultProfileLocation] = useState<LocationSuggestion | null>(null);
+  const [selectedLocation, setSelectedLocation] = useState<LocationSuggestion | null>(
+    storedLocationSelection.mode === 'CUSTOM'
+      ? storedLocationSelection.location
+      : null,
+  );
+  const [defaultLocation, setDefaultLocation] = useState<LocationSuggestion | null>(null);
+  const [defaultLocationSource, setDefaultLocationSource] =
+    useState<DefaultLocationSource>('FALLBACK');
   const [pendingLocation, setPendingLocation] = useState<LocationSuggestion | null>(null);
+  const [favoriteLocations, setFavoriteLocations] = useState<FavoriteLocation[]>([]);
+  const [isLoadingFavoriteLocations, setIsLoadingFavoriteLocations] = useState(true);
+  const [favoriteLocationsError, setFavoriteLocationsError] = useState<string | null>(null);
 
   const locationSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [filterError, setFilterError] = useState<string | null>(null);
   const [appliedSearchText, setAppliedSearchText] = useState('');
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
-    null,
-  );
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
 
   const [appliedFilters, setAppliedFilters] =
     useState<HomeFiltersDraft>(DEFAULT_FILTERS);
@@ -313,25 +412,115 @@ export function useHomeViewModel(): HomeViewModel {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
-  const [isProfileLocationReady, setIsProfileLocationReady] = useState(false);
+  const [isLocationContextReady, setIsLocationContextReady] = useState(false);
+  const [isResolvingDefaultLocation, setIsResolvingDefaultLocation] = useState(true);
 
-  const loadProfileLocation = useCallback(async () => {
+  const syncSelectedLocationWithDefault = useCallback(
+    (resolvedDefaultLocation: LocationSuggestion) => {
+      const persistedSelection = getHomeLocationSelection(locationSelectionScope);
+
+      if (
+        persistedSelection.mode === 'CUSTOM' &&
+        persistedSelection.location
+      ) {
+        setSelectedLocation(persistedSelection.location);
+        return persistedSelection.location;
+      }
+
+      setSelectedLocation(resolvedDefaultLocation);
+      return resolvedDefaultLocation;
+    },
+    [locationSelectionScope],
+  );
+
+  const persistLocationSelection = useCallback(
+    (
+      mode: 'DEFAULT' | 'CUSTOM',
+      location: LocationSuggestion | null,
+    ) => {
+      setHomeLocationSelection(locationSelectionScope, {
+        mode,
+        location: mode === 'CUSTOM' ? location : null,
+      });
+    },
+    [locationSelectionScope],
+  );
+
+  useEffect(() => {
+    const persistedSelection = getHomeLocationSelection(locationSelectionScope);
+    setSelectedLocation(
+      persistedSelection.mode === 'CUSTOM'
+        ? persistedSelection.location
+        : null,
+    );
+  }, [locationSelectionScope]);
+
+  const resolveDefaultLocation = useCallback(async () => {
+    setIsResolvingDefaultLocation(true);
+
     if (!token) {
-      setSelectedLocation(null);
-      setIsProfileLocationReady(true);
-      return;
+      setDefaultLocation(FALLBACK_LOCATION);
+      setDefaultLocationSource('FALLBACK');
+      syncSelectedLocationWithDefault(FALLBACK_LOCATION);
+      setIsLocationContextReady(true);
+      setIsResolvingDefaultLocation(false);
+      return FALLBACK_LOCATION;
     }
 
     try {
       const profile = await getMyProfile(token);
       const profileLocation = profileToSelectedLocation(profile);
-      setDefaultProfileLocation(profileLocation);
-      setSelectedLocation(profileLocation);
+
+      if (profileLocation) {
+        setDefaultLocation(profileLocation);
+        setDefaultLocationSource('PROFILE');
+        syncSelectedLocationWithDefault(profileLocation);
+        return profileLocation;
+      }
     } catch {
-      setDefaultProfileLocation(null);
-      setSelectedLocation(null);
+      // Fall through to live-location resolution when profile lookup fails.
+    }
+
+    try {
+      const liveLocation = await getCurrentLocationSuggestion();
+
+      if (liveLocation) {
+        setDefaultLocation(liveLocation);
+        setDefaultLocationSource('LIVE');
+        syncSelectedLocationWithDefault(liveLocation);
+        return liveLocation;
+      }
+    } catch {
+      // Fall through to the hardcoded fallback location.
+    }
+
+    setDefaultLocation(FALLBACK_LOCATION);
+    setDefaultLocationSource('FALLBACK');
+    syncSelectedLocationWithDefault(FALLBACK_LOCATION);
+    return FALLBACK_LOCATION;
+  }, [syncSelectedLocationWithDefault, token]);
+
+  const fetchFavoriteLocations = useCallback(async () => {
+    if (!token) {
+      setFavoriteLocations([]);
+      setFavoriteLocationsError(null);
+      setIsLoadingFavoriteLocations(false);
+      return;
+    }
+
+    setIsLoadingFavoriteLocations(true);
+    setFavoriteLocationsError(null);
+
+    try {
+      const response = await listFavoriteLocations(token);
+      setFavoriteLocations(
+        sortFavoriteLocations(response.items).slice(0, MAX_FAVORITE_LOCATION_OPTIONS),
+      );
+    } catch (error) {
+      setFavoriteLocations([]);
+      setFavoriteLocationsError(getFavoriteLocationsErrorMessage(error));
     } finally {
-      setIsProfileLocationReady(true);
+      setIsLoadingFavoriteLocations(false);
     }
   }, [token]);
 
@@ -360,6 +549,8 @@ export function useHomeViewModel(): HomeViewModel {
         return;
       }
 
+      const activeLocation = selectedLocation ?? defaultLocation ?? FALLBACK_LOCATION;
+
       try {
         if (mode === 'initial') setIsLoading(true);
         if (mode === 'refresh') setIsRefreshing(true);
@@ -381,8 +572,8 @@ export function useHomeViewModel(): HomeViewModel {
 
         const response = await listEvents(
           {
-            lat: selectedLocation ? Number(selectedLocation.lat) : DEFAULT_LOCATION.lat,
-            lon: selectedLocation ? Number(selectedLocation.lon) : DEFAULT_LOCATION.lon,
+            lat: Number(activeLocation.lat),
+            lon: Number(activeLocation.lon),
             radius_meters: appliedFilters.radiusKm * 1000,
             q: appliedSearchText || undefined,
             category_ids:
@@ -417,7 +608,7 @@ export function useHomeViewModel(): HomeViewModel {
         if (mode === 'loadMore') setIsLoadingMore(false);
       }
     },
-    [token, appliedSearchText, selectedCategoryId, appliedFilters, selectedLocation]
+    [token, selectedLocation, defaultLocation, appliedSearchText, selectedCategoryId, appliedFilters],
   );
 
   useEffect(() => {
@@ -425,19 +616,36 @@ export function useHomeViewModel(): HomeViewModel {
   }, [loadCategories]);
 
   useEffect(() => {
-    setIsProfileLocationReady(false);
-    void loadProfileLocation();
-  }, [loadProfileLocation]);
+    let isMounted = true;
+
+    setIsLocationContextReady(false);
+    setIsResolvingDefaultLocation(true);
+
+    void resolveDefaultLocation()
+      .finally(() => {
+        if (!isMounted) return;
+        setIsLocationContextReady(true);
+        setIsResolvingDefaultLocation(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [resolveDefaultLocation]);
 
   useEffect(() => {
-    if (!isProfileLocationReady) return;
+    void fetchFavoriteLocations();
+  }, [fetchFavoriteLocations]);
+
+  useEffect(() => {
+    if (!isLocationContextReady) return;
 
     const timeout = setTimeout(() => {
       void loadEvents('initial');
     }, 300);
 
     return () => clearTimeout(timeout);
-  }, [isProfileLocationReady, loadEvents]);
+  }, [isLocationContextReady, loadEvents]);
 
   const updateSearchText = useCallback((value: string) => {
     setSearchText(value);
@@ -448,13 +656,11 @@ export function useHomeViewModel(): HomeViewModel {
 
     const trimmed = value.trim();
 
-    // Clear search immediately when input is emptied
     if (trimmed.length === 0) {
       setAppliedSearchText('');
       return;
     }
 
-    // Only auto-search with at least 2 characters
     if (trimmed.length < 2) return;
 
     searchTimeoutRef.current = setTimeout(() => {
@@ -474,18 +680,19 @@ export function useHomeViewModel(): HomeViewModel {
   }, []);
 
   const openLocationModal = useCallback(() => {
-    setPendingLocation(selectedLocation);
-    setLocationQuery(
-      locationsMatch(selectedLocation, defaultProfileLocation)
-        ? ''
-        : selectedLocation?.display_name ?? '',
-    );
+    setPendingLocation(null);
+    setLocationQuery('');
     setLocationSuggestions([]);
     setIsSearchingLocation(false);
     setIsLocationModalOpen(true);
-  }, [defaultProfileLocation, selectedLocation]);
+  }, []);
 
   const closeLocationModal = useCallback(() => {
+    if (locationSearchTimeoutRef.current) {
+      clearTimeout(locationSearchTimeoutRef.current);
+      locationSearchTimeoutRef.current = null;
+    }
+
     setPendingLocation(null);
     setLocationQuery('');
     setLocationSuggestions([]);
@@ -521,29 +728,65 @@ export function useHomeViewModel(): HomeViewModel {
         setLocationSuggestions(results);
       } finally {
         setIsSearchingLocation(false);
+        locationSearchTimeoutRef.current = null;
       }
     }, 300);
   }, []);
 
-  const selectLocationSuggestion = useCallback((suggestion: LocationSuggestion) => {
+  const selectSavedLocationOption = useCallback((suggestion: LocationSuggestion) => {
+    if (locationSearchTimeoutRef.current) {
+      clearTimeout(locationSearchTimeoutRef.current);
+      locationSearchTimeoutRef.current = null;
+    }
+
     setPendingLocation(suggestion);
-    setLocationQuery(suggestion.display_name);
-    setLocationSuggestions([]);
-  }, []);
-
-  const applySelectedLocation = useCallback(() => {
-    setSelectedLocation(pendingLocation ?? defaultProfileLocation ?? null);
-    setLocationSuggestions([]);
-    setLocationQuery('');
-    setIsLocationModalOpen(false);
-  }, [defaultProfileLocation, pendingLocation]);
-
-  const resetLocationDraft = useCallback(() => {
-    setPendingLocation(defaultProfileLocation);
     setLocationQuery('');
     setLocationSuggestions([]);
     setIsSearchingLocation(false);
-  }, [defaultProfileLocation]);
+  }, []);
+
+  const selectLocationSuggestion = useCallback((suggestion: LocationSuggestion) => {
+    if (locationSearchTimeoutRef.current) {
+      clearTimeout(locationSearchTimeoutRef.current);
+      locationSearchTimeoutRef.current = null;
+    }
+
+    setPendingLocation(suggestion);
+    setLocationQuery(suggestion.display_name);
+    setLocationSuggestions([]);
+    setIsSearchingLocation(false);
+  }, []);
+
+  const applySelectedLocation = useCallback(() => {
+    if (!pendingLocation) {
+      return;
+    }
+
+    const nextLocation = pendingLocation ?? defaultLocation ?? FALLBACK_LOCATION;
+    const followsDefault =
+      defaultLocation != null && locationsMatch(nextLocation, defaultLocation);
+
+    persistLocationSelection(
+      followsDefault ? 'DEFAULT' : 'CUSTOM',
+      followsDefault ? null : nextLocation,
+    );
+    setSelectedLocation(nextLocation);
+    setLocationSuggestions([]);
+    setLocationQuery('');
+    setIsLocationModalOpen(false);
+  }, [defaultLocation, pendingLocation, persistLocationSelection]);
+
+  const resetLocationDraft = useCallback(() => {
+    if (locationSearchTimeoutRef.current) {
+      clearTimeout(locationSearchTimeoutRef.current);
+      locationSearchTimeoutRef.current = null;
+    }
+
+    setPendingLocation(null);
+    setLocationQuery('');
+    setLocationSuggestions([]);
+    setIsSearchingLocation(false);
+  }, []);
 
   const openFilterModal = useCallback(() => {
     setFilterDraft(appliedFilters);
@@ -652,14 +895,22 @@ export function useHomeViewModel(): HomeViewModel {
     await loadEvents('refresh');
   }, [loadEvents]);
 
+  const retryFavoriteLocations = useCallback(async () => {
+    await fetchFavoriteLocations();
+  }, [fetchFavoriteLocations]);
+
   const silentRefresh = useCallback(async () => {
     if (!token) return;
 
+    await fetchFavoriteLocations();
+
     try {
-      const profile = await getMyProfile(token);
-      const profileLocation = profileToSelectedLocation(profile);
-      setDefaultProfileLocation(profileLocation);
-      setSelectedLocation(profileLocation);
+      const refreshedDefaultLocation = await resolveDefaultLocation();
+      const persistedSelection = getHomeLocationSelection(locationSelectionScope);
+      const activeLocation =
+        persistedSelection.mode === 'CUSTOM' && persistedSelection.location
+          ? persistedSelection.location
+          : refreshedDefaultLocation;
 
       const combinedCategoryIds =
         selectedCategoryId != null
@@ -670,8 +921,8 @@ export function useHomeViewModel(): HomeViewModel {
 
       const response = await listEvents(
         {
-          lat: profileLocation ? Number(profileLocation.lat) : DEFAULT_LOCATION.lat,
-          lon: profileLocation ? Number(profileLocation.lon) : DEFAULT_LOCATION.lon,
+          lat: Number(activeLocation.lat),
+          lon: Number(activeLocation.lon),
           radius_meters: appliedFilters.radiusKm * 1000,
           q: appliedSearchText || undefined,
           category_ids:
@@ -691,14 +942,33 @@ export function useHomeViewModel(): HomeViewModel {
       setNextCursor(response.page_info.next_cursor);
       setEvents(excludeInProgressEvents(response.items));
     } catch {
-      // Silent — don't overwrite existing data on failure
+      // Silent refresh should not overwrite existing content with an error state.
+    } finally {
+      setIsResolvingDefaultLocation(false);
     }
-  }, [token, appliedSearchText, selectedCategoryId, appliedFilters]);
+  }, [
+    token,
+    fetchFavoriteLocations,
+    resolveDefaultLocation,
+    locationSelectionScope,
+    appliedSearchText,
+    selectedCategoryId,
+    appliedFilters,
+  ]);
 
-    return {
+  const favoriteLocationOptions: HomeLocationOption[] = favoriteLocations.map((location) => ({
+    id: location.id,
+    title: location.name,
+    subtitle: location.address,
+    suggestion: favoriteLocationToSuggestion(location),
+  }));
+
+  return {
     locationLabel: selectedLocation
       ? formatEventLocation(selectedLocation.display_name)
-      : DEFAULT_LOCATION_LABEL,
+      : isResolvingDefaultLocation
+        ? 'Locating...'
+        : DEFAULT_LOCATION_LABEL,
     locationQuery,
     categories,
     selectedCategoryId,
@@ -716,6 +986,19 @@ export function useHomeViewModel(): HomeViewModel {
     isSearchingLocation,
     isLocationModalOpen,
     pendingLocation,
+    defaultLocationOption: {
+      title: 'Use Default Location',
+      subtitle: getDefaultLocationSubtitle(
+        defaultLocationSource,
+        defaultLocation,
+        isResolvingDefaultLocation,
+      ),
+      suggestion: defaultLocation,
+      isLoading: isResolvingDefaultLocation && !defaultLocation,
+    },
+    favoriteLocationOptions,
+    isLoadingFavoriteLocations,
+    favoriteLocationsError,
     updateSearchText,
     submitSearch,
     selectCategory,
@@ -731,9 +1014,11 @@ export function useHomeViewModel(): HomeViewModel {
     openLocationModal,
     closeLocationModal,
     updateLocationQuery,
+    selectSavedLocationOption,
     selectLocationSuggestion,
     applySelectedLocation,
     resetLocationDraft,
+    retryFavoriteLocations,
     loadMoreEvents,
     refreshEvents,
     silentRefresh,

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -127,10 +127,16 @@ export default function HomeView() {
         selectedLocation={vm.pendingLocation}
         onClose={vm.closeLocationModal}
         onReset={vm.resetLocationDraft}
+        onRetryFavoriteLocations={vm.retryFavoriteLocations}
         onChangeQuery={vm.updateLocationQuery}
+        onSelectSavedLocation={vm.selectSavedLocationOption}
         onSelectSuggestion={vm.selectLocationSuggestion}
         onApply={vm.applySelectedLocation}
         anchorTop={locationPopupTop}
+        defaultOption={vm.defaultLocationOption}
+        favoriteOptions={vm.favoriteLocationOptions}
+        isLoadingFavoriteLocations={vm.isLoadingFavoriteLocations}
+        favoriteLocationsError={vm.favoriteLocationsError}
       />
     </SafeAreaView>
   );

--- a/mobile/src/views/profile/EditProfileView.test.tsx
+++ b/mobile/src/views/profile/EditProfileView.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { router } from 'expo-router';
+import EditProfileView from './EditProfileView';
+import { useEditProfileViewModel } from '@/viewmodels/profile/useEditProfileViewModel';
+
+jest.mock('expo-router', () => ({
+  router: {
+    back: jest.fn(),
+    replace: jest.fn(),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => {
+  const ReactLocal = require('react');
+  return {
+    MaterialIcons: ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', { 'data-icon': name }),
+    Ionicons: ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', { 'data-icon': name }),
+  };
+});
+
+jest.mock('@react-native-community/datetimepicker', () => {
+  const ReactLocal = require('react');
+  return function MockDateTimePicker() {
+    return ReactLocal.createElement('div', { 'data-testid': 'datetimepicker' });
+  };
+});
+
+jest.mock('@/viewmodels/profile/useEditProfileViewModel', () => ({
+  GENDER_OPTIONS: [
+    { label: 'Male', value: 'MALE' },
+    { label: 'Female', value: 'FEMALE' },
+  ],
+  DISPLAY_NAME_MAX_LENGTH: 64,
+  BIO_MAX_LENGTH: 512,
+  useEditProfileViewModel: jest.fn(),
+}));
+
+const mockUseEditProfileViewModel = jest.mocked(useEditProfileViewModel);
+
+function buildViewModel(overrides: Partial<ReturnType<typeof useEditProfileViewModel>> = {}) {
+  return {
+    formData: {
+      displayName: 'John Doe',
+      bio: 'Bio',
+      phoneNumber: '+905551112233',
+      gender: '',
+      birthDate: '',
+      defaultLocationAddress: 'Kadikoy, Istanbul, Turkiye',
+      defaultLocationLat: 40.9909,
+      defaultLocationLon: 29.0293,
+    },
+    errors: {},
+    isLoading: false,
+    isSaving: false,
+    isUploadingAvatar: false,
+    apiError: null,
+    imageError: null,
+    successMessage: null,
+    canEditGender: true,
+    canEditBirthDate: true,
+    locationQuery: 'Kadikoy, Istanbul, Turkiye',
+    locationSuggestions: [],
+    isSearchingLocation: false,
+    selectedImageUri: null,
+    updateField: jest.fn(),
+    pickAvatar: jest.fn(),
+    removeAvatar: jest.fn(),
+    updateLocationQuery: jest.fn(),
+    selectLocationSuggestion: jest.fn(),
+    clearLocation: jest.fn(),
+    handleSave: jest.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe('EditProfileView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('replaces to the profile tab after a successful save', async () => {
+    const handleSave = jest.fn().mockResolvedValue(true);
+    mockUseEditProfileViewModel.mockReturnValue(
+      buildViewModel({ handleSave }) as ReturnType<typeof useEditProfileViewModel>,
+    );
+
+    render(<EditProfileView />);
+
+    fireEvent.click(screen.getByLabelText('Save profile'));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+      expect(router.replace).toHaveBeenCalledWith('/(tabs)/profile');
+    });
+  });
+
+  it('does not navigate away when save fails', async () => {
+    const handleSave = jest.fn().mockResolvedValue(false);
+    mockUseEditProfileViewModel.mockReturnValue(
+      buildViewModel({ handleSave }) as ReturnType<typeof useEditProfileViewModel>,
+    );
+
+    render(<EditProfileView />);
+
+    fireEvent.click(screen.getByLabelText('Save profile'));
+
+    await waitFor(() => {
+      expect(handleSave).toHaveBeenCalledTimes(1);
+    });
+
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/views/profile/EditProfileView.tsx
+++ b/mobile/src/views/profile/EditProfileView.tsx
@@ -11,7 +11,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { router } from 'expo-router';
+import { router, type Href } from 'expo-router';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import {
   useEditProfileViewModel,
@@ -68,8 +68,7 @@ export default function EditProfileView() {
   const handleSave = async () => {
     const success = await vm.handleSave();
     if (success) {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      router.back();
+      router.replace('/(tabs)/profile' as Href);
     }
   };
 


### PR DESCRIPTION
## 📋 Summary
Updates the mobile Home location flow so the location picker can use the user’s actual default location, show saved favorite locations as quick-pick options, and fall back to live location only when no default is set, with the existing Istanbul fallback if permission is denied or live lookup fails.

Also improves the picker UX so it always opens as a clean form with the search bar visible, no option preselected, and no implicit apply. While the user is searching, search results take over the panel and the default/favorite quick-picks are hidden. The applied location now persists across tab switches and home refocuses instead of snapping back to the default. Finally, saving the Edit Profile screen now dismisses back to the Profile tab immediately after a successful save.

## 🔄 Changes

### Home Location Resolution
* **Profile Integration:** Uses profile default location when available.
* **Live Location:** If no profile default exists, requests live location.
* **Fallback:** If live location is unavailable or denied, falls back to the existing Istanbul default.

### Favorites Support
* Fetches up to **3 favorite locations** from the backend.
* Shows loading, empty, and error states for favorite locations in the picker.
* Allows the user to explicitly apply a favorite location to Home discovery.

### Picker UX
* **Search Bar:** Always visible.
* **State:** Picker opens with a reset form; nothing is shown as selected initially.
* **Validation:** `Apply Location` stays disabled until the user explicitly selects a location.
* **Dynamic UI:** While searching, only search results are shown; default and favorite quick-picks are hidden.

### Persistence & Services
* **State Store:** Added `mobile/src/services/homeLocationSelectionStore.ts` to preserve selection across tab switches/remounts.
* **Logic:** `silentRefresh()` now respects a user-selected custom location instead of overwriting it.
* **New Service:** Added `mobile/src/services/deviceLocationService.ts` for Expo live-location lookup and reverse geocoding.

### UI & Navigation
* **Wiring:** Updated `useHomeViewModel.ts`, `LocationPickerPanel.tsx`, and `HomeView.tsx`.
* **Profile Save:** `EditProfileView.tsx` now replaces to `/(tabs)/profile` immediately after a successful save.
* **Expo:** Added `expo-location` dependency and permission text in `app.json`.

## 🧪 Testing

### Automated
```bash
cd mobile
npx jest src/viewmodels/home/useHomeViewModel.test.tsx src/components/home/LocationPickerPanel.test.tsx --runInBand
npx jest src/views/profile/EditProfileView.test.tsx --runInBand
npx tsc --noEmit
```

* **Focused Jest suites pass.**
* **TypeScript check (tsc) passes.**

### Manual
* **Location Picker:** Verified search bar visibility and reset state on open.
* **Quick-Picks:** Verified visibility of `Use Default Location` and favorite locations.
* **Search Behavior:** Verified that quick-picks hide when typing and search results appear.
* **Selection Logic:** Confirmed `Apply Location` triggers discovery reload only after selection.
* **Tab Persistence:** Confirmed applied location remains active when switching tabs.
* **Profile Flow:** Confirmed immediate dismissal of Edit Profile screen upon saving.

## 🔗 Related
Closes #391