### PR TITLE
feat(backend): add missing event and join-flow constraint validations (#467)

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -1546,6 +1546,37 @@ func (r *EventRepository) GetEventByID(ctx context.Context, eventID uuid.UUID) (
 	return event, nil
 }
 
+// GetRequesterForJoin loads the minimal user fields required to enforce
+// participation eligibility checks (age, gender).
+func (r *EventRepository) GetRequesterForJoin(ctx context.Context, userID uuid.UUID) (*domain.User, error) {
+	const query = `SELECT id, gender, birth_date FROM app_user WHERE id = $1`
+
+	var (
+		id        uuid.UUID
+		gender    pgtype.Text
+		birthDate pgtype.Date
+	)
+
+	err := r.pool.QueryRow(ctx, query, userID).Scan(&id, &gender, &birthDate)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get requester for join: %w", err)
+	}
+
+	user := &domain.User{ID: id}
+	if gender.Valid {
+		g := gender.String
+		user.Gender = &g
+	}
+	if birthDate.Valid {
+		t := birthDate.Time
+		user.BirthDate = &t
+	}
+	return user, nil
+}
+
 // GetEventImageState returns the event host and current image version for direct uploads.
 func (r *EventRepository) GetEventImageState(ctx context.Context, eventID uuid.UUID) (*imageuploadapp.EventImageState, error) {
 	var state imageuploadapp.EventImageState

--- a/backend/internal/application/event/repository.go
+++ b/backend/internal/application/event/repository.go
@@ -24,6 +24,7 @@ type Repository interface {
 	ListEventPendingJoinRequests(ctx context.Context, eventID uuid.UUID, params EventCollectionPageParams) ([]EventDetailPendingJoinRequestRecord, error)
 	ListEventInvitations(ctx context.Context, eventID uuid.UUID, params EventCollectionPageParams) ([]EventDetailInvitationRecord, error)
 	GetEventByID(ctx context.Context, eventID uuid.UUID) (*domain.Event, error)
+	GetRequesterForJoin(ctx context.Context, userID uuid.UUID) (*domain.User, error)
 	TransitionEventStatuses(ctx context.Context) error
 	CancelEvent(ctx context.Context, eventID uuid.UUID, canceledApprovedParticipantCount int) error
 	CompleteEvent(ctx context.Context, eventID uuid.UUID) error

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -48,7 +48,7 @@ func NewService(
 // CreateEvent validates the input, then persists the event with its location,
 // tags, and constraints in a single transaction.
 func (s *Service) CreateEvent(ctx context.Context, hostID uuid.UUID, input CreateEventInput) (*CreateEventResult, error) {
-	errs := validateCreateEventInput(input)
+	errs := validateCreateEventInput(input, s.now().UTC())
 	if len(errs) > 0 {
 		return nil, domain.ValidationError(errs)
 	}

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -246,11 +246,14 @@ func (s *Service) ListEventInvitations(
 // participation record has status APPROVED.
 //
 // Errors:
-//   - 404 event_not_found        – event does not exist
-//   - 403 host_cannot_join       – caller is the event host
-//   - 409 event_join_not_allowed – event is not PUBLIC
-//   - 409 capacity_exceeded      – event has reached maximum capacity
-//   - 409 already_participating  – caller already has a participation record
+//   - 404 event_not_found            – event does not exist
+//   - 403 host_cannot_join           – caller is the event host
+//   - 409 event_join_not_allowed     – event is not PUBLIC
+//   - 409 capacity_exceeded          – event has reached maximum capacity
+//   - 409 already_participating      – caller already has a participation record
+//   - 400 profile_incomplete         – event has an age/gender restriction but user profile is missing the required field
+//   - 409 age_requirement_not_met    – user is below the event's minimum age
+//   - 409 gender_requirement_not_met – user gender does not match the event's preferred gender
 func (s *Service) JoinEvent(ctx context.Context, userID, eventID uuid.UUID) (*JoinEventResult, error) {
 	event, err := s.eventRepo.GetEventByID(ctx, eventID)
 	if err != nil {
@@ -274,6 +277,10 @@ func (s *Service) JoinEvent(ctx context.Context, userID, eventID uuid.UUID) (*Jo
 
 	if event.Capacity != nil && event.ApprovedParticipantCount >= *event.Capacity {
 		return nil, domain.ConflictError(domain.ErrorCodeCapacityExceeded, "This event has reached its maximum capacity.")
+	}
+
+	if err := s.ensureRequesterEligible(ctx, userID, event); err != nil {
+		return nil, err
 	}
 
 	p, err := s.participationService.CreateApprovedParticipation(ctx, eventID, userID)
@@ -325,10 +332,13 @@ func (s *Service) LeaveEvent(ctx context.Context, userID, eventID uuid.UUID) (*L
 // The host must approve the request before the user becomes a participant.
 //
 // Errors:
-//   - 404 event_not_found        – event does not exist
-//   - 403 host_cannot_join       – caller is the event host
-//   - 409 event_join_not_allowed – event is not PROTECTED
-//   - 409 already_requested      – caller already has a pending request
+//   - 404 event_not_found            – event does not exist
+//   - 403 host_cannot_join           – caller is the event host
+//   - 409 event_join_not_allowed     – event is not PROTECTED
+//   - 409 already_requested          – caller already has a pending request
+//   - 400 profile_incomplete         – event has an age/gender restriction but user profile is missing the required field
+//   - 409 age_requirement_not_met    – user is below the event's minimum age
+//   - 409 gender_requirement_not_met – user gender does not match the event's preferred gender
 func (s *Service) RequestJoin(ctx context.Context, userID, eventID uuid.UUID, input RequestJoinInput) (*RequestJoinResult, error) {
 	event, err := s.eventRepo.GetEventByID(ctx, eventID)
 	if err != nil {
@@ -348,6 +358,10 @@ func (s *Service) RequestJoin(ctx context.Context, userID, eventID uuid.UUID, in
 
 	if event.PrivacyLevel != domain.PrivacyProtected {
 		return nil, domain.ConflictError(domain.ErrorCodeEventJoinNotAllowed, "Only PROTECTED events accept join requests.")
+	}
+
+	if err := s.ensureRequesterEligible(ctx, userID, event); err != nil {
+		return nil, err
 	}
 
 	jr, err := s.joinRequestService.CreatePendingJoinRequest(ctx, eventID, userID, event.HostID, join_request.CreatePendingJoinRequestInput{
@@ -671,4 +685,24 @@ func encodeNextEventCollectionCursor(createdAt time.Time, entityID uuid.UUID) (*
 	}
 
 	return &encoded, nil
+}
+
+// ensureRequesterEligible loads the requester's profile fields and runs the
+// shared domain eligibility check. It returns nil when the user is eligible
+// to join or request to join the given event.
+func (s *Service) ensureRequesterEligible(ctx context.Context, userID uuid.UUID, ev *domain.Event) error {
+	if ev.MinimumAge == nil && ev.PreferredGender == nil {
+		return nil
+	}
+	user, err := s.eventRepo.GetRequesterForJoin(ctx, userID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return domain.BadRequestError(domain.ErrorCodeProfileIncomplete, "Your account was not found.")
+		}
+		return err
+	}
+	if appErr := domain.CheckParticipationEligibility(user, ev, s.now().UTC()); appErr != nil {
+		return appErr
+	}
+	return nil
 }

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -732,6 +732,16 @@ func TestCreateEventValidationMissingStartTime(t *testing.T) {
 	assertValidationDetail(t, err, "start_time")
 }
 
+func TestCreateEventValidationPastStartTime(t *testing.T) {
+	svc, _, _, _ := newTestEventService()
+	input := validInput()
+	input.StartTime = time.Now().UTC().Add(-time.Hour)
+
+	_, err := svc.CreateEvent(context.Background(), uuid.New(), input)
+
+	assertValidationDetail(t, err, "start_time")
+}
+
 func TestCreateEventValidationEndTimeBeforeStartTime(t *testing.T) {
 	// given
 	svc, _, _, _ := newTestEventService()

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -1343,6 +1343,22 @@ func protectedEvent(hostID uuid.UUID) *domain.Event {
 	}
 }
 
+func ptrInt(v int) *int {
+	return &v
+}
+
+func ptrTime(v time.Time) *time.Time {
+	return &v
+}
+
+func ptrString(v string) *string {
+	return &v
+}
+
+func ptrGender(v domain.EventParticipantGender) *domain.EventParticipantGender {
+	return &v
+}
+
 func TestCancelEventRunsEventAndParticipationUpdatesInsideOneUnitOfWork(t *testing.T) {
 	hostID := uuid.New()
 	ev := publicEventWithCapacity(hostID, 10, 3)
@@ -1551,6 +1567,66 @@ func TestJoinEventAllowsWhenUnderCapacity(t *testing.T) {
 	}
 	if result.Status != domain.ParticipationStatusApproved {
 		t.Fatalf("expected status APPROVED, got %q", result.Status)
+	}
+}
+
+func TestJoinEventRejectsUnderageUser(t *testing.T) {
+	hostID := uuid.New()
+	joinerID := uuid.New()
+	ev := publicEvent(hostID)
+	ev.MinimumAge = ptrInt(18)
+	svc, repo, _, _ := newTestEventServiceWithEvent(ev)
+	repo.requesters[joinerID] = &domain.User{
+		ID:        joinerID,
+		BirthDate: ptrTime(time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)),
+	}
+
+	_, err := svc.JoinEvent(context.Background(), joinerID, ev.ID)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if appErr, ok := errors.AsType[*domain.AppError](err); !ok || appErr.Code != domain.ErrorCodeAgeRequirementNotMet {
+		t.Fatalf("expected age_requirement_not_met, got %v", err)
+	}
+}
+
+func TestJoinEventRejectsMismatchedGender(t *testing.T) {
+	hostID := uuid.New()
+	joinerID := uuid.New()
+	ev := publicEvent(hostID)
+	ev.PreferredGender = ptrGender(domain.GenderFemale)
+	svc, repo, _, _ := newTestEventServiceWithEvent(ev)
+	repo.requesters[joinerID] = &domain.User{
+		ID:     joinerID,
+		Gender: ptrString(string(domain.GenderMale)),
+	}
+
+	_, err := svc.JoinEvent(context.Background(), joinerID, ev.ID)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if appErr, ok := errors.AsType[*domain.AppError](err); !ok || appErr.Code != domain.ErrorCodeGenderRequirementNotMet {
+		t.Fatalf("expected gender_requirement_not_met, got %v", err)
+	}
+}
+
+func TestJoinEventRejectsMissingBirthDateWhenAgeRestricted(t *testing.T) {
+	hostID := uuid.New()
+	joinerID := uuid.New()
+	ev := publicEvent(hostID)
+	ev.MinimumAge = ptrInt(18)
+	svc, repo, _, _ := newTestEventServiceWithEvent(ev)
+	repo.requesters[joinerID] = &domain.User{ID: joinerID}
+
+	_, err := svc.JoinEvent(context.Background(), joinerID, ev.ID)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if appErr, ok := errors.AsType[*domain.AppError](err); !ok || appErr.Code != domain.ErrorCodeProfileIncomplete {
+		t.Fatalf("expected profile_incomplete, got %v", err)
 	}
 }
 

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -33,25 +33,27 @@ func (u *fakeUnitOfWork) RunInTx(ctx context.Context, fn func(ctx context.Contex
 
 // fakeEventRepo is an in-memory implementation of Repository.
 type fakeEventRepo struct {
-	err                error
-	discoverErr        error
-	detailErr          error
-	events             map[uuid.UUID]*domain.Event
-	favoriteRecords    []FavoriteEventRecord
-	discoverRecords    []DiscoverableEventRecord
-	detailRecord       *EventDetailRecord
-	hostSummaryRecord  *EventHostContextSummaryRecord
-	participantRecords []EventDetailApprovedParticipantRecord
-	joinRequestRecords []EventDetailPendingJoinRequestRecord
-	invitationRecords  []EventDetailInvitationRecord
-	discoverCallCount  int
-	lastDiscoverUserID uuid.UUID
-	lastDiscoverParams DiscoverEventsParams
-	lastDetailUserID   uuid.UUID
-	lastDetailEventID  uuid.UUID
-	lastCollectionPage EventCollectionPageParams
-	lastCancelCtx      context.Context
-	lastCancelCount    int
+	err                    error
+	discoverErr            error
+	detailErr              error
+	events                 map[uuid.UUID]*domain.Event
+	favoriteRecords        []FavoriteEventRecord
+	discoverRecords        []DiscoverableEventRecord
+	detailRecord           *EventDetailRecord
+	hostSummaryRecord      *EventHostContextSummaryRecord
+	participantRecords     []EventDetailApprovedParticipantRecord
+	joinRequestRecords     []EventDetailPendingJoinRequestRecord
+	invitationRecords      []EventDetailInvitationRecord
+	discoverCallCount      int
+	lastDiscoverUserID     uuid.UUID
+	lastDiscoverParams     DiscoverEventsParams
+	lastDetailUserID       uuid.UUID
+	lastDetailEventID      uuid.UUID
+	lastCollectionPage     EventCollectionPageParams
+	lastCancelCtx          context.Context
+	lastCancelCount        int
+	requesters             map[uuid.UUID]*domain.User
+	getRequesterForJoinErr error
 }
 
 func (r *fakeEventRepo) CreateEvent(_ context.Context, params CreateEventParams) (*domain.Event, error) {
@@ -194,6 +196,16 @@ func (r *fakeEventRepo) ListDiscoverableEvents(_ context.Context, userID uuid.UU
 	}
 
 	return r.discoverRecords, nil
+}
+
+func (r *fakeEventRepo) GetRequesterForJoin(_ context.Context, userID uuid.UUID) (*domain.User, error) {
+	if r.getRequesterForJoinErr != nil {
+		return nil, r.getRequesterForJoinErr
+	}
+	if user, ok := r.requesters[userID]; ok {
+		return user, nil
+	}
+	return nil, domain.ErrNotFound
 }
 
 // fakeParticipationService is an in-memory implementation of ParticipationService.
@@ -362,7 +374,8 @@ func (s *fakeJoinRequestService) RejectJoinRequest(
 
 func newTestEventService() (*Service, *fakeEventRepo, *fakeParticipationService, *fakeJoinRequestService) {
 	eventRepo := &fakeEventRepo{
-		events: make(map[uuid.UUID]*domain.Event),
+		events:     make(map[uuid.UUID]*domain.Event),
+		requesters: map[uuid.UUID]*domain.User{},
 	}
 	participationService := &fakeParticipationService{}
 	joinRequestService := &fakeJoinRequestService{}
@@ -1292,7 +1305,10 @@ func TestDiscoverEventsBuildsNextCursorFromLastReturnedItem(t *testing.T) {
 
 // newTestEventServiceWithEvent wires a service with a pre-loaded event in the fake repo.
 func newTestEventServiceWithEvent(e *domain.Event) (*Service, *fakeEventRepo, *fakeParticipationService, *fakeJoinRequestService) {
-	eventRepo := &fakeEventRepo{events: map[uuid.UUID]*domain.Event{e.ID: e}}
+	eventRepo := &fakeEventRepo{
+		events:     map[uuid.UUID]*domain.Event{e.ID: e},
+		requesters: map[uuid.UUID]*domain.User{},
+	}
 	participationService := &fakeParticipationService{}
 	joinRequestService := &fakeJoinRequestService{}
 	return NewService(eventRepo, participationService, joinRequestService, &fakeUnitOfWork{}), eventRepo, participationService, joinRequestService

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -1749,6 +1749,48 @@ func TestRequestJoinRejectsPublicEvent(t *testing.T) {
 	}
 }
 
+func TestRequestJoinRejectsUnderageUser(t *testing.T) {
+	hostID := uuid.New()
+	joinerID := uuid.New()
+	ev := protectedEvent(hostID)
+	ev.MinimumAge = ptrInt(18)
+	svc, repo, _, _ := newTestEventServiceWithEvent(ev)
+	repo.requesters[joinerID] = &domain.User{
+		ID:        joinerID,
+		BirthDate: ptrTime(time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)),
+	}
+
+	_, err := svc.RequestJoin(context.Background(), joinerID, ev.ID, RequestJoinInput{})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if appErr, ok := errors.AsType[*domain.AppError](err); !ok || appErr.Code != domain.ErrorCodeAgeRequirementNotMet {
+		t.Fatalf("expected age_requirement_not_met, got %v", err)
+	}
+}
+
+func TestRequestJoinRejectsMismatchedGender(t *testing.T) {
+	hostID := uuid.New()
+	joinerID := uuid.New()
+	ev := protectedEvent(hostID)
+	ev.PreferredGender = ptrGender(domain.GenderFemale)
+	svc, repo, _, _ := newTestEventServiceWithEvent(ev)
+	repo.requesters[joinerID] = &domain.User{
+		ID:     joinerID,
+		Gender: ptrString(string(domain.GenderMale)),
+	}
+
+	_, err := svc.RequestJoin(context.Background(), joinerID, ev.ID, RequestJoinInput{})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if appErr, ok := errors.AsType[*domain.AppError](err); !ok || appErr.Code != domain.ErrorCodeGenderRequirementNotMet {
+		t.Fatalf("expected gender_requirement_not_met, got %v", err)
+	}
+}
+
 func TestApproveJoinRequestDelegatesToJoinRequestService(t *testing.T) {
 	hostID := uuid.New()
 	ev := protectedEvent(hostID)

--- a/backend/internal/application/event/validator.go
+++ b/backend/internal/application/event/validator.go
@@ -3,13 +3,14 @@ package event
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 )
 
 // validateCreateEventInput checks the application-level invariants for create-event
 // requests after delivery adapters have parsed wire-specific values.
-func validateCreateEventInput(input CreateEventInput) map[string]string {
+func validateCreateEventInput(input CreateEventInput, now time.Time) map[string]string {
 	errs := make(map[string]string)
 
 	if strings.TrimSpace(input.Title) == "" {
@@ -38,6 +39,8 @@ func validateCreateEventInput(input CreateEventInput) map[string]string {
 
 	if input.StartTime.IsZero() {
 		errs["start_time"] = "start_time is required"
+	} else if !input.StartTime.After(now) {
+		errs["start_time"] = "start_time must be in the future"
 	}
 
 	if input.EndTime != nil && input.StartTime.IsZero() {

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -54,6 +54,9 @@ const (
 	ErrorCodeEventNotLeaveable               = "event_not_leaveable"
 	ErrorCodeFavoriteLocationNotFound        = "favorite_location_not_found"
 	ErrorCodeFavoriteLocationLimitExceeded   = "favorite_location_limit_exceeded"
+	ErrorCodeAgeRequirementNotMet            = "age_requirement_not_met"
+	ErrorCodeGenderRequirementNotMet         = "gender_requirement_not_met"
+	ErrorCodeProfileIncomplete               = "profile_incomplete"
 
 	ErrorCodeImageUploadTokenInvalid    = "image_upload_token_invalid"
 	ErrorCodeImageUploadNotAllowed      = "image_upload_not_allowed"

--- a/backend/internal/domain/join_eligibility.go
+++ b/backend/internal/domain/join_eligibility.go
@@ -1,0 +1,60 @@
+package domain
+
+import "time"
+
+// CheckParticipationEligibility returns a non-nil *AppError when the user does
+// not satisfy the event's participation restrictions. It is called by both
+// the direct-join and join-request flows so that every caller enforces the
+// same rules regardless of delivery layer.
+//
+// Errors:
+//   - 400 profile_incomplete        – restriction exists but user has not set the relevant field
+//   - 409 age_requirement_not_met   – user is below the event's minimum age
+//   - 409 gender_requirement_not_met – user gender does not match the preferred gender
+func CheckParticipationEligibility(user *User, event *Event, now time.Time) *AppError {
+	if event.MinimumAge != nil {
+		if user.BirthDate == nil {
+			return BadRequestError(
+				ErrorCodeProfileIncomplete,
+				"Your birth date must be set on your profile to join age-restricted events.",
+			)
+		}
+		if !HasMinimumAge(*user.BirthDate, *event.MinimumAge, now) {
+			return ConflictError(
+				ErrorCodeAgeRequirementNotMet,
+				"You do not meet the minimum age required by this event.",
+			)
+		}
+	}
+
+	if event.PreferredGender != nil {
+		if user.Gender == nil {
+			return BadRequestError(
+				ErrorCodeProfileIncomplete,
+				"Your gender must be set on your profile to join this event.",
+			)
+		}
+		if *user.Gender != string(*event.PreferredGender) {
+			return ConflictError(
+				ErrorCodeGenderRequirementNotMet,
+				"This event is restricted to participants of a specific gender.",
+			)
+		}
+	}
+
+	return nil
+}
+
+// HasMinimumAge reports whether a person born on birthDate has reached at
+// least minAge years by now. It accounts for whether the user's birthday has
+// passed this year. Comparison is done by month/day (rather than day-of-year)
+// so the result is correct across leap years.
+func HasMinimumAge(birthDate time.Time, minAge int, now time.Time) bool {
+	age := now.Year() - birthDate.Year()
+	nowMonth, nowDay := now.Month(), now.Day()
+	bMonth, bDay := birthDate.Month(), birthDate.Day()
+	if nowMonth < bMonth || (nowMonth == bMonth && nowDay < bDay) {
+		age--
+	}
+	return age >= minAge
+}

--- a/backend/internal/domain/join_eligibility_test.go
+++ b/backend/internal/domain/join_eligibility_test.go
@@ -1,0 +1,93 @@
+package domain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+)
+
+func ptrString(s string) *string                                               { return &s }
+func ptrInt(i int) *int                                                        { return &i }
+func ptrTime(t time.Time) *time.Time                                           { return &t }
+func ptrGender(g domain.EventParticipantGender) *domain.EventParticipantGender { return &g }
+
+// referenceNow is a fixed "now" used to keep age arithmetic deterministic.
+var referenceNow = time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+
+func TestCheckParticipationEligibilityAllowsWhenNoRestrictions(t *testing.T) {
+	user := &domain.User{BirthDate: ptrTime(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))}
+	event := &domain.Event{}
+
+	if err := domain.CheckParticipationEligibility(user, event, referenceNow); err != nil {
+		t.Fatalf("expected eligibility, got %v", err)
+	}
+}
+
+func TestCheckParticipationEligibilityRejectsUnderageUser(t *testing.T) {
+	user := &domain.User{BirthDate: ptrTime(time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC))} // 11 yrs old at reference
+	event := &domain.Event{MinimumAge: ptrInt(18)}
+
+	err := domain.CheckParticipationEligibility(user, event, referenceNow)
+	if err == nil || err.Code != domain.ErrorCodeAgeRequirementNotMet {
+		t.Fatalf("expected age_requirement_not_met, got %v", err)
+	}
+	if err.Status != domain.StatusConflict {
+		t.Fatalf("expected 409 status, got %d", err.Status)
+	}
+}
+
+func TestCheckParticipationEligibilityRequiresBirthDateWhenAgeRestricted(t *testing.T) {
+	user := &domain.User{BirthDate: nil}
+	event := &domain.Event{MinimumAge: ptrInt(18)}
+
+	err := domain.CheckParticipationEligibility(user, event, referenceNow)
+	if err == nil || err.Code != domain.ErrorCodeProfileIncomplete {
+		t.Fatalf("expected profile_incomplete, got %v", err)
+	}
+	if err.Status != domain.StatusBadRequest {
+		t.Fatalf("expected 400 status, got %d", err.Status)
+	}
+}
+
+func TestCheckParticipationEligibilityAllowsAtExactMinimumAge(t *testing.T) {
+	// Born exactly 18 years before reference → eligible.
+	user := &domain.User{BirthDate: ptrTime(time.Date(2008, 4, 18, 0, 0, 0, 0, time.UTC))}
+	event := &domain.Event{MinimumAge: ptrInt(18)}
+
+	if err := domain.CheckParticipationEligibility(user, event, referenceNow); err != nil {
+		t.Fatalf("expected eligibility, got %v", err)
+	}
+}
+
+func TestCheckParticipationEligibilityRejectsMismatchedGender(t *testing.T) {
+	user := &domain.User{Gender: ptrString(string(domain.GenderMale))}
+	event := &domain.Event{PreferredGender: ptrGender(domain.GenderFemale)}
+
+	err := domain.CheckParticipationEligibility(user, event, referenceNow)
+	if err == nil || err.Code != domain.ErrorCodeGenderRequirementNotMet {
+		t.Fatalf("expected gender_requirement_not_met, got %v", err)
+	}
+	if err.Status != domain.StatusConflict {
+		t.Fatalf("expected 409 status, got %d", err.Status)
+	}
+}
+
+func TestCheckParticipationEligibilityRequiresGenderWhenGenderRestricted(t *testing.T) {
+	user := &domain.User{Gender: nil}
+	event := &domain.Event{PreferredGender: ptrGender(domain.GenderFemale)}
+
+	err := domain.CheckParticipationEligibility(user, event, referenceNow)
+	if err == nil || err.Code != domain.ErrorCodeProfileIncomplete {
+		t.Fatalf("expected profile_incomplete, got %v", err)
+	}
+}
+
+func TestCheckParticipationEligibilityAllowsMatchingGender(t *testing.T) {
+	user := &domain.User{Gender: ptrString(string(domain.GenderFemale))}
+	event := &domain.Event{PreferredGender: ptrGender(domain.GenderFemale)}
+
+	if err := domain.CheckParticipationEligibility(user, event, referenceNow); err != nil {
+		t.Fatalf("expected eligibility, got %v", err)
+	}
+}

--- a/backend/tests_integration/common/fixtures.go
+++ b/backend/tests_integration/common/fixtures.go
@@ -49,6 +49,20 @@ func WithUserVerifiedAt(verifiedAt time.Time) UserOption {
 	}
 }
 
+// WithUserGender overrides the default (nil) gender for the fixture.
+func WithUserGender(gender string) UserOption {
+	return func(f *userFixture) {
+		f.gender = &gender
+	}
+}
+
+// WithUserBirthDate overrides the default (nil) birth date for the fixture.
+func WithUserBirthDate(birthDate time.Time) UserOption {
+	return func(f *userFixture) {
+		f.birthDate = &birthDate
+	}
+}
+
 // GivenUser persists a user fixture through the provided auth repository.
 func GivenUser(t *testing.T, repo authapp.Repository, opts ...UserOption) *domain.User {
 	t.Helper()

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -2402,6 +2402,12 @@ type routeDiscoveryEventSeed struct {
 func createDiscoveryEvent(t *testing.T, harness *common.EventHarness, seed discoveryEventSeed) uuid.UUID {
 	t.Helper()
 
+	createStartTime := seed.StartTime
+	backdate := !seed.StartTime.IsZero() && !seed.StartTime.After(time.Now().UTC())
+	if backdate {
+		createStartTime = time.Now().UTC().Add(time.Hour)
+	}
+
 	result, err := harness.Service.CreateEvent(context.Background(), seed.HostID, eventapp.CreateEventInput{
 		Title:        seed.Title,
 		Description:  common.StringPtr(seed.Description),
@@ -2409,7 +2415,7 @@ func createDiscoveryEvent(t *testing.T, harness *common.EventHarness, seed disco
 		LocationType: domain.LocationPoint,
 		Lat:          &seed.Lat,
 		Lon:          &seed.Lon,
-		StartTime:    seed.StartTime,
+		StartTime:    createStartTime,
 		PrivacyLevel: seed.PrivacyLevel,
 		Tags:         seed.Tags,
 	})
@@ -2420,6 +2426,17 @@ func createDiscoveryEvent(t *testing.T, harness *common.EventHarness, seed disco
 	eventID, err := uuid.Parse(result.ID)
 	if err != nil {
 		t.Fatalf("uuid.Parse() error = %v", err)
+	}
+
+	if backdate {
+		if _, err := common.RequirePool(t).Exec(
+			context.Background(),
+			`UPDATE event SET start_time = $2 WHERE id = $1`,
+			eventID,
+			seed.StartTime,
+		); err != nil {
+			t.Fatalf("backdate event start_time error = %v", err)
+		}
 	}
 
 	return eventID
@@ -2616,6 +2633,100 @@ func setJoinRequestUpdatedAt(t *testing.T, joinRequestID uuid.UUID, updatedAt ti
 	); err != nil {
 		t.Fatalf("update join_request updated_at error = %v", err)
 	}
+}
+
+func TestIntegrationJoinEventRejectsUnderageUser(t *testing.T) {
+	t.Parallel()
+
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	joiner := common.GivenUser(t, harness.AuthRepo,
+		common.WithUserBirthDate(time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)),
+	)
+	eventID := createPublicEventWithMinAge(t, harness, host.ID, 18)
+
+	_, err := harness.Service.JoinEvent(context.Background(), joiner.ID, eventID)
+
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeAgeRequirementNotMet)
+}
+
+func TestIntegrationRequestJoinRejectsMismatchedGender(t *testing.T) {
+	t.Parallel()
+
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	joiner := common.GivenUser(t, harness.AuthRepo,
+		common.WithUserGender(string(domain.GenderMale)),
+	)
+	eventID := createProtectedEventWithPreferredGender(t, harness, host.ID, domain.GenderFemale)
+
+	_, err := harness.Service.RequestJoin(context.Background(), joiner.ID, eventID, eventapp.RequestJoinInput{})
+
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeGenderRequirementNotMet)
+}
+
+// createPublicEventWithMinAge builds a PUBLIC event with the given minimum age
+// restriction via the real event service and returns its ID.
+func createPublicEventWithMinAge(t *testing.T, harness *common.EventHarness, hostID uuid.UUID, minAge int) uuid.UUID {
+	t.Helper()
+
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	categoryID := common.GivenEventCategory(t)
+	lat := 41.0
+	lon := 29.0
+
+	result, err := harness.Service.CreateEvent(context.Background(), hostID, eventapp.CreateEventInput{
+		Title:        "Age-restricted event " + uuid.NewString()[:8],
+		Description:  common.StringPtr("Age-restricted integration fixture"),
+		CategoryID:   &categoryID,
+		LocationType: domain.LocationPoint,
+		Lat:          &lat,
+		Lon:          &lon,
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPublic,
+		MinimumAge:   &minAge,
+	})
+	if err != nil {
+		t.Fatalf("CreateEvent() error = %v", err)
+	}
+
+	id, err := uuid.Parse(result.ID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() error = %v", err)
+	}
+	return id
+}
+
+// createProtectedEventWithPreferredGender builds a PROTECTED event with a preferred
+// gender restriction via the real event service and returns its ID.
+func createProtectedEventWithPreferredGender(t *testing.T, harness *common.EventHarness, hostID uuid.UUID, gender domain.EventParticipantGender) uuid.UUID {
+	t.Helper()
+
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	categoryID := common.GivenEventCategory(t)
+	lat := 41.0
+	lon := 29.0
+
+	result, err := harness.Service.CreateEvent(context.Background(), hostID, eventapp.CreateEventInput{
+		Title:           "Gender-restricted event " + uuid.NewString()[:8],
+		Description:     common.StringPtr("Gender-restricted integration fixture"),
+		CategoryID:      &categoryID,
+		LocationType:    domain.LocationPoint,
+		Lat:             &lat,
+		Lon:             &lon,
+		StartTime:       startTime,
+		PrivacyLevel:    domain.PrivacyProtected,
+		PreferredGender: &gender,
+	})
+	if err != nil {
+		t.Fatalf("CreateEvent() error = %v", err)
+	}
+
+	id, err := uuid.Parse(result.ID)
+	if err != nil {
+		t.Fatalf("uuid.Parse() error = %v", err)
+	}
+	return id
 }
 
 func createProtectedEventWithCapacity(t *testing.T, harness *common.EventHarness, hostID uuid.UUID, capacity int) uuid.UUID {

--- a/docs/backend/constraint-audit.md
+++ b/docs/backend/constraint-audit.md
@@ -1,0 +1,22 @@
+# Backend Participation & Event Constraint Audit — Issue #467
+
+_Last updated: 2026-04-18_
+
+| Constraint                               | Stored in                    | Enforced server-side?          | Enforcement location                                    | Test reference                         |
+|------------------------------------------|------------------------------|--------------------------------|---------------------------------------------------------|----------------------------------------|
+| Capacity (approved ≤ capacity)           | `event.capacity`             | ✅ Yes                          | `event.Service.JoinEvent`, `join_request_repo.ApproveJoinRequest` | `service_test.TestJoinEventRejectsFullCapacity` |
+| Host cannot join                         | `event.host_id`              | ✅ Yes                          | `event.Service.JoinEvent`, `event.Service.RequestJoin`  | `TestJoinEventRejectsHost`             |
+| Privacy level (PUBLIC vs PROTECTED)      | `event.privacy_level`        | ✅ Yes                          | `event.Service.JoinEvent`, `event.Service.RequestJoin`  | `TestJoinEventRejectsProtectedEvent`   |
+| Event status (not CANCELED/COMPLETED)    | `event.status`               | ✅ Yes                          | `event.Service.JoinEvent`, `event.Service.RequestJoin`, `event.Service.ApproveJoinRequest` | _existing coverage_ |
+| Duplicate participation / pending request| `participation`, `join_request` | ✅ Yes (repo)                | `participation_repo`, `join_request_repo`               | _existing coverage_                    |
+| Rejection cooldown (72h)                 | `join_request.updated_at`    | ✅ Yes                          | `join_request_repo.handleExistingJoinRequestForCreate`  | _existing coverage_                    |
+| **Minimum age**                          | `event.minimum_age`          | ⚠️ **Partially — create-event shape only; join-time enforcement missing** | —                                                       | _added in plan Tasks 4–6_              |
+| **Preferred gender**                     | `event.preferred_gender`     | ⚠️ **Partially — create-event shape only; join-time enforcement missing** | —                                                       | _added in plan Tasks 4–6_              |
+| **Language restrictions**                | `event_constraint` (free-form)| ⚠️ Not structurally enforceable (no language field on user) | — | _follow-up issue_ |
+| **Start time must be in future**         | `event.start_time`           | ❌ **Missing**                  | —                                                       | _added in plan Task 8_                 |
+
+## Decisions
+
+- Eligibility checks live in a pure domain helper (`domain.CheckParticipationEligibility`), not inlined in `JoinEvent` / `RequestJoin`, so REST handlers, future admin APIs, and background jobs share one implementation.
+- When a restricted event requires a gender/birthdate that the requester has not set, the server returns 400 `profile_incomplete` rather than silently bypassing the check.
+- Language restrictions require a schema change (user language field + typed constraint rows); tracked in a separate follow-up issue.

--- a/docs/backend/constraint-audit.md
+++ b/docs/backend/constraint-audit.md
@@ -1,6 +1,6 @@
 # Backend Participation & Event Constraint Audit — Issue #467
 
-_Last updated: 2026-04-18_
+_Last updated: 2026-04-19_
 
 | Constraint                               | Stored in                    | Enforced server-side?          | Enforcement location                                    | Test reference                         |
 |------------------------------------------|------------------------------|--------------------------------|---------------------------------------------------------|----------------------------------------|
@@ -10,10 +10,10 @@ _Last updated: 2026-04-18_
 | Event status (not CANCELED/COMPLETED)    | `event.status`               | ✅ Yes                          | `event.Service.JoinEvent`, `event.Service.RequestJoin`, `event.Service.ApproveJoinRequest` | _existing coverage_ |
 | Duplicate participation / pending request| `participation`, `join_request` | ✅ Yes (repo)                | `participation_repo`, `join_request_repo`               | _existing coverage_                    |
 | Rejection cooldown (72h)                 | `join_request.updated_at`    | ✅ Yes                          | `join_request_repo.handleExistingJoinRequestForCreate`  | _existing coverage_                    |
-| **Minimum age**                          | `event.minimum_age`          | ⚠️ **Partially — create-event shape only; join-time enforcement missing** | —                                                       | _added in plan Tasks 4–6_              |
-| **Preferred gender**                     | `event.preferred_gender`     | ⚠️ **Partially — create-event shape only; join-time enforcement missing** | —                                                       | _added in plan Tasks 4–6_              |
+| Minimum age                              | `event.minimum_age`          | ✅ Yes                          | `domain.CheckParticipationEligibility` called from `event.Service.JoinEvent`, `event.Service.RequestJoin` | `TestJoinEventRejectsUnderageUser`, `TestRequestJoinRejectsUnderageUser`, `TestIntegrationJoinEventRejectsUnderageUser` |
+| Preferred gender                         | `event.preferred_gender`     | ✅ Yes                          | `domain.CheckParticipationEligibility` called from `event.Service.JoinEvent`, `event.Service.RequestJoin` | `TestJoinEventRejectsMismatchedGender`, `TestRequestJoinRejectsMismatchedGender`, `TestIntegrationRequestJoinRejectsMismatchedGender` |
 | **Language restrictions**                | `event_constraint` (free-form)| ⚠️ Not structurally enforceable (no language field on user) | — | _follow-up issue_ |
-| **Start time must be in future**         | `event.start_time`           | ❌ **Missing**                  | —                                                       | _added in plan Task 8_                 |
+| Start time must be in future             | `event.start_time`           | ✅ Yes                          | `validateCreateEventInput` in `event.Service.CreateEvent` | `TestCreateEventValidationPastStartTime` |
 
 ## Decisions
 

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -825,7 +825,7 @@ paths:
                     status: APPROVED
                     created_at: "2026-03-26T11:00:00+03:00"
         '400':
-          description: Invalid event ID format.
+          description: "Invalid event ID format, or the requester's profile is missing a field required by the event (`profile_incomplete`)."
           content:
             application/json:
               schema:
@@ -838,6 +838,18 @@ paths:
                       message: The request body contains invalid fields. See error.details for field-specific messages.
                       details:
                         id: must be a valid UUID
+                profile_incomplete_birth_date:
+                  summary: User birth date is missing on an age-restricted event
+                  value:
+                    error:
+                      code: profile_incomplete
+                      message: Your birth date must be set on your profile to join age-restricted events.
+                profile_incomplete_gender:
+                  summary: User gender is missing on a gender-restricted event
+                  value:
+                    error:
+                      code: profile_incomplete
+                      message: Your gender must be set on your profile to join this event.
         '401':
           description: Missing or invalid access token.
           content:
@@ -870,8 +882,10 @@ paths:
                       message: The requested event does not exist.
         '409':
           description: |
-            Conflict. Either the user is already participating (`already_participating`) or
-            the event privacy level does not allow direct join (`event_join_not_allowed`).
+            Conflict. Either the user is already participating (`already_participating`),
+            the event privacy level does not allow direct join (`event_join_not_allowed`),
+            the requester is below the event's minimum age (`age_requirement_not_met`), or
+            the requester's gender does not match the event's preferred gender (`gender_requirement_not_met`).
           content:
             application/json:
               schema:
@@ -887,6 +901,18 @@ paths:
                     error:
                       code: event_join_not_allowed
                       message: Only PUBLIC events can be joined directly.
+                age_requirement_not_met:
+                  summary: Requester is below the event's minimum age
+                  value:
+                    error:
+                      code: age_requirement_not_met
+                      message: You do not meet the minimum age required by this event.
+                gender_requirement_not_met:
+                  summary: Requester gender does not match the event's preferred gender
+                  value:
+                    error:
+                      code: gender_requirement_not_met
+                      message: This event is restricted to participants of a specific gender.
         '500':
           description: Unexpected server error.
           content:
@@ -1172,7 +1198,7 @@ paths:
                     status: PENDING
                     created_at: "2026-03-26T12:00:00+03:00"
         '400':
-          description: Invalid event ID format or malformed JSON body.
+          description: "Invalid event ID format, malformed JSON body, or the requester's profile is missing a field required by the event (`profile_incomplete`)."
           content:
             application/json:
               schema:
@@ -1185,6 +1211,18 @@ paths:
                       message: The request body contains invalid fields. See error.details for field-specific messages.
                       details:
                         id: must be a valid UUID
+                profile_incomplete_birth_date:
+                  summary: User birth date is missing on an age-restricted event
+                  value:
+                    error:
+                      code: profile_incomplete
+                      message: Your birth date must be set on your profile to join age-restricted events.
+                profile_incomplete_gender:
+                  summary: User gender is missing on a gender-restricted event
+                  value:
+                    error:
+                      code: profile_incomplete
+                      message: Your gender must be set on your profile to join this event.
         '401':
           description: Missing or invalid access token.
           content:
@@ -1219,8 +1257,10 @@ paths:
           description: |
             Conflict. The caller already has a pending request (`already_requested`), is already
             participating (`already_participating`), the event privacy level does not allow join
-            requests (`event_join_not_allowed`), or a rejection cooldown is still active
-            (`join_request_cooldown_active`).
+            requests (`event_join_not_allowed`), a rejection cooldown is still active
+            (`join_request_cooldown_active`), the requester is below the event's minimum age
+            (`age_requirement_not_met`), or the requester's gender does not match the event's
+            preferred gender (`gender_requirement_not_met`).
           content:
             application/json:
               schema:
@@ -1246,6 +1286,18 @@ paths:
                     error:
                       code: join_request_cooldown_active
                       message: You must wait 3 days after rejection before requesting to join this event again.
+                age_requirement_not_met:
+                  summary: Requester is below the event's minimum age
+                  value:
+                    error:
+                      code: age_requirement_not_met
+                      message: You do not meet the minimum age required by this event.
+                gender_requirement_not_met:
+                  summary: Requester gender does not match the event's preferred gender
+                  value:
+                    error:
+                      code: gender_requirement_not_met
+                      message: This event is restricted to participants of a specific gender.
         '500':
           description: Unexpected server error.
           content:
@@ -1821,6 +1873,14 @@ paths:
                       message: The request body contains invalid fields. See error.details for field-specific messages.
                       details:
                         category_id: must reference an existing event category id
+                start_time_in_past:
+                  summary: start_time is not in the future
+                  value:
+                    error:
+                      code: validation_error
+                      message: The request body contains invalid fields. See error.details for field-specific messages.
+                      details:
+                        start_time: start_time must be in the future
         '401':
           description: Missing or invalid access token.
           content:


### PR DESCRIPTION
## 📋 Summary                                                                                                         
  Closes the server-side validation gaps in event and join flows so the backend
  enforces participation restrictions (age, gender) and event-lifecycle invariants                                      
  (past `start_time`) regardless of client behavior. Adds the audit deliverable                                         
  called for in the issue body and documents the new error codes in the OpenAPI spec.                                   
                                                                                                                        
  ## 🔄 Changes                                                                                                         
  - **Audit** (`docs/backend/constraint-audit.md`): present vs. missing constraint                                      
    matrix with enforcement locations and test references.                                                              
  - **Domain** (`internal/domain/`):                                                                                    
    - New pure helper `CheckParticipationEligibility(user, event, now)` and                                             
      `HasMinimumAge(birthDate, minAge, now)` in `join_eligibility.go`.                                                 
    - New error codes `profile_incomplete` (400), `age_requirement_not_met` (409),                                      
      `gender_requirement_not_met` (409).                                                                               
  - **Application** (`internal/application/event/`):                                                                    
    - `Service.JoinEvent` and `Service.RequestJoin` now call                                                            
      `ensureRequesterEligible`, which loads the requester and runs the domain                                          
      check.                                                                                                            
    - `validateCreateEventInput` rejects non-future `start_time` with                                                   
      `validation_error` + `details.start_time = "start_time must be in the future"`.                                   
  - **Repository** (`internal/adapter/in/postgres/event_repo.go`): new                                                  
    `GetRequesterForJoin(ctx, userID)` loads `birth_date` and `gender` for the                                          
    eligibility check.                                                                                                  
  - **Tests**: 6 new unit tests (`application/event`) and 2 integration tests                                           
    (`tests_integration/event_test.go`) covering under-age, mismatched gender,                                          
    missing-birthdate-on-age-restricted, past-start-time, etc.
  - **OpenAPI** (`docs/openapi/event.yaml`): documented new 400/409 error codes                                         
    on `joinEvent`, `requestJoinEvent`, and new `start_time_in_past` sub-example                                        
    on `createEvent`.                                                                                                   
                                                                                                                        
  ## 🧪 Testing                                                                                                         
  - `cd backend && go vet ./... && gofmt -l .` → clean                                                                  
  - `cd backend && go test -short ./...` → all packages PASS                                                            
  - `cd backend && PATH="/Applications/Docker.app/Contents/Resources/bin:$PATH" \
     go test ./tests_integration/...` → full integration suite PASS (requires                                           
    Docker Desktop running for testcontainers to provision Postgres+PostGIS)                                            
  - YAML parse check on the OpenAPI spec:                                                                               
    `python3 -c "import yaml; yaml.safe_load(open('docs/openapi/event.yaml'))"`                                         
                                                                                                                        
  ## 🔗 Related                                                                                                         
  Closes #467  