### PR TITLE
feat(backend): add ticketing flow in backend

### DIFF
--- a/backend/internal/adapter/in/jwt/ticket_token_manager.go
+++ b/backend/internal/adapter/in/jwt/ticket_token_manager.go
@@ -1,0 +1,99 @@
+package jwt
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	ticketapp "github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
+	gojwt "github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+type ticketTokenClaims struct {
+	TicketID        string `json:"ticket_id"`
+	ParticipationID string `json:"participation_id"`
+	EventID         string `json:"event_id"`
+	UserID          string `json:"user_id"`
+	Version         int    `json:"version"`
+	gojwt.RegisteredClaims
+}
+
+// TicketTokenManager signs and verifies short-lived QR ticket tokens.
+type TicketTokenManager struct {
+	Secret []byte
+}
+
+var _ ticketapp.QRTokenManager = (*TicketTokenManager)(nil)
+
+// Issue creates a signed HS256 token from ticket QR claims.
+func (m TicketTokenManager) Issue(claims ticketapp.QRTokenClaims) (string, error) {
+	tokenClaims := ticketTokenClaims{
+		TicketID:        claims.TicketID.String(),
+		ParticipationID: claims.ParticipationID.String(),
+		EventID:         claims.EventID.String(),
+		UserID:          claims.UserID.String(),
+		Version:         claims.Version,
+		RegisteredClaims: gojwt.RegisteredClaims{
+			IssuedAt:  gojwt.NewNumericDate(claims.IssuedAt),
+			ExpiresAt: gojwt.NewNumericDate(claims.ExpiresAt),
+		},
+	}
+
+	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, tokenClaims)
+	signed, err := token.SignedString(m.Secret)
+	if err != nil {
+		return "", err
+	}
+	return signed, nil
+}
+
+// Verify parses and validates a signed ticket QR token.
+func (m TicketTokenManager) Verify(tokenString string) (*ticketapp.QRTokenClaims, error) {
+	claims := &ticketTokenClaims{}
+	token, err := gojwt.ParseWithClaims(tokenString, claims, func(token *gojwt.Token) (any, error) {
+		if token.Method != gojwt.SigningMethodHS256 {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return m.Secret, nil
+	}, gojwt.WithExpirationRequired(), gojwt.WithIssuedAt())
+	if err != nil || !token.Valid {
+		return nil, fmt.Errorf("invalid ticket token: %w", err)
+	}
+
+	ticketID, err := uuid.Parse(claims.TicketID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ticket_id claim: %w", err)
+	}
+	participationID, err := uuid.Parse(claims.ParticipationID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid participation_id claim: %w", err)
+	}
+	eventID, err := uuid.Parse(claims.EventID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid event_id claim: %w", err)
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user_id claim: %w", err)
+	}
+	if claims.ExpiresAt == nil || claims.IssuedAt == nil {
+		return nil, fmt.Errorf("ticket token is missing time claims")
+	}
+
+	return &ticketapp.QRTokenClaims{
+		TicketID:        ticketID,
+		ParticipationID: participationID,
+		EventID:         eventID,
+		UserID:          userID,
+		Version:         claims.Version,
+		IssuedAt:        claims.IssuedAt.UTC(),
+		ExpiresAt:       claims.ExpiresAt.UTC(),
+	}, nil
+}
+
+// Hash returns a deterministic SHA-256 hash of the plaintext signed token.
+func (m TicketTokenManager) Hash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/adapter/in/jwt/ticket_token_manager_test.go
+++ b/backend/internal/adapter/in/jwt/ticket_token_manager_test.go
@@ -1,0 +1,69 @@
+package jwt
+
+import (
+	"testing"
+	"time"
+
+	ticketapp "github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
+	"github.com/google/uuid"
+)
+
+func TestTicketTokenManagerIssuesAndVerifiesClaims(t *testing.T) {
+	// given
+	manager := TicketTokenManager{Secret: []byte("ticket-secret")}
+	claims := ticketapp.QRTokenClaims{
+		TicketID:        uuid.New(),
+		ParticipationID: uuid.New(),
+		EventID:         uuid.New(),
+		UserID:          uuid.New(),
+		Version:         42,
+		IssuedAt:        time.Now().UTC().Truncate(time.Second),
+		ExpiresAt:       time.Now().UTC().Add(10 * time.Second).Truncate(time.Second),
+	}
+
+	// when
+	token, err := manager.Issue(claims)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	parsed, err := manager.Verify(token)
+
+	// then
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if parsed.TicketID != claims.TicketID || parsed.ParticipationID != claims.ParticipationID || parsed.EventID != claims.EventID || parsed.UserID != claims.UserID {
+		t.Fatalf("parsed claims do not match original: %+v", parsed)
+	}
+	if parsed.Version != claims.Version {
+		t.Fatalf("expected version %d, got %d", claims.Version, parsed.Version)
+	}
+	if manager.Hash(token) == token || manager.Hash(token) == "" {
+		t.Fatal("expected token hash to be non-empty and different from plaintext")
+	}
+}
+
+func TestTicketTokenManagerRejectsExpiredToken(t *testing.T) {
+	// given
+	manager := TicketTokenManager{Secret: []byte("ticket-secret")}
+	token, err := manager.Issue(ticketapp.QRTokenClaims{
+		TicketID:        uuid.New(),
+		ParticipationID: uuid.New(),
+		EventID:         uuid.New(),
+		UserID:          uuid.New(),
+		Version:         1,
+		IssuedAt:        time.Now().UTC().Add(-20 * time.Second),
+		ExpiresAt:       time.Now().UTC().Add(-10 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	// when
+	_, err = manager.Verify(token)
+
+	// then
+	if err == nil {
+		t.Fatal("expected expired token to be rejected")
+	}
+}

--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -1643,7 +1643,7 @@ func (r *EventRepository) CancelEvent(ctx context.Context, eventID uuid.UUID, ca
 // CompleteEvent sets the event status to COMPLETED when it is ACTIVE or IN_PROGRESS.
 // Returns ErrEventNotCompletable when the event is CANCELED, COMPLETED, or any other non-completable status.
 func (r *EventRepository) CompleteEvent(ctx context.Context, eventID uuid.UUID) error {
-	tag, err := r.pool.Exec(ctx, `
+	tag, err := r.db.Exec(ctx, `
 		UPDATE event
 		SET status = 'COMPLETED', updated_at = NOW()
 		WHERE id = $1 AND status IN ('ACTIVE', 'IN_PROGRESS')
@@ -1668,18 +1668,29 @@ func (r *EventRepository) CompleteEvent(ctx context.Context, eventID uuid.UUID) 
 // Participation activity does not advance updated_at.
 func (r *EventRepository) TransitionEventStatuses(ctx context.Context) error {
 	_, err := r.pool.Exec(ctx, `
-		UPDATE event
-		SET status = CASE
-			WHEN end_time IS NOT NULL AND end_time < NOW()                                                         THEN 'COMPLETED'
-			WHEN start_time < NOW() - INTERVAL '60 days'                                                          THEN 'COMPLETED'
-			WHEN start_time < NOW() - INTERVAL '30 days' AND updated_at < NOW() - INTERVAL '7 days'               THEN 'COMPLETED'
-			ELSE 'IN_PROGRESS'
-		END
-		WHERE status IN ('ACTIVE', 'IN_PROGRESS')
-		  AND (
-		    start_time < NOW()
-		    OR (end_time IS NOT NULL AND end_time < NOW())
-		  )
+		WITH transitioned AS (
+			UPDATE event
+			SET status = CASE
+				WHEN end_time IS NOT NULL AND end_time < NOW()                                           THEN 'COMPLETED'
+				WHEN start_time < NOW() - INTERVAL '60 days'                                            THEN 'COMPLETED'
+				WHEN start_time < NOW() - INTERVAL '30 days' AND updated_at < NOW() - INTERVAL '7 days' THEN 'COMPLETED'
+				ELSE 'IN_PROGRESS'
+			END
+			WHERE status IN ('ACTIVE', 'IN_PROGRESS')
+			  AND (
+			    start_time < NOW()
+			    OR (end_time IS NOT NULL AND end_time < NOW())
+			  )
+			RETURNING id, status
+		)
+		UPDATE ticket t
+		SET status = 'EXPIRED',
+		    updated_at = NOW()
+		FROM participation p
+		JOIN transitioned e ON e.id = p.event_id
+		WHERE t.participation_id = p.id
+		  AND e.status = 'COMPLETED'
+		  AND t.status IN ('ACTIVE', 'PENDING')
 	`)
 	return err
 }

--- a/backend/internal/adapter/in/postgres/ticket_repo.go
+++ b/backend/internal/adapter/in/postgres/ticket_repo.go
@@ -1,0 +1,518 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	ticketapp "github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TicketRepository is the Postgres-backed implementation of ticket.Repository.
+type TicketRepository struct {
+	pool *pgxpool.Pool
+	db   execer
+}
+
+var _ ticketapp.Repository = (*TicketRepository)(nil)
+
+// NewTicketRepository returns a repository that executes queries against the given connection pool.
+func NewTicketRepository(pool *pgxpool.Pool) *TicketRepository {
+	return &TicketRepository{
+		pool: pool,
+		db:   contextualRunner{fallback: pool},
+	}
+}
+
+// CreateTicketForParticipation creates or reactivates a non-terminal ticket for a protected participation.
+func (r *TicketRepository) CreateTicketForParticipation(ctx context.Context, participationID uuid.UUID, status domain.TicketStatus) (*domain.Ticket, error) {
+	row := r.db.QueryRow(ctx, `
+		WITH participation_event AS (
+			SELECT p.id AS participation_id,
+			       COALESCE(e.end_time, e.start_time + INTERVAL '60 days') AS expires_at
+			FROM participation p
+			JOIN event e ON e.id = p.event_id
+			WHERE p.id = $1
+			  AND e.privacy_level = $3
+		),
+		reactivated AS (
+			UPDATE ticket t
+			SET status = $2,
+			    qr_token_version = 0,
+			    last_issued_qr_token_hash = NULL,
+			    expires_at = pe.expires_at,
+			    used_at = NULL,
+			    canceled_at = NULL,
+			    updated_at = NOW()
+			FROM participation_event pe
+			WHERE t.participation_id = pe.participation_id
+			  AND t.status IN ($4, $5, $6)
+			RETURNING t.id, t.participation_id, t.status, t.qr_token_version, t.last_issued_qr_token_hash,
+			          t.expires_at, t.used_at, t.canceled_at, t.created_at, t.updated_at
+		),
+		inserted AS (
+			INSERT INTO ticket (participation_id, status, expires_at)
+			SELECT participation_id, $2, expires_at
+			FROM participation_event
+			WHERE NOT EXISTS (SELECT 1 FROM reactivated)
+			ON CONFLICT DO NOTHING
+			RETURNING id, participation_id, status, qr_token_version, last_issued_qr_token_hash,
+			          expires_at, used_at, canceled_at, created_at, updated_at
+		)
+		SELECT id, participation_id, status, qr_token_version, last_issued_qr_token_hash,
+		       expires_at, used_at, canceled_at, created_at, updated_at
+		FROM reactivated
+		UNION ALL
+		SELECT id, participation_id, status, qr_token_version, last_issued_qr_token_hash,
+		       expires_at, used_at, canceled_at, created_at, updated_at
+		FROM inserted
+		LIMIT 1
+	`, participationID, status, domain.PrivacyProtected, domain.TicketStatusExpired, domain.TicketStatusCanceled, domain.TicketStatusUsed)
+
+	ticket, err := scanTicket(row)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeTicketNotFound, "The linked protected participation does not exist.")
+		}
+		return nil, fmt.Errorf("create ticket for participation: %w", err)
+	}
+	return ticket, nil
+}
+
+// CancelTicketForParticipation cancels a non-terminal ticket for the participation.
+func (r *TicketRepository) CancelTicketForParticipation(ctx context.Context, participationID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE ticket
+		SET status = $2,
+		    canceled_at = COALESCE(canceled_at, NOW()),
+		    updated_at = NOW()
+		WHERE participation_id = $1
+		  AND status IN ($3, $4)
+	`, participationID, domain.TicketStatusCanceled, domain.TicketStatusActive, domain.TicketStatusPending)
+	if err != nil {
+		return fmt.Errorf("cancel ticket for participation: %w", err)
+	}
+	return nil
+}
+
+// CancelTicketsForEvent cancels all non-terminal tickets for an event.
+func (r *TicketRepository) CancelTicketsForEvent(ctx context.Context, eventID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE ticket t
+		SET status = $2,
+		    canceled_at = COALESCE(t.canceled_at, NOW()),
+		    updated_at = NOW()
+		FROM participation p
+		WHERE p.id = t.participation_id
+		  AND p.event_id = $1
+		  AND t.status IN ($3, $4)
+	`, eventID, domain.TicketStatusCanceled, domain.TicketStatusActive, domain.TicketStatusPending)
+	if err != nil {
+		return fmt.Errorf("cancel tickets for event: %w", err)
+	}
+	return nil
+}
+
+// ExpireTicketsForEvent expires all unused non-terminal tickets for an event.
+func (r *TicketRepository) ExpireTicketsForEvent(ctx context.Context, eventID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE ticket t
+		SET status = $2,
+		    updated_at = NOW()
+		FROM participation p
+		WHERE p.id = t.participation_id
+		  AND p.event_id = $1
+		  AND t.status IN ($3, $4)
+	`, eventID, domain.TicketStatusExpired, domain.TicketStatusActive, domain.TicketStatusPending)
+	if err != nil {
+		return fmt.Errorf("expire tickets for event: %w", err)
+	}
+	return nil
+}
+
+// ListTicketsByUser returns ticket summaries for the given user.
+func (r *TicketRepository) ListTicketsByUser(ctx context.Context, userID uuid.UUID) ([]ticketapp.TicketRecord, error) {
+	rows, err := r.db.Query(ctx, ticketRecordSelect(`
+		WHERE user_id = $1
+		ORDER BY start_time ASC, created_at ASC
+	`, "NULL::double precision", "NULL::double precision"), userID)
+	if err != nil {
+		return nil, fmt.Errorf("list tickets by user: %w", err)
+	}
+	defer rows.Close()
+
+	records := []ticketapp.TicketRecord{}
+	for rows.Next() {
+		record, err := scanTicketRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, *record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list tickets by user rows: %w", err)
+	}
+	return records, nil
+}
+
+// GetTicketDetail returns a ticket detail projection when the ticket belongs to the user.
+func (r *TicketRepository) GetTicketDetail(ctx context.Context, userID, ticketID uuid.UUID) (*ticketapp.TicketRecord, error) {
+	record, err := scanTicketRecord(r.db.QueryRow(ctx, ticketRecordSelect(`
+		WHERE user_id = $1
+		  AND id = $2
+	`, "NULL::double precision", "NULL::double precision"), userID, ticketID))
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return record, nil
+}
+
+// GetTicketAccessForUser returns ticket state plus distance from the caller's provided coordinates.
+func (r *TicketRepository) GetTicketAccessForUser(ctx context.Context, userID, ticketID uuid.UUID, lat, lon float64, forUpdate bool) (*ticketapp.TicketAccessRecord, error) {
+	_ = forUpdate
+	record, err := scanTicketAccessRecord(r.db.QueryRow(ctx, ticketRecordSelect(`
+		WHERE user_id = $1
+		  AND id = $2
+		`, "$3::double precision", "$4::double precision"), userID, ticketID, lat, lon))
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return record, nil
+}
+
+// StoreIssuedToken stores only the hash and monotonically increasing token version.
+func (r *TicketRepository) StoreIssuedToken(ctx context.Context, ticketID uuid.UUID, version int, tokenHash string) error {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE ticket
+		SET qr_token_version = $2,
+		    last_issued_qr_token_hash = $3,
+		    updated_at = NOW()
+		WHERE id = $1
+	`, ticketID, version, tokenHash)
+	if err != nil {
+		return fmt.Errorf("store issued ticket token: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NotFoundError(domain.ErrorCodeTicketNotFound, "The requested ticket does not exist.")
+	}
+	return nil
+}
+
+// GetTicketForScan returns locked ticket state for host scan validation.
+func (r *TicketRepository) GetTicketForScan(ctx context.Context, eventID, ticketID uuid.UUID, forUpdate bool) (*ticketapp.TicketScanRecord, error) {
+	query := `
+		SELECT t.id, t.participation_id, t.status, t.qr_token_version, t.last_issued_qr_token_hash,
+		       t.expires_at, t.used_at, t.canceled_at, t.created_at, t.updated_at,
+		       p.id, p.event_id, p.user_id, p.status, p.created_at, p.updated_at,
+		       e.id, e.status, e.privacy_level, e.host_id
+		FROM ticket t
+		JOIN participation p ON p.id = t.participation_id
+		JOIN event e ON e.id = p.event_id
+		WHERE t.id = $1
+		  AND e.id = $2
+	`
+	if forUpdate {
+		query += ` FOR UPDATE OF t`
+	}
+
+	record, err := scanTicketScanRecord(r.db.QueryRow(ctx, query, ticketID, eventID))
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return record, nil
+}
+
+// MarkTicketUsed marks an ACTIVE ticket as USED.
+func (r *TicketRepository) MarkTicketUsed(ctx context.Context, ticketID uuid.UUID) (*domain.Ticket, error) {
+	ticket, err := scanTicket(r.db.QueryRow(ctx, `
+		UPDATE ticket
+		SET status = $2,
+		    used_at = NOW(),
+		    updated_at = NOW()
+		WHERE id = $1
+		  AND status = $3
+		RETURNING id, participation_id, status, qr_token_version, last_issued_qr_token_hash,
+		          expires_at, used_at, canceled_at, created_at, updated_at
+	`, ticketID, domain.TicketStatusUsed, domain.TicketStatusActive))
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.ConflictError(domain.ErrorCodeTicketScanRejected, "The ticket can no longer be used.")
+		}
+		return nil, fmt.Errorf("mark ticket used: %w", err)
+	}
+	return ticket, nil
+}
+
+func ticketRecordSelect(whereClause, latExpr, lonExpr string) string {
+	return `
+		WITH ticket_base AS (
+			SELECT t.id, t.participation_id, t.status, t.qr_token_version, t.last_issued_qr_token_hash,
+			       t.expires_at, t.used_at, t.canceled_at, t.created_at, t.updated_at,
+			       p.event_id, p.user_id, p.status AS participation_status, p.created_at AS participation_created_at, p.updated_at AS participation_updated_at,
+			       e.title, e.status AS event_status, e.privacy_level, e.start_time, e.end_time, e.location_type,
+			       el.address,
+			       CASE
+			           WHEN e.location_type = 'ROUTE' THEN ST_StartPoint(el.geom::geometry)
+			           ELSE el.geom::geometry
+			       END AS anchor_geom
+			FROM ticket t
+			JOIN participation p ON p.id = t.participation_id
+			JOIN event e ON e.id = p.event_id
+			JOIN event_location el ON el.event_id = e.id
+		)
+		SELECT id, participation_id, status, qr_token_version, last_issued_qr_token_hash,
+		       expires_at, used_at, canceled_at, created_at, updated_at,
+		       event_id, user_id, participation_status, participation_created_at, participation_updated_at,
+		       title, event_status, privacy_level, start_time, end_time, location_type, address,
+		       ST_Y(anchor_geom) AS anchor_lat,
+		       ST_X(anchor_geom) AS anchor_lon,
+		       CASE
+		           WHEN ` + latExpr + ` IS NULL OR ` + lonExpr + ` IS NULL THEN 0::double precision
+		           ELSE ST_Distance(anchor_geom::geography, ST_SetSRID(ST_MakePoint(` + lonExpr + `, ` + latExpr + `), 4326)::geography)
+		       END AS distance_meters
+		FROM ticket_base
+	` + whereClause
+}
+
+func scanTicket(row pgx.Row) (*domain.Ticket, error) {
+	var (
+		ticket     domain.Ticket
+		status     string
+		tokenHash  pgtype.Text
+		usedAt     pgtype.Timestamptz
+		canceledAt pgtype.Timestamptz
+	)
+	if err := row.Scan(
+		&ticket.ID,
+		&ticket.ParticipationID,
+		&status,
+		&ticket.QRTokenVersion,
+		&tokenHash,
+		&ticket.ExpiresAt,
+		&usedAt,
+		&canceledAt,
+		&ticket.CreatedAt,
+		&ticket.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+	parsedStatus, ok := domain.ParseTicketStatus(status)
+	if !ok {
+		return nil, fmt.Errorf("unknown ticket status %q", status)
+	}
+	ticket.Status = parsedStatus
+	ticket.LastIssuedQRTokenHash = textPtr(tokenHash)
+	ticket.UsedAt = timestamptzPtr(usedAt)
+	ticket.CanceledAt = timestamptzPtr(canceledAt)
+	return &ticket, nil
+}
+
+func scanTicketRecord(row pgx.Row) (*ticketapp.TicketRecord, error) {
+	accessRecord, err := scanTicketAccessRecord(row)
+	if err != nil {
+		return nil, err
+	}
+	return &accessRecord.TicketRecord, nil
+}
+
+func scanTicketAccessRecord(row pgx.Row) (*ticketapp.TicketAccessRecord, error) {
+	var (
+		ticket                 domain.Ticket
+		ticketStatus           string
+		tokenHash              pgtype.Text
+		usedAt                 pgtype.Timestamptz
+		canceledAt             pgtype.Timestamptz
+		eventID                uuid.UUID
+		userID                 uuid.UUID
+		participationStatus    string
+		participationCreatedAt time.Time
+		participationUpdatedAt time.Time
+		eventTitle             string
+		eventStatus            string
+		privacyLevel           string
+		startTime              time.Time
+		endTime                pgtype.Timestamptz
+		locationType           string
+		address                pgtype.Text
+		anchorLat              float64
+		anchorLon              float64
+		distanceMeters         float64
+	)
+
+	err := row.Scan(
+		&ticket.ID,
+		&ticket.ParticipationID,
+		&ticketStatus,
+		&ticket.QRTokenVersion,
+		&tokenHash,
+		&ticket.ExpiresAt,
+		&usedAt,
+		&canceledAt,
+		&ticket.CreatedAt,
+		&ticket.UpdatedAt,
+		&eventID,
+		&userID,
+		&participationStatus,
+		&participationCreatedAt,
+		&participationUpdatedAt,
+		&eventTitle,
+		&eventStatus,
+		&privacyLevel,
+		&startTime,
+		&endTime,
+		&locationType,
+		&address,
+		&anchorLat,
+		&anchorLon,
+		&distanceMeters,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("scan ticket record: %w", err)
+	}
+
+	parsedTicketStatus, ok := domain.ParseTicketStatus(ticketStatus)
+	if !ok {
+		return nil, fmt.Errorf("unknown ticket status %q", ticketStatus)
+	}
+	parsedParticipationStatus, ok := domain.ParseParticipationStatus(participationStatus)
+	if !ok {
+		return nil, fmt.Errorf("unknown participation status %q", participationStatus)
+	}
+	parsedEventStatus := domain.EventStatus(eventStatus)
+	parsedPrivacyLevel, ok := domain.ParseEventPrivacyLevel(privacyLevel)
+	if !ok {
+		return nil, fmt.Errorf("unknown event privacy level %q", privacyLevel)
+	}
+	parsedLocationType, ok := domain.ParseEventLocationType(locationType)
+	if !ok {
+		return nil, fmt.Errorf("unknown event location type %q", locationType)
+	}
+
+	ticket.Status = parsedTicketStatus
+	ticket.LastIssuedQRTokenHash = textPtr(tokenHash)
+	ticket.UsedAt = timestamptzPtr(usedAt)
+	ticket.CanceledAt = timestamptzPtr(canceledAt)
+
+	record := &ticketapp.TicketAccessRecord{
+		TicketRecord: ticketapp.TicketRecord{
+			Ticket: ticket,
+			Participation: domain.Participation{
+				ID:        ticket.ParticipationID,
+				EventID:   eventID,
+				UserID:    userID,
+				Status:    parsedParticipationStatus,
+				CreatedAt: participationCreatedAt,
+				UpdatedAt: participationUpdatedAt,
+			},
+			EventID:      eventID,
+			EventTitle:   eventTitle,
+			EventStatus:  parsedEventStatus,
+			PrivacyLevel: parsedPrivacyLevel,
+			StartTime:    startTime,
+			LocationType: parsedLocationType,
+			Address:      textPtr(address),
+			Anchor: domain.GeoPoint{
+				Lat: anchorLat,
+				Lon: anchorLon,
+			},
+		},
+		UserID:         userID,
+		DistanceMeters: distanceMeters,
+	}
+	if endTime.Valid {
+		record.EndTime = &endTime.Time
+	}
+	return record, nil
+}
+
+func scanTicketScanRecord(row pgx.Row) (*ticketapp.TicketScanRecord, error) {
+	var (
+		ticket              domain.Ticket
+		ticketStatus        string
+		tokenHash           pgtype.Text
+		usedAt              pgtype.Timestamptz
+		canceledAt          pgtype.Timestamptz
+		participation       domain.Participation
+		participationStatus string
+		eventID             uuid.UUID
+		eventStatus         string
+		privacyLevel        string
+		hostID              uuid.UUID
+	)
+	err := row.Scan(
+		&ticket.ID,
+		&ticket.ParticipationID,
+		&ticketStatus,
+		&ticket.QRTokenVersion,
+		&tokenHash,
+		&ticket.ExpiresAt,
+		&usedAt,
+		&canceledAt,
+		&ticket.CreatedAt,
+		&ticket.UpdatedAt,
+		&participation.ID,
+		&participation.EventID,
+		&participation.UserID,
+		&participationStatus,
+		&participation.CreatedAt,
+		&participation.UpdatedAt,
+		&eventID,
+		&eventStatus,
+		&privacyLevel,
+		&hostID,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("scan ticket scan record: %w", err)
+	}
+	parsedTicketStatus, ok := domain.ParseTicketStatus(ticketStatus)
+	if !ok {
+		return nil, fmt.Errorf("unknown ticket status %q", ticketStatus)
+	}
+	parsedParticipationStatus, ok := domain.ParseParticipationStatus(participationStatus)
+	if !ok {
+		return nil, fmt.Errorf("unknown participation status %q", participationStatus)
+	}
+	parsedPrivacyLevel, ok := domain.ParseEventPrivacyLevel(privacyLevel)
+	if !ok {
+		return nil, fmt.Errorf("unknown event privacy level %q", privacyLevel)
+	}
+	ticket.Status = parsedTicketStatus
+	ticket.LastIssuedQRTokenHash = textPtr(tokenHash)
+	ticket.UsedAt = timestamptzPtr(usedAt)
+	ticket.CanceledAt = timestamptzPtr(canceledAt)
+	participation.Status = parsedParticipationStatus
+
+	return &ticketapp.TicketScanRecord{
+		Ticket:        ticket,
+		Participation: participation,
+		EventID:       eventID,
+		EventStatus:   domain.EventStatus(eventStatus),
+		PrivacyLevel:  parsedPrivacyLevel,
+		HostID:        hostID,
+		UserID:        participation.UserID,
+	}, nil
+}

--- a/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler.go
+++ b/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler.go
@@ -1,0 +1,228 @@
+package ticket_handler
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+const clientSurfaceHeader = "X-Client-Surface"
+
+// Handler groups HTTP handlers that delegate to the ticket use-case port.
+type Handler struct {
+	service ticket.UseCase
+}
+
+// NewHandler creates a ticket handler backed by the given ticket use case.
+func NewHandler(service ticket.UseCase) *Handler {
+	return &Handler{service: service}
+}
+
+// RegisterRoutes mounts ticket endpoints.
+func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler) {
+	me := router.Group("/me", auth)
+	me.Get("/tickets", handler.ListMyTickets)
+	me.Get("/tickets/:ticketId", handler.GetMyTicket)
+	me.Get("/tickets/:ticketId/qr-stream", handler.StreamQRToken)
+
+	host := router.Group("/host", auth)
+	host.Post("/events/:eventId/ticket-scans", handler.ScanTicket)
+}
+
+// ListMyTickets handles GET /me/tickets.
+func (h *Handler) ListMyTickets(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ListMyTickets(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+// GetMyTicket handles GET /me/tickets/:ticketId.
+func (h *Handler) GetMyTicket(c *fiber.Ctx) error {
+	ticketID, err := parseTicketID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.GetMyTicket(c.UserContext(), claims.UserID, ticketID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+// StreamQRToken handles GET /me/tickets/:ticketId/qr-stream.
+func (h *Handler) StreamQRToken(c *fiber.Ctx) error {
+	if err := requireMobileClient(c); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	ticketID, err := parseTicketID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	input, err := parseQRTokenInput(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	firstToken, err := h.service.IssueQRToken(c.UserContext(), claims.UserID, ticketID, input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"ticket qr stream opened",
+		httpapi.OperationAttr("ticket.qr_stream"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("ticket_id", ticketID.String()),
+	)
+
+	done := c.Context().Done()
+	c.Set(fiber.HeaderContentType, "text/event-stream")
+	c.Set(fiber.HeaderCacheControl, "no-cache, no-store")
+	c.Set(fiber.HeaderConnection, "keep-alive")
+	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		writeSSE(w, "qr_token", firstToken)
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				refreshCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				nextToken, err := h.service.IssueQRToken(refreshCtx, claims.UserID, ticketID, input)
+				cancel()
+				select {
+				case <-done:
+					return
+				default:
+				}
+				if err != nil {
+					writeSSE(w, "error", fiber.Map{"message": err.Error()})
+					return
+				}
+				writeSSE(w, "qr_token", nextToken)
+			}
+		}
+	})
+	return nil
+}
+
+// ScanTicket handles POST /host/events/:eventId/ticket-scans.
+func (h *Handler) ScanTicket(c *fiber.Ctx) error {
+	if err := requireMobileClient(c); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	eventID, err := parseEventID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	var body scanTicketBody
+	if err := c.BodyParser(&body); err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"body": "must be valid JSON"}))
+	}
+	if strings.TrimSpace(body.QRToken) == "" {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{
+			"qr_token": "qr_token is required", // #nosec G101 -- JSON field name and validation text, not a secret
+		}))
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ScanTicket(c.UserContext(), claims.UserID, eventID, ticket.ScanTicketInput{QRToken: body.QRToken})
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"ticket scan completed",
+		httpapi.OperationAttr("ticket.scan"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.String("result", result.Result),
+	)
+
+	return c.JSON(result)
+}
+
+type scanTicketBody struct {
+	QRToken string `json:"qr_token"`
+}
+
+func requireMobileClient(c *fiber.Ctx) error {
+	if strings.EqualFold(strings.TrimSpace(c.Get(clientSurfaceHeader)), "MOBILE") {
+		return nil
+	}
+	return domain.ForbiddenError(domain.ErrorCodeTicketClientNotSupported, "This ticket operation is supported only by the mobile client.")
+}
+
+func parseTicketID(c *fiber.Ctx) (uuid.UUID, error) {
+	ticketID, err := uuid.Parse(c.Params("ticketId"))
+	if err != nil {
+		return uuid.Nil, domain.ValidationError(map[string]string{"ticketId": "must be a valid UUID"})
+	}
+	return ticketID, nil
+}
+
+func parseEventID(c *fiber.Ctx) (uuid.UUID, error) {
+	eventID, err := uuid.Parse(c.Params("eventId"))
+	if err != nil {
+		return uuid.Nil, domain.ValidationError(map[string]string{"eventId": "must be a valid UUID"})
+	}
+	return eventID, nil
+}
+
+func parseQRTokenInput(c *fiber.Ctx) (ticket.QRTokenInput, error) {
+	lat, err := parseRequiredFloatQuery(c, "lat")
+	if err != nil {
+		return ticket.QRTokenInput{}, err
+	}
+	lon, err := parseRequiredFloatQuery(c, "lon")
+	if err != nil {
+		return ticket.QRTokenInput{}, err
+	}
+	return ticket.QRTokenInput{Lat: lat, Lon: lon}, nil
+}
+
+func parseRequiredFloatQuery(c *fiber.Ctx, key string) (float64, error) {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return 0, domain.ValidationError(map[string]string{key: key + " is required"})
+	}
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, domain.ValidationError(map[string]string{key: key + " must be a number"})
+	}
+	return value, nil
+}
+
+func writeSSE(w *bufio.Writer, event string, data any) {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		payload = []byte(`{"message":"failed to encode event"}`)
+	}
+	_, _ = fmt.Fprintf(w, "event: %s\n", event)
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", payload)
+	_ = w.Flush()
+}

--- a/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler_test.go
@@ -1,0 +1,141 @@
+package ticket_handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+type fakeTicketService struct {
+	scanInput      ticket.ScanTicketInput
+	scanHostUserID uuid.UUID
+	scanEventID    uuid.UUID
+}
+
+func (s *fakeTicketService) CreateTicketForParticipation(context.Context, *domain.Participation, domain.TicketStatus) (*domain.Ticket, error) {
+	return nil, nil
+}
+
+func (s *fakeTicketService) CancelTicketForParticipation(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (s *fakeTicketService) CancelTicketsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (s *fakeTicketService) ExpireTicketsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (s *fakeTicketService) ListMyTickets(context.Context, uuid.UUID) (*ticket.ListTicketsResult, error) {
+	return &ticket.ListTicketsResult{Items: []ticket.TicketListItem{}}, nil
+}
+
+func (s *fakeTicketService) GetMyTicket(context.Context, uuid.UUID, uuid.UUID) (*ticket.TicketDetailResult, error) {
+	now := time.Now().UTC()
+	return &ticket.TicketDetailResult{
+		Ticket: ticket.TicketInfo{ID: uuid.NewString(), Status: domain.TicketStatusActive, ExpiresAt: now.Add(time.Hour), CreatedAt: now, UpdatedAt: now},
+	}, nil
+}
+
+func (s *fakeTicketService) IssueQRToken(context.Context, uuid.UUID, uuid.UUID, ticket.QRTokenInput) (*ticket.QRTokenResult, error) {
+	return &ticket.QRTokenResult{Token: "signed-token", ExpiresAt: time.Now().UTC().Add(10 * time.Second), Version: 1}, nil
+}
+
+func (s *fakeTicketService) ScanTicket(_ context.Context, hostUserID, eventID uuid.UUID, input ticket.ScanTicketInput) (*ticket.ScanTicketResult, error) {
+	s.scanInput = input
+	s.scanHostUserID = hostUserID
+	s.scanEventID = eventID
+	status := domain.TicketStatusUsed
+	return &ticket.ScanTicketResult{Result: ticket.ScanResultAccepted, TicketStatus: &status}, nil
+}
+
+type fakeVerifier struct {
+	claims *domain.AuthClaims
+}
+
+func (v fakeVerifier) VerifyAccessToken(string) (*domain.AuthClaims, error) {
+	return v.claims, nil
+}
+
+func TestScanTicketRequiresMobileHeader(t *testing.T) {
+	app := newTicketTestApp(&fakeTicketService{}, uuid.New())
+	req := httptest.NewRequest(fiber.MethodPost, "/host/events/"+uuid.NewString()+"/ticket-scans", bytes.NewBufferString(`{"qr_token":"token"}`))
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", fiber.StatusForbidden, resp.StatusCode)
+	}
+}
+
+func TestScanTicketParsesBodyAndForwardsToService(t *testing.T) {
+	userID := uuid.New()
+	eventID := uuid.New()
+	service := &fakeTicketService{}
+	app := newTicketTestApp(service, userID)
+	req := httptest.NewRequest(fiber.MethodPost, "/host/events/"+eventID.String()+"/ticket-scans", bytes.NewBufferString(`{"qr_token":"signed-token"}`))
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	req.Header.Set(clientSurfaceHeader, "MOBILE")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if service.scanHostUserID != userID || service.scanEventID != eventID || service.scanInput.QRToken != "signed-token" {
+		t.Fatalf("service received wrong scan input: host=%s event=%s input=%+v", service.scanHostUserID, service.scanEventID, service.scanInput)
+	}
+	var body ticket.ScanTicketResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response error = %v", err)
+	}
+	if body.Result != ticket.ScanResultAccepted {
+		t.Fatalf("expected ACCEPTED, got %+v", body)
+	}
+}
+
+func TestListMyTicketsDoesNotRequireMobileHeader(t *testing.T) {
+	app := newTicketTestApp(&fakeTicketService{}, uuid.New())
+	req := httptest.NewRequest(fiber.MethodGet, "/me/tickets", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+}
+
+func newTicketTestApp(service ticket.UseCase, userID uuid.UUID) *fiber.App {
+	app := fiber.New()
+	handler := NewHandler(service)
+	RegisterRoutes(app, handler, httpapi.RequireAuth(fakeVerifier{claims: &domain.AuthClaims{
+		UserID:   userID,
+		Username: "user",
+		Email:    "user@example.com",
+	}}))
+	return app
+}

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/participation"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
@@ -17,6 +18,7 @@ type Service struct {
 	eventRepo            Repository
 	participationService participation.UseCase
 	joinRequestService   join_request.UseCase
+	ticketService        ticket.LifecycleUseCase
 	unitOfWork           uow.UnitOfWork
 	now                  func() time.Time
 }
@@ -35,14 +37,19 @@ func NewService(
 	participationService participation.UseCase,
 	joinRequestService join_request.UseCase,
 	unitOfWork uow.UnitOfWork,
+	ticketLifecycle ...ticket.LifecycleUseCase,
 ) *Service {
-	return &Service{
+	service := &Service{
 		eventRepo:            eventRepo,
 		participationService: participationService,
 		joinRequestService:   joinRequestService,
 		unitOfWork:           unitOfWork,
 		now:                  time.Now,
 	}
+	if len(ticketLifecycle) > 0 {
+		service.ticketService = ticketLifecycle[0]
+	}
+	return service
 }
 
 // CreateEvent validates the input, then persists the event with its location,
@@ -315,7 +322,18 @@ func (s *Service) LeaveEvent(ctx context.Context, userID, eventID uuid.UUID) (*L
 		return nil, domain.ConflictError(domain.ErrorCodeEventNotLeaveable, "This event can no longer be left.")
 	}
 
-	p, err := s.participationService.LeaveParticipation(ctx, eventID, userID)
+	var p *domain.Participation
+	err = s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		var err error
+		p, err = s.participationService.LeaveParticipation(ctx, eventID, userID)
+		if err != nil {
+			return err
+		}
+		if s.ticketService != nil {
+			return s.ticketService.CancelTicketForParticipation(ctx, p.ID)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -457,6 +475,12 @@ func (s *Service) CancelEvent(ctx context.Context, userID, eventID uuid.UUID) er
 			return err
 		}
 
+		if s.ticketService != nil {
+			if err := s.ticketService.CancelTicketsForEvent(ctx, eventID); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 }
@@ -475,14 +499,21 @@ func (s *Service) CompleteEvent(ctx context.Context, userID, eventID uuid.UUID) 
 		return domain.ForbiddenError(domain.ErrorCodeEventCompleteNotAllowed, "Only the event host can complete this event.")
 	}
 
-	if err := s.eventRepo.CompleteEvent(ctx, eventID); err != nil {
-		if errors.Is(err, ErrEventNotCompletable) {
-			return domain.ConflictError(domain.ErrorCodeEventNotCompletable, "The event cannot be completed because it is already CANCELED or COMPLETED.")
+	return s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		if err := s.eventRepo.CompleteEvent(ctx, eventID); err != nil {
+			if errors.Is(err, ErrEventNotCompletable) {
+				return domain.ConflictError(domain.ErrorCodeEventNotCompletable, "The event cannot be completed because it is already CANCELED or COMPLETED.")
+			}
+			return err
 		}
-		return err
-	}
 
-	return nil
+		if s.ticketService != nil {
+			if err := s.ticketService.ExpireTicketsForEvent(ctx, eventID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // AddFavorite saves an event to the user's favorites list.

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -280,6 +280,41 @@ type fakeJoinRequestService struct {
 	lastInput         join_request.CreatePendingJoinRequestInput
 }
 
+type fakeTicketLifecycle struct {
+	cancelParticipationCallCount int
+	cancelEventCallCount         int
+	expireEventCallCount         int
+	lastParticipationID          uuid.UUID
+	lastCancelEventID            uuid.UUID
+	lastExpireEventID            uuid.UUID
+	err                          error
+}
+
+func (s *fakeTicketLifecycle) CreateTicketForParticipation(_ context.Context, participation *domain.Participation, status domain.TicketStatus) (*domain.Ticket, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &domain.Ticket{ID: uuid.New(), ParticipationID: participation.ID, Status: status}, nil
+}
+
+func (s *fakeTicketLifecycle) CancelTicketForParticipation(_ context.Context, participationID uuid.UUID) error {
+	s.cancelParticipationCallCount++
+	s.lastParticipationID = participationID
+	return s.err
+}
+
+func (s *fakeTicketLifecycle) CancelTicketsForEvent(_ context.Context, eventID uuid.UUID) error {
+	s.cancelEventCallCount++
+	s.lastCancelEventID = eventID
+	return s.err
+}
+
+func (s *fakeTicketLifecycle) ExpireTicketsForEvent(_ context.Context, eventID uuid.UUID) error {
+	s.expireEventCallCount++
+	s.lastExpireEventID = eventID
+	return s.err
+}
+
 func (s *fakeJoinRequestService) CreatePendingJoinRequest(
 	_ context.Context,
 	eventID, userID, hostUserID uuid.UUID,
@@ -1324,6 +1359,17 @@ func newTestEventServiceWithEvent(e *domain.Event) (*Service, *fakeEventRepo, *f
 	return NewService(eventRepo, participationService, joinRequestService, &fakeUnitOfWork{}), eventRepo, participationService, joinRequestService
 }
 
+func newTestEventServiceWithEventAndTickets(e *domain.Event) (*Service, *fakeEventRepo, *fakeParticipationService, *fakeJoinRequestService, *fakeTicketLifecycle) {
+	eventRepo := &fakeEventRepo{
+		events:     map[uuid.UUID]*domain.Event{e.ID: e},
+		requesters: map[uuid.UUID]*domain.User{},
+	}
+	participationService := &fakeParticipationService{}
+	joinRequestService := &fakeJoinRequestService{}
+	ticketService := &fakeTicketLifecycle{}
+	return NewService(eventRepo, participationService, joinRequestService, &fakeUnitOfWork{}, ticketService), eventRepo, participationService, joinRequestService, ticketService
+}
+
 func publicEvent(hostID uuid.UUID) *domain.Event {
 	return &domain.Event{
 		ID:           uuid.New(),
@@ -1396,6 +1442,20 @@ func TestCancelEventRunsEventAndParticipationUpdatesInsideOneUnitOfWork(t *testi
 	}
 }
 
+func TestCancelEventCancelsTicketsInsideUnitOfWork(t *testing.T) {
+	hostID := uuid.New()
+	ev := publicEvent(hostID)
+	svc, _, _, _, ticketService := newTestEventServiceWithEventAndTickets(ev)
+
+	if err := svc.CancelEvent(context.Background(), hostID, ev.ID); err != nil {
+		t.Fatalf("CancelEvent() error = %v", err)
+	}
+
+	if ticketService.cancelEventCallCount != 1 || ticketService.lastCancelEventID != ev.ID {
+		t.Fatalf("expected ticket cancellation for event %s, got calls=%d event=%s", ev.ID, ticketService.cancelEventCallCount, ticketService.lastCancelEventID)
+	}
+}
+
 func TestCancelEventRollsBackUnitOfWorkWhenParticipationCancelFails(t *testing.T) {
 	hostID := uuid.New()
 	ev := publicEvent(hostID)
@@ -1423,6 +1483,20 @@ func TestCompleteEventHostSuccess(t *testing.T) {
 	}
 	if ev.Status != domain.EventStatusCompleted {
 		t.Fatalf("expected status COMPLETED, got %q", ev.Status)
+	}
+}
+
+func TestCompleteEventExpiresTickets(t *testing.T) {
+	hostID := uuid.New()
+	ev := publicEvent(hostID)
+	svc, _, _, _, ticketService := newTestEventServiceWithEventAndTickets(ev)
+
+	if err := svc.CompleteEvent(context.Background(), hostID, ev.ID); err != nil {
+		t.Fatalf("CompleteEvent() error = %v", err)
+	}
+
+	if ticketService.expireEventCallCount != 1 || ticketService.lastExpireEventID != ev.ID {
+		t.Fatalf("expected ticket expiry for event %s, got calls=%d event=%s", ev.ID, ticketService.expireEventCallCount, ticketService.lastExpireEventID)
 	}
 }
 
@@ -1659,6 +1733,28 @@ func TestLeaveEventSuccessReturnsLeaved(t *testing.T) {
 	}
 	if participationService.lastLeaveEventID != ev.ID || participationService.lastLeaveUserID != participantID {
 		t.Fatalf("expected leave participation service to receive event %s and user %s", ev.ID, participantID)
+	}
+}
+
+func TestLeaveEventCancelsLinkedTicket(t *testing.T) {
+	hostID := uuid.New()
+	participantID := uuid.New()
+	ev := leaveableEvent(hostID)
+	svc, _, participationService, _, ticketService := newTestEventServiceWithEventAndTickets(ev)
+
+	result, err := svc.LeaveEvent(context.Background(), participantID, ev.ID)
+
+	if err != nil {
+		t.Fatalf("LeaveEvent() error = %v", err)
+	}
+	if ticketService.cancelParticipationCallCount != 1 {
+		t.Fatalf("expected ticket cancellation once, got %d", ticketService.cancelParticipationCallCount)
+	}
+	if ticketService.lastParticipationID != uuid.MustParse(result.ParticipationID) {
+		t.Fatalf("expected ticket cancellation for participation %s, got %s", result.ParticipationID, ticketService.lastParticipationID)
+	}
+	if participationService.leaveCallCount != 1 {
+		t.Fatalf("expected leave participation service to be called once")
 	}
 }
 

--- a/backend/internal/application/join_request/service.go
+++ b/backend/internal/application/join_request/service.go
@@ -2,26 +2,39 @@ package join_request
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
+
+var tracer = otel.Tracer("github.com/bounswe/bounswe2026group11/backend/internal/application/join_request")
 
 // Service owns join-request-specific application behavior.
 type Service struct {
 	repo       Repository
 	unitOfWork uow.UnitOfWork
+	tickets    ticket.LifecycleUseCase
 }
 
 var _ UseCase = (*Service)(nil)
 
 // NewService constructs a join request service backed by its own repository.
-func NewService(repo Repository, unitOfWork uow.UnitOfWork) *Service {
-	return &Service{
+func NewService(repo Repository, unitOfWork uow.UnitOfWork, ticketLifecycle ...ticket.LifecycleUseCase) *Service {
+	service := &Service{
 		repo:       repo,
 		unitOfWork: unitOfWork,
 	}
+	if len(ticketLifecycle) > 0 {
+		service.tickets = ticketLifecycle[0]
+	}
+	return service
 }
 
 // CreatePendingJoinRequest persists a PENDING join request for the given event,
@@ -55,6 +68,15 @@ func (s *Service) ApproveJoinRequest(
 	ctx context.Context,
 	eventID, joinRequestID, hostUserID uuid.UUID,
 ) (*ApproveJoinRequestResult, error) {
+	ctx, span := tracer.Start(ctx, "join_request.approve")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("operation", "join_request.approve"),
+		attribute.String("event_id", eventID.String()),
+		attribute.String("join_request_id", joinRequestID.String()),
+		attribute.String("host_user_id", hostUserID.String()),
+	)
+
 	var result *ApproveJoinRequestResult
 	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
 		var err error
@@ -63,10 +85,63 @@ func (s *Service) ApproveJoinRequest(
 			JoinRequestID: joinRequestID,
 			HostUserID:    hostUserID,
 		})
+		if err != nil {
+			slog.ErrorContext(ctx, "join request approval failed",
+				"operation", "join_request.approve",
+				"event_id", eventID.String(),
+				"join_request_id", joinRequestID.String(),
+				"host_user_id", hostUserID.String(),
+				"error", err,
+			)
+			return err
+		}
+		if result == nil || result.Participation == nil {
+			err := errors.New("join request approval returned no participation")
+			slog.ErrorContext(ctx, "join request approval failed",
+				"operation", "join_request.approve",
+				"event_id", eventID.String(),
+				"join_request_id", joinRequestID.String(),
+				"host_user_id", hostUserID.String(),
+				"error", err,
+			)
+			return err
+		}
+		if s.tickets != nil {
+			slog.InfoContext(ctx, "join request approved; creating ticket",
+				"operation", "join_request.approve.ticket_create",
+				"event_id", eventID.String(),
+				"join_request_id", joinRequestID.String(),
+				"host_user_id", hostUserID.String(),
+				"participation_id", result.Participation.ID.String(),
+				"participant_user_id", result.Participation.UserID.String(),
+				"ticket_status", domain.TicketStatusActive.String(),
+			)
+			_, err = s.tickets.CreateTicketForParticipation(ctx, result.Participation, domain.TicketStatusActive)
+			if err != nil {
+				slog.ErrorContext(ctx, "ticket creation after join request approval failed",
+					"operation", "join_request.approve.ticket_create",
+					"event_id", eventID.String(),
+					"join_request_id", joinRequestID.String(),
+					"host_user_id", hostUserID.String(),
+					"participation_id", result.Participation.ID.String(),
+					"participant_user_id", result.Participation.UserID.String(),
+					"ticket_status", domain.TicketStatusActive.String(),
+					"error", err,
+				)
+			}
+		}
 		return err
 	})
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
+	}
+	if result != nil && result.Participation != nil {
+		span.SetAttributes(
+			attribute.String("participation_id", result.Participation.ID.String()),
+			attribute.String("participant_user_id", result.Participation.UserID.String()),
+		)
 	}
 
 	return result, nil

--- a/backend/internal/application/join_request/service_test.go
+++ b/backend/internal/application/join_request/service_test.go
@@ -16,6 +16,35 @@ func (u *fakeUnitOfWork) RunInTx(ctx context.Context, fn func(ctx context.Contex
 	return fn(ctx)
 }
 
+type fakeTicketLifecycle struct {
+	createCallCount   int
+	lastParticipation *domain.Participation
+	lastStatus        domain.TicketStatus
+	err               error
+}
+
+func (f *fakeTicketLifecycle) CreateTicketForParticipation(_ context.Context, participation *domain.Participation, status domain.TicketStatus) (*domain.Ticket, error) {
+	f.createCallCount++
+	f.lastParticipation = participation
+	f.lastStatus = status
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &domain.Ticket{ID: uuid.New(), ParticipationID: participation.ID, Status: status}, nil
+}
+
+func (f *fakeTicketLifecycle) CancelTicketForParticipation(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeTicketLifecycle) CancelTicketsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeTicketLifecycle) ExpireTicketsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+
 type fakeJoinRequestRepo struct {
 	err               error
 	callCount         int
@@ -183,6 +212,33 @@ func TestApproveJoinRequestDelegatesToRepo(t *testing.T) {
 	}
 	if repo.lastApproveParams.EventID != eventID || repo.lastApproveParams.JoinRequestID != joinRequestID || repo.lastApproveParams.HostUserID != hostUserID {
 		t.Fatalf("expected approve params to match event %s, join request %s, host %s", eventID, joinRequestID, hostUserID)
+	}
+}
+
+func TestApproveJoinRequestCreatesActiveTicket(t *testing.T) {
+	// given
+	repo := &fakeJoinRequestRepo{}
+	tickets := &fakeTicketLifecycle{}
+	service := NewService(repo, &fakeUnitOfWork{}, tickets)
+	eventID := uuid.New()
+	joinRequestID := uuid.New()
+	hostUserID := uuid.New()
+
+	// when
+	result, err := service.ApproveJoinRequest(context.Background(), eventID, joinRequestID, hostUserID)
+
+	// then
+	if err != nil {
+		t.Fatalf("ApproveJoinRequest() error = %v", err)
+	}
+	if tickets.createCallCount != 1 {
+		t.Fatalf("expected ticket creation once, got %d", tickets.createCallCount)
+	}
+	if tickets.lastParticipation == nil || tickets.lastParticipation.ID != result.Participation.ID {
+		t.Fatalf("expected ticket participation %s, got %+v", result.Participation.ID, tickets.lastParticipation)
+	}
+	if tickets.lastStatus != domain.TicketStatusActive {
+		t.Fatalf("expected ticket status ACTIVE, got %q", tickets.lastStatus)
 	}
 }
 

--- a/backend/internal/application/ticket/ports.go
+++ b/backend/internal/application/ticket/ports.go
@@ -1,0 +1,16 @@
+package ticket
+
+import "time"
+
+// QRTokenManager signs, verifies, and hashes short-lived QR tokens.
+type QRTokenManager interface {
+	Issue(claims QRTokenClaims) (string, error)
+	Verify(token string) (*QRTokenClaims, error)
+	Hash(token string) string
+}
+
+// Settings holds ticket service policy knobs.
+type Settings struct {
+	QRTokenTTL      time.Duration
+	ProximityMeters float64
+}

--- a/backend/internal/application/ticket/repository.go
+++ b/backend/internal/application/ticket/repository.go
@@ -1,0 +1,22 @@
+package ticket
+
+import (
+	"context"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// Repository is the application-layer persistence port for ticket flows.
+type Repository interface {
+	CreateTicketForParticipation(ctx context.Context, participationID uuid.UUID, status domain.TicketStatus) (*domain.Ticket, error)
+	CancelTicketForParticipation(ctx context.Context, participationID uuid.UUID) error
+	CancelTicketsForEvent(ctx context.Context, eventID uuid.UUID) error
+	ExpireTicketsForEvent(ctx context.Context, eventID uuid.UUID) error
+	ListTicketsByUser(ctx context.Context, userID uuid.UUID) ([]TicketRecord, error)
+	GetTicketDetail(ctx context.Context, userID, ticketID uuid.UUID) (*TicketRecord, error)
+	GetTicketAccessForUser(ctx context.Context, userID, ticketID uuid.UUID, lat, lon float64, forUpdate bool) (*TicketAccessRecord, error)
+	StoreIssuedToken(ctx context.Context, ticketID uuid.UUID, version int, tokenHash string) error
+	GetTicketForScan(ctx context.Context, eventID, ticketID uuid.UUID, forUpdate bool) (*TicketScanRecord, error)
+	MarkTicketUsed(ctx context.Context, ticketID uuid.UUID) (*domain.Ticket, error)
+}

--- a/backend/internal/application/ticket/service.go
+++ b/backend/internal/application/ticket/service.go
@@ -1,0 +1,611 @@
+package ticket
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+const (
+	defaultQRTokenTTL      = 10 * time.Second
+	defaultProximityMeters = 200.0
+)
+
+var tracer = otel.Tracer("github.com/bounswe/bounswe2026group11/backend/internal/application/ticket")
+
+// Service owns ticket-specific application behavior.
+type Service struct {
+	repo       Repository
+	unitOfWork uow.UnitOfWork
+	tokens     QRTokenManager
+	settings   Settings
+	now        func() time.Time
+}
+
+var _ UseCase = (*Service)(nil)
+
+// NewService constructs a ticket service backed by its repository and token manager.
+func NewService(repo Repository, unitOfWork uow.UnitOfWork, tokens QRTokenManager, settings Settings) *Service {
+	if settings.QRTokenTTL <= 0 {
+		settings.QRTokenTTL = defaultQRTokenTTL
+	}
+	if settings.ProximityMeters <= 0 {
+		settings.ProximityMeters = defaultProximityMeters
+	}
+	return &Service{
+		repo:       repo,
+		unitOfWork: unitOfWork,
+		tokens:     tokens,
+		settings:   settings,
+		now:        time.Now,
+	}
+}
+
+// CreateTicketForParticipation creates the protected-event ticket linked to an approved participation.
+func (s *Service) CreateTicketForParticipation(ctx context.Context, participation *domain.Participation, status domain.TicketStatus) (*domain.Ticket, error) {
+	ctx, span := tracer.Start(ctx, "ticket.create_for_participation")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("operation", "ticket.create_for_participation"),
+		attribute.String("ticket_status", status.String()),
+	)
+
+	if participation == nil {
+		err := errors.New("create ticket: participation is nil")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		slog.ErrorContext(ctx, "ticket creation failed",
+			"operation", "ticket.create_for_participation",
+			"ticket_status", status.String(),
+			"error", err,
+		)
+		return nil, err
+	}
+	span.SetAttributes(
+		attribute.String("participation_id", participation.ID.String()),
+		attribute.String("event_id", participation.EventID.String()),
+		attribute.String("participant_user_id", participation.UserID.String()),
+	)
+
+	var result *domain.Ticket
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		var err error
+		result, err = s.repo.CreateTicketForParticipation(ctx, participation.ID, status)
+		return err
+	})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		slog.ErrorContext(ctx, "ticket creation failed",
+			"operation", "ticket.create_for_participation",
+			"participation_id", participation.ID.String(),
+			"event_id", participation.EventID.String(),
+			"participant_user_id", participation.UserID.String(),
+			"ticket_status", status.String(),
+			"error", err,
+		)
+		return nil, err
+	}
+	span.SetAttributes(attribute.String("ticket_id", result.ID.String()))
+	slog.InfoContext(ctx, "ticket created",
+		"operation", "ticket.create_for_participation",
+		"ticket_id", result.ID.String(),
+		"participation_id", participation.ID.String(),
+		"event_id", participation.EventID.String(),
+		"participant_user_id", participation.UserID.String(),
+		"ticket_status", result.Status.String(),
+	)
+	return result, nil
+}
+
+// CancelTicketForParticipation cancels a non-terminal ticket linked to the participation, if present.
+func (s *Service) CancelTicketForParticipation(ctx context.Context, participationID uuid.UUID) error {
+	ctx, span := tracer.Start(ctx, "ticket.cancel_for_participation")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("operation", "ticket.cancel_for_participation"),
+		attribute.String("participation_id", participationID.String()),
+	)
+
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		return s.repo.CancelTicketForParticipation(ctx, participationID)
+	})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		slog.ErrorContext(ctx, "ticket cancellation failed",
+			"operation", "ticket.cancel_for_participation",
+			"participation_id", participationID.String(),
+			"error", err,
+		)
+		return err
+	}
+	slog.InfoContext(ctx, "ticket canceled for participation",
+		"operation", "ticket.cancel_for_participation",
+		"participation_id", participationID.String(),
+	)
+	return nil
+}
+
+// CancelTicketsForEvent cancels all non-terminal tickets linked to an event.
+func (s *Service) CancelTicketsForEvent(ctx context.Context, eventID uuid.UUID) error {
+	ctx, span := tracer.Start(ctx, "ticket.cancel_for_event")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("operation", "ticket.cancel_for_event"),
+		attribute.String("event_id", eventID.String()),
+	)
+
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		return s.repo.CancelTicketsForEvent(ctx, eventID)
+	})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		slog.ErrorContext(ctx, "event ticket cancellation failed",
+			"operation", "ticket.cancel_for_event",
+			"event_id", eventID.String(),
+			"error", err,
+		)
+		return err
+	}
+	slog.InfoContext(ctx, "event tickets canceled",
+		"operation", "ticket.cancel_for_event",
+		"event_id", eventID.String(),
+	)
+	return nil
+}
+
+// ExpireTicketsForEvent expires all unused non-terminal tickets linked to an event.
+func (s *Service) ExpireTicketsForEvent(ctx context.Context, eventID uuid.UUID) error {
+	ctx, span := tracer.Start(ctx, "ticket.expire_for_event")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("operation", "ticket.expire_for_event"),
+		attribute.String("event_id", eventID.String()),
+	)
+
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		return s.repo.ExpireTicketsForEvent(ctx, eventID)
+	})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		slog.ErrorContext(ctx, "event ticket expiration failed",
+			"operation", "ticket.expire_for_event",
+			"event_id", eventID.String(),
+			"error", err,
+		)
+		return err
+	}
+	slog.InfoContext(ctx, "event tickets expired",
+		"operation", "ticket.expire_for_event",
+		"event_id", eventID.String(),
+	)
+	return nil
+}
+
+// ListMyTickets returns tickets owned by the authenticated user.
+func (s *Service) ListMyTickets(ctx context.Context, userID uuid.UUID) (*ListTicketsResult, error) {
+	records, err := s.repo.ListTicketsByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]TicketListItem, len(records))
+	for i, record := range records {
+		items[i] = toTicketListItem(record)
+	}
+	return &ListTicketsResult{Items: items}, nil
+}
+
+// GetMyTicket returns a single ticket detail owned by the authenticated user.
+func (s *Service) GetMyTicket(ctx context.Context, userID, ticketID uuid.UUID) (*TicketDetailResult, error) {
+	record, err := s.repo.GetTicketDetail(ctx, userID, ticketID)
+	if err != nil {
+		return nil, err
+	}
+	if record == nil {
+		return nil, domain.NotFoundError(domain.ErrorCodeTicketNotFound, "The requested ticket does not exist.")
+	}
+	return toTicketDetailResult(*record, s.settings.ProximityMeters, s.now().UTC()), nil
+}
+
+// IssueQRToken validates current access and issues a short-lived signed token.
+func (s *Service) IssueQRToken(ctx context.Context, userID, ticketID uuid.UUID, input QRTokenInput) (*QRTokenResult, error) {
+	ctx, span := tracer.Start(ctx, "ticket.issue_qr_token")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("operation", "ticket.issue_qr_token"),
+		attribute.String("user_id", userID.String()),
+		attribute.String("ticket_id", ticketID.String()),
+	)
+
+	var result *QRTokenResult
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		record, err := s.repo.GetTicketAccessForUser(ctx, userID, ticketID, input.Lat, input.Lon, true)
+		if err != nil {
+			slog.ErrorContext(ctx, "ticket qr token access lookup failed",
+				"operation", "ticket.issue_qr_token",
+				"user_id", userID.String(),
+				"ticket_id", ticketID.String(),
+				"error", err,
+			)
+			return err
+		}
+		if record == nil {
+			err := domain.NotFoundError(domain.ErrorCodeTicketNotFound, "The requested ticket does not exist.")
+			slog.InfoContext(ctx, "ticket qr token rejected",
+				"operation", "ticket.issue_qr_token",
+				"user_id", userID.String(),
+				"ticket_id", ticketID.String(),
+				"reason", domain.ErrorCodeTicketNotFound,
+			)
+			return err
+		}
+		span.SetAttributes(
+			attribute.String("event_id", record.EventID.String()),
+			attribute.String("participation_id", record.Participation.ID.String()),
+		)
+		if err := validateQRAccess(*record, s.settings.ProximityMeters, s.now().UTC()); err != nil {
+			slog.InfoContext(ctx, "ticket qr token rejected",
+				"operation", "ticket.issue_qr_token",
+				"user_id", userID.String(),
+				"ticket_id", ticketID.String(),
+				"event_id", record.EventID.String(),
+				"participation_id", record.Participation.ID.String(),
+				"ticket_status", record.Ticket.Status.String(),
+				"participation_status", record.Participation.Status.String(),
+				"event_status", string(record.EventStatus),
+				"error", err,
+			)
+			return err
+		}
+
+		issuedAt := s.now().UTC()
+		expiresAt := issuedAt.Add(s.settings.QRTokenTTL)
+		version := record.Ticket.QRTokenVersion + 1
+		token, err := s.tokens.Issue(QRTokenClaims{
+			TicketID:        record.Ticket.ID,
+			ParticipationID: record.Participation.ID,
+			EventID:         record.EventID,
+			UserID:          userID,
+			Version:         version,
+			IssuedAt:        issuedAt,
+			ExpiresAt:       expiresAt,
+		})
+		if err != nil {
+			slog.ErrorContext(ctx, "ticket qr token signing failed",
+				"operation", "ticket.issue_qr_token",
+				"user_id", userID.String(),
+				"ticket_id", ticketID.String(),
+				"event_id", record.EventID.String(),
+				"participation_id", record.Participation.ID.String(),
+				"version", version,
+				"error", err,
+			)
+			return err
+		}
+		if err := s.repo.StoreIssuedToken(ctx, record.Ticket.ID, version, s.tokens.Hash(token)); err != nil {
+			slog.ErrorContext(ctx, "ticket qr token persistence failed",
+				"operation", "ticket.issue_qr_token",
+				"user_id", userID.String(),
+				"ticket_id", ticketID.String(),
+				"event_id", record.EventID.String(),
+				"participation_id", record.Participation.ID.String(),
+				"version", version,
+				"error", err,
+			)
+			return err
+		}
+		result = &QRTokenResult{
+			Token:     token,
+			ExpiresAt: expiresAt,
+			Version:   version,
+		}
+		return nil
+	})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	span.SetAttributes(attribute.Int("ticket_qr_version", result.Version))
+	slog.InfoContext(ctx, "ticket qr token issued",
+		"operation", "ticket.issue_qr_token",
+		"user_id", userID.String(),
+		"ticket_id", ticketID.String(),
+		"version", result.Version,
+	)
+	return result, nil
+}
+
+// ScanTicket verifies a scanned QR token and marks its ticket USED when all checks pass.
+func (s *Service) ScanTicket(ctx context.Context, hostUserID, eventID uuid.UUID, input ScanTicketInput) (*ScanTicketResult, error) {
+	ctx, span := tracer.Start(ctx, "ticket.scan")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("operation", "ticket.scan"),
+		attribute.String("host_user_id", hostUserID.String()),
+		attribute.String("event_id", eventID.String()),
+	)
+
+	token := strings.TrimSpace(input.QRToken)
+	if token == "" {
+		logTicketScanRejected(ctx, hostUserID, eventID, uuid.Nil, RejectReasonInvalidToken)
+		return rejected(RejectReasonInvalidToken), nil
+	}
+
+	claims, err := s.tokens.Verify(token)
+	if err != nil {
+		logTicketScanRejected(ctx, hostUserID, eventID, uuid.Nil, RejectReasonInvalidToken)
+		return rejected(RejectReasonInvalidToken), nil
+	}
+	span.SetAttributes(
+		attribute.String("ticket_id", claims.TicketID.String()),
+		attribute.String("participation_id", claims.ParticipationID.String()),
+		attribute.String("participant_user_id", claims.UserID.String()),
+		attribute.Int("ticket_qr_version", claims.Version),
+	)
+	if claims.EventID != eventID {
+		logTicketScanRejected(ctx, hostUserID, eventID, claims.TicketID, RejectReasonEventMismatch)
+		return rejected(RejectReasonEventMismatch), nil
+	}
+
+	var result *ScanTicketResult
+	err = s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		record, err := s.repo.GetTicketForScan(ctx, eventID, claims.TicketID, true)
+		if err != nil {
+			slog.ErrorContext(ctx, "ticket scan lookup failed",
+				"operation", "ticket.scan",
+				"host_user_id", hostUserID.String(),
+				"event_id", eventID.String(),
+				"ticket_id", claims.TicketID.String(),
+				"error", err,
+			)
+			return err
+		}
+		if record == nil {
+			result = rejected(RejectReasonTicketNotFound)
+			logTicketScanRejected(ctx, hostUserID, eventID, claims.TicketID, RejectReasonTicketNotFound)
+			return nil
+		}
+		if record.HostID != hostUserID {
+			err := domain.ForbiddenError(domain.ErrorCodeEventHostManagementNotAllowed, "Only the event host can scan tickets for this event.")
+			slog.InfoContext(ctx, "ticket scan rejected",
+				"operation", "ticket.scan",
+				"host_user_id", hostUserID.String(),
+				"event_id", eventID.String(),
+				"ticket_id", record.Ticket.ID.String(),
+				"participation_id", record.Participation.ID.String(),
+				"reason", domain.ErrorCodeEventHostManagementNotAllowed,
+			)
+			return err
+		}
+		if reason := scanRejectReason(*record, *claims, s.tokens.Hash(token)); reason != "" {
+			result = rejected(reason)
+			logTicketScanRejected(ctx, hostUserID, eventID, record.Ticket.ID, reason,
+				"participation_id", record.Participation.ID.String(),
+				"participant_user_id", record.UserID.String(),
+				"ticket_status", record.Ticket.Status.String(),
+				"participation_status", record.Participation.Status.String(),
+				"event_status", string(record.EventStatus),
+			)
+			return nil
+		}
+
+		used, err := s.repo.MarkTicketUsed(ctx, record.Ticket.ID)
+		if err != nil {
+			slog.ErrorContext(ctx, "ticket usage persistence failed",
+				"operation", "ticket.scan",
+				"host_user_id", hostUserID.String(),
+				"event_id", eventID.String(),
+				"ticket_id", record.Ticket.ID.String(),
+				"participation_id", record.Participation.ID.String(),
+				"error", err,
+			)
+			return err
+		}
+		result = accepted(*record, used.Status)
+		return nil
+	})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	if result != nil {
+		span.SetAttributes(attribute.String("ticket_scan_result", result.Result))
+		if result.Reason != nil {
+			span.SetAttributes(attribute.String("ticket_scan_reject_reason", *result.Reason))
+		}
+	}
+	if result != nil && result.Result == ScanResultAccepted {
+		slog.InfoContext(ctx, "ticket scan accepted",
+			"operation", "ticket.scan",
+			"host_user_id", hostUserID.String(),
+			"event_id", eventID.String(),
+			"ticket_id", claims.TicketID.String(),
+			"participation_id", claims.ParticipationID.String(),
+			"participant_user_id", claims.UserID.String(),
+		)
+	}
+	return result, nil
+}
+
+func logTicketScanRejected(ctx context.Context, hostUserID, eventID, ticketID uuid.UUID, reason string, attrs ...any) {
+	fields := []any{
+		"operation", "ticket.scan",
+		"host_user_id", hostUserID.String(),
+		"event_id", eventID.String(),
+		"reason", reason,
+	}
+	if ticketID != uuid.Nil {
+		fields = append(fields, "ticket_id", ticketID.String())
+	}
+	fields = append(fields, attrs...)
+	slog.InfoContext(ctx, "ticket scan rejected", fields...)
+}
+
+func validateQRAccess(record TicketAccessRecord, proximityMeters float64, now time.Time) error {
+	if record.Ticket.Status != domain.TicketStatusActive {
+		return domain.ConflictError(domain.ErrorCodeTicketNotActive, "Only ACTIVE tickets can issue QR tokens.")
+	}
+	if record.Participation.Status != domain.ParticipationStatusApproved {
+		return domain.ConflictError(domain.ErrorCodeTicketNotActive, "The linked participation is not approved.")
+	}
+	if record.EventStatus != domain.EventStatusActive && record.EventStatus != domain.EventStatusInProgress {
+		return domain.ConflictError(domain.ErrorCodeTicketNotActive, "The event is not accepting ticket access.")
+	}
+	if record.PrivacyLevel != domain.PrivacyProtected {
+		return domain.ConflictError(domain.ErrorCodeTicketNotActive, "Only PROTECTED events support tickets.")
+	}
+	if !record.Ticket.ExpiresAt.After(now) {
+		return domain.ConflictError(domain.ErrorCodeTicketNotActive, "The ticket has expired.")
+	}
+	if record.DistanceMeters > proximityMeters {
+		return domain.ForbiddenError(domain.ErrorCodeTicketProximityRequired, "You must be near the event location to show this ticket QR.")
+	}
+	return nil
+}
+
+func scanRejectReason(record TicketScanRecord, claims QRTokenClaims, tokenHash string) string {
+	if record.Participation.ID != claims.ParticipationID {
+		return RejectReasonParticipationMismatch
+	}
+	if record.UserID != claims.UserID {
+		return RejectReasonInvalidToken
+	}
+	if record.Ticket.Status == domain.TicketStatusUsed {
+		return RejectReasonTicketAlreadyUsed
+	}
+	if record.Ticket.Status != domain.TicketStatusActive {
+		return RejectReasonTicketNotActive
+	}
+	if record.Participation.Status != domain.ParticipationStatusApproved {
+		return RejectReasonParticipationInvalid
+	}
+	if record.EventStatus != domain.EventStatusActive && record.EventStatus != domain.EventStatusInProgress {
+		return RejectReasonEventInvalid
+	}
+	if record.PrivacyLevel != domain.PrivacyProtected {
+		return RejectReasonEventInvalid
+	}
+	if claims.Version != record.Ticket.QRTokenVersion {
+		return RejectReasonTokenOldVersion
+	}
+	if record.Ticket.LastIssuedQRTokenHash == nil || *record.Ticket.LastIssuedQRTokenHash != tokenHash {
+		return RejectReasonTokenNotLatest
+	}
+	return ""
+}
+
+func rejected(reason string) *ScanTicketResult {
+	return &ScanTicketResult{
+		Result: ScanResultRejected,
+		Reason: &reason,
+	}
+}
+
+func accepted(record TicketScanRecord, status domain.TicketStatus) *ScanTicketResult {
+	ticketID := record.Ticket.ID.String()
+	participationID := record.Participation.ID.String()
+	userID := record.UserID.String()
+	return &ScanTicketResult{
+		Result:          ScanResultAccepted,
+		TicketID:        &ticketID,
+		ParticipationID: &participationID,
+		UserID:          &userID,
+		TicketStatus:    &status,
+	}
+}
+
+func toTicketListItem(record TicketRecord) TicketListItem {
+	return TicketListItem{
+		TicketID:      record.Ticket.ID.String(),
+		Status:        record.Ticket.Status,
+		ExpiresAt:     record.Ticket.ExpiresAt,
+		Event:         toTicketEventSummary(record),
+		Participation: toTicketParticipationInfo(record.Participation),
+	}
+}
+
+func toTicketDetailResult(record TicketRecord, proximityMeters float64, now time.Time) *TicketDetailResult {
+	return &TicketDetailResult{
+		Ticket: TicketInfo{
+			ID:        record.Ticket.ID.String(),
+			Status:    record.Ticket.Status,
+			ExpiresAt: record.Ticket.ExpiresAt,
+			UsedAt:    record.Ticket.UsedAt,
+			CreatedAt: record.Ticket.CreatedAt,
+			UpdatedAt: record.Ticket.UpdatedAt,
+		},
+		Participation: toTicketParticipationInfo(record.Participation),
+		Event:         toTicketEventSummary(record),
+		Location: TicketLocationSummary{
+			Type:      record.LocationType,
+			Address:   record.Address,
+			AnchorLat: record.Anchor.Lat,
+			AnchorLon: record.Anchor.Lon,
+		},
+		QRAccess: buildQRAccessInfo(record, proximityMeters, now),
+	}
+}
+
+func toTicketParticipationInfo(participation domain.Participation) TicketParticipationInfo {
+	return TicketParticipationInfo{
+		ID:     participation.ID.String(),
+		Status: participation.Status,
+	}
+}
+
+func toTicketEventSummary(record TicketRecord) TicketEventSummary {
+	return TicketEventSummary{
+		ID:           record.EventID.String(),
+		Title:        record.EventTitle,
+		Status:       record.EventStatus,
+		PrivacyLevel: record.PrivacyLevel,
+		StartTime:    record.StartTime,
+		EndTime:      record.EndTime,
+		LocationType: record.LocationType,
+		Address:      record.Address,
+	}
+}
+
+func buildQRAccessInfo(record TicketRecord, proximityMeters float64, now time.Time) QRAccessInfo {
+	reason := qrAccessReason(record, now)
+	return QRAccessInfo{
+		RequiresLocationPermission: true,
+		RequiresProximity:          true,
+		ProximityMeters:            proximityMeters,
+		EligibleNow:                reason == nil,
+		Reason:                     reason,
+	}
+}
+
+func qrAccessReason(record TicketRecord, now time.Time) *string {
+	var reason string
+	switch {
+	case record.Ticket.Status == domain.TicketStatusPending:
+		reason = "PARTICIPATION_PENDING_REAPPROVAL"
+	case record.Ticket.Status != domain.TicketStatusActive:
+		reason = "TICKET_" + record.Ticket.Status.String()
+	case record.Participation.Status != domain.ParticipationStatusApproved:
+		reason = "PARTICIPATION_" + record.Participation.Status.String()
+	case record.EventStatus != domain.EventStatusActive && record.EventStatus != domain.EventStatusInProgress:
+		reason = "EVENT_" + string(record.EventStatus)
+	case !record.Ticket.ExpiresAt.After(now):
+		reason = "TICKET_EXPIRED"
+	default:
+		return nil
+	}
+	return &reason
+}

--- a/backend/internal/application/ticket/service_dto.go
+++ b/backend/internal/application/ticket/service_dto.go
@@ -1,0 +1,164 @@
+package ticket
+
+import (
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+const (
+	ScanResultAccepted = "ACCEPTED"
+	ScanResultRejected = "REJECTED"
+
+	RejectReasonInvalidToken          = "INVALID_TOKEN"
+	RejectReasonTicketNotFound        = "TICKET_NOT_FOUND"
+	RejectReasonTicketAlreadyUsed     = "TICKET_ALREADY_USED"
+	RejectReasonTicketNotActive       = "TICKET_NOT_ACTIVE"
+	RejectReasonParticipationInvalid  = "PARTICIPATION_INVALID"
+	RejectReasonEventInvalid          = "EVENT_INVALID"
+	RejectReasonTokenOldVersion       = "TOKEN_OLD_VERSION" // #nosec G101 -- wire rejection reason, not a secret
+	RejectReasonTokenNotLatest        = "TOKEN_NOT_LATEST"
+	RejectReasonEventMismatch         = "EVENT_MISMATCH"
+	RejectReasonParticipationMismatch = "PARTICIPATION_MISMATCH"
+)
+
+// QRTokenInput carries the caller's current location for QR issuance.
+type QRTokenInput struct {
+	Lat float64
+	Lon float64
+}
+
+// QRTokenResult is the short-lived token payload sent over SSE.
+type QRTokenResult struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+	Version   int       `json:"version"`
+}
+
+// ScanTicketInput carries a scanned short-lived QR token.
+type ScanTicketInput struct {
+	QRToken string
+}
+
+// ScanTicketResult is returned to the host scanner flow.
+type ScanTicketResult struct {
+	Result          string               `json:"result"`
+	Reason          *string              `json:"reason,omitempty"`
+	TicketID        *string              `json:"ticket_id,omitempty"`
+	ParticipationID *string              `json:"participation_id,omitempty"`
+	UserID          *string              `json:"user_id,omitempty"`
+	TicketStatus    *domain.TicketStatus `json:"ticket_status,omitempty"`
+}
+
+// ListTicketsResult wraps the caller's tickets.
+type ListTicketsResult struct {
+	Items []TicketListItem `json:"items"`
+}
+
+// TicketListItem is the compact ticket-card payload.
+type TicketListItem struct {
+	TicketID      string                  `json:"ticket_id"`
+	Status        domain.TicketStatus     `json:"status"`
+	ExpiresAt     time.Time               `json:"expires_at"`
+	Event         TicketEventSummary      `json:"event"`
+	Participation TicketParticipationInfo `json:"participation"`
+}
+
+// TicketDetailResult is the full ticket detail payload.
+type TicketDetailResult struct {
+	Ticket        TicketInfo              `json:"ticket"`
+	Participation TicketParticipationInfo `json:"participation"`
+	Event         TicketEventSummary      `json:"event"`
+	Location      TicketLocationSummary   `json:"location"`
+	QRAccess      QRAccessInfo            `json:"qr_access"`
+}
+
+// TicketInfo contains persisted ticket fields safe for clients.
+type TicketInfo struct {
+	ID        string              `json:"id"`
+	Status    domain.TicketStatus `json:"status"`
+	ExpiresAt time.Time           `json:"expires_at"`
+	UsedAt    *time.Time          `json:"used_at,omitempty"`
+	CreatedAt time.Time           `json:"created_at"`
+	UpdatedAt time.Time           `json:"updated_at"`
+}
+
+// TicketParticipationInfo summarizes the linked participation.
+type TicketParticipationInfo struct {
+	ID     string                     `json:"id"`
+	Status domain.ParticipationStatus `json:"status"`
+}
+
+// TicketEventSummary summarizes the linked event.
+type TicketEventSummary struct {
+	ID           string                   `json:"id"`
+	Title        string                   `json:"title"`
+	Status       domain.EventStatus       `json:"status"`
+	PrivacyLevel domain.EventPrivacyLevel `json:"privacy_level"`
+	StartTime    time.Time                `json:"start_time"`
+	EndTime      *time.Time               `json:"end_time,omitempty"`
+	LocationType domain.EventLocationType `json:"location_type"`
+	Address      *string                  `json:"address"`
+}
+
+// TicketLocationSummary exposes the backend proximity anchor.
+type TicketLocationSummary struct {
+	Type      domain.EventLocationType `json:"type"`
+	Address   *string                  `json:"address"`
+	AnchorLat float64                  `json:"anchor_lat"`
+	AnchorLon float64                  `json:"anchor_lon"`
+}
+
+// QRAccessInfo tells mobile whether QR streaming can be attempted.
+type QRAccessInfo struct {
+	RequiresLocationPermission bool    `json:"requires_location_permission"`
+	RequiresProximity          bool    `json:"requires_proximity"`
+	ProximityMeters            float64 `json:"proximity_meters"`
+	EligibleNow                bool    `json:"eligible_now"`
+	Reason                     *string `json:"reason,omitempty"`
+}
+
+// TicketRecord is the repository-level projection for ticket list/detail responses.
+type TicketRecord struct {
+	Ticket        domain.Ticket
+	Participation domain.Participation
+	EventID       uuid.UUID
+	EventTitle    string
+	EventStatus   domain.EventStatus
+	PrivacyLevel  domain.EventPrivacyLevel
+	StartTime     time.Time
+	EndTime       *time.Time
+	LocationType  domain.EventLocationType
+	Address       *string
+	Anchor        domain.GeoPoint
+}
+
+// TicketAccessRecord contains all state needed to issue a QR token.
+type TicketAccessRecord struct {
+	TicketRecord
+	UserID         uuid.UUID
+	DistanceMeters float64
+}
+
+// TicketScanRecord contains all state needed to accept or reject a scan.
+type TicketScanRecord struct {
+	Ticket        domain.Ticket
+	Participation domain.Participation
+	EventID       uuid.UUID
+	EventStatus   domain.EventStatus
+	PrivacyLevel  domain.EventPrivacyLevel
+	HostID        uuid.UUID
+	UserID        uuid.UUID
+}
+
+// QRTokenClaims is the signed short-lived ticket token payload.
+type QRTokenClaims struct {
+	TicketID        uuid.UUID
+	ParticipationID uuid.UUID
+	EventID         uuid.UUID
+	UserID          uuid.UUID
+	Version         int
+	IssuedAt        time.Time
+	ExpiresAt       time.Time
+}

--- a/backend/internal/application/ticket/service_test.go
+++ b/backend/internal/application/ticket/service_test.go
@@ -1,0 +1,267 @@
+package ticket
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+type fakeUnitOfWork struct {
+	callCount int
+}
+
+func (u *fakeUnitOfWork) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	u.callCount++
+	return fn(ctx)
+}
+
+type fakeTokenManager struct {
+	verifyClaims *QRTokenClaims
+	verifyErr    error
+	issuedClaims QRTokenClaims
+}
+
+func (m *fakeTokenManager) Issue(claims QRTokenClaims) (string, error) {
+	m.issuedClaims = claims
+	return "signed-token", nil
+}
+
+func (m *fakeTokenManager) Verify(_ string) (*QRTokenClaims, error) {
+	if m.verifyErr != nil {
+		return nil, m.verifyErr
+	}
+	return m.verifyClaims, nil
+}
+
+func (m *fakeTokenManager) Hash(token string) string {
+	return "hash:" + token
+}
+
+type fakeTicketRepo struct {
+	err                   error
+	createdParticipation  uuid.UUID
+	createdStatus         domain.TicketStatus
+	canceledParticipation uuid.UUID
+	canceledEvent         uuid.UUID
+	expiredEvent          uuid.UUID
+	listRecords           []TicketRecord
+	detailRecord          *TicketRecord
+	accessRecord          *TicketAccessRecord
+	scanRecord            *TicketScanRecord
+	storedVersion         int
+	storedHash            string
+	usedTicketID          uuid.UUID
+}
+
+func (r *fakeTicketRepo) CreateTicketForParticipation(_ context.Context, participationID uuid.UUID, status domain.TicketStatus) (*domain.Ticket, error) {
+	r.createdParticipation = participationID
+	r.createdStatus = status
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &domain.Ticket{ID: uuid.New(), ParticipationID: participationID, Status: status}, nil
+}
+
+func (r *fakeTicketRepo) CancelTicketForParticipation(_ context.Context, participationID uuid.UUID) error {
+	r.canceledParticipation = participationID
+	return r.err
+}
+
+func (r *fakeTicketRepo) CancelTicketsForEvent(_ context.Context, eventID uuid.UUID) error {
+	r.canceledEvent = eventID
+	return r.err
+}
+
+func (r *fakeTicketRepo) ExpireTicketsForEvent(_ context.Context, eventID uuid.UUID) error {
+	r.expiredEvent = eventID
+	return r.err
+}
+
+func (r *fakeTicketRepo) ListTicketsByUser(_ context.Context, _ uuid.UUID) ([]TicketRecord, error) {
+	return r.listRecords, r.err
+}
+
+func (r *fakeTicketRepo) GetTicketDetail(_ context.Context, _, _ uuid.UUID) (*TicketRecord, error) {
+	return r.detailRecord, r.err
+}
+
+func (r *fakeTicketRepo) GetTicketAccessForUser(_ context.Context, _, _ uuid.UUID, _, _ float64, _ bool) (*TicketAccessRecord, error) {
+	return r.accessRecord, r.err
+}
+
+func (r *fakeTicketRepo) StoreIssuedToken(_ context.Context, _ uuid.UUID, version int, tokenHash string) error {
+	r.storedVersion = version
+	r.storedHash = tokenHash
+	return r.err
+}
+
+func (r *fakeTicketRepo) GetTicketForScan(_ context.Context, _, _ uuid.UUID, _ bool) (*TicketScanRecord, error) {
+	return r.scanRecord, r.err
+}
+
+func (r *fakeTicketRepo) MarkTicketUsed(_ context.Context, ticketID uuid.UUID) (*domain.Ticket, error) {
+	r.usedTicketID = ticketID
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &domain.Ticket{ID: ticketID, Status: domain.TicketStatusUsed}, nil
+}
+
+func TestIssueQRTokenStoresNextVersionAndHash(t *testing.T) {
+	// given
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	record := activeTicketAccessRecord(now)
+	repo := &fakeTicketRepo{accessRecord: record}
+	tokens := &fakeTokenManager{}
+	service := NewService(repo, &fakeUnitOfWork{}, tokens, Settings{QRTokenTTL: 10 * time.Second, ProximityMeters: 200})
+	service.now = func() time.Time { return now }
+
+	// when
+	result, err := service.IssueQRToken(context.Background(), record.UserID, record.Ticket.ID, QRTokenInput{Lat: 41, Lon: 29})
+
+	// then
+	if err != nil {
+		t.Fatalf("IssueQRToken() error = %v", err)
+	}
+	if result.Token != "signed-token" || result.Version != record.Ticket.QRTokenVersion+1 {
+		t.Fatalf("unexpected token result: %+v", result)
+	}
+	if repo.storedVersion != result.Version || repo.storedHash != "hash:signed-token" {
+		t.Fatalf("expected stored version/hash, got version=%d hash=%q", repo.storedVersion, repo.storedHash)
+	}
+	if tokens.issuedClaims.TicketID != record.Ticket.ID || tokens.issuedClaims.ParticipationID != record.Participation.ID {
+		t.Fatalf("issued claims do not match record: %+v", tokens.issuedClaims)
+	}
+}
+
+func TestIssueQRTokenRejectsFarLocation(t *testing.T) {
+	// given
+	now := time.Now().UTC()
+	record := activeTicketAccessRecord(now)
+	record.DistanceMeters = 201
+	service := NewService(&fakeTicketRepo{accessRecord: record}, &fakeUnitOfWork{}, &fakeTokenManager{}, Settings{ProximityMeters: 200})
+	service.now = func() time.Time { return now }
+
+	// when
+	_, err := service.IssueQRToken(context.Background(), record.UserID, record.Ticket.ID, QRTokenInput{})
+
+	// then
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) || appErr.Code != domain.ErrorCodeTicketProximityRequired {
+		t.Fatalf("expected proximity error, got %T %v", err, err)
+	}
+}
+
+func TestScanTicketMarksActiveLatestTokenUsed(t *testing.T) {
+	// given
+	now := time.Now().UTC()
+	record := activeTicketScanRecord(now)
+	claims := &QRTokenClaims{
+		TicketID:        record.Ticket.ID,
+		ParticipationID: record.Participation.ID,
+		EventID:         record.EventID,
+		UserID:          record.UserID,
+		Version:         record.Ticket.QRTokenVersion,
+		IssuedAt:        now,
+		ExpiresAt:       now.Add(10 * time.Second),
+	}
+	repo := &fakeTicketRepo{scanRecord: record}
+	service := NewService(repo, &fakeUnitOfWork{}, &fakeTokenManager{verifyClaims: claims}, Settings{})
+
+	// when
+	result, err := service.ScanTicket(context.Background(), record.HostID, record.EventID, ScanTicketInput{QRToken: "signed-token"})
+
+	// then
+	if err != nil {
+		t.Fatalf("ScanTicket() error = %v", err)
+	}
+	if result.Result != ScanResultAccepted || result.TicketStatus == nil || *result.TicketStatus != domain.TicketStatusUsed {
+		t.Fatalf("expected accepted USED result, got %+v", result)
+	}
+	if repo.usedTicketID != record.Ticket.ID {
+		t.Fatalf("expected used ticket %s, got %s", record.Ticket.ID, repo.usedTicketID)
+	}
+}
+
+func TestScanTicketRejectsOldVersion(t *testing.T) {
+	// given
+	now := time.Now().UTC()
+	record := activeTicketScanRecord(now)
+	claims := &QRTokenClaims{
+		TicketID:        record.Ticket.ID,
+		ParticipationID: record.Participation.ID,
+		EventID:         record.EventID,
+		UserID:          record.UserID,
+		Version:         record.Ticket.QRTokenVersion - 1,
+		IssuedAt:        now,
+		ExpiresAt:       now.Add(10 * time.Second),
+	}
+	service := NewService(&fakeTicketRepo{scanRecord: record}, &fakeUnitOfWork{}, &fakeTokenManager{verifyClaims: claims}, Settings{})
+
+	// when
+	result, err := service.ScanTicket(context.Background(), record.HostID, record.EventID, ScanTicketInput{QRToken: "signed-token"})
+
+	// then
+	if err != nil {
+		t.Fatalf("ScanTicket() error = %v", err)
+	}
+	if result.Result != ScanResultRejected || result.Reason == nil || *result.Reason != RejectReasonTokenOldVersion {
+		t.Fatalf("expected old-version rejection, got %+v", result)
+	}
+}
+
+func activeTicketAccessRecord(now time.Time) *TicketAccessRecord {
+	ticketID := uuid.New()
+	participationID := uuid.New()
+	userID := uuid.New()
+	eventID := uuid.New()
+	return &TicketAccessRecord{
+		TicketRecord: TicketRecord{
+			Ticket: domain.Ticket{
+				ID:              ticketID,
+				ParticipationID: participationID,
+				Status:          domain.TicketStatusActive,
+				QRTokenVersion:  4,
+				ExpiresAt:       now.Add(time.Hour),
+				CreatedAt:       now.Add(-time.Hour),
+				UpdatedAt:       now,
+			},
+			Participation: domain.Participation{
+				ID:        participationID,
+				EventID:   eventID,
+				UserID:    userID,
+				Status:    domain.ParticipationStatusApproved,
+				CreatedAt: now.Add(-time.Hour),
+				UpdatedAt: now,
+			},
+			EventID:      eventID,
+			EventTitle:   "Protected Event",
+			EventStatus:  domain.EventStatusActive,
+			PrivacyLevel: domain.PrivacyProtected,
+			StartTime:    now.Add(time.Hour),
+			LocationType: domain.LocationPoint,
+			Anchor:       domain.GeoPoint{Lat: 41, Lon: 29},
+		},
+		UserID:         userID,
+		DistanceMeters: 5,
+	}
+}
+
+func activeTicketScanRecord(now time.Time) *TicketScanRecord {
+	access := activeTicketAccessRecord(now)
+	hash := "hash:signed-token"
+	access.Ticket.LastIssuedQRTokenHash = &hash
+	return &TicketScanRecord{
+		Ticket:        access.Ticket,
+		Participation: access.Participation,
+		EventID:       access.EventID,
+		EventStatus:   access.EventStatus,
+		PrivacyLevel:  access.PrivacyLevel,
+		HostID:        uuid.New(),
+		UserID:        access.UserID,
+	}
+}

--- a/backend/internal/application/ticket/usecase.go
+++ b/backend/internal/application/ticket/usecase.go
@@ -1,0 +1,25 @@
+package ticket
+
+import (
+	"context"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// UseCase is the inbound application port for ticket flows.
+type UseCase interface {
+	LifecycleUseCase
+	ListMyTickets(ctx context.Context, userID uuid.UUID) (*ListTicketsResult, error)
+	GetMyTicket(ctx context.Context, userID, ticketID uuid.UUID) (*TicketDetailResult, error)
+	IssueQRToken(ctx context.Context, userID, ticketID uuid.UUID, input QRTokenInput) (*QRTokenResult, error)
+	ScanTicket(ctx context.Context, hostUserID, eventID uuid.UUID, input ScanTicketInput) (*ScanTicketResult, error)
+}
+
+// LifecycleUseCase exposes ticket lifecycle mutations used by other application services.
+type LifecycleUseCase interface {
+	CreateTicketForParticipation(ctx context.Context, participation *domain.Participation, status domain.TicketStatus) (*domain.Ticket, error)
+	CancelTicketForParticipation(ctx context.Context, participationID uuid.UUID) error
+	CancelTicketsForEvent(ctx context.Context, eventID uuid.UUID) error
+	ExpireTicketsForEvent(ctx context.Context, eventID uuid.UUID) error
+}

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/participation"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/profile"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/bounswe/bounswe2026group11/backend/internal/infrastructure/config"
@@ -44,6 +45,7 @@ type Container struct {
 	eventRepo               *postgres.EventRepository
 	participationRepo       *postgres.ParticipationRepository
 	joinRequestRepo         *postgres.JoinRequestRepository
+	ticketRepo              *postgres.TicketRepository
 	ratingRepo              *postgres.RatingRepository
 	categoryRepo            *postgres.CategoryRepository
 	profileRepo             *postgres.ProfileRepository
@@ -52,6 +54,7 @@ type Container struct {
 	EventService            event.UseCase
 	ParticipationService    participation.UseCase
 	JoinRequestService      join_request.UseCase
+	TicketService           ticket.UseCase
 	RatingService           rating.UseCase
 	CategoryService         category.UseCase
 	ProfileService          profile.UseCase
@@ -92,11 +95,13 @@ func New(ctx context.Context) (*Container, error) {
 	container.eventRepo = postgres.NewEventRepository(container.DB)
 	container.participationRepo = postgres.NewParticipationRepository(container.DB)
 	container.joinRequestRepo = postgres.NewJoinRequestRepository(container.DB)
+	container.ticketRepo = postgres.NewTicketRepository(container.DB)
 	container.ratingRepo = postgres.NewRatingRepository(container.DB)
 	container.categoryRepo = postgres.NewCategoryRepository(container.DB)
 	container.profileRepo = postgres.NewProfileRepository(container.DB)
 	container.favoriteLocationRepo = postgres.NewFavoriteLocationRepository(container.DB)
 	container.ParticipationService = newParticipationService(container)
+	container.TicketService = newTicketService(container)
 	container.JoinRequestService = newJoinRequestService(container)
 	container.RatingService = newRatingService(container)
 	container.AuthService = newAuthService(container)
@@ -178,7 +183,7 @@ func buildSpacesStorage(cfg *config.Config) *spacesadapter.Storage {
 
 // newEventService wires the event use case with its driven adapters.
 func newEventService(c *Container) event.UseCase {
-	return event.NewService(c.eventRepo, c.ParticipationService, c.JoinRequestService, c.UnitOfWork)
+	return event.NewService(c.eventRepo, c.ParticipationService, c.JoinRequestService, c.UnitOfWork, c.TicketService)
 }
 
 // newParticipationService wires the participation use-case service with its
@@ -190,7 +195,20 @@ func newParticipationService(c *Container) participation.UseCase {
 // newJoinRequestService wires the join request use-case service with its
 // driven adapter.
 func newJoinRequestService(c *Container) join_request.UseCase {
-	return join_request.NewService(c.joinRequestRepo, c.UnitOfWork)
+	return join_request.NewService(c.joinRequestRepo, c.UnitOfWork, c.TicketService)
+}
+
+// newTicketService wires the ticket use-case service with its driven adapters.
+func newTicketService(c *Container) ticket.UseCase {
+	return ticket.NewService(
+		c.ticketRepo,
+		c.UnitOfWork,
+		jwtadapter.TicketTokenManager{Secret: []byte(c.Config.JWTSecret)},
+		ticket.Settings{
+			QRTokenTTL:      10 * time.Second,
+			ProximityMeters: 200,
+		},
+	)
 }
 
 // newCategoryService wires the category use-case service with its driven adapter.

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -62,6 +62,13 @@ const (
 	ErrorCodeImageUploadNotAllowed      = "image_upload_not_allowed"
 	ErrorCodeImageUploadIncomplete      = "image_upload_incomplete"
 	ErrorCodeImageUploadVersionConflict = "image_upload_version_conflict"
+
+	ErrorCodeTicketNotFound           = "ticket_not_found"
+	ErrorCodeTicketNotActive          = "ticket_not_active"
+	ErrorCodeTicketNotOwned           = "ticket_not_owned"
+	ErrorCodeTicketScanRejected       = "ticket_scan_rejected"
+	ErrorCodeTicketProximityRequired  = "ticket_proximity_required"
+	ErrorCodeTicketClientNotSupported = "ticket_client_not_supported"
 )
 
 // ErrNotFound is a sentinel error returned when a queried entity does not exist.

--- a/backend/internal/domain/ticket.go
+++ b/backend/internal/domain/ticket.go
@@ -1,0 +1,56 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TicketStatus defines the lifecycle state of a protected-event entry ticket.
+type TicketStatus string
+
+const (
+	// TicketStatusActive means the participant can request short-lived QR tokens.
+	TicketStatusActive TicketStatus = "ACTIVE"
+	// TicketStatusPending is reserved for future event re-approval flows.
+	TicketStatusPending TicketStatus = "PENDING"
+	// TicketStatusExpired marks an unused ticket whose event access window is over.
+	TicketStatusExpired TicketStatus = "EXPIRED"
+	// TicketStatusUsed marks a ticket accepted by a host scan.
+	TicketStatusUsed TicketStatus = "USED"
+	// TicketStatusCanceled marks a ticket canceled by leave/cancel flows.
+	TicketStatusCanceled TicketStatus = "CANCELED"
+)
+
+var ticketStatuses = map[string]TicketStatus{
+	string(TicketStatusActive):   TicketStatusActive,
+	string(TicketStatusPending):  TicketStatusPending,
+	string(TicketStatusExpired):  TicketStatusExpired,
+	string(TicketStatusUsed):     TicketStatusUsed,
+	string(TicketStatusCanceled): TicketStatusCanceled,
+}
+
+// ParseTicketStatus converts a wire or persistence string into a domain status.
+func ParseTicketStatus(value string) (TicketStatus, bool) {
+	status, ok := ticketStatuses[value]
+	return status, ok
+}
+
+// String returns the serialized wire value of the ticket status.
+func (s TicketStatus) String() string {
+	return string(s)
+}
+
+// Ticket is the protected-event access entity linked to a participation.
+type Ticket struct {
+	ID                    uuid.UUID
+	ParticipationID       uuid.UUID
+	Status                TicketStatus
+	QRTokenVersion        int
+	LastIssuedQRTokenHash *string
+	ExpiresAt             time.Time
+	UsedAt                *time.Time
+	CanceledAt            *time.Time
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}

--- a/backend/internal/domain/ticket_test.go
+++ b/backend/internal/domain/ticket_test.go
@@ -1,0 +1,27 @@
+package domain
+
+import "testing"
+
+func TestParseTicketStatusAcceptsKnownStatuses(t *testing.T) {
+	for _, status := range []TicketStatus{
+		TicketStatusActive,
+		TicketStatusPending,
+		TicketStatusExpired,
+		TicketStatusUsed,
+		TicketStatusCanceled,
+	} {
+		parsed, ok := ParseTicketStatus(status.String())
+		if !ok {
+			t.Fatalf("expected status %q to parse", status)
+		}
+		if parsed != status {
+			t.Fatalf("expected %q, got %q", status, parsed)
+		}
+	}
+}
+
+func TestParseTicketStatusRejectsUnknownStatus(t *testing.T) {
+	if _, ok := ParseTicketStatus("active"); ok {
+		t.Fatal("expected lowercase status to be rejected")
+	}
+}

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/image_upload_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/profile_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/rating_handler"
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/ticket_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/bootstrap"
 	"github.com/gofiber/contrib/otelfiber/v2"
 	"github.com/gofiber/fiber/v2"
@@ -47,6 +48,10 @@ func NewHTTP(container *bootstrap.Container) *fiber.App {
 	// Rating routes
 	ratingHandler := rating_handler.NewRatingHandler(container.RatingService)
 	rating_handler.RegisterRatingRoutes(app, ratingHandler, auth)
+
+	// Ticket routes
+	ticketHandler := ticket_handler.NewHandler(container.TicketService)
+	ticket_handler.RegisterRoutes(app, ticketHandler, auth)
 
 	// Category routes (public, no auth required)
 	categoryHandler := category_handler.NewCategoryHandler(container.CategoryService)

--- a/backend/migrations/000021_ticket_lifecycle.down.sql
+++ b/backend/migrations/000021_ticket_lifecycle.down.sql
@@ -1,0 +1,25 @@
+DROP INDEX IF EXISTS idx_ticket_status;
+DROP INDEX IF EXISTS idx_ticket_participation_id;
+DROP INDEX IF EXISTS uq_ticket_participation_non_terminal;
+
+ALTER TABLE ticket
+    DROP CONSTRAINT IF EXISTS chk_ticket_status,
+    DROP COLUMN IF EXISTS canceled_at,
+    DROP COLUMN IF EXISTS used_at,
+    DROP COLUMN IF EXISTS last_issued_qr_token_hash,
+    DROP COLUMN IF EXISTS qr_token_version;
+
+ALTER TABLE ticket
+    ADD COLUMN IF NOT EXISTS qr_token TEXT;
+
+UPDATE ticket
+SET qr_token = id::text
+WHERE qr_token IS NULL OR qr_token = '';
+
+ALTER TABLE ticket
+    ALTER COLUMN qr_token SET NOT NULL,
+    ALTER COLUMN status DROP NOT NULL,
+    ALTER COLUMN status DROP DEFAULT,
+    ALTER COLUMN expires_at DROP NOT NULL;
+
+CREATE UNIQUE INDEX idx_ticket_qr ON ticket (qr_token);

--- a/backend/migrations/000021_ticket_lifecycle.up.sql
+++ b/backend/migrations/000021_ticket_lifecycle.up.sql
@@ -1,0 +1,38 @@
+DROP INDEX IF EXISTS idx_ticket_qr;
+
+ALTER TABLE ticket
+    DROP COLUMN IF EXISTS qr_token,
+    ADD COLUMN IF NOT EXISTS qr_token_version INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS last_issued_qr_token_hash TEXT,
+    ADD COLUMN IF NOT EXISTS used_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS canceled_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE ticket
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
+
+UPDATE ticket
+SET status = 'ACTIVE'
+WHERE status IS NULL OR status = '';
+
+UPDATE ticket t
+SET expires_at = COALESCE(e.end_time, e.start_time + INTERVAL '60 days')
+FROM participation p
+JOIN event e ON e.id = p.event_id
+WHERE p.id = t.participation_id
+  AND t.expires_at IS NULL;
+
+ALTER TABLE ticket
+    ALTER COLUMN status SET NOT NULL,
+    ALTER COLUMN status SET DEFAULT 'ACTIVE',
+    ALTER COLUMN expires_at SET NOT NULL;
+
+ALTER TABLE ticket
+    ADD CONSTRAINT chk_ticket_status
+        CHECK (status IN ('ACTIVE', 'PENDING', 'EXPIRED', 'USED', 'CANCELED'));
+
+CREATE UNIQUE INDEX uq_ticket_participation_non_terminal
+    ON ticket (participation_id)
+    WHERE status IN ('ACTIVE', 'PENDING');
+
+CREATE INDEX idx_ticket_participation_id ON ticket (participation_id);
+CREATE INDEX idx_ticket_status ON ticket (status);

--- a/backend/tests_integration/common/harness.go
+++ b/backend/tests_integration/common/harness.go
@@ -19,6 +19,7 @@ import (
 	participationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/participation"
 	profileapp "github.com/bounswe/bounswe2026group11/backend/internal/application/profile"
 	ratingapp "github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
+	ticketapp "github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/jackc/pgx/v5"
 )
@@ -83,6 +84,7 @@ func NewAuthHarness(t *testing.T) *AuthHarness {
 type EventHarness struct {
 	Service        eventapp.UseCase
 	EventRepo      *postgresrepo.EventRepository
+	TicketService  ticketapp.UseCase
 	RatingService  ratingapp.UseCase
 	ProfileService profileapp.UseCase
 	AuthRepo       authapp.Repository
@@ -103,15 +105,26 @@ func NewEventHarness(t *testing.T) *EventHarness {
 	eventRepo := postgresrepo.NewEventRepository(pool)
 	participationRepo := postgresrepo.NewParticipationRepository(pool)
 	joinRequestRepo := postgresrepo.NewJoinRequestRepository(pool)
+	ticketRepo := postgresrepo.NewTicketRepository(pool)
 	ratingRepo := postgresrepo.NewRatingRepository(pool)
 	profileRepo := postgresrepo.NewProfileRepository(pool)
 	unitOfWork := postgresrepo.NewUnitOfWork(pool)
 	participationService := participationapp.NewService(participationRepo)
-	joinRequestService := joinrequestapp.NewService(joinRequestRepo, unitOfWork)
+	ticketService := ticketapp.NewService(
+		ticketRepo,
+		unitOfWork,
+		jwtadapter.TicketTokenManager{Secret: []byte("integration-test-secret")},
+		ticketapp.Settings{
+			QRTokenTTL:      10 * time.Second,
+			ProximityMeters: 200,
+		},
+	)
+	joinRequestService := joinrequestapp.NewService(joinRequestRepo, unitOfWork, ticketService)
 
 	return &EventHarness{
-		Service:   eventapp.NewService(eventRepo, participationService, joinRequestService, unitOfWork),
-		EventRepo: eventRepo,
+		Service:       eventapp.NewService(eventRepo, participationService, joinRequestService, unitOfWork, ticketService),
+		EventRepo:     eventRepo,
+		TicketService: ticketService,
 		RatingService: ratingapp.NewService(ratingRepo, unitOfWork, ratingapp.Settings{
 			GlobalPrior: 4.0,
 			BayesianM:   5,

--- a/backend/tests_integration/ticket_test.go
+++ b/backend/tests_integration/ticket_test.go
@@ -1,0 +1,187 @@
+//go:build integration
+
+package tests_integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
+	ticketapp "github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
+	"github.com/google/uuid"
+)
+
+func TestProtectedJoinApprovalCreatesActiveTicket(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventRef := common.GivenProtectedEvent(t, harness.Service, host.ID)
+
+	joinRequest, err := harness.Service.RequestJoin(context.Background(), participant.ID, eventRef.ID, eventapp.RequestJoinInput{})
+	if err != nil {
+		t.Fatalf("RequestJoin() error = %v", err)
+	}
+	joinRequestID := uuid.MustParse(joinRequest.JoinRequestID)
+
+	if _, err := harness.Service.ApproveJoinRequest(context.Background(), host.ID, eventRef.ID, joinRequestID); err != nil {
+		t.Fatalf("ApproveJoinRequest() error = %v", err)
+	}
+
+	tickets, err := harness.TicketService.ListMyTickets(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("ListMyTickets() error = %v", err)
+	}
+	if len(tickets.Items) != 1 {
+		t.Fatalf("expected 1 ticket, got %d", len(tickets.Items))
+	}
+	if tickets.Items[0].Status != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE ticket, got %q", tickets.Items[0].Status)
+	}
+	if tickets.Items[0].Event.ID != eventRef.ID.String() {
+		t.Fatalf("expected ticket for event %s, got %s", eventRef.ID, tickets.Items[0].Event.ID)
+	}
+}
+
+func TestPublicJoinCreatesNoTicket(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventRef := common.GivenPublicEvent(t, harness.Service, host.ID)
+
+	if _, err := harness.Service.JoinEvent(context.Background(), participant.ID, eventRef.ID); err != nil {
+		t.Fatalf("JoinEvent() error = %v", err)
+	}
+
+	tickets, err := harness.TicketService.ListMyTickets(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("ListMyTickets() error = %v", err)
+	}
+	if len(tickets.Items) != 0 {
+		t.Fatalf("expected no tickets for public join, got %d", len(tickets.Items))
+	}
+}
+
+func TestTicketQRScanAcceptsOnceThenRejectsReuse(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventRef := common.GivenProtectedEvent(t, harness.Service, host.ID)
+	ticketID := approveProtectedParticipantAndReturnTicketID(t, harness, host.ID, participant.ID, eventRef.ID)
+
+	qr, err := harness.TicketService.IssueQRToken(context.Background(), participant.ID, ticketID, ticketapp.QRTokenInput{Lat: 41.0, Lon: 29.0})
+	if err != nil {
+		t.Fatalf("IssueQRToken() error = %v", err)
+	}
+
+	accepted, err := harness.TicketService.ScanTicket(context.Background(), host.ID, eventRef.ID, ticketapp.ScanTicketInput{QRToken: qr.Token})
+	if err != nil {
+		t.Fatalf("ScanTicket() error = %v", err)
+	}
+	if accepted.Result != ticketapp.ScanResultAccepted {
+		t.Fatalf("expected ACCEPTED scan, got %+v", accepted)
+	}
+
+	rejected, err := harness.TicketService.ScanTicket(context.Background(), host.ID, eventRef.ID, ticketapp.ScanTicketInput{QRToken: qr.Token})
+	if err != nil {
+		t.Fatalf("ScanTicket() reuse error = %v", err)
+	}
+	if rejected.Result != ticketapp.ScanResultRejected || rejected.Reason == nil || *rejected.Reason != ticketapp.RejectReasonTicketAlreadyUsed {
+		t.Fatalf("expected already-used rejection, got %+v", rejected)
+	}
+}
+
+func TestTicketDetailOwnershipAndProximity(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	other := common.GivenUser(t, harness.AuthRepo)
+	eventRef := common.GivenProtectedEvent(t, harness.Service, host.ID)
+	ticketID := approveProtectedParticipantAndReturnTicketID(t, harness, host.ID, participant.ID, eventRef.ID)
+
+	detail, err := harness.TicketService.GetMyTicket(context.Background(), participant.ID, ticketID)
+	if err != nil {
+		t.Fatalf("GetMyTicket() error = %v", err)
+	}
+	if !detail.QRAccess.EligibleNow {
+		t.Fatalf("expected active approved ticket to be QR-eligible, got %+v", detail.QRAccess)
+	}
+
+	_, err = harness.TicketService.GetMyTicket(context.Background(), other.ID, ticketID)
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeTicketNotFound)
+
+	_, err = harness.TicketService.IssueQRToken(context.Background(), participant.ID, ticketID, ticketapp.QRTokenInput{Lat: 40.0, Lon: 28.0})
+	common.RequireAppErrorCode(t, err, domain.ErrorCodeTicketProximityRequired)
+}
+
+func TestEventCancelCancelsTickets(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventRef := common.GivenProtectedEvent(t, harness.Service, host.ID)
+	ticketID := approveProtectedParticipantAndReturnTicketID(t, harness, host.ID, participant.ID, eventRef.ID)
+
+	if err := harness.Service.CancelEvent(context.Background(), host.ID, eventRef.ID); err != nil {
+		t.Fatalf("CancelEvent() error = %v", err)
+	}
+
+	detail, err := harness.TicketService.GetMyTicket(context.Background(), participant.ID, ticketID)
+	if err != nil {
+		t.Fatalf("GetMyTicket() error = %v", err)
+	}
+	if detail.Ticket.Status != domain.TicketStatusCanceled {
+		t.Fatalf("expected CANCELED ticket, got %q", detail.Ticket.Status)
+	}
+}
+
+func TestEventStatusTransitionExpiresUnusedTickets(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventRef := common.GivenProtectedEvent(t, harness.Service, host.ID)
+	ticketID := approveProtectedParticipantAndReturnTicketID(t, harness, host.ID, participant.ID, eventRef.ID)
+
+	_, err := common.RequirePool(t).Exec(context.Background(), `
+		UPDATE event
+		SET start_time = $2,
+		    updated_at = $3
+		WHERE id = $1
+	`, eventRef.ID, time.Now().UTC().Add(-61*24*time.Hour), time.Now().UTC().Add(-61*24*time.Hour))
+	if err != nil {
+		t.Fatalf("update event into expiry window error = %v", err)
+	}
+
+	if err := harness.EventRepo.TransitionEventStatuses(context.Background()); err != nil {
+		t.Fatalf("TransitionEventStatuses() error = %v", err)
+	}
+
+	detail, err := harness.TicketService.GetMyTicket(context.Background(), participant.ID, ticketID)
+	if err != nil {
+		t.Fatalf("GetMyTicket() error = %v", err)
+	}
+	if detail.Ticket.Status != domain.TicketStatusExpired {
+		t.Fatalf("expected EXPIRED ticket, got %q", detail.Ticket.Status)
+	}
+}
+
+func approveProtectedParticipantAndReturnTicketID(t *testing.T, harness *common.EventHarness, hostID, participantID, eventID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	joinRequest, err := harness.Service.RequestJoin(context.Background(), participantID, eventID, eventapp.RequestJoinInput{})
+	if err != nil {
+		t.Fatalf("RequestJoin() error = %v", err)
+	}
+	if _, err := harness.Service.ApproveJoinRequest(context.Background(), hostID, eventID, uuid.MustParse(joinRequest.JoinRequestID)); err != nil {
+		t.Fatalf("ApproveJoinRequest() error = %v", err)
+	}
+	tickets, err := harness.TicketService.ListMyTickets(context.Background(), participantID)
+	if err != nil {
+		t.Fatalf("ListMyTickets() error = %v", err)
+	}
+	if len(tickets.Items) != 1 {
+		t.Fatalf("expected one ticket, got %d", len(tickets.Items))
+	}
+	return uuid.MustParse(tickets.Items[0].TicketID)
+}

--- a/docs/design/ticket-system.md
+++ b/docs/design/ticket-system.md
@@ -1,0 +1,315 @@
+# Ticket System
+
+## Purpose
+
+The backend uses a separate `ticket` entity to control physical entry for `PROTECTED` events.
+
+A ticket is linked to a participation, but it is not the same thing as participation:
+
+- participation answers whether a user is part of the event
+- ticket answers whether that participant can present a short-lived QR token for entry
+- the QR token itself is temporary access material, not the long-lived business entity
+
+## Current Scope
+
+The current implementation supports:
+
+- ticket creation for approved participants of protected events
+- ticket listing and detail for the ticket owner
+- short-lived QR token issuance over SSE
+- host-side QR scan validation
+- ticket cancellation when the participant leaves
+- ticket cancellation when the event is canceled
+- ticket expiration when the event becomes completed
+
+The current implementation does **not** support event-update reapproval yet.
+
+- `PENDING` exists as a valid ticket status in the schema and domain model
+- the backend does not currently transition tickets into `PENDING`
+- there is no event-update flow that reopens approval for existing participants in this version
+
+## Platform Boundary
+
+QR-related flows are backend-supported only for the mobile client.
+
+- `GET /me/tickets` and `GET /me/tickets/{ticketId}` are normal authenticated endpoints
+- `GET /me/tickets/{ticketId}/qr-stream` requires `X-Client-Surface: MOBILE`
+- `POST /host/events/{eventId}/ticket-scans` requires `X-Client-Surface: MOBILE`
+
+This is enforced in the backend, not only documented at product level.
+
+## Domain Model
+
+### Participation statuses
+
+- `APPROVED`
+- `PENDING`
+- `CANCELED`
+- `LEAVED`
+
+### Ticket statuses
+
+- `ACTIVE`
+- `PENDING`
+- `EXPIRED`
+- `USED`
+- `CANCELED`
+
+### Ticket shape
+
+```ts
+Ticket {
+  id: UUID
+  participationId: UUID
+  status: "ACTIVE" | "PENDING" | "EXPIRED" | "USED" | "CANCELED"
+  qrTokenVersion: number
+  lastIssuedQrTokenHash?: string
+  expiresAt: timestamp
+  usedAt?: timestamp
+  canceledAt?: timestamp
+  createdAt: timestamp
+  updatedAt: timestamp
+}
+```
+
+## Persistence Rules
+
+- plaintext QR tokens are not stored
+- only the latest issued token hash is stored
+- `qrTokenVersion` is incremented every time a new QR token is issued
+- old token versions are rejected during scan
+- each participation can have at most one non-terminal ticket in `ACTIVE` or `PENDING`
+
+## Current Participation to Ticket Mapping
+
+The current backend behavior is narrower than the full original design.
+
+| Participation transition | Current ticket behavior |
+|---|---|
+| protected join request approved -> `APPROVED` | create `ACTIVE` ticket |
+| public direct join -> `APPROVED` | no ticket |
+| participant leaves -> `LEAVED` | set ticket to `CANCELED` |
+| event canceled -> `CANCELED` | set ticket to `CANCELED` |
+| event completed | set unused `ACTIVE` or `PENDING` tickets to `EXPIRED` |
+| successful host scan | set ticket to `USED` |
+
+Notes:
+
+- host internal participation rows do not get tickets
+- current flows do not create `PENDING` tickets
+- `USED`, `CANCELED`, and `EXPIRED` are terminal in the current implementation
+
+## Ticket Creation Flow
+
+Tickets are created only when a host approves a join request for a protected event.
+
+Flow:
+
+1. the host approves a `PENDING` join request
+2. the backend creates or reactivates the participant's `APPROVED` participation
+3. in the same unit of work, the backend creates an `ACTIVE` ticket
+
+Public events do not create tickets because they do not use the protected entry flow.
+
+## Ticket Read APIs
+
+### `GET /me/tickets`
+
+Returns the authenticated user's tickets with:
+
+- ticket id
+- ticket status
+- ticket expiration
+- event summary
+- participation summary
+
+QR tokens are never returned from this endpoint.
+
+### `GET /me/tickets/{ticketId}`
+
+Returns:
+
+- ticket fields
+- participation summary
+- event summary
+- location anchor summary
+- `qr_access` state
+
+`qr_access` is a backend-computed summary that tells the client whether the ticket is currently eligible to start QR presentation.
+
+## QR Token Issuance
+
+### Endpoint
+
+`GET /me/tickets/{ticketId}/qr-stream?lat={lat}&lon={lon}`
+
+### Current behavior
+
+When the connection opens, the backend:
+
+1. checks that the caller owns the ticket
+2. checks that the event is `PROTECTED`
+3. checks that participation is `APPROVED`
+4. checks that ticket status is `ACTIVE`
+5. checks that event status is `ACTIVE` or `IN_PROGRESS`
+6. checks that `expiresAt` is still in the future
+7. checks that the caller is within 200 meters of the event anchor
+8. issues a signed token valid for 10 seconds
+9. stores the new token hash and increments `qrTokenVersion`
+
+After that, the stream emits a fresh `qr_token` event every 10 seconds.
+
+### Current event location anchor
+
+- if the event location type is `POINT`, the event point is used
+- if the event location type is `ROUTE`, the first point of the route is used
+
+### Current SSE behavior
+
+The current implementation emits:
+
+- `qr_token`
+- `error`
+
+It does not currently emit:
+
+- `ticket_status_changed`
+- `keepalive`
+
+If a later token refresh fails, the stream emits an `error` event and stops.
+
+### Example event
+
+```text
+event: qr_token
+data: {"token":"signed-short-lived-token","expires_at":"2026-04-26T12:00:10Z","version":42}
+```
+
+## QR Token Contents
+
+Each issued token contains:
+
+```json
+{
+  "ticket_id": "uuid",
+  "participation_id": "uuid",
+  "event_id": "uuid",
+  "user_id": "uuid",
+  "version": 42,
+  "issued_at": "2026-04-26T12:00:00Z",
+  "expires_at": "2026-04-26T12:00:10Z"
+}
+```
+
+The token is:
+
+- signed
+- short-lived
+- versioned
+- validated against the latest stored hash on scan
+
+## Host Scan Flow
+
+### Endpoint
+
+`POST /host/events/{eventId}/ticket-scans`
+
+Request body:
+
+```json
+{
+  "qr_token": "signed-short-lived-token"
+}
+```
+
+### Current validation
+
+The backend:
+
+1. requires the mobile client header
+2. requires that the caller is the host of the event
+3. verifies the token signature and expiration
+4. verifies that token `event_id` matches the scanned event
+5. loads the ticket in a locked transaction
+6. verifies ticket and participation linkage
+7. verifies the token version matches `qrTokenVersion`
+8. verifies the token hash matches `lastIssuedQrTokenHash`
+9. verifies ticket status is still `ACTIVE`
+10. verifies participation is still `APPROVED`
+11. verifies event status is still `ACTIVE` or `IN_PROGRESS`
+
+On success:
+
+- the ticket is marked `USED`
+- `usedAt` is set
+- the response returns `result: ACCEPTED`
+
+On failure:
+
+- the ticket state is unchanged
+- the response returns `result: REJECTED`
+- the response includes a machine-readable reason
+
+### Current reject reasons
+
+- `INVALID_TOKEN`
+- `TICKET_NOT_FOUND`
+- `TICKET_ALREADY_USED`
+- `TICKET_NOT_ACTIVE`
+- `PARTICIPATION_INVALID`
+- `EVENT_INVALID`
+- `TOKEN_OLD_VERSION`
+- `TOKEN_NOT_LATEST`
+- `EVENT_MISMATCH`
+- `PARTICIPATION_MISMATCH`
+
+## Expiration and Cancellation
+
+### Leave event
+
+When a participant leaves an event:
+
+- participation becomes `LEAVED`
+- the linked non-terminal ticket becomes `CANCELED`
+- both happen in the same unit of work
+
+### Cancel event
+
+When a host cancels an event:
+
+- the event becomes `CANCELED`
+- non-leaved participations are canceled through the existing participation flow
+- linked non-terminal tickets become `CANCELED`
+- these changes run in the same unit of work
+
+### Complete event / automatic event transition
+
+When an event becomes `COMPLETED`:
+
+- unused `ACTIVE` and `PENDING` tickets become `EXPIRED`
+- `USED` tickets remain `USED`
+- `CANCELED` tickets remain `CANCELED`
+
+This happens in two places:
+
+- explicit event completion
+- the background event status transition job
+
+## Current Limitations
+
+- no event-update reapproval flow yet
+- no current path that produces `PENDING` tickets
+- the QR stream uses the location sent when the connection opens
+- if the client's location changes materially, the mobile app must reconnect with new `lat` and `lon` values
+- the SSE implementation currently refreshes on a fixed 10-second interval and stops on refresh error instead of sending a richer state machine
+
+## Source of Truth
+
+For request and response contracts, use:
+
+- [ticket.yaml](/Users/kaanunsel/Developer/social-event-mapper/docs/openapi/ticket.yaml)
+
+For implementation details, the current backend behavior is defined by:
+
+- [service.go](/Users/kaanunsel/Developer/social-event-mapper/backend/internal/application/ticket/service.go)
+- [ticket_handler.go](/Users/kaanunsel/Developer/social-event-mapper/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler.go)

--- a/docs/openapi/ticket.yaml
+++ b/docs/openapi/ticket.yaml
@@ -1,0 +1,323 @@
+openapi: 3.1.0
+info:
+  title: Social Event Mapper Ticket API
+  version: 0.1.0
+  description: |
+    Ticket endpoints for protected-event mobile entry flows.
+
+    QR display and QR scanning are product-supported only in the mobile app. QR
+    stream and scan endpoints require `X-Client-Surface: MOBILE` in addition to
+    bearer authentication.
+servers:
+  - url: /api
+tags:
+  - name: Tickets
+    description: Protected-event ticket list, detail, QR stream, and host scan contracts.
+security:
+  - bearerAuth: []
+paths:
+  /me/tickets:
+    get:
+      tags: [Tickets]
+      summary: List my tickets
+      operationId: listMyTickets
+      responses:
+        '200':
+          description: Ticket list returned successfully. QR tokens are never included.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListTicketsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /me/tickets/{ticketId}:
+    get:
+      tags: [Tickets]
+      summary: Get my ticket detail
+      operationId: getMyTicket
+      parameters:
+        - $ref: '#/components/parameters/TicketId'
+      responses:
+        '200':
+          description: Ticket detail returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketDetailResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Ticket not found or not owned by the caller.
+  /me/tickets/{ticketId}/qr-stream:
+    get:
+      tags: [Tickets]
+      summary: Stream short-lived QR tokens
+      operationId: streamTicketQR
+      description: |
+        Opens a Server-Sent Events stream and emits an initial `qr_token`, then a
+        refreshed token every 10 seconds. The backend validates ticket ownership,
+        ACTIVE ticket status, APPROVED participation, ACTIVE/IN_PROGRESS protected
+        event status, ticket business expiry, and 200-meter proximity before issuing
+        each token.
+      parameters:
+        - $ref: '#/components/parameters/TicketId'
+        - $ref: '#/components/parameters/MobileSurface'
+        - name: lat
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+        - name: lon
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+      responses:
+        '200':
+          description: SSE stream opened.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+              examples:
+                qrToken:
+                  value: |
+                    event: qr_token
+                    data: {"token":"signed-short-lived-token","expires_at":"2026-04-26T12:00:10Z","version":42}
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Missing mobile surface header or caller is outside proximity.
+        '404':
+          description: Ticket not found.
+        '409':
+          description: Ticket, participation, or event is not eligible for QR issuance.
+  /host/events/{eventId}/ticket-scans:
+    post:
+      tags: [Tickets]
+      summary: Scan a participant ticket
+      operationId: scanTicket
+      description: |
+        Host-only mobile endpoint. A successful scan atomically marks the ticket
+        `USED`. Rejected scans return `result: REJECTED` and a machine-readable
+        reason without changing ticket state.
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: '#/components/parameters/MobileSurface'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [qr_token]
+              properties:
+                qr_token:
+                  type: string
+      responses:
+        '200':
+          description: Scan evaluated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketScanResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Missing mobile surface header or caller is not the event host.
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    TicketId:
+      name: ticketId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    MobileSurface:
+      name: X-Client-Surface
+      in: header
+      required: true
+      schema:
+        type: string
+        enum: [MOBILE]
+  responses:
+    BadRequest:
+      description: Invalid path, query, or JSON body.
+    Unauthorized:
+      description: Missing or invalid bearer token.
+  schemas:
+    TicketStatus:
+      type: string
+      enum: [ACTIVE, PENDING, EXPIRED, USED, CANCELED]
+    ParticipationStatus:
+      type: string
+      enum: [APPROVED, PENDING, CANCELED, LEAVED]
+    EventStatus:
+      type: string
+      enum: [ACTIVE, IN_PROGRESS, COMPLETED, CANCELED]
+    ListTicketsResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TicketListItem'
+    TicketListItem:
+      type: object
+      required: [ticket_id, status, expires_at, event, participation]
+      properties:
+        ticket_id:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/TicketStatus'
+        expires_at:
+          type: string
+          format: date-time
+        event:
+          $ref: '#/components/schemas/TicketEvent'
+        participation:
+          $ref: '#/components/schemas/TicketParticipation'
+    TicketDetailResponse:
+      type: object
+      required: [ticket, participation, event, location, qr_access]
+      properties:
+        ticket:
+          type: object
+          required: [id, status, expires_at, created_at, updated_at]
+          properties:
+            id:
+              type: string
+              format: uuid
+            status:
+              $ref: '#/components/schemas/TicketStatus'
+            expires_at:
+              type: string
+              format: date-time
+            used_at:
+              type: string
+              format: date-time
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+        participation:
+          $ref: '#/components/schemas/TicketParticipation'
+        event:
+          $ref: '#/components/schemas/TicketEvent'
+        location:
+          type: object
+          required: [type, anchor_lat, anchor_lon]
+          properties:
+            type:
+              type: string
+              enum: [POINT, ROUTE]
+            address:
+              type: string
+            anchor_lat:
+              type: number
+            anchor_lon:
+              type: number
+        qr_access:
+          type: object
+          required: [requires_location_permission, requires_proximity, proximity_meters, eligible_now]
+          properties:
+            requires_location_permission:
+              type: boolean
+            requires_proximity:
+              type: boolean
+            proximity_meters:
+              type: number
+              example: 200
+            eligible_now:
+              type: boolean
+            reason:
+              type: string
+              example: PARTICIPATION_PENDING_REAPPROVAL
+    TicketParticipation:
+      type: object
+      required: [id, status]
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/ParticipationStatus'
+    TicketEvent:
+      type: object
+      required: [id, title, status, privacy_level, start_time, location_type]
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        status:
+          $ref: '#/components/schemas/EventStatus'
+        privacy_level:
+          type: string
+          enum: [PROTECTED]
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        location_type:
+          type: string
+          enum: [POINT, ROUTE]
+        address:
+          type: string
+    TicketScanResponse:
+      type: object
+      required: [result]
+      properties:
+        result:
+          type: string
+          enum: [ACCEPTED, REJECTED]
+        reason:
+          type: string
+          enum:
+            - INVALID_TOKEN
+            - TICKET_NOT_FOUND
+            - TICKET_ALREADY_USED
+            - TICKET_NOT_ACTIVE
+            - PARTICIPATION_INVALID
+            - EVENT_INVALID
+            - TOKEN_OLD_VERSION
+            - TOKEN_NOT_LATEST
+            - EVENT_MISMATCH
+            - PARTICIPATION_MISMATCH
+        ticket_id:
+          type: string
+          format: uuid
+        participation_id:
+          type: string
+          format: uuid
+        user_id:
+          type: string
+          format: uuid
+        ticket_status:
+          $ref: '#/components/schemas/TicketStatus'


### PR DESCRIPTION
## 📋 Summary
Implements the backend ticketing flow for protected events end to end. This adds ticket lifecycle management, short-lived QR issuance, host-side ticket scanning, and the supporting API, persistence, and test coverage so protected-event entry can be managed consistently from the backend.

## 🔄 Changes
- Added the ticket domain model and lifecycle statuses: `ACTIVE`, `PENDING`, `EXPIRED`, `USED`, `CANCELED`
- Added a new ticket migration to replace plaintext QR storage with versioned short-lived token support
- Implemented the backend ticket application layer, repository, and JWT-based QR token manager
- Added authenticated ticket endpoints:
  - `GET /me/tickets`
  - `GET /me/tickets/{ticketId}`
  - `GET /me/tickets/{ticketId}/qr-stream`
  - `POST /host/events/{eventId}/ticket-scans`
- Enforced mobile-only QR/scan access with `X-Client-Surface: MOBILE`
- Integrated ticket lifecycle into existing event flows:
  - protected join approval creates an `ACTIVE` ticket
  - leaving an event cancels the linked ticket
  - canceling an event cancels linked tickets
  - completing or auto-completing an event expires unused tickets
- Added OpenAPI documentation for the ticket API
- Added unit, handler, JWT, and integration tests for ticket creation, listing, detail, QR issuance, scan acceptance/rejection, ownership, proximity, cancel, and expiry flows
- Updated the ticket design document to describe the current implemented flow in English

## 🧪 Testing
- Run `go test ./...` from `backend/`
- Run `go test -tags=integration ./tests_integration` from `backend/`
- Run `./shipcheck.sh` from `backend/`

## 🔗 Related
Closes #446
