### PR TITLE
feat(mobile): add push notification integration via firebase

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -13,11 +13,22 @@
         {
           "locationWhenInUsePermission": "Allow Social Event Mapper to access your location so we can suggest nearby events and fill in your current location when you do not have a default location set."
         }
-      ]
+      ],
+      "@react-native-firebase/app",
+      "@react-native-firebase/messaging"
     ],
+    "ios": {
+      "bundleIdentifier": "com.bounswe2026group11.socialeventmapper",
+      "googleServicesFile": "./firebase/GoogleService-Info.plist",
+      "infoPlist": {
+        "UIBackgroundModes": ["remote-notification"]
+      }
+    },
     "android": {
       "package": "com.bounswe2026group11.socialeventmapper",
-      "versionCode": 1
+      "versionCode": 1,
+      "googleServicesFile": "./firebase/google-services.json",
+      "permissions": ["android.permission.POST_NOTIFICATIONS"]
     },
     "experiments": {
       "typedRoutes": true

--- a/mobile/firebase/GoogleService-Info.plist
+++ b/mobile/firebase/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyArBaDqwPeRh2Gs0-DHmj2IK6i1tsNWpAA</string>
+	<key>GCM_SENDER_ID</key>
+	<string>592904673539</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.bounswe2026group11.socialeventmapper</string>
+	<key>PROJECT_ID</key>
+	<string>social-event-mapper-01</string>
+	<key>STORAGE_BUCKET</key>
+	<string>social-event-mapper-01.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:592904673539:ios:4b3a40f59390a799d6b136</string>
+</dict>
+</plist>

--- a/mobile/firebase/google-services.json
+++ b/mobile/firebase/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "592904673539",
+    "project_id": "social-event-mapper-01",
+    "storage_bucket": "social-event-mapper-01.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:592904673539:android:57e37b113e236c59d6b136",
+        "android_client_info": {
+          "package_name": "com.bounswe2026group11.socialeventmapper"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDzLBJA6n1DMofBpZKyuzv0yVvNMibgjvQ"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,3 @@
+// FCM background handler must register before Expo Router initializes.
+import './src/firebase/messagingBootstrap';
+import 'expo-router/entry';

--- a/mobile/jest.config.cjs
+++ b/mobile/jest.config.cjs
@@ -15,6 +15,9 @@ module.exports = {
     '^expo-location$': '<rootDir>/jest/mocks/expo-location.js',
     '^expo-secure-store$': '<rootDir>/jest/mocks/expo-secure-store.js',
     '^react-native-svg$': '<rootDir>/jest/mocks/react-native-svg.js',
+    '^@react-native-firebase/app$': '<rootDir>/jest/mocks/react-native-firebase-app.js',
+    '^@react-native-firebase/messaging$':
+      '<rootDir>/jest/mocks/react-native-firebase-messaging.js',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   clearMocks: true,

--- a/mobile/jest/mocks/react-native-firebase-app.js
+++ b/mobile/jest/mocks/react-native-firebase-app.js
@@ -1,0 +1,9 @@
+/** Jest stub — native Firebase is not available in Node. */
+module.exports = {
+  __esModule: true,
+  default: {
+    app: () => ({
+      name: '[DEFAULT]',
+    }),
+  },
+};

--- a/mobile/jest/mocks/react-native-firebase-messaging.js
+++ b/mobile/jest/mocks/react-native-firebase-messaging.js
@@ -1,0 +1,33 @@
+/** Jest stub for modular `@react-native-firebase/messaging` API. */
+
+const unsub = jest.fn();
+
+const messagingStub = {
+  requestPermission: jest.fn(() => Promise.resolve(1)),
+  getToken: jest.fn(() => Promise.resolve('test-fcm-token')),
+  registerDeviceForRemoteMessages: jest.fn(() => Promise.resolve(undefined)),
+  onTokenRefresh: jest.fn(() => unsub),
+  onMessage: jest.fn(() => unsub),
+  onNotificationOpenedApp: jest.fn(() => unsub),
+  getInitialNotification: jest.fn(() => Promise.resolve(null)),
+};
+
+module.exports = {
+  AuthorizationStatus: {
+    NOT_DETERMINED: -1,
+    DENIED: 0,
+    AUTHORIZED: 1,
+    PROVISIONAL: 2,
+    EPHEMERAL: 3,
+  },
+  getMessaging: jest.fn(() => messagingStub),
+  requestPermission: (messaging) => messaging.requestPermission(),
+  registerDeviceForRemoteMessages: (messaging) =>
+    messaging.registerDeviceForRemoteMessages(),
+  getToken: (messaging) => messaging.getToken(),
+  onTokenRefresh: (messaging, listener) => messaging.onTokenRefresh(listener),
+  onMessage: (messaging, listener) => messaging.onMessage(listener),
+  onNotificationOpenedApp: (messaging, listener) =>
+    messaging.onNotificationOpenedApp(listener),
+  getInitialNotification: (messaging) => messaging.getInitialNotification(),
+};

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@react-native-community/datetimepicker": "^9.1.0",
         "@react-native-community/slider": "5.1.2",
+        "@react-native-firebase/app": "^24.0.0",
+        "@react-native-firebase/messaging": "^24.0.0",
         "expo": "~55.0.8",
         "expo-image-manipulator": "~55.0.13",
         "expo-image-picker": "~55.0.16",
@@ -2251,6 +2253,645 @@
         "excpretty": "build/cli.js"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/@firebase/ai/-/ai-2.9.0.tgz",
+      "integrity": "sha512-NPvBBuvdGo9x3esnABAucFYmqbBmXvyTMimBq2PCuLZbdANZoHzGlx7vfzbwNDaEtCBq4RGGNMliLIv6bZ+PtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.20",
+      "resolved": "https://registry.npmmirror.com/@firebase/analytics/-/analytics-0.10.20.tgz",
+      "integrity": "sha512-adGTNVUWH5q66tI/OQuKLSN6mamPpfYhj0radlH2xt+3eL6NFPtXoOs+ulvs+UsmK27vNFx5FjRDfWk+TyduHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmmirror.com/@firebase/analytics-compat/-/analytics-compat-0.2.26.tgz",
+      "integrity": "sha512-0j2ruLOoVSwwcXAF53AMoniJKnkwiTjGVfic5LDzqiRkR13vb5j6TXMeix787zbLeQtN/m1883Yv1TxI0gItbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.20",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.1",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.9",
+      "resolved": "https://registry.npmmirror.com/@firebase/app/-/app-0.14.9.tgz",
+      "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/app-check/-/app-check-0.11.1.tgz",
+      "integrity": "sha512-gmKfwQ2k8aUQlOyRshc+fOQLq0OwUmibIZvpuY1RDNu2ho0aTMlwxOuEiJeYOs7AxzhSx7gnXPFNsXCFbnvXUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/app-check-compat/-/app-check-compat-0.4.1.tgz",
+      "integrity": "sha512-yjSvSl5B1u4CirnxhzirN1uiTRCRfx+/qtfbyeyI+8Cx8Cw1RWAIO/OqytPSVwLYbJJ1vEC3EHfxazRaMoWKaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.1",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmmirror.com/@firebase/app-compat/-/app-compat-0.5.9.tgz",
+      "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.9",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/auth/-/auth-1.12.1.tgz",
+      "integrity": "sha512-nXKj7d5bMBlnq6XpcQQpmnSVwEeHBkoVbY/+Wk0P1ebLSICoH4XPtvKOFlXKfIHmcS84mLQ99fk3njlDGKSDtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/auth-compat/-/auth-compat-0.6.3.tgz",
+      "integrity": "sha512-nHOkupcYuGVxI1AJJ/OBhLPaRokbP14Gq4nkkoVvf1yvuREEWqdnrYB/CdsSnPxHMAnn5wJIKngxBF9jNX7s/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.12.1",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.1",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmmirror.com/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmmirror.com/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/component/-/component-0.7.1.tgz",
+      "integrity": "sha512-mFzsm7CLHR60o08S23iLUY8m/i6kLpOK87wdEFPLhdlCahaxKmWOwSVGiWoENYSmFJJoDhrR3gKSCxz7ENdIww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/@firebase/data-connect/-/data-connect-0.4.0.tgz",
+      "integrity": "sha512-vLXM6WHNIR3VtEeYNUb/5GTsUOyl3Of4iWNZHBe1i9f88sYFnxybJNWVBjvJ7flhCyF8UdxGpzWcUnv6F5vGfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/database/-/database-1.1.1.tgz",
+      "integrity": "sha512-LwIXe8+mVHY5LBPulWECOOIEXDiatyECp/BOlu0gOhe+WOcKjWHROaCbLlkFTgHMY7RHr5MOxkLP/tltWAH3dA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/database-compat/-/database-compat-2.1.1.tgz",
+      "integrity": "sha512-heAEVZ9Z8c8PnBUcmGh91JHX0cXcVa1yESW/xkLuwaX7idRFyLiN8sl73KXpR8ZArGoPXVQDanBnk6SQiekRCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/database": "1.1.1",
+        "@firebase/database-types": "1.0.17",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmmirror.com/@firebase/database-types/-/database-types-1.0.17.tgz",
+      "integrity": "sha512-4eWaM5fW3qEIHjGzfi3cf0Jpqi1xQsAdT6rSDE1RZPrWu8oGjgrq6ybMjobtyHQFgwGCykBm4YM89qDzc+uG/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.14.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmmirror.com/@firebase/firestore/-/firestore-4.12.0.tgz",
+      "integrity": "sha512-PM47OyiiAAoAMB8kkq4Je14mTciaRoAPDd3ng3Ckqz9i2TX9D9LfxIRcNzP/OxzNV4uBKRq6lXoOggkJBQR3Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "@firebase/webchannel-wrapper": "1.0.5",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmmirror.com/@firebase/firestore-compat/-/firestore-compat-0.4.6.tgz",
+      "integrity": "sha512-NgVyR4hHHN2FvSNQOtbgBOuVsEdD/in30d9FKbEvvITiAChrBN2nBstmhfjI4EOTnHaP8zigwvkNYFI9yKGAkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/firestore": "4.12.0",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmmirror.com/@firebase/functions/-/functions-0.13.2.tgz",
+      "integrity": "sha512-tHduUD+DeokM3NB1QbHCvEMoL16e8Z8JSkmuVA4ROoJKPxHn8ibnecHPO2e3nVCJR1D9OjuKvxz4gksfq92/ZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.1",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmmirror.com/@firebase/functions-compat/-/functions-compat-0.4.2.tgz",
+      "integrity": "sha512-YNxgnezvZDkqxqXa6cT7/oTeD4WXbxgIP7qZp4LFnathQv5o2omM6EoIhXiT9Ie5AoQDcIhG9Y3/dj+DFJGaGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/functions": "0.13.2",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.20",
+      "resolved": "https://registry.npmmirror.com/@firebase/installations/-/installations-0.6.20.tgz",
+      "integrity": "sha512-LOzvR7XHPbhS0YB5ANXhqXB5qZlntPpwU/4KFwhSNpXNsGk/sBQ9g5hepi0y0/MfenJLe2v7t644iGOOElQaHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/util": "1.14.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmmirror.com/@firebase/installations-compat/-/installations-compat-0.2.20.tgz",
+      "integrity": "sha512-9C9pL/DIEGucmoPj8PlZTnztbX3nhNj5RTYVpUM7wQq/UlHywaYv99969JU/WHLvi9ptzIogXYS9d1eZ6XFe9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmmirror.com/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.24",
+      "resolved": "https://registry.npmmirror.com/@firebase/messaging/-/messaging-0.12.24.tgz",
+      "integrity": "sha512-UtKoubegAhHyehcB7iQjvQ8OVITThPbbWk3g2/2ze42PrQr6oe6OmCElYQkBrE5RDCeMTNucXejbdulrQ2XwVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.14.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmmirror.com/@firebase/messaging-compat/-/messaging-compat-0.2.24.tgz",
+      "integrity": "sha512-wXH8FrKbJvFuFe6v98TBhAtvgknxKIZtGM/wCVsfpOGmaAE80bD8tBxztl+uochjnFb9plihkd6mC4y7sZXSpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/messaging": "0.12.24",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmmirror.com/@firebase/performance/-/performance-0.7.10.tgz",
+      "integrity": "sha512-8nRFld+Ntzp5cLKzZuG9g+kBaSn8Ks9dmn87UQGNFDygbmR6ebd8WawauEXiJjMj1n70ypkvAOdE+lzeyfXtGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmmirror.com/@firebase/performance-compat/-/performance-compat-0.2.23.tgz",
+      "integrity": "sha512-c7qOAGBUAOpIuUlHu1axWcrCVtIYKPMhH0lMnoCDWnPwn1HcPuPUBVTWETbC7UWw71RMJF8DpirfWXzMWJQfgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.10",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/remote-config/-/remote-config-0.8.1.tgz",
+      "integrity": "sha512-L86TReBnPiiJOWd7k9iaiE9f7rHtMpjAoYN0fH2ey2ZRzsOChHV0s5sYf1+IIUYzplzsE46pjlmAUNkRRKwHSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/installations": "0.6.20",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmmirror.com/@firebase/remote-config-compat/-/remote-config-compat-0.2.22.tgz",
+      "integrity": "sha512-uW/eNKKtRBot2gnCC5mnoy5Voo2wMzZuQ7dwqqGHU176fO9zFgMwKiRzk+aaC99NLrFk1KOmr0ZVheD+zdJmjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.8.1",
+        "@firebase/remote-config-types": "0.5.0",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmmirror.com/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
+      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/storage/-/storage-0.14.1.tgz",
+      "integrity": "sha512-uIpYgBBsv1vIET+5xV20XT7wwqV+H4GFp6PBzfmLUcEgguS4SWNFof56Z3uOC2lNDh0KDda1UflYq2VwD9Nefw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/@firebase/storage-compat/-/storage-compat-0.4.1.tgz",
+      "integrity": "sha512-bgl3FHHfXAmBgzIK/Fps6Xyv2HiAQlSTov07CBL+RGGhrC5YIk4lruS8JVIC+UkujRdYvnf8cpQFGn2RCilJ/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.1",
+        "@firebase/storage": "0.14.1",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.14.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmmirror.com/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmmirror.com/@firebase/util/-/util-1.14.0.tgz",
+      "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
+      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmmirror.com/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmmirror.com/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3047,6 +3688,70 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -3562,6 +4267,40 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.1.2.tgz",
       "integrity": "sha512-UV/MjCyCtSjS5BQDrrGIMmCXm309xEG6XbR0Dj65kzTraJSVDxSjQS2uBUXgX+5SZUOCzCxzv3OufOZBdtQY4w==",
       "license": "MIT"
+    },
+    "node_modules/@react-native-firebase/app": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmmirror.com/@react-native-firebase/app/-/app-24.0.0.tgz",
+      "integrity": "sha512-rLWNd8/4FjKYV7PeDR9uiT5vwYWdJ7dJ1yiIIaZ/eL+Y56Ij2iXbqRCUu4zWkvu/ZrJfaGOyT12Vhy1SLy0NMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "firebase": "12.10.0"
+      },
+      "peerDependencies": {
+        "expo": ">=47.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native-firebase/messaging": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmmirror.com/@react-native-firebase/messaging/-/messaging-24.0.0.tgz",
+      "integrity": "sha512-rODaV83e8mR+Y9EPDblfSpy4rM+alriiq5306RyzPryhsyu+guj4fhGwZpESWwhmk9fKjsnshv++aFA50xFjhg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@react-native-firebase/app": "24.0.0",
+        "expo": ">=47.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.83.2",
@@ -6525,6 +7264,18 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmmirror.com/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
@@ -6617,6 +7368,42 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmmirror.com/firebase/-/firebase-12.10.0.tgz",
+      "integrity": "sha512-tAjHnEirksqWpa+NKDUSUMjulOnsTcsPC1X1rQ+gwPtjlhJS572na91CwaBXQJHXharIrfj7sw/okDkXOsphjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.9.0",
+        "@firebase/analytics": "0.10.20",
+        "@firebase/analytics-compat": "0.2.26",
+        "@firebase/app": "0.14.9",
+        "@firebase/app-check": "0.11.1",
+        "@firebase/app-check-compat": "0.4.1",
+        "@firebase/app-compat": "0.5.9",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.12.1",
+        "@firebase/auth-compat": "0.6.3",
+        "@firebase/data-connect": "0.4.0",
+        "@firebase/database": "1.1.1",
+        "@firebase/database-compat": "2.1.1",
+        "@firebase/firestore": "4.12.0",
+        "@firebase/firestore-compat": "0.4.6",
+        "@firebase/functions": "0.13.2",
+        "@firebase/functions-compat": "0.4.2",
+        "@firebase/installations": "0.6.20",
+        "@firebase/installations-compat": "0.2.20",
+        "@firebase/messaging": "0.12.24",
+        "@firebase/messaging-compat": "0.2.24",
+        "@firebase/performance": "0.7.10",
+        "@firebase/performance-compat": "0.2.23",
+        "@firebase/remote-config": "0.8.1",
+        "@firebase/remote-config-compat": "0.2.22",
+        "@firebase/storage": "0.14.1",
+        "@firebase/storage-compat": "0.4.1",
+        "@firebase/util": "1.14.0"
       }
     },
     "node_modules/flow-enums-runtime": {
@@ -6921,6 +7708,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmmirror.com/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6970,6 +7763,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -8797,6 +9596,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -8898,6 +9703,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -10419,6 +11230,30 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {
@@ -12718,6 +13553,12 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmmirror.com/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -12726,6 +13567,29 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmmirror.com/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmmirror.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "social-event-mapper",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
@@ -12,6 +12,8 @@
   "dependencies": {
     "@react-native-community/datetimepicker": "^9.1.0",
     "@react-native-community/slider": "5.1.2",
+    "@react-native-firebase/app": "^24.0.0",
+    "@react-native-firebase/messaging": "^24.0.0",
     "expo": "~55.0.8",
     "expo-image-manipulator": "~55.0.13",
     "expo-image-picker": "~55.0.16",

--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -1,3 +1,6 @@
+import '@/firebase/appFirebase';
+
+import { PushMessagingHost } from '@/components/common/PushMessagingHost';
 import { Stack, router, usePathname, type Href } from 'expo-router';
 import { useEffect } from 'react';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
@@ -33,6 +36,7 @@ function AppStack() {
 export default function RootLayout() {
   return (
     <AuthProvider>
+      <PushMessagingHost />
       <AppStack />
     </AuthProvider>
   );

--- a/mobile/src/components/common/PushMessagingHost.tsx
+++ b/mobile/src/components/common/PushMessagingHost.tsx
@@ -1,0 +1,17 @@
+import { usePushMessaging } from '@/firebase/usePushMessaging';
+
+/** Mount once under providers to enable FCM token + foreground alerts. */
+export function PushMessagingHost() {
+  usePushMessaging(
+    __DEV__
+      ? {
+          onFcmToken: (token) => {
+            console.log('[FCM] (prefix for quick scan)', `${token.slice(0, 40)}…`);
+            console.log('[FCM token — copy full line for Firebase test]', token);
+          },
+        }
+      : undefined,
+  );
+
+  return null;
+}

--- a/mobile/src/firebase/appFirebase.ts
+++ b/mobile/src/firebase/appFirebase.ts
@@ -1,0 +1,11 @@
+/**
+ * Firebase App (native) — requires `firebase/google-services.json` and
+ * `firebase/GoogleService-Info.plist` from the Firebase Console (see mobile/app.json).
+ */
+import firebase from '@react-native-firebase/app';
+
+export type { FirebaseApp } from '@react-native-firebase/app';
+
+export function getFirebaseApp() {
+  return firebase.app();
+}

--- a/mobile/src/firebase/messagingBootstrap.js
+++ b/mobile/src/firebase/messagingBootstrap.js
@@ -1,0 +1,2 @@
+/** Default shim; overridden by `.native.*` / `.web.*`. */
+export {};

--- a/mobile/src/firebase/messagingBootstrap.native.js
+++ b/mobile/src/firebase/messagingBootstrap.native.js
@@ -1,0 +1,4 @@
+import { getMessaging, setBackgroundMessageHandler } from '@react-native-firebase/messaging';
+
+/** Must stay fast; invoked in a headless context on Android. */
+setBackgroundMessageHandler(getMessaging(), async () => {});

--- a/mobile/src/firebase/messagingBootstrap.web.js
+++ b/mobile/src/firebase/messagingBootstrap.web.js
@@ -1,0 +1,2 @@
+/** No-op on web; native uses `messagingBootstrap.native.js`. */
+export {};

--- a/mobile/src/firebase/usePushMessaging.ts
+++ b/mobile/src/firebase/usePushMessaging.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react';
+import { Alert, PermissionsAndroid, Platform } from 'react-native';
+import {
+  AuthorizationStatus,
+  getInitialNotification,
+  getMessaging,
+  getToken,
+  onMessage,
+  onNotificationOpenedApp,
+  onTokenRefresh,
+  registerDeviceForRemoteMessages,
+  requestPermission,
+} from '@react-native-firebase/messaging';
+
+async function ensureAndroidPostNotificationsPermission(): Promise<boolean> {
+  if (Platform.OS !== 'android' || Platform.Version < 33) {
+    return true;
+  }
+  const result = await PermissionsAndroid.request(
+    PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+  );
+  return result === PermissionsAndroid.RESULTS.GRANTED;
+}
+
+export type PushMessagingOptions = {
+  /** Called whenever an FCM token is acquired or rotated (send this to your server). */
+  onFcmToken?: (token: string) => void;
+};
+
+/** Registers foreground listeners and requests permission + token. Not used on web. */
+export function usePushMessaging(options?: PushMessagingOptions) {
+  const onFcmTokenRef = useRef(options?.onFcmToken);
+  useEffect(() => {
+    onFcmTokenRef.current = options?.onFcmToken;
+  }, [options?.onFcmToken]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+      return undefined;
+    }
+
+    const unsubscribers: Array<() => void> = [];
+
+    (async () => {
+      const messaging = getMessaging();
+
+      const notificationsOk = await ensureAndroidPostNotificationsPermission();
+      if (!notificationsOk) {
+        return;
+      }
+
+      const status = await requestPermission(messaging);
+      const notificationsAllowed =
+        status === AuthorizationStatus.AUTHORIZED ||
+        status === AuthorizationStatus.PROVISIONAL ||
+        status === AuthorizationStatus.EPHEMERAL;
+
+      if (!notificationsAllowed) {
+        return;
+      }
+
+      if (Platform.OS === 'ios') {
+        await registerDeviceForRemoteMessages(messaging);
+      }
+
+      const pushTokenToServer = async () => {
+        const token = await getToken(messaging);
+        onFcmTokenRef.current?.(token);
+      };
+
+      await pushTokenToServer();
+
+      unsubscribers.push(onTokenRefresh(messaging, () => pushTokenToServer()));
+
+      unsubscribers.push(
+        onMessage(messaging, (remoteMessage) => {
+          const title = remoteMessage.notification?.title ?? 'Notification';
+          const body = remoteMessage.notification?.body;
+          if (body) {
+            Alert.alert(title, body);
+          }
+        }),
+      );
+
+      unsubscribers.push(onNotificationOpenedApp(messaging, () => {}));
+
+      await getInitialNotification(messaging);
+    })();
+
+    return () => unsubscribers.forEach((u) => u());
+  }, []);
+}


### PR DESCRIPTION
## 📋 Summary

Adds **Firebase** (native `@react-native-firebase/app`) and **Firebase Cloud Messaging (push)** support to the Expo-based mobile app. Includes FCM background handler wiring, permission/token flow, foreground notification handling (Alert), Jest mocks, and logging of the **full FCM token** in dev for Firebase Console test sends.

## 🔄 Changes

- Adds `@react-native-firebase/app` and `@react-native-firebase/messaging`; updates `app.json` with Firebase **config plugins**, Android **`POST_NOTIFICATIONS`**, iOS **`UIBackgroundModes` → `remote-notification`**, and paths to **`google-services.json`** / **`GoogleService-Info.plist`**.
- Root **`index.js`**: imports `messagingBootstrap` first (`.native` / `.web`), then **`expo-router/entry`**; **`package.json`** `"main"` set to **`index.js`**.
- **`src/firebase/`**: `appFirebase.ts`, `messagingBootstrap.*`, **`usePushMessaging`** (permissions, token, `onMessage`, `onTokenRefresh`, etc.), **`PushMessagingHost`** mounted in **`_layout.tsx`**.
- **`mobile/firebase/`**: config files wired to Expo/plugin paths (real values come from Firebase Console).
- Jest mocks for **`@react-native-firebase/app`** and **`@react-native-firebase/messaging`** plus **`moduleNameMapper`** updates.

## 🧪 Testing

- Ran `cd mobile && npm test` and `npx tsc --noEmit`.
- Android emulator: granted notification permission, sent a test notification from Firebase Console; verified token via Metro / `adb logcat` (**`[FCM token — copy full line for Firebase test]`** line).
- Requires a native dev build (not Expo Go): `expo run:android` / `expo run:ios` (and `prebuild` if needed).

## 🔗 Related

Closes #514