### PR TITLE
devops(backend): re-structure backend logs and remove fanout logging

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -21,6 +21,24 @@ Read `/AGENTS.md` first, then use this file for backend work.
 - Add inline comments inside methods when the flow is trivial-to-misread, constraint-heavy, or otherwise hard to infer from the code alone.
 - Do not add comments that only restate the code. Comments should explain intent, invariants, edge cases, or why a decision exists.
 
+## Observability and logging
+
+- Prefer **structured application logs** at meaningful business boundaries instead of logging every incoming HTTP request.
+- Keep backend request-level telemetry in **OpenTelemetry metrics/traces**; do not reintroduce generic per-request info logs when route/span metrics already cover that need.
+- When adding logs in HTTP handlers or application-entry boundaries, use the shared structured logging helpers under `internal/adapter/out/httpapi/` so field names stay consistent across the backend.
+- Include safe, low-noise context that helps debugging and correlation:
+  - operation name (for example `event.discover`, `profile.update`)
+  - stable IDs such as `user_id`, `event_id`, `join_request_id`, `favorite_location_id` when relevant
+  - low-cardinality result fields such as `result_count`, `has_next`, booleans, or status-like fields
+- For request/query/filter context, prefer a **single summary string field** (for example `query_summary`) over exploding many dynamic attributes; this keeps cardinality under control in New Relic.
+- Do **not** log secrets or confidential payloads. Never log tokens, passwords, OTP/reset/confirm tokens, raw authorization headers, or sensitive free-form user content unless there is an explicit, reviewed reason and the value is redacted.
+- Be especially careful with user-editable text fields. Prefer logging presence/absence, counts, or updated field names instead of raw values unless the field is clearly non-sensitive and operationally necessary.
+- When OTLP/New Relic is configured, backend logs are expected to go through the OpenTelemetry pipeline instead of stdout. Do not add alternate console logging paths that duplicate those records.
+- If you add a new high-value endpoint or mutation, consider whether it also needs a structured success log for observability. Keep the wording short, action-oriented, and consistent with existing messages.
+- If you change observability bootstrap behavior, preserve both of these contracts unless the task explicitly changes them:
+  - HTTP metrics/traces continue to flow through the OpenTelemetry middleware
+  - application logs continue to expose `level`/severity information in New Relic
+
 ## API documentation
 
 - After completing backend development, add or update the relevant OpenAPI documentation under `/docs/openapi/`.

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
@@ -1,6 +1,8 @@
 package event_handler
 
 import (
+	"fmt"
+	"log/slog"
 	"net/url"
 	"strconv"
 	"strings"
@@ -60,6 +62,16 @@ func (h *EventHandler) DiscoverEvents(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event discovery completed",
+		httpapi.OperationAttr("event.discover"),
+		httpapi.OptionalUserIDAttr(userID),
+		httpapi.QuerySummaryAttr(summarizeDiscoverEventsInput(input)),
+		slog.Int("result_count", len(result.Items)),
+		slog.Bool("has_next", result.PageInfo.HasNext),
+	)
+
 	return c.JSON(result)
 }
 
@@ -75,6 +87,14 @@ func (h *EventHandler) GetEventDetail(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event detail fetched",
+		httpapi.OperationAttr("event.detail"),
+		httpapi.OptionalUserIDAttr(userID),
+		httpapi.EventIDAttr(eventID),
+	)
 
 	c.Set(fiber.HeaderCacheControl, "private, no-store")
 	c.Set(fiber.HeaderVary, fiber.HeaderAuthorization)
@@ -93,6 +113,14 @@ func (h *EventHandler) GetEventHostContextSummary(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event host context fetched",
+		httpapi.OperationAttr("event.host_context"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+	)
 
 	return c.JSON(result)
 }
@@ -115,6 +143,17 @@ func (h *EventHandler) ListEventApprovedParticipants(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event participants listed",
+		httpapi.OperationAttr("event.participants.list"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		httpapi.QuerySummaryAttr(summarizeEventCollectionInput(input)),
+		slog.Int("result_count", len(result.Items)),
+		slog.Bool("has_next", result.PageInfo.HasNext),
+	)
+
 	return c.JSON(result)
 }
 
@@ -136,6 +175,17 @@ func (h *EventHandler) ListEventPendingJoinRequests(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event join requests listed",
+		httpapi.OperationAttr("event.join_requests.list"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		httpapi.QuerySummaryAttr(summarizeEventCollectionInput(input)),
+		slog.Int("result_count", len(result.Items)),
+		slog.Bool("has_next", result.PageInfo.HasNext),
+	)
+
 	return c.JSON(result)
 }
 
@@ -156,6 +206,17 @@ func (h *EventHandler) ListEventInvitations(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event invitations listed",
+		httpapi.OperationAttr("event.invitations.list"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		httpapi.QuerySummaryAttr(summarizeEventCollectionInput(input)),
+		slog.Int("result_count", len(result.Items)),
+		slog.Bool("has_next", result.PageInfo.HasNext),
+	)
 
 	return c.JSON(result)
 }
@@ -185,6 +246,15 @@ func (h *EventHandler) CreateEvent(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event created",
+		httpapi.OperationAttr("event.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("created_event_id", result.ID),
+		httpapi.QuerySummaryAttr(summarizeCreateEventInput(input)),
+	)
 
 	return c.Status(fiber.StatusCreated).JSON(result)
 }
@@ -289,6 +359,15 @@ func (h *EventHandler) JoinEvent(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event joined",
+		httpapi.OperationAttr("event.join"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.String("participation_id", result.ParticipationID),
+	)
+
 	return c.Status(fiber.StatusCreated).JSON(result)
 }
 
@@ -305,6 +384,15 @@ func (h *EventHandler) LeaveEvent(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event left",
+		httpapi.OperationAttr("event.leave"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.String("participation_id", result.ParticipationID),
+	)
 
 	return c.JSON(result)
 }
@@ -332,6 +420,15 @@ func (h *EventHandler) RequestJoin(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event join request created",
+		httpapi.OperationAttr("event.join_request.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		httpapi.QuerySummaryAttr(httpapi.JoinSummary(httpapi.BoolSummary("has_message", body.Message != nil && strings.TrimSpace(*body.Message) != ""))),
+	)
+
 	return c.Status(fiber.StatusCreated).JSON(result)
 }
 
@@ -353,6 +450,16 @@ func (h *EventHandler) ApproveJoinRequest(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event join request approved",
+		httpapi.OperationAttr("event.join_request.approve"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		httpapi.JoinRequestIDAttr(joinRequestID),
+		slog.String("participation_id", result.ParticipationID),
+	)
 
 	return c.JSON(result)
 }
@@ -376,6 +483,15 @@ func (h *EventHandler) RejectJoinRequest(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event join request rejected",
+		httpapi.OperationAttr("event.join_request.reject"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		httpapi.JoinRequestIDAttr(joinRequestID),
+	)
+
 	return c.JSON(result)
 }
 
@@ -391,6 +507,14 @@ func (h *EventHandler) CancelEvent(c *fiber.Ctx) error {
 	if err := h.service.CancelEvent(c.UserContext(), claims.UserID, eventID); err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event canceled",
+		httpapi.OperationAttr("event.cancel"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+	)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }
@@ -408,6 +532,14 @@ func (h *EventHandler) CompleteEvent(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event completed",
+		httpapi.OperationAttr("event.complete"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+	)
+
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -422,6 +554,14 @@ func (h *EventHandler) AddFavorite(c *fiber.Ctx) error {
 	if err := h.service.AddFavorite(c.UserContext(), claims.UserID, eventID); err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event favorited",
+		httpapi.OperationAttr("event.favorite.add"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+	)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }
@@ -438,7 +578,90 @@ func (h *EventHandler) RemoveFavorite(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event favorite removed",
+		httpapi.OperationAttr("event.favorite.remove"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+	)
+
 	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func summarizeDiscoverEventsInput(input event.DiscoverEventsInput) string {
+	parts := []string{
+		fmt.Sprintf("lat_set=%t", input.Lat != nil),
+		fmt.Sprintf("lon_set=%t", input.Lon != nil),
+		fmt.Sprintf("radius_meters=%s", optionalIntSummaryValue(input.RadiusMeters)),
+		fmt.Sprintf("limit=%s", optionalIntSummaryValue(input.Limit)),
+		fmt.Sprintf("q=%s", optionalStringSummaryValue(input.Query)),
+		fmt.Sprintf("privacy_levels=%d", len(input.PrivacyLevels)),
+		fmt.Sprintf("category_ids=%d", len(input.CategoryIDs)),
+		fmt.Sprintf("tag_names=%d", len(input.TagNames)),
+		fmt.Sprintf("start_from=%s", optionalTimeSummaryValue(input.StartFrom)),
+		fmt.Sprintf("start_to=%s", optionalTimeSummaryValue(input.StartTo)),
+		fmt.Sprintf("only_favorited=%t", input.OnlyFavorited),
+		fmt.Sprintf("sort_by=%s", optionalSortBySummaryValue(input.SortBy)),
+		fmt.Sprintf("cursor=%s", optionalStringSummaryValue(input.Cursor)),
+	}
+	return strings.Join(parts, " ")
+}
+
+func summarizeEventCollectionInput(input event.ListEventCollectionInput) string {
+	return httpapi.JoinSummary(
+		fmt.Sprintf("limit=%s", optionalIntSummaryValue(input.Limit)),
+		fmt.Sprintf("cursor=%s", optionalStringSummaryValue(input.Cursor)),
+	)
+}
+
+func summarizeCreateEventInput(input event.CreateEventInput) string {
+	return httpapi.JoinSummary(
+		fmt.Sprintf("category_id=%s", optionalIntSummaryValue(input.CategoryID)),
+		fmt.Sprintf("privacy_level=%s", input.PrivacyLevel),
+		fmt.Sprintf("location_type=%s", input.LocationType),
+		fmt.Sprintf("route_points=%d", len(input.RoutePoints)),
+		fmt.Sprintf("tags=%d", len(input.Tags)),
+		fmt.Sprintf("constraints=%d", len(input.Constraints)),
+		fmt.Sprintf("capacity_set=%t", input.Capacity != nil),
+		fmt.Sprintf("minimum_age_set=%t", input.MinimumAge != nil),
+		fmt.Sprintf("preferred_gender_set=%t", input.PreferredGender != nil),
+		fmt.Sprintf("end_time_set=%t", input.EndTime != nil),
+		fmt.Sprintf("image_url_set=%t", input.ImageURL != nil && strings.TrimSpace(*input.ImageURL) != ""),
+		fmt.Sprintf("start_time=%s", input.StartTime.UTC().Format(time.RFC3339)),
+	)
+}
+
+func optionalIntSummaryValue(value *int) string {
+	if value == nil {
+		return "<nil>"
+	}
+	return strconv.Itoa(*value)
+}
+
+func optionalStringSummaryValue(value *string) string {
+	if value == nil {
+		return "<nil>"
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return "<empty>"
+	}
+	return trimmed
+}
+
+func optionalTimeSummaryValue(value *time.Time) string {
+	if value == nil {
+		return "<nil>"
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func optionalSortBySummaryValue(value *domain.EventDiscoverySort) string {
+	if value == nil {
+		return "<nil>"
+	}
+	return string(*value)
 }
 
 func parseEventIDParam(c *fiber.Ctx) (uuid.UUID, error) {

--- a/backend/internal/adapter/out/httpapi/favorite_location_handler/favorite_location_handler.go
+++ b/backend/internal/adapter/out/httpapi/favorite_location_handler/favorite_location_handler.go
@@ -1,6 +1,8 @@
 package favorite_location_handler
 
 import (
+	"log/slog"
+
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
 	favoritelocationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/favorite_location"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
@@ -36,6 +38,14 @@ func (h *Handler) ListFavoriteLocations(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"favorite locations fetched",
+		httpapi.OperationAttr("favorite_location.list"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(result.Items)),
+	)
+
 	return c.JSON(result)
 }
 
@@ -58,6 +68,14 @@ func (h *Handler) CreateFavoriteLocation(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"favorite location created",
+		httpapi.OperationAttr("favorite_location.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("created_favorite_location_id", result.ID),
+	)
 
 	return c.Status(fiber.StatusCreated).JSON(result)
 }
@@ -90,6 +108,14 @@ func (h *Handler) UpdateFavoriteLocation(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"favorite location updated",
+		httpapi.OperationAttr("favorite_location.update"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.FavoriteLocationIDAttr(favoriteLocationID),
+	)
+
 	return c.JSON(result)
 }
 
@@ -104,6 +130,14 @@ func (h *Handler) DeleteFavoriteLocation(c *fiber.Ctx) error {
 	if err := h.service.DeleteMyFavoriteLocation(c.UserContext(), claims.UserID, favoriteLocationID); err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"favorite location deleted",
+		httpapi.OperationAttr("favorite_location.delete"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.FavoriteLocationIDAttr(favoriteLocationID),
+	)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
@@ -1,6 +1,7 @@
 package image_upload_handler
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
@@ -40,6 +41,16 @@ func (h *Handler) CreateProfileAvatarUpload(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"profile avatar upload URL created",
+		httpapi.OperationAttr("image_upload.profile_avatar.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("base_url", result.BaseURL),
+		slog.Int("upload_count", len(result.Uploads)),
+		slog.Int("version", result.Version),
+	)
+
 	return c.JSON(result)
 }
 
@@ -56,6 +67,13 @@ func (h *Handler) ConfirmProfileAvatarUpload(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"profile avatar upload confirmed",
+		httpapi.OperationAttr("image_upload.profile_avatar.confirm"),
+		httpapi.UserIDAttr(claims.UserID),
+	)
+
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -71,6 +89,17 @@ func (h *Handler) CreateEventImageUpload(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event image upload URL created",
+		httpapi.OperationAttr("image_upload.event_image.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.String("base_url", result.BaseURL),
+		slog.Int("upload_count", len(result.Uploads)),
+		slog.Int("version", result.Version),
+	)
 
 	return c.JSON(result)
 }
@@ -91,6 +120,14 @@ func (h *Handler) ConfirmEventImageUpload(c *fiber.Ctx) error {
 	if err := h.service.ConfirmEventImageUpload(c.UserContext(), claims.UserID, eventID, body); err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event image upload confirmed",
+		httpapi.OperationAttr("image_upload.event_image.confirm"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+	)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/backend/internal/adapter/out/httpapi/logging.go
+++ b/backend/internal/adapter/out/httpapi/logging.go
@@ -1,0 +1,98 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// LogInfo emits a structured info-level application log.
+func LogInfo(ctx context.Context, msg string, attrs ...slog.Attr) {
+	log(ctx, slog.LevelInfo, msg, attrs...)
+}
+
+func log(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) {
+	logger := slog.Default()
+	if len(attrs) > 0 {
+		logger.LogAttrs(ctx, level, msg, attrs...)
+		return
+	}
+	logger.Log(ctx, level, msg)
+}
+
+// UserIDAttr records the authenticated user ID for log correlation.
+func UserIDAttr(userID uuid.UUID) slog.Attr {
+	return slog.String("user_id", userID.String())
+}
+
+// OptionalUserIDAttr records the caller identity, or "anonymous" when the
+// request is not authenticated.
+func OptionalUserIDAttr(userID uuid.UUID) slog.Attr {
+	if userID == uuid.Nil {
+		return slog.String("user_id", "anonymous")
+	}
+	return UserIDAttr(userID)
+}
+
+func EventIDAttr(eventID uuid.UUID) slog.Attr {
+	return slog.String("event_id", eventID.String())
+}
+
+func JoinRequestIDAttr(joinRequestID uuid.UUID) slog.Attr {
+	return slog.String("join_request_id", joinRequestID.String())
+}
+
+func FavoriteLocationIDAttr(favoriteLocationID uuid.UUID) slog.Attr {
+	return slog.String("favorite_location_id", favoriteLocationID.String())
+}
+
+func ParticipantUserIDAttr(userID uuid.UUID) slog.Attr {
+	return slog.String("participant_user_id", userID.String())
+}
+
+func QuerySummaryAttr(summary string) slog.Attr {
+	return slog.String("query_summary", summary)
+}
+
+func OperationAttr(operation string) slog.Attr {
+	return slog.String("operation", operation)
+}
+
+func BoolSummary(label string, value bool) string {
+	if value {
+		return label + "=true"
+	}
+	return label + "=false"
+}
+
+func CountSummary(label string, value int) string {
+	return fmt.Sprintf("%s=%d", label, value)
+}
+
+func StringSummary(label, value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return label + "=<empty>"
+	}
+	return fmt.Sprintf("%s=%s", label, trimmed)
+}
+
+func StringPtrSummary(label string, value *string) string {
+	if value == nil {
+		return label + "=<nil>"
+	}
+	return StringSummary(label, *value)
+}
+
+func JoinSummary(parts ...string) string {
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	return strings.Join(filtered, " ")
+}

--- a/backend/internal/adapter/out/httpapi/middleware.go
+++ b/backend/internal/adapter/out/httpapi/middleware.go
@@ -1,9 +1,7 @@
 package httpapi
 
 import (
-	"log/slog"
 	"strings"
-	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/gofiber/fiber/v2"
@@ -75,22 +73,6 @@ func OptionalAuth(verifier domain.TokenVerifier) fiber.Handler {
 func UserClaims(c *fiber.Ctx) *domain.AuthClaims {
 	claims, _ := c.Locals(contextKeyUserClaims).(*domain.AuthClaims)
 	return claims
-}
-
-// RequestLogger returns a middleware that logs the HTTP method, path, status
-// code, and latency of every request using the structured logger.
-func RequestLogger() fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		start := time.Now()
-		err := c.Next()
-		slog.InfoContext(c.UserContext(), "request",
-			"method", c.Method(),
-			"path", c.Path(),
-			"status", c.Response().StatusCode(),
-			"latency", time.Since(start).String(),
-		)
-		return err
-	}
 }
 
 // extractBearer parses "Bearer <token>" from an Authorization header value.

--- a/backend/internal/adapter/out/httpapi/middleware_test.go
+++ b/backend/internal/adapter/out/httpapi/middleware_test.go
@@ -119,26 +119,3 @@ func TestRequireAuthValidToken(t *testing.T) {
 		t.Fatalf("expected 200, got %d — body: %s", resp.StatusCode, body)
 	}
 }
-
-func TestRequestLoggerPassesThrough(t *testing.T) {
-	// given
-	app := fiber.New()
-	app.Use(RequestLogger())
-	app.Get("/health", func(c *fiber.Ctx) error {
-		return c.SendStatus(fiber.StatusOK)
-	})
-
-	req := httptest.NewRequest(fiber.MethodGet, "/health", nil)
-
-	// when
-	resp, err := app.Test(req)
-	if err != nil {
-		t.Fatalf("application.Test() error = %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// then
-	if resp.StatusCode != fiber.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-}

--- a/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
+++ b/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
@@ -1,6 +1,9 @@
 package profile_handler
 
 import (
+	"log/slog"
+	"strings"
+
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/event"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/profile"
@@ -40,6 +43,13 @@ func (h *ProfileHandler) GetMyProfile(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my profile fetched",
+		httpapi.OperationAttr("profile.get"),
+		httpapi.UserIDAttr(claims.UserID),
+	)
+
 	return c.JSON(result)
 }
 
@@ -50,6 +60,14 @@ func (h *ProfileHandler) GetMyHostedEvents(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my hosted events fetched",
+		httpapi.OperationAttr("profile.events.hosted"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(events)),
+	)
 	return c.JSON(fiber.Map{"events": events})
 }
 
@@ -60,6 +78,14 @@ func (h *ProfileHandler) GetMyUpcomingEvents(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my upcoming events fetched",
+		httpapi.OperationAttr("profile.events.upcoming"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(events)),
+	)
 	return c.JSON(fiber.Map{"events": events})
 }
 
@@ -70,6 +96,14 @@ func (h *ProfileHandler) GetMyCompletedEvents(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my completed events fetched",
+		httpapi.OperationAttr("profile.events.completed"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(events)),
+	)
 	return c.JSON(fiber.Map{"events": events})
 }
 
@@ -80,6 +114,14 @@ func (h *ProfileHandler) GetMyCanceledEvents(c *fiber.Ctx) error {
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my canceled events fetched",
+		httpapi.OperationAttr("profile.events.canceled"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(events)),
+	)
 	return c.JSON(fiber.Map{"events": events})
 }
 
@@ -120,6 +162,14 @@ func (h *ProfileHandler) UpdateMyProfile(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my profile updated",
+		httpapi.OperationAttr("profile.update"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.QuerySummaryAttr(summarizeUpdatedProfileFields(body)),
+	)
+
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -131,5 +181,48 @@ func (h *ProfileHandler) ListFavoriteEvents(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my favorite events fetched",
+		httpapi.OperationAttr("profile.favorites.list"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(result.Items)),
+	)
+
 	return c.JSON(result)
+}
+
+func summarizeUpdatedProfileFields(body updateProfileBody) string {
+	fields := make([]string, 0, 9)
+	if body.PhoneNumber != nil {
+		fields = append(fields, "phone_number")
+	}
+	if body.Gender != nil {
+		fields = append(fields, "gender")
+	}
+	if body.BirthDate != nil {
+		fields = append(fields, "birth_date")
+	}
+	if body.DefaultLocationAddress != nil {
+		fields = append(fields, "default_location_address")
+	}
+	if body.DefaultLocationLat != nil {
+		fields = append(fields, "default_location_lat")
+	}
+	if body.DefaultLocationLon != nil {
+		fields = append(fields, "default_location_lon")
+	}
+	if body.DisplayName != nil {
+		fields = append(fields, "display_name")
+	}
+	if body.Bio != nil {
+		fields = append(fields, "bio")
+	}
+	if body.AvatarURL != nil {
+		fields = append(fields, "avatar_url")
+	}
+	if len(fields) == 0 {
+		return "updated_fields=<none>"
+	}
+	return "updated_fields=" + strings.Join(fields, ",")
 }

--- a/backend/internal/adapter/out/httpapi/rating_handler/rating_handler.go
+++ b/backend/internal/adapter/out/httpapi/rating_handler/rating_handler.go
@@ -1,6 +1,9 @@
 package rating_handler
 
 import (
+	"log/slog"
+	"strings"
+
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
 	ratingapp "github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
@@ -45,6 +48,16 @@ func (h *RatingHandler) UpsertEventRating(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, svcErr)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event rating upserted",
+		httpapi.OperationAttr("rating.event.upsert"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.Int("rating", input.Rating),
+		slog.Bool("has_message", input.Message != nil && strings.TrimSpace(*input.Message) != ""),
+	)
+
 	return c.JSON(result)
 }
 
@@ -59,6 +72,14 @@ func (h *RatingHandler) DeleteEventRating(c *fiber.Ctx) error {
 	if err := h.service.DeleteEventRating(c.UserContext(), claims.UserID, eventID); err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event rating deleted",
+		httpapi.OperationAttr("rating.event.delete"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+	)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }
@@ -85,6 +106,17 @@ func (h *RatingHandler) UpsertParticipantRating(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, svcErr)
 	}
 
+	httpapi.LogInfo(
+		c.UserContext(),
+		"participant rating upserted",
+		httpapi.OperationAttr("rating.participant.upsert"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		httpapi.ParticipantUserIDAttr(participantUserID),
+		slog.Int("rating", input.Rating),
+		slog.Bool("has_message", input.Message != nil && strings.TrimSpace(*input.Message) != ""),
+	)
+
 	return c.JSON(result)
 }
 
@@ -103,6 +135,15 @@ func (h *RatingHandler) DeleteParticipantRating(c *fiber.Ctx) error {
 	if err := h.service.DeleteParticipantRating(c.UserContext(), claims.UserID, eventID, participantUserID); err != nil {
 		return httpapi.WriteError(c, err)
 	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"participant rating deleted",
+		httpapi.OperationAttr("rating.participant.delete"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		httpapi.ParticipantUserIDAttr(participantUserID),
+	)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/backend/internal/infrastructure/observability/otel.go
+++ b/backend/internal/infrastructure/observability/otel.go
@@ -46,9 +46,9 @@ func (r *Runtime) LoggerProvider() *sdklog.LoggerProvider {
 	return r.loggerProvider
 }
 
-// ConfigureLogger installs the process-wide logger. It always writes JSON logs
-// to stdout and, when a LoggerProvider is available, mirrors them into the
-// OpenTelemetry logs pipeline.
+// ConfigureLogger installs the process-wide logger. Without a LoggerProvider it
+// writes JSON logs to stdout. When a LoggerProvider is available, it sends logs
+// only to the OpenTelemetry pipeline so container stdout stays quiet.
 func ConfigureLogger(provider *sdklog.LoggerProvider) {
 	stdoutHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
 	if provider == nil {
@@ -61,7 +61,7 @@ func ConfigureLogger(provider *sdklog.LoggerProvider) {
 		otelslog.WithLoggerProvider(provider),
 		otelslog.WithSource(true),
 	)
-	slog.SetDefault(slog.New(newFanoutHandler(stdoutHandler, otelHandler)))
+	slog.SetDefault(slog.New(newLevelAttrHandler(otelHandler)))
 }
 
 // Setup initializes OpenTelemetry traces, metrics, and logs when an OTLP
@@ -168,49 +168,45 @@ func newResource(ctx context.Context, appEnv string) (*resource.Resource, error)
 	return res, nil
 }
 
-type fanoutHandler struct {
-	handlers []slog.Handler
+type levelAttrHandler struct {
+	next slog.Handler
 }
 
-func newFanoutHandler(handlers ...slog.Handler) slog.Handler {
-	filtered := make([]slog.Handler, 0, len(handlers))
-	for _, handler := range handlers {
-		if handler != nil {
-			filtered = append(filtered, handler)
+func newLevelAttrHandler(next slog.Handler) slog.Handler {
+	if next == nil {
+		return nil
+	}
+	return &levelAttrHandler{next: next}
+}
+
+func (h *levelAttrHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *levelAttrHandler) Handle(ctx context.Context, record slog.Record) error {
+	cloned := record.Clone()
+	if !recordHasAttr(record, slog.LevelKey) {
+		cloned.AddAttrs(slog.String(slog.LevelKey, record.Level.String()))
+	}
+	return h.next.Handle(ctx, cloned)
+}
+
+func (h *levelAttrHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &levelAttrHandler{next: h.next.WithAttrs(attrs)}
+}
+
+func (h *levelAttrHandler) WithGroup(name string) slog.Handler {
+	return &levelAttrHandler{next: h.next.WithGroup(name)}
+}
+
+func recordHasAttr(record slog.Record, key string) bool {
+	found := false
+	record.Attrs(func(attr slog.Attr) bool {
+		if attr.Key == key {
+			found = true
+			return false
 		}
-	}
-	return &fanoutHandler{handlers: filtered}
-}
-
-func (h *fanoutHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	for _, handler := range h.handlers {
-		if handler.Enabled(ctx, level) {
-			return true
-		}
-	}
-	return false
-}
-
-func (h *fanoutHandler) Handle(ctx context.Context, record slog.Record) error {
-	var err error
-	for _, handler := range h.handlers {
-		err = errors.Join(err, handler.Handle(ctx, record.Clone()))
-	}
-	return err
-}
-
-func (h *fanoutHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	next := make([]slog.Handler, 0, len(h.handlers))
-	for _, handler := range h.handlers {
-		next = append(next, handler.WithAttrs(attrs))
-	}
-	return &fanoutHandler{handlers: next}
-}
-
-func (h *fanoutHandler) WithGroup(name string) slog.Handler {
-	next := make([]slog.Handler, 0, len(h.handlers))
-	for _, handler := range h.handlers {
-		next = append(next, handler.WithGroup(name))
-	}
-	return &fanoutHandler{handlers: next}
+		return true
+	})
+	return found
 }

--- a/backend/internal/infrastructure/observability/otel_test.go
+++ b/backend/internal/infrastructure/observability/otel_test.go
@@ -7,7 +7,29 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
+
+	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
+
+type captureHandler struct {
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, record slog.Record) error {
+	h.records = append(h.records, record.Clone())
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *captureHandler) WithGroup(name string) slog.Handler {
+	return h
+}
 
 func TestSetupDisabledWithoutEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
@@ -43,4 +65,92 @@ func TestConfigureLoggerWritesToStdoutWithoutProvider(t *testing.T) {
 	if !strings.Contains(string(output), "\"msg\":\"hello\"") {
 		t.Fatalf("expected stdout log output, got %s", string(output))
 	}
+}
+
+func TestConfigureLoggerSkipsStdoutWhenProviderIsConfigured(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	originalStdout := os.Stdout
+	os.Stdout = writer
+	defer func() { os.Stdout = originalStdout }()
+
+	provider := sdklog.NewLoggerProvider()
+	defer func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown provider: %v", err)
+		}
+	}()
+
+	ConfigureLogger(provider)
+	slog.Info("hello", "component", "test")
+	_ = writer.Close()
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if len(strings.TrimSpace(string(output))) != 0 {
+		t.Fatalf("expected no stdout log output, got %s", string(output))
+	}
+}
+
+func TestLevelAttrHandlerAddsLevelAttribute(t *testing.T) {
+	sink := &captureHandler{}
+	handler := newLevelAttrHandler(sink)
+
+	record := slog.NewRecord(timeNowForTest(), slog.LevelWarn, "warn message", 0)
+	if err := handler.Handle(context.Background(), record); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	if len(sink.records) != 1 {
+		t.Fatalf("expected one record, got %d", len(sink.records))
+	}
+
+	level := ""
+	sink.records[0].Attrs(func(attr slog.Attr) bool {
+		if attr.Key == slog.LevelKey {
+			level = attr.Value.String()
+			return false
+		}
+		return true
+	})
+	if level != "WARN" {
+		t.Fatalf("expected WARN level attr, got %q", level)
+	}
+}
+
+func TestLevelAttrHandlerDoesNotDuplicateExistingLevelAttribute(t *testing.T) {
+	sink := &captureHandler{}
+	handler := newLevelAttrHandler(sink)
+
+	record := slog.NewRecord(timeNowForTest(), slog.LevelInfo, "info message", 0)
+	record.AddAttrs(slog.String(slog.LevelKey, "custom"))
+	if err := handler.Handle(context.Background(), record); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	levelAttrs := 0
+	lastValue := ""
+	sink.records[0].Attrs(func(attr slog.Attr) bool {
+		if attr.Key == slog.LevelKey {
+			levelAttrs++
+			lastValue = attr.Value.String()
+		}
+		return true
+	})
+	if levelAttrs != 1 {
+		t.Fatalf("expected one level attr, got %d", levelAttrs)
+	}
+	if lastValue != "custom" {
+		t.Fatalf("expected custom level attr, got %q", lastValue)
+	}
+}
+
+func timeNowForTest() (now time.Time) {
+	return time.Unix(1710000000, 0)
 }

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -28,8 +28,9 @@ func NewHTTP(container *bootstrap.Container) *fiber.App {
 		},
 	})
 
+	// otelfiber emits request traces and HTTP metrics; application logs stay
+	// focused on high-signal business actions inside handlers.
 	app.Use(otelfiber.Middleware())
-	app.Use(httpapi.RequestLogger())
 
 	registerHealthRoute(app)
 

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -12,6 +12,7 @@ http {
     default_type application/octet-stream;
     sendfile on;
     keepalive_timeout 65;
+    access_log off;
 
     real_ip_header CF-Connecting-IP;
     real_ip_recursive on;


### PR DESCRIPTION
## 📋 Summary
Improve backend observability by replacing noisy per-request stdout logging with high-signal structured application logs, and by making logger delivery environment-aware for New Relic. When OTLP/New Relic is configured, logs are sent only to the telemetry pipeline; otherwise the backend falls back to JSON stdout logs.

## 🔄 Changes
- Added consistent structured logging helpers for backend HTTP handlers.
- Added focused business-event logs to important backend flows instead of logging every incoming request.
- Logged safe contextual fields such as `user_id`, `event_id`, operation names, result counts, and query/input summaries without exposing confidential data.
- Added structured logs to event discovery/detail/mutation flows, `/me` profile flows, favorite locations, image uploads, and ratings.
- Removed the generic request logger middleware that was writing every request to stdout.
- Kept HTTP request metrics/traces via `otelfiber` so request-level telemetry remains available in New Relic metrics.
- Updated observability bootstrap so logs include an explicit `level` field in the OTLP pipeline.
- Changed logger behavior so stdout logging is used only as a fallback when OTLP/New Relic is not configured.
- Added/updated observability tests for stdout fallback behavior and OTLP-only behavior.

## 🧪 Testing
- Ran `go test ./...` in `backend/`
- Ran `./shipcheck.sh` in `backend/`
- Verified all backend checks passed, including unit tests, integration tests, linting, static analysis, and build steps

## 🔗 Related
- Related to backend observability / New Relic logging improvements