### PR TITLE
feat(backend): implement in-app notification system

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -41,6 +41,7 @@ func main() {
 	defer container.Close()
 
 	container.StartEventExpiryJob(ctx, 1*time.Minute)
+	container.StartNotificationRetentionJob(ctx, 24*time.Hour)
 
 	app := server.NewHTTP(container)
 	addr := fmt.Sprintf(":%d", container.Config.AppPort)

--- a/backend/internal/adapter/in/firebasepush/provider.go
+++ b/backend/internal/adapter/in/firebasepush/provider.go
@@ -98,14 +98,19 @@ func (s *Sender) Send(ctx context.Context, message notificationapp.PushSendMessa
 		data["deep_link"] = strings.TrimSpace(*message.DeepLink)
 	}
 
+	notificationPayload := map[string]string{
+		"title": message.Title,
+		"body":  message.Body,
+	}
+	if message.ImageURL != nil && strings.TrimSpace(*message.ImageURL) != "" {
+		notificationPayload["image"] = strings.TrimSpace(*message.ImageURL)
+	}
+
 	payload := map[string]any{
 		"message": map[string]any{
-			"token": message.Token,
-			"notification": map[string]string{
-				"title": message.Title,
-				"body":  message.Body,
-			},
-			"data": data,
+			"token":        message.Token,
+			"notification": notificationPayload,
+			"data":         data,
 		},
 	}
 	body, err := json.Marshal(payload)

--- a/backend/internal/adapter/in/postgres/notification_repo.go
+++ b/backend/internal/adapter/in/postgres/notification_repo.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -183,23 +184,197 @@ func (r *NotificationRepository) ListActiveDevicesForUsers(ctx context.Context, 
 	return devices, nil
 }
 
-func (r *NotificationRepository) CreateNotification(ctx context.Context, params notificationapp.CreateNotificationParams) error {
+func (r *NotificationRepository) CreateNotificationIfAbsent(ctx context.Context, params notificationapp.CreateNotificationParams) (*notificationapp.CreateNotificationResult, error) {
+	data, err := marshalNotificationData(params.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	var created bool
+	notification, err := scanNotificationWithCreated(r.db.QueryRow(ctx, `
+		WITH inserted AS (
+			INSERT INTO notification (
+				event_id,
+				receiver_user_id,
+				title,
+				type,
+				body,
+				is_read,
+				deep_link,
+				image_url,
+				data,
+				idempotency_key,
+				read_at,
+				deleted_at,
+				created_at,
+				updated_at
+			)
+			VALUES ($1, $2, $3, $4, $5, FALSE, $6, $7, $8, $9, NULL, NULL, $10, $10)
+			ON CONFLICT (receiver_user_id, idempotency_key) DO NOTHING
+			RETURNING id, event_id, receiver_user_id, title, type, body, is_read, read_at, deleted_at,
+				deep_link, image_url, data, idempotency_key, created_at, updated_at, TRUE AS created
+		)
+		SELECT id, event_id, receiver_user_id, title, type, body, is_read, read_at, deleted_at,
+			deep_link, image_url, data, idempotency_key, created_at, updated_at, created
+		FROM inserted
+		UNION ALL
+		SELECT id, event_id, receiver_user_id, title, type, body, is_read, read_at, deleted_at,
+			deep_link, image_url, data, idempotency_key, created_at, updated_at, FALSE AS created
+		FROM notification
+		WHERE receiver_user_id = $2
+		  AND idempotency_key = $9
+		LIMIT 1
+	`, params.EventID, params.UserID, params.Title, params.Type, params.Body, params.DeepLink, params.ImageURL, data, params.IdempotencyKey, params.CreatedAt), &created)
+	if err != nil {
+		return nil, fmt.Errorf("insert notification: %w", err)
+	}
+	return &notificationapp.CreateNotificationResult{Notification: *notification, Created: created}, nil
+}
+
+func (r *NotificationRepository) ListNotifications(ctx context.Context, params notificationapp.ListNotificationsParams) ([]domain.Notification, error) {
+	var (
+		cursorCreatedAt *time.Time
+		cursorID        *uuid.UUID
+	)
+	if params.DecodedCursor != nil {
+		cursorCreatedAt = &params.DecodedCursor.CreatedAt
+		cursorID = &params.DecodedCursor.NotificationID
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT id, event_id, receiver_user_id, title, type, body, is_read, read_at, deleted_at,
+			deep_link, image_url, data, idempotency_key, created_at, updated_at
+		FROM notification
+		WHERE receiver_user_id = $1
+		  AND deleted_at IS NULL
+		  AND created_at >= $2
+		  AND ($4 = FALSE OR is_read = FALSE)
+		  AND ($5::timestamptz IS NULL OR (created_at, id) < ($5::timestamptz, $6::uuid))
+		ORDER BY created_at DESC, id DESC
+		LIMIT $3
+	`, params.UserID, params.VisibleAfter, params.RepositoryFetchLimit, params.OnlyUnread, cursorCreatedAt, cursorID)
+	if err != nil {
+		return nil, fmt.Errorf("list notifications: %w", err)
+	}
+	defer rows.Close()
+
+	notifications := []domain.Notification{}
+	for rows.Next() {
+		notification, err := scanNotification(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan notification: %w", err)
+		}
+		notifications = append(notifications, *notification)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate notifications: %w", err)
+	}
+	return notifications, nil
+}
+
+func (r *NotificationRepository) CountUnreadNotifications(ctx context.Context, userID uuid.UUID, visibleAfter time.Time) (int, error) {
+	var count int
+	if err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM notification
+		WHERE receiver_user_id = $1
+		  AND deleted_at IS NULL
+		  AND is_read = FALSE
+		  AND created_at >= $2
+	`, userID, visibleAfter).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count unread notifications: %w", err)
+	}
+	return count, nil
+}
+
+func (r *NotificationRepository) MarkNotificationRead(ctx context.Context, userID, notificationID uuid.UUID, readAt, visibleAfter time.Time) (bool, error) {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE notification
+		SET is_read = TRUE,
+		    read_at = COALESCE(read_at, $3),
+		    updated_at = $3
+		WHERE receiver_user_id = $1
+		  AND id = $2
+		  AND deleted_at IS NULL
+		  AND created_at >= $4
+	`, userID, notificationID, readAt, visibleAfter)
+	if err != nil {
+		return false, fmt.Errorf("mark notification read: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (r *NotificationRepository) MarkAllNotificationsRead(ctx context.Context, userID uuid.UUID, readAt, visibleAfter time.Time) (int, error) {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE notification
+		SET is_read = TRUE,
+		    read_at = COALESCE(read_at, $2),
+		    updated_at = $2
+		WHERE receiver_user_id = $1
+		  AND deleted_at IS NULL
+		  AND is_read = FALSE
+		  AND created_at >= $3
+	`, userID, readAt, visibleAfter)
+	if err != nil {
+		return 0, fmt.Errorf("mark all notifications read: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+func (r *NotificationRepository) SoftDeleteNotification(ctx context.Context, userID, notificationID uuid.UUID, deletedAt, visibleAfter time.Time) error {
 	if _, err := r.db.Exec(ctx, `
-		INSERT INTO notification (
-			event_id,
+		UPDATE notification
+		SET deleted_at = COALESCE(deleted_at, $3),
+		    updated_at = $3
+		WHERE receiver_user_id = $1
+		  AND id = $2
+		  AND deleted_at IS NULL
+		  AND created_at >= $4
+	`, userID, notificationID, deletedAt, visibleAfter); err != nil {
+		return fmt.Errorf("soft delete notification: %w", err)
+	}
+	return nil
+}
+
+func (r *NotificationRepository) SoftDeleteAllNotifications(ctx context.Context, userID uuid.UUID, deletedAt, visibleAfter time.Time) error {
+	if _, err := r.db.Exec(ctx, `
+		UPDATE notification
+		SET deleted_at = COALESCE(deleted_at, $2),
+		    updated_at = $2
+		WHERE receiver_user_id = $1
+		  AND deleted_at IS NULL
+		  AND created_at >= $3
+	`, userID, deletedAt, visibleAfter); err != nil {
+		return fmt.Errorf("soft delete all notifications: %w", err)
+	}
+	return nil
+}
+
+func (r *NotificationRepository) DeleteExpiredNotifications(ctx context.Context, cutoff time.Time) (int, error) {
+	tag, err := r.db.Exec(ctx, `
+		DELETE FROM notification
+		WHERE created_at < $1
+	`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("delete expired notifications: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+func (r *NotificationRepository) CreateDeliveryAttempt(ctx context.Context, params notificationapp.CreateDeliveryAttemptParams) error {
+	if _, err := r.db.Exec(ctx, `
+		INSERT INTO notification_delivery_attempt (
+			notification_id,
 			receiver_user_id,
-			title,
-			type,
-			body,
-			is_read,
-			deep_link,
-			delivery_method,
+			method,
 			status,
+			push_device_id,
+			error_summary,
 			sent_at
 		)
-		VALUES ($1, $2, $3, $4, $5, FALSE, $6, $7, $8, $9)
-	`, params.EventID, params.UserID, params.Title, params.Type, params.Body, params.DeepLink, params.DeliveryMethod, params.Status, params.SentAt); err != nil {
-		return fmt.Errorf("insert notification: %w", err)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, params.NotificationID, params.UserID, params.Method, params.Status, params.PushDeviceID, params.ErrorSummary, params.SentAt); err != nil {
+		return fmt.Errorf("insert notification delivery attempt: %w", err)
 	}
 	return nil
 }
@@ -238,6 +413,78 @@ func scanPushDevice(row pgx.Row) (*domain.PushDevice, error) {
 	device.DeviceInfo = textPtr(deviceInfo)
 	device.RevokedAt = timestamptzPtr(revokedAt)
 	return &device, nil
+}
+
+func scanNotification(row pgx.Row) (*domain.Notification, error) {
+	return scanNotificationWithCreated(row, nil)
+}
+
+func scanNotificationWithCreated(row pgx.Row, created *bool) (*domain.Notification, error) {
+	var (
+		notification domain.Notification
+		eventID      pgtype.UUID
+		typ          pgtype.Text
+		readAt       pgtype.Timestamptz
+		deletedAt    pgtype.Timestamptz
+		deepLink     pgtype.Text
+		imageURL     pgtype.Text
+		data         []byte
+	)
+
+	dest := []any{
+		&notification.ID,
+		&eventID,
+		&notification.ReceiverUserID,
+		&notification.Title,
+		&typ,
+		&notification.Body,
+		&notification.IsRead,
+		&readAt,
+		&deletedAt,
+		&deepLink,
+		&imageURL,
+		&data,
+		&notification.IdempotencyKey,
+		&notification.CreatedAt,
+		&notification.UpdatedAt,
+	}
+	if created != nil {
+		dest = append(dest, created)
+	}
+	if err := row.Scan(dest...); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+
+	notification.EventID = uuidPtr(eventID)
+	notification.Type = textPtr(typ)
+	notification.ReadAt = timestamptzPtr(readAt)
+	notification.DeletedAt = timestamptzPtr(deletedAt)
+	notification.DeepLink = textPtr(deepLink)
+	notification.ImageURL = textPtr(imageURL)
+	notification.Data = map[string]string{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &notification.Data); err != nil {
+			return nil, fmt.Errorf("unmarshal notification data: %w", err)
+		}
+	}
+	if notification.Data == nil {
+		notification.Data = map[string]string{}
+	}
+	return &notification, nil
+}
+
+func marshalNotificationData(data map[string]string) ([]byte, error) {
+	if data == nil {
+		data = map[string]string{}
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal notification data: %w", err)
+	}
+	return raw, nil
 }
 
 var _ notificationapp.Repository = (*NotificationRepository)(nil)

--- a/backend/internal/adapter/out/httpapi/notification_handler/dto.go
+++ b/backend/internal/adapter/out/httpapi/notification_handler/dto.go
@@ -14,3 +14,35 @@ type registerPushDeviceResponse struct {
 	ActiveDeviceCount int       `json:"active_device_count"`
 	UpdatedAt         time.Time `json:"updated_at"`
 }
+
+type notificationResponse struct {
+	ID        string            `json:"id"`
+	EventID   *string           `json:"event_id"`
+	Title     string            `json:"title"`
+	Body      string            `json:"body"`
+	Type      *string           `json:"type"`
+	DeepLink  *string           `json:"deep_link"`
+	ImageURL  *string           `json:"image_url"`
+	Data      map[string]string `json:"data"`
+	IsRead    bool              `json:"is_read"`
+	ReadAt    *time.Time        `json:"read_at"`
+	CreatedAt time.Time         `json:"created_at"`
+}
+
+type listNotificationsResponse struct {
+	Items    []notificationResponse `json:"items"`
+	PageInfo notificationPageInfo   `json:"page_info"`
+}
+
+type notificationPageInfo struct {
+	NextCursor *string `json:"next_cursor"`
+	HasNext    bool    `json:"has_next"`
+}
+
+type unreadCountResponse struct {
+	UnreadCount int `json:"unread_count"`
+}
+
+type markAllReadResponse struct {
+	UpdatedCount int `json:"updated_count"`
+}

--- a/backend/internal/adapter/out/httpapi/notification_handler/notification_handler.go
+++ b/backend/internal/adapter/out/httpapi/notification_handler/notification_handler.go
@@ -1,7 +1,13 @@
 package notification_handler
 
 import (
+	"bufio"
+	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
 	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
@@ -12,17 +18,30 @@ import (
 
 // Handler groups HTTP handlers that delegate to the notification use case.
 type Handler struct {
-	service notificationapp.UseCase
+	service  notificationapp.UseCase
+	realtime notificationapp.RealtimeBroker
 }
 
-func NewHandler(service notificationapp.UseCase) *Handler {
-	return &Handler{service: service}
+func NewHandler(service notificationapp.UseCase, realtime ...notificationapp.RealtimeBroker) *Handler {
+	handler := &Handler{service: service}
+	if len(realtime) > 0 {
+		handler.realtime = realtime[0]
+	}
+	return handler
 }
 
 func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler) {
 	me := router.Group("/me", auth)
 	me.Put("/push-devices/:installation_id", handler.RegisterPushDevice)
 	me.Delete("/push-devices/:installation_id", handler.UnregisterPushDevice)
+	me.Get("/notifications/stream", handler.StreamNotifications)
+	me.Get("/notifications/unread", handler.ListUnreadNotifications)
+	me.Get("/notifications/unread-count", handler.GetUnreadNotificationCount)
+	me.Patch("/notifications/read", handler.MarkAllNotificationsRead)
+	me.Get("/notifications", handler.ListNotifications)
+	me.Patch("/notifications/:notification_id/read", handler.MarkNotificationRead)
+	me.Delete("/notifications/:notification_id", handler.DeleteNotification)
+	me.Delete("/notifications", handler.DeleteAllNotifications)
 }
 
 // RegisterPushDevice handles PUT /me/push-devices/:installation_id.
@@ -89,12 +108,168 @@ func (h *Handler) UnregisterPushDevice(c *fiber.Ctx) error {
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
+// ListNotifications handles GET /me/notifications.
+func (h *Handler) ListNotifications(c *fiber.Ctx) error {
+	return h.listNotifications(c, false)
+}
+
+// ListUnreadNotifications handles GET /me/notifications/unread.
+func (h *Handler) ListUnreadNotifications(c *fiber.Ctx) error {
+	return h.listNotifications(c, true)
+}
+
+func (h *Handler) listNotifications(c *fiber.Ctx, onlyUnread bool) error {
+	input, err := parseListNotificationsInput(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	input.UserID = httpapi.UserClaims(c).UserID
+	input.OnlyUnread = onlyUnread
+
+	result, err := h.service.ListNotifications(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	return c.JSON(toListNotificationsResponse(result))
+}
+
+// GetUnreadNotificationCount handles GET /me/notifications/unread-count.
+func (h *Handler) GetUnreadNotificationCount(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.CountUnreadNotifications(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(unreadCountResponse{UnreadCount: result.UnreadCount})
+}
+
+// MarkNotificationRead handles PATCH /me/notifications/:notification_id/read.
+func (h *Handler) MarkNotificationRead(c *fiber.Ctx) error {
+	notificationID, err := parseNotificationID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	if err := h.service.MarkNotificationRead(c.UserContext(), claims.UserID, notificationID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// MarkAllNotificationsRead handles PATCH /me/notifications/read.
+func (h *Handler) MarkAllNotificationsRead(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.MarkAllNotificationsRead(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(markAllReadResponse{UpdatedCount: result.UpdatedCount})
+}
+
+// DeleteNotification handles DELETE /me/notifications/:notification_id.
+func (h *Handler) DeleteNotification(c *fiber.Ctx) error {
+	notificationID, err := parseNotificationID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	if err := h.service.DeleteNotification(c.UserContext(), claims.UserID, notificationID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// DeleteAllNotifications handles DELETE /me/notifications.
+func (h *Handler) DeleteAllNotifications(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	if err := h.service.DeleteAllNotifications(c.UserContext(), claims.UserID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// StreamNotifications handles GET /me/notifications/stream.
+func (h *Handler) StreamNotifications(c *fiber.Ctx) error {
+	if h.realtime == nil {
+		return httpapi.WriteError(c, fmt.Errorf("notification realtime broker is not configured"))
+	}
+
+	claims := httpapi.UserClaims(c)
+	sub := h.realtime.Subscribe(claims.UserID)
+	if sub == nil {
+		return httpapi.WriteError(c, fmt.Errorf("notification realtime broker is not configured"))
+	}
+
+	c.Set(fiber.HeaderContentType, "text/event-stream")
+	c.Set(fiber.HeaderCacheControl, "no-cache")
+	c.Set(fiber.HeaderConnection, "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
+
+	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer sub.Cancel()
+		ticker := time.NewTicker(20 * time.Second)
+		defer ticker.Stop()
+
+		if !writeSSE(w, "heartbeat", "", []byte("{}")) {
+			return
+		}
+
+		for {
+			select {
+			case notification, ok := <-sub.Events:
+				if !ok {
+					return
+				}
+				payload, err := json.Marshal(toNotificationResponse(notification))
+				if err != nil {
+					return
+				}
+				if !writeSSE(w, "notification", notification.ID.String(), payload) {
+					return
+				}
+			case <-ticker.C:
+				if !writeSSE(w, "heartbeat", "", []byte("{}")) {
+					return
+				}
+			}
+		}
+	})
+
+	return nil
+}
+
 func parseInstallationID(c *fiber.Ctx) (uuid.UUID, error) {
 	installationID, err := uuid.Parse(c.Params("installation_id"))
 	if err != nil {
 		return uuid.Nil, domain.ValidationError(map[string]string{"installation_id": "must be a valid UUID"})
 	}
 	return installationID, nil
+}
+
+func parseNotificationID(c *fiber.Ctx) (uuid.UUID, error) {
+	notificationID, err := uuid.Parse(c.Params("notification_id"))
+	if err != nil {
+		return uuid.Nil, domain.ValidationError(map[string]string{"notification_id": "must be a valid UUID"})
+	}
+	return notificationID, nil
+}
+
+func parseListNotificationsInput(c *fiber.Ctx) (notificationapp.ListNotificationsInput, error) {
+	input := notificationapp.ListNotificationsInput{}
+	if rawLimit := strings.TrimSpace(c.Query("limit")); rawLimit != "" {
+		limit, err := strconv.Atoi(rawLimit)
+		if err != nil {
+			return input, domain.ValidationError(map[string]string{"limit": "must be an integer"})
+		}
+		input.Limit = &limit
+	}
+	if rawCursor := strings.TrimSpace(c.Query("cursor")); rawCursor != "" {
+		input.Cursor = &rawCursor
+	}
+	return input, nil
 }
 
 func toRegisterDeviceInput(body registerPushDeviceBody) (notificationapp.RegisterDeviceInput, map[string]string) {
@@ -111,4 +286,58 @@ func toRegisterDeviceInput(body registerPushDeviceBody) (notificationapp.Registe
 		input.Platform = *body.Platform
 	}
 	return input, errs
+}
+
+func toListNotificationsResponse(result *notificationapp.ListNotificationsResult) listNotificationsResponse {
+	items := make([]notificationResponse, len(result.Items))
+	for i, notification := range result.Items {
+		items[i] = toNotificationResponse(notification)
+	}
+	return listNotificationsResponse{
+		Items: items,
+		PageInfo: notificationPageInfo{
+			NextCursor: result.PageInfo.NextCursor,
+			HasNext:    result.PageInfo.HasNext,
+		},
+	}
+}
+
+func toNotificationResponse(notification domain.Notification) notificationResponse {
+	var eventID *string
+	if notification.EventID != nil {
+		value := notification.EventID.String()
+		eventID = &value
+	}
+	data := notification.Data
+	if data == nil {
+		data = map[string]string{}
+	}
+	return notificationResponse{
+		ID:        notification.ID.String(),
+		EventID:   eventID,
+		Title:     notification.Title,
+		Body:      notification.Body,
+		Type:      notification.Type,
+		DeepLink:  notification.DeepLink,
+		ImageURL:  notification.ImageURL,
+		Data:      data,
+		IsRead:    notification.IsRead,
+		ReadAt:    notification.ReadAt,
+		CreatedAt: notification.CreatedAt,
+	}
+}
+
+func writeSSE(w *bufio.Writer, event, id string, data []byte) bool {
+	if id != "" {
+		if _, err := fmt.Fprintf(w, "id: %s\n", id); err != nil {
+			return false
+		}
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\n", event); err != nil {
+		return false
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+		return false
+	}
+	return w.Flush() == nil
 }

--- a/backend/internal/adapter/out/httpapi/notification_handler/notification_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/notification_handler/notification_handler_test.go
@@ -3,6 +3,7 @@ package notification_handler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -88,10 +89,93 @@ func TestUnregisterPushDeviceRequiresAuthentication(t *testing.T) {
 	}
 }
 
+func TestListNotificationsParsesPagination(t *testing.T) {
+	// given
+	service := &stubNotificationService{}
+	app := newNotificationTestApp(service, authedNotificationVerifier())
+	req := httptest.NewRequest(fiber.MethodGet, "/me/notifications?limit=10&cursor=test-cursor", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if service.listCallCount != 1 {
+		t.Fatalf("expected list to be called once, got %d", service.listCallCount)
+	}
+	if service.lastListInput.Limit == nil || *service.lastListInput.Limit != 10 {
+		t.Fatalf("expected limit 10, got %+v", service.lastListInput.Limit)
+	}
+	if service.lastListInput.Cursor == nil || *service.lastListInput.Cursor != "test-cursor" {
+		t.Fatalf("expected cursor to be forwarded, got %+v", service.lastListInput.Cursor)
+	}
+}
+
+func TestGetUnreadNotificationCountReturnsCount(t *testing.T) {
+	// given
+	service := &stubNotificationService{unreadCount: 3}
+	app := newNotificationTestApp(service, authedNotificationVerifier())
+	req := httptest.NewRequest(fiber.MethodGet, "/me/notifications/unread-count", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	var body unreadCountResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response error = %v", err)
+	}
+	if body.UnreadCount != 3 {
+		t.Fatalf("expected unread count 3, got %d", body.UnreadCount)
+	}
+}
+
+func TestMarkNotificationReadRejectsInvalidNotificationID(t *testing.T) {
+	// given
+	service := &stubNotificationService{}
+	app := newNotificationTestApp(service, authedNotificationVerifier())
+	req := httptest.NewRequest(fiber.MethodPatch, "/me/notifications/not-a-uuid/read", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+	if service.markReadCallCount != 0 {
+		t.Fatalf("expected mark read not to be called, got %d", service.markReadCallCount)
+	}
+}
+
 type stubNotificationService struct {
 	registerCallCount    int
 	unregisterCallCount  int
+	listCallCount        int
+	markReadCallCount    int
+	unreadCount          int
 	lastRegisterInput    notificationapp.RegisterDeviceInput
+	lastListInput        notificationapp.ListNotificationsInput
 	lastUnregisterUserID uuid.UUID
 	lastUnregisterID     uuid.UUID
 }
@@ -112,6 +196,53 @@ func (s *stubNotificationService) UnregisterDevice(_ context.Context, userID, in
 	s.lastUnregisterUserID = userID
 	s.lastUnregisterID = installationID
 	return nil
+}
+
+func (s *stubNotificationService) ListNotifications(_ context.Context, input notificationapp.ListNotificationsInput) (*notificationapp.ListNotificationsResult, error) {
+	s.listCallCount++
+	s.lastListInput = input
+	return &notificationapp.ListNotificationsResult{
+		Items: []domain.Notification{
+			{
+				ID:             uuid.New(),
+				ReceiverUserID: input.UserID,
+				Title:          "Event update",
+				Body:           "A new update is available.",
+				Data:           map[string]string{},
+				CreatedAt:      time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+			},
+		},
+		PageInfo: notificationapp.NotificationPageInfo{HasNext: false},
+	}, nil
+}
+
+func (s *stubNotificationService) CountUnreadNotifications(_ context.Context, _ uuid.UUID) (*notificationapp.UnreadCountResult, error) {
+	return &notificationapp.UnreadCountResult{UnreadCount: s.unreadCount}, nil
+}
+
+func (s *stubNotificationService) MarkNotificationRead(_ context.Context, _, _ uuid.UUID) error {
+	s.markReadCallCount++
+	return nil
+}
+
+func (s *stubNotificationService) MarkAllNotificationsRead(_ context.Context, _ uuid.UUID) (*notificationapp.MarkAllReadResult, error) {
+	return &notificationapp.MarkAllReadResult{UpdatedCount: 1}, nil
+}
+
+func (s *stubNotificationService) DeleteNotification(_ context.Context, _, _ uuid.UUID) error {
+	return nil
+}
+
+func (s *stubNotificationService) DeleteAllNotifications(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+func (s *stubNotificationService) DeleteExpiredNotifications(_ context.Context) (int, error) {
+	return 0, nil
+}
+
+func (s *stubNotificationService) SendNotificationToUsers(_ context.Context, _ notificationapp.SendNotificationInput) (*notificationapp.SendNotificationResult, error) {
+	return &notificationapp.SendNotificationResult{}, nil
 }
 
 func (s *stubNotificationService) SendPushToUsers(_ context.Context, _ notificationapp.SendPushInput) (*notificationapp.SendPushResult, error) {

--- a/backend/internal/application/notification/broker.go
+++ b/backend/internal/application/notification/broker.go
@@ -1,0 +1,106 @@
+package notification
+
+import (
+	"context"
+	"sync"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+const realtimeSubscriptionBuffer = 16
+
+type brokerSubscription struct {
+	id     uuid.UUID
+	userID uuid.UUID
+	events chan domain.Notification
+}
+
+// Broker stores active in-process SSE subscriptions by user id.
+type Broker struct {
+	mu            sync.Mutex
+	subscriptions map[uuid.UUID]map[uuid.UUID]*brokerSubscription
+}
+
+var _ RealtimeBroker = (*Broker)(nil)
+
+func NewBroker() *Broker {
+	return &Broker{subscriptions: map[uuid.UUID]map[uuid.UUID]*brokerSubscription{}}
+}
+
+func (b *Broker) Subscribe(userID uuid.UUID) *Subscription {
+	if b == nil {
+		return nil
+	}
+
+	sub := &brokerSubscription{
+		id:     uuid.New(),
+		userID: userID,
+		events: make(chan domain.Notification, realtimeSubscriptionBuffer),
+	}
+
+	b.mu.Lock()
+	if b.subscriptions == nil {
+		b.subscriptions = map[uuid.UUID]map[uuid.UUID]*brokerSubscription{}
+	}
+	if b.subscriptions[userID] == nil {
+		b.subscriptions[userID] = map[uuid.UUID]*brokerSubscription{}
+	}
+	b.subscriptions[userID][sub.id] = sub
+	b.mu.Unlock()
+
+	return &Subscription{
+		ID:     sub.id,
+		UserID: userID,
+		Events: sub.events,
+		Cancel: func() {
+			b.unsubscribe(userID, sub.id)
+		},
+	}
+}
+
+func (b *Broker) Publish(_ context.Context, userID uuid.UUID, notification domain.Notification) int {
+	if b == nil {
+		return 0
+	}
+
+	var stale []*brokerSubscription
+	delivered := 0
+
+	b.mu.Lock()
+	for id, sub := range b.subscriptions[userID] {
+		select {
+		case sub.events <- notification:
+			delivered++
+		default:
+			delete(b.subscriptions[userID], id)
+			stale = append(stale, sub)
+		}
+	}
+	if len(b.subscriptions[userID]) == 0 {
+		delete(b.subscriptions, userID)
+	}
+	b.mu.Unlock()
+
+	for _, sub := range stale {
+		close(sub.events)
+	}
+
+	return delivered
+}
+
+func (b *Broker) unsubscribe(userID, subscriptionID uuid.UUID) {
+	b.mu.Lock()
+	sub, ok := b.subscriptions[userID][subscriptionID]
+	if ok {
+		delete(b.subscriptions[userID], subscriptionID)
+		if len(b.subscriptions[userID]) == 0 {
+			delete(b.subscriptions, userID)
+		}
+	}
+	b.mu.Unlock()
+
+	if ok {
+		close(sub.events)
+	}
+}

--- a/backend/internal/application/notification/cursor.go
+++ b/backend/internal/application/notification/cursor.go
@@ -1,0 +1,52 @@
+package notification
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+func encodeNotificationCursor(cursor NotificationCursor) (string, error) {
+	raw, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("marshal notification cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func decodeNotificationCursor(token string) (*NotificationCursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return nil, fmt.Errorf("decode notification cursor: %w", err)
+	}
+
+	var cursor NotificationCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil {
+		return nil, fmt.Errorf("unmarshal notification cursor: %w", err)
+	}
+	if cursor.CreatedAt.IsZero() {
+		return nil, fmt.Errorf("cursor is missing created_at")
+	}
+	if cursor.NotificationID == uuid.Nil {
+		return nil, fmt.Errorf("cursor is missing notification_id")
+	}
+	return &cursor, nil
+}
+
+func buildNextNotificationCursor(items []domain.Notification, hasNext bool) (*string, error) {
+	if !hasNext || len(items) == 0 {
+		return nil, nil
+	}
+	last := items[len(items)-1]
+	encoded, err := encodeNotificationCursor(NotificationCursor{
+		CreatedAt:      last.CreatedAt,
+		NotificationID: last.ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &encoded, nil
+}

--- a/backend/internal/application/notification/repository.go
+++ b/backend/internal/application/notification/repository.go
@@ -17,13 +17,22 @@ type Repository interface {
 	RevokeDevice(ctx context.Context, userID, installationID uuid.UUID, revokedAt time.Time) (bool, error)
 	RevokeDeviceByID(ctx context.Context, deviceID uuid.UUID, revokedAt time.Time) error
 	ListActiveDevicesForUsers(ctx context.Context, userIDs []uuid.UUID) ([]domain.PushDevice, error)
-	CreateNotification(ctx context.Context, params CreateNotificationParams) error
+	CreateNotificationIfAbsent(ctx context.Context, params CreateNotificationParams) (*CreateNotificationResult, error)
+	ListNotifications(ctx context.Context, params ListNotificationsParams) ([]domain.Notification, error)
+	CountUnreadNotifications(ctx context.Context, userID uuid.UUID, visibleAfter time.Time) (int, error)
+	MarkNotificationRead(ctx context.Context, userID, notificationID uuid.UUID, readAt, visibleAfter time.Time) (bool, error)
+	MarkAllNotificationsRead(ctx context.Context, userID uuid.UUID, readAt, visibleAfter time.Time) (int, error)
+	SoftDeleteNotification(ctx context.Context, userID, notificationID uuid.UUID, deletedAt, visibleAfter time.Time) error
+	SoftDeleteAllNotifications(ctx context.Context, userID uuid.UUID, deletedAt, visibleAfter time.Time) error
+	DeleteExpiredNotifications(ctx context.Context, cutoff time.Time) (int, error)
+	CreateDeliveryAttempt(ctx context.Context, params CreateDeliveryAttemptParams) error
 }
 
 type PushSendMessage struct {
 	Token    string
 	Title    string
 	Body     string
+	ImageURL *string
 	DeepLink *string
 	Data     map[string]string
 }
@@ -35,4 +44,18 @@ type PushSendResult struct {
 // PushSender sends a single push message through the configured provider.
 type PushSender interface {
 	Send(ctx context.Context, message PushSendMessage) (*PushSendResult, error)
+}
+
+// RealtimeBroker owns active in-process SSE subscriptions.
+type RealtimeBroker interface {
+	Publish(ctx context.Context, userID uuid.UUID, notification domain.Notification) int
+	Subscribe(userID uuid.UUID) *Subscription
+}
+
+// Subscription is one active SSE stream registered for a user.
+type Subscription struct {
+	ID     uuid.UUID
+	UserID uuid.UUID
+	Events <-chan domain.Notification
+	Cancel func()
 }

--- a/backend/internal/application/notification/service.go
+++ b/backend/internal/application/notification/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
@@ -15,19 +16,24 @@ import (
 type Service struct {
 	repo       Repository
 	sender     PushSender
+	realtime   RealtimeBroker
 	unitOfWork uow.UnitOfWork
 	now        func() time.Time
 }
 
 var _ UseCase = (*Service)(nil)
 
-func NewService(repo Repository, sender PushSender, unitOfWork uow.UnitOfWork) *Service {
-	return &Service{
+func NewService(repo Repository, sender PushSender, unitOfWork uow.UnitOfWork, realtime ...RealtimeBroker) *Service {
+	service := &Service{
 		repo:       repo,
 		sender:     sender,
 		unitOfWork: unitOfWork,
 		now:        time.Now,
 	}
+	if len(realtime) > 0 {
+		service.realtime = realtime[0]
+	}
+	return service
 }
 
 func (s *Service) RegisterDevice(ctx context.Context, input RegisterDeviceInput) (*RegisterDeviceResult, error) {
@@ -89,18 +95,202 @@ func (s *Service) UnregisterDevice(ctx context.Context, userID, installationID u
 	})
 }
 
+func (s *Service) ListNotifications(ctx context.Context, input ListNotificationsInput) (*ListNotificationsResult, error) {
+	params, err := normalizeListNotificationsInput(input, s.now().UTC())
+	if err != nil {
+		return nil, err
+	}
+
+	records, err := s.repo.ListNotifications(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("list notifications: %w", err)
+	}
+
+	hasNext := len(records) > params.Limit
+	if hasNext {
+		records = records[:params.Limit]
+	}
+	nextCursor, err := buildNextNotificationCursor(records, hasNext)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListNotificationsResult{
+		Items: records,
+		PageInfo: NotificationPageInfo{
+			NextCursor: nextCursor,
+			HasNext:    hasNext,
+		},
+	}, nil
+}
+
+func (s *Service) CountUnreadNotifications(ctx context.Context, userID uuid.UUID) (*UnreadCountResult, error) {
+	count, err := s.repo.CountUnreadNotifications(ctx, userID, s.visibleAfter())
+	if err != nil {
+		return nil, fmt.Errorf("count unread notifications: %w", err)
+	}
+	return &UnreadCountResult{UnreadCount: count}, nil
+}
+
+func (s *Service) MarkNotificationRead(ctx context.Context, userID, notificationID uuid.UUID) error {
+	readAt := s.now().UTC()
+	updated, err := s.repo.MarkNotificationRead(ctx, userID, notificationID, readAt, s.visibleAfter())
+	if err != nil {
+		return fmt.Errorf("mark notification read: %w", err)
+	}
+	if !updated {
+		return domain.NotFoundError(domain.ErrorCodeNotificationNotFound, "The requested notification does not exist.")
+	}
+	return nil
+}
+
+func (s *Service) MarkAllNotificationsRead(ctx context.Context, userID uuid.UUID) (*MarkAllReadResult, error) {
+	readAt := s.now().UTC()
+	updated, err := s.repo.MarkAllNotificationsRead(ctx, userID, readAt, s.visibleAfter())
+	if err != nil {
+		return nil, fmt.Errorf("mark all notifications read: %w", err)
+	}
+	return &MarkAllReadResult{UpdatedCount: updated}, nil
+}
+
+func (s *Service) DeleteNotification(ctx context.Context, userID, notificationID uuid.UUID) error {
+	now := s.now().UTC()
+	if err := s.repo.SoftDeleteNotification(ctx, userID, notificationID, now, s.visibleAfter()); err != nil {
+		return fmt.Errorf("delete notification: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) DeleteAllNotifications(ctx context.Context, userID uuid.UUID) error {
+	now := s.now().UTC()
+	if err := s.repo.SoftDeleteAllNotifications(ctx, userID, now, s.visibleAfter()); err != nil {
+		return fmt.Errorf("delete all notifications: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) DeleteExpiredNotifications(ctx context.Context) (int, error) {
+	deleted, err := s.repo.DeleteExpiredNotifications(ctx, s.visibleAfter())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired notifications: %w", err)
+	}
+	return deleted, nil
+}
+
+func (s *Service) SendNotificationToUsers(ctx context.Context, input SendNotificationInput) (*SendNotificationResult, error) {
+	if appErr := validateSendNotificationInput(input); appErr != nil {
+		return nil, appErr
+	}
+
+	now := s.now().UTC()
+	result := &SendNotificationResult{
+		TargetUserCount: len(uniqueUserIDs(input.UserIDs)),
+	}
+
+	for userID := range uniqueUserIDs(input.UserIDs) {
+		createResult, err := s.repo.CreateNotificationIfAbsent(ctx, CreateNotificationParams{
+			UserID:         userID,
+			EventID:        input.EventID,
+			Title:          strings.TrimSpace(input.Title),
+			Type:           input.Type,
+			Body:           strings.TrimSpace(input.Body),
+			DeepLink:       input.DeepLink,
+			ImageURL:       input.ImageURL,
+			Data:           input.Data,
+			IdempotencyKey: strings.TrimSpace(input.IdempotencyKey),
+			CreatedAt:      now,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create notification: %w", err)
+		}
+		if !createResult.Created {
+			result.IdempotentCount++
+			continue
+		}
+		result.CreatedCount++
+
+		delivered := 0
+		if s.realtime != nil {
+			delivered = s.realtime.Publish(ctx, userID, createResult.Notification)
+		}
+		if delivered > 0 {
+			result.SSEDeliveryCount += delivered
+			for i := 0; i < delivered; i++ {
+				sentAt := now
+				if err := s.repo.CreateDeliveryAttempt(ctx, CreateDeliveryAttemptParams{
+					NotificationID: createResult.Notification.ID,
+					UserID:         userID,
+					Method:         domain.NotificationDeliveryMethodSSE,
+					Status:         domain.NotificationDeliveryStatusSent,
+					SentAt:         &sentAt,
+				}); err != nil {
+					return nil, fmt.Errorf("store sse delivery attempt: %w", err)
+				}
+			}
+			continue
+		}
+
+		pushResult, err := s.sendPushForNotification(ctx, createResult.Notification)
+		if err != nil {
+			return nil, err
+		}
+		result.PushActiveDeviceCount += pushResult.ActiveDeviceCount
+		result.PushSentCount += pushResult.SentCount
+		result.PushFailedCount += pushResult.FailedCount
+		result.InvalidTokenCount += pushResult.InvalidTokenCount
+	}
+
+	slog.InfoContext(ctx, "notifications sent",
+		"operation", "notification.send",
+		"target_user_count", result.TargetUserCount,
+		"created_count", result.CreatedCount,
+		"idempotent_count", result.IdempotentCount,
+		"sse_delivery_count", result.SSEDeliveryCount,
+		"push_active_device_count", result.PushActiveDeviceCount,
+		"push_sent_count", result.PushSentCount,
+		"push_failed_count", result.PushFailedCount,
+		"invalid_token_count", result.InvalidTokenCount,
+	)
+
+	return result, nil
+}
+
 func (s *Service) SendPushToUsers(ctx context.Context, input SendPushInput) (*SendPushResult, error) {
 	if appErr := validateSendPushInput(input); appErr != nil {
 		return nil, appErr
 	}
 
-	devices, err := s.repo.ListActiveDevicesForUsers(ctx, input.UserIDs)
+	result, err := s.SendNotificationToUsers(ctx, SendNotificationInput{
+		UserIDs:        input.UserIDs,
+		Title:          input.Title,
+		Body:           input.Body,
+		Type:           input.Type,
+		DeepLink:       input.DeepLink,
+		Data:           input.Data,
+		EventID:        input.EventID,
+		IdempotencyKey: "PUSH:" + uuid.NewString(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendPushResult{
+		TargetUserCount:   result.TargetUserCount,
+		ActiveDeviceCount: result.PushActiveDeviceCount,
+		SentCount:         result.PushSentCount,
+		FailedCount:       result.PushFailedCount,
+		InvalidTokenCount: result.InvalidTokenCount,
+	}, nil
+}
+
+func (s *Service) sendPushForNotification(ctx context.Context, notification domain.Notification) (*SendPushResult, error) {
+	devices, err := s.repo.ListActiveDevicesForUsers(ctx, []uuid.UUID{notification.ReceiverUserID})
 	if err != nil {
 		return nil, fmt.Errorf("list active push devices: %w", err)
 	}
 
 	result := &SendPushResult{
-		TargetUserCount:   len(uniqueUserIDs(input.UserIDs)),
+		TargetUserCount:   1,
 		ActiveDeviceCount: len(devices),
 	}
 	now := s.now().UTC()
@@ -108,14 +298,16 @@ func (s *Service) SendPushToUsers(ctx context.Context, input SendPushInput) (*Se
 	for _, device := range devices {
 		sendResult, sendErr := s.sender.Send(ctx, PushSendMessage{
 			Token:    device.FCMToken,
-			Title:    input.Title,
-			Body:     input.Body,
-			DeepLink: input.DeepLink,
-			Data:     input.Data,
+			Title:    notification.Title,
+			Body:     notification.Body,
+			ImageURL: notification.ImageURL,
+			DeepLink: notification.DeepLink,
+			Data:     notification.Data,
 		})
 
-		status := domain.NotificationStatusSent
+		status := domain.NotificationDeliveryStatusSent
 		sentAt := &now
+		var errorSummary *string
 		if sendErr != nil {
 			slog.ErrorContext(ctx, "push notification delivery failed",
 				"operation", "notification.push.device_send",
@@ -123,8 +315,9 @@ func (s *Service) SendPushToUsers(ctx context.Context, input SendPushInput) (*Se
 				"device_id", device.ID.String(),
 				"error", sendErr,
 			)
-			status = domain.NotificationStatusFailed
+			status = domain.NotificationDeliveryStatusFailed
 			sentAt = nil
+			errorSummary = shortErrorSummary(sendErr)
 			result.FailedCount++
 		} else {
 			result.SentCount++
@@ -136,29 +329,18 @@ func (s *Service) SendPushToUsers(ctx context.Context, input SendPushInput) (*Se
 			}
 		}
 
-		if err := s.repo.CreateNotification(ctx, CreateNotificationParams{
+		if err := s.repo.CreateDeliveryAttempt(ctx, CreateDeliveryAttemptParams{
+			NotificationID: notification.ID,
 			UserID:         device.UserID,
-			EventID:        input.EventID,
-			Title:          input.Title,
-			Type:           input.Type,
-			Body:           input.Body,
-			DeepLink:       input.DeepLink,
-			DeliveryMethod: domain.NotificationDeliveryMethodFCM,
+			Method:         domain.NotificationDeliveryMethodFCM,
 			Status:         status,
+			PushDeviceID:   &device.ID,
+			ErrorSummary:   errorSummary,
 			SentAt:         sentAt,
 		}); err != nil {
-			return nil, fmt.Errorf("store push notification result: %w", err)
+			return nil, fmt.Errorf("store push delivery attempt: %w", err)
 		}
 	}
-
-	slog.InfoContext(ctx, "push notifications sent",
-		"operation", "notification.push.send",
-		"target_user_count", result.TargetUserCount,
-		"active_device_count", result.ActiveDeviceCount,
-		"sent_count", result.SentCount,
-		"failed_count", result.FailedCount,
-		"invalid_token_count", result.InvalidTokenCount,
-	)
 
 	return result, nil
 }
@@ -169,4 +351,19 @@ func uniqueUserIDs(userIDs []uuid.UUID) map[uuid.UUID]struct{} {
 		seen[userID] = struct{}{}
 	}
 	return seen
+}
+
+func (s *Service) visibleAfter() time.Time {
+	return s.now().UTC().AddDate(0, 0, -NotificationRetentionDays)
+}
+
+func shortErrorSummary(err error) *string {
+	if err == nil {
+		return nil
+	}
+	value := err.Error()
+	if len(value) > 512 {
+		value = value[:512]
+	}
+	return &value
 }

--- a/backend/internal/application/notification/service_dto.go
+++ b/backend/internal/application/notification/service_dto.go
@@ -8,6 +8,9 @@ import (
 )
 
 const MaxActiveDevicesPerUser = 2
+const DefaultNotificationLimit = 25
+const MaxNotificationLimit = 50
+const NotificationRetentionDays = 90
 
 type RegisterDeviceInput struct {
 	UserID         uuid.UUID
@@ -34,12 +37,60 @@ type SendPushInput struct {
 	EventID  *uuid.UUID
 }
 
+type SendNotificationInput struct {
+	UserIDs        []uuid.UUID
+	Title          string
+	Body           string
+	Type           *string
+	DeepLink       *string
+	Data           map[string]string
+	EventID        *uuid.UUID
+	ImageURL       *string
+	IdempotencyKey string
+}
+
 type SendPushResult struct {
 	TargetUserCount   int
 	ActiveDeviceCount int
 	SentCount         int
 	FailedCount       int
 	InvalidTokenCount int
+}
+
+type SendNotificationResult struct {
+	TargetUserCount       int
+	CreatedCount          int
+	IdempotentCount       int
+	SSEDeliveryCount      int
+	PushActiveDeviceCount int
+	PushSentCount         int
+	PushFailedCount       int
+	InvalidTokenCount     int
+}
+
+type ListNotificationsInput struct {
+	UserID     uuid.UUID
+	OnlyUnread bool
+	Limit      *int
+	Cursor     *string
+}
+
+type ListNotificationsResult struct {
+	Items    []domain.Notification `json:"items"`
+	PageInfo NotificationPageInfo  `json:"page_info"`
+}
+
+type NotificationPageInfo struct {
+	NextCursor *string `json:"next_cursor"`
+	HasNext    bool    `json:"has_next"`
+}
+
+type UnreadCountResult struct {
+	UnreadCount int `json:"unread_count"`
+}
+
+type MarkAllReadResult struct {
+	UpdatedCount int `json:"updated_count"`
 }
 
 type RegisterDeviceParams struct {
@@ -58,7 +109,37 @@ type CreateNotificationParams struct {
 	Type           *string
 	Body           string
 	DeepLink       *string
-	DeliveryMethod string
-	Status         string
+	ImageURL       *string
+	Data           map[string]string
+	IdempotencyKey string
+	CreatedAt      time.Time
+}
+
+type CreateNotificationResult struct {
+	Notification domain.Notification
+	Created      bool
+}
+
+type ListNotificationsParams struct {
+	UserID               uuid.UUID
+	OnlyUnread           bool
+	Limit                int
+	RepositoryFetchLimit int
+	DecodedCursor        *NotificationCursor
+	VisibleAfter         time.Time
+}
+
+type NotificationCursor struct {
+	CreatedAt      time.Time `json:"created_at"`
+	NotificationID uuid.UUID `json:"notification_id"`
+}
+
+type CreateDeliveryAttemptParams struct {
+	NotificationID uuid.UUID
+	UserID         uuid.UUID
+	Method         domain.NotificationDeliveryMethod
+	Status         domain.NotificationDeliveryStatus
+	PushDeviceID   *uuid.UUID
+	ErrorSummary   *string
 	SentAt         *time.Time
 }

--- a/backend/internal/application/notification/service_test.go
+++ b/backend/internal/application/notification/service_test.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 	"time"
 
@@ -103,14 +104,94 @@ func TestSendPushToUsersStoresResultsAndRevokesInvalidToken(t *testing.T) {
 	if repo.devices[invalidDeviceID].RevokedAt == nil {
 		t.Fatal("expected invalid device to be revoked")
 	}
-	if len(repo.notifications) != 2 {
-		t.Fatalf("expected 2 notification rows, got %d", len(repo.notifications))
+	if len(repo.notifications) != 1 {
+		t.Fatalf("expected 1 inbox notification row, got %d", len(repo.notifications))
+	}
+	if len(repo.deliveryAttempts) != 2 {
+		t.Fatalf("expected 2 delivery attempts, got %d", len(repo.deliveryAttempts))
+	}
+}
+
+func TestSendNotificationToUsersSkipsPushWhenSSEReceivesNotification(t *testing.T) {
+	// given
+	repo := newFakeNotificationRepo()
+	broker := NewBroker()
+	sender := &recordingPushSender{}
+	svc := NewService(repo, sender, fakeUnitOfWork{}, broker)
+	svc.now = func() time.Time { return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC) }
+	userID := uuid.New()
+	repo.addDevice(userID, uuid.New(), "push-token", svc.now())
+	sub := broker.Subscribe(userID)
+	defer sub.Cancel()
+
+	// when
+	result, err := svc.SendNotificationToUsers(context.Background(), SendNotificationInput{
+		UserIDs:        []uuid.UUID{userID},
+		Title:          "Event update",
+		Body:           "A new update is available.",
+		IdempotencyKey: "event:update:1",
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("SendNotificationToUsers() error = %v", err)
+	}
+	if result.SSEDeliveryCount != 1 || result.PushActiveDeviceCount != 0 {
+		t.Fatalf("expected SSE delivery and no push, got %#v", result)
+	}
+	if sender.sentCount != 0 {
+		t.Fatalf("expected no push sends, got %d", sender.sentCount)
+	}
+	select {
+	case notification := <-sub.Events:
+		if notification.Title != "Event update" {
+			t.Fatalf("unexpected notification title %q", notification.Title)
+		}
+	default:
+		t.Fatal("expected notification on SSE subscription")
+	}
+}
+
+func TestSendNotificationToUsersIsIdempotent(t *testing.T) {
+	// given
+	repo := newFakeNotificationRepo()
+	sender := &recordingPushSender{}
+	svc := NewService(repo, sender, fakeUnitOfWork{})
+	svc.now = func() time.Time { return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC) }
+	userID := uuid.New()
+	repo.addDevice(userID, uuid.New(), "push-token", svc.now())
+	input := SendNotificationInput{
+		UserIDs:        []uuid.UUID{userID},
+		Title:          "Event update",
+		Body:           "A new update is available.",
+		IdempotencyKey: "event:update:1",
+	}
+
+	// when
+	if _, err := svc.SendNotificationToUsers(context.Background(), input); err != nil {
+		t.Fatalf("SendNotificationToUsers(first) error = %v", err)
+	}
+	result, err := svc.SendNotificationToUsers(context.Background(), input)
+
+	// then
+	if err != nil {
+		t.Fatalf("SendNotificationToUsers(second) error = %v", err)
+	}
+	if result.IdempotentCount != 1 || result.CreatedCount != 0 {
+		t.Fatalf("expected idempotent duplicate, got %#v", result)
+	}
+	if len(repo.notifications) != 1 {
+		t.Fatalf("expected one inbox notification, got %d", len(repo.notifications))
+	}
+	if sender.sentCount != 1 {
+		t.Fatalf("expected push to be sent only once, got %d", sender.sentCount)
 	}
 }
 
 type fakeNotificationRepo struct {
-	devices       map[uuid.UUID]*domain.PushDevice
-	notifications []CreateNotificationParams
+	devices          map[uuid.UUID]*domain.PushDevice
+	notifications    map[uuid.UUID]*domain.Notification
+	deliveryAttempts []CreateDeliveryAttemptParams
 }
 
 type fakeUnitOfWork struct{}
@@ -120,7 +201,10 @@ func (fakeUnitOfWork) RunInTx(ctx context.Context, fn func(context.Context) erro
 }
 
 func newFakeNotificationRepo() *fakeNotificationRepo {
-	return &fakeNotificationRepo{devices: map[uuid.UUID]*domain.PushDevice{}}
+	return &fakeNotificationRepo{
+		devices:       map[uuid.UUID]*domain.PushDevice{},
+		notifications: map[uuid.UUID]*domain.Notification{},
+	}
 }
 
 func (r *fakeNotificationRepo) LockUser(_ context.Context, userID uuid.UUID) error {
@@ -210,8 +294,127 @@ func (r *fakeNotificationRepo) ListActiveDevicesForUsers(_ context.Context, user
 	return devices, nil
 }
 
-func (r *fakeNotificationRepo) CreateNotification(_ context.Context, params CreateNotificationParams) error {
-	r.notifications = append(r.notifications, params)
+func (r *fakeNotificationRepo) CreateNotificationIfAbsent(_ context.Context, params CreateNotificationParams) (*CreateNotificationResult, error) {
+	for _, notification := range r.notifications {
+		if notification.ReceiverUserID == params.UserID && notification.IdempotencyKey == params.IdempotencyKey {
+			return &CreateNotificationResult{Notification: *notification, Created: false}, nil
+		}
+	}
+	notification := &domain.Notification{
+		ID:             uuid.New(),
+		EventID:        params.EventID,
+		ReceiverUserID: params.UserID,
+		Title:          params.Title,
+		Type:           params.Type,
+		Body:           params.Body,
+		DeepLink:       params.DeepLink,
+		ImageURL:       params.ImageURL,
+		Data:           params.Data,
+		IdempotencyKey: params.IdempotencyKey,
+		CreatedAt:      params.CreatedAt,
+		UpdatedAt:      params.CreatedAt,
+	}
+	if notification.Data == nil {
+		notification.Data = map[string]string{}
+	}
+	r.notifications[notification.ID] = notification
+	return &CreateNotificationResult{Notification: *notification, Created: true}, nil
+}
+
+func (r *fakeNotificationRepo) ListNotifications(_ context.Context, params ListNotificationsParams) ([]domain.Notification, error) {
+	notifications := []domain.Notification{}
+	for _, notification := range r.notifications {
+		if notification.ReceiverUserID != params.UserID || notification.DeletedAt != nil || notification.CreatedAt.Before(params.VisibleAfter) {
+			continue
+		}
+		if params.OnlyUnread && notification.IsRead {
+			continue
+		}
+		if params.DecodedCursor != nil && !notificationBeforeCursor(*notification, *params.DecodedCursor) {
+			continue
+		}
+		notifications = append(notifications, *notification)
+	}
+	sort.Slice(notifications, func(i, j int) bool {
+		if notifications[i].CreatedAt.Equal(notifications[j].CreatedAt) {
+			return notifications[i].ID.String() > notifications[j].ID.String()
+		}
+		return notifications[i].CreatedAt.After(notifications[j].CreatedAt)
+	})
+	if len(notifications) > params.RepositoryFetchLimit {
+		notifications = notifications[:params.RepositoryFetchLimit]
+	}
+	return notifications, nil
+}
+
+func (r *fakeNotificationRepo) CountUnreadNotifications(_ context.Context, userID uuid.UUID, visibleAfter time.Time) (int, error) {
+	count := 0
+	for _, notification := range r.notifications {
+		if notification.ReceiverUserID == userID && !notification.IsRead && notification.DeletedAt == nil && !notification.CreatedAt.Before(visibleAfter) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (r *fakeNotificationRepo) MarkNotificationRead(_ context.Context, userID, notificationID uuid.UUID, readAt, visibleAfter time.Time) (bool, error) {
+	notification := r.notifications[notificationID]
+	if notification == nil || notification.ReceiverUserID != userID || notification.DeletedAt != nil || notification.CreatedAt.Before(visibleAfter) {
+		return false, nil
+	}
+	notification.IsRead = true
+	if notification.ReadAt == nil {
+		notification.ReadAt = &readAt
+	}
+	notification.UpdatedAt = readAt
+	return true, nil
+}
+
+func (r *fakeNotificationRepo) MarkAllNotificationsRead(_ context.Context, userID uuid.UUID, readAt, visibleAfter time.Time) (int, error) {
+	count := 0
+	for _, notification := range r.notifications {
+		if notification.ReceiverUserID == userID && !notification.IsRead && notification.DeletedAt == nil && !notification.CreatedAt.Before(visibleAfter) {
+			notification.IsRead = true
+			notification.ReadAt = &readAt
+			notification.UpdatedAt = readAt
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (r *fakeNotificationRepo) SoftDeleteNotification(_ context.Context, userID, notificationID uuid.UUID, deletedAt, visibleAfter time.Time) error {
+	notification := r.notifications[notificationID]
+	if notification != nil && notification.ReceiverUserID == userID && notification.DeletedAt == nil && !notification.CreatedAt.Before(visibleAfter) {
+		notification.DeletedAt = &deletedAt
+		notification.UpdatedAt = deletedAt
+	}
+	return nil
+}
+
+func (r *fakeNotificationRepo) SoftDeleteAllNotifications(_ context.Context, userID uuid.UUID, deletedAt, visibleAfter time.Time) error {
+	for _, notification := range r.notifications {
+		if notification.ReceiverUserID == userID && notification.DeletedAt == nil && !notification.CreatedAt.Before(visibleAfter) {
+			notification.DeletedAt = &deletedAt
+			notification.UpdatedAt = deletedAt
+		}
+	}
+	return nil
+}
+
+func (r *fakeNotificationRepo) DeleteExpiredNotifications(_ context.Context, cutoff time.Time) (int, error) {
+	count := 0
+	for id, notification := range r.notifications {
+		if notification.CreatedAt.Before(cutoff) {
+			delete(r.notifications, id)
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (r *fakeNotificationRepo) CreateDeliveryAttempt(_ context.Context, params CreateDeliveryAttemptParams) error {
+	r.deliveryAttempts = append(r.deliveryAttempts, params)
 	return nil
 }
 
@@ -258,4 +461,18 @@ func (s fakePushSender) Send(_ context.Context, message PushSendMessage) (*PushS
 		return &PushSendResult{InvalidToken: true}, errors.New("invalid token")
 	}
 	return &PushSendResult{}, nil
+}
+
+type recordingPushSender struct {
+	sentCount int
+}
+
+func (s *recordingPushSender) Send(_ context.Context, _ PushSendMessage) (*PushSendResult, error) {
+	s.sentCount++
+	return &PushSendResult{}, nil
+}
+
+func notificationBeforeCursor(notification domain.Notification, cursor NotificationCursor) bool {
+	return notification.CreatedAt.Before(cursor.CreatedAt) ||
+		(notification.CreatedAt.Equal(cursor.CreatedAt) && notification.ID.String() < cursor.NotificationID.String())
 }

--- a/backend/internal/application/notification/usecase.go
+++ b/backend/internal/application/notification/usecase.go
@@ -10,5 +10,13 @@ import (
 type UseCase interface {
 	RegisterDevice(ctx context.Context, input RegisterDeviceInput) (*RegisterDeviceResult, error)
 	UnregisterDevice(ctx context.Context, userID, installationID uuid.UUID) error
+	ListNotifications(ctx context.Context, input ListNotificationsInput) (*ListNotificationsResult, error)
+	CountUnreadNotifications(ctx context.Context, userID uuid.UUID) (*UnreadCountResult, error)
+	MarkNotificationRead(ctx context.Context, userID, notificationID uuid.UUID) error
+	MarkAllNotificationsRead(ctx context.Context, userID uuid.UUID) (*MarkAllReadResult, error)
+	DeleteNotification(ctx context.Context, userID, notificationID uuid.UUID) error
+	DeleteAllNotifications(ctx context.Context, userID uuid.UUID) error
+	DeleteExpiredNotifications(ctx context.Context) (int, error)
+	SendNotificationToUsers(ctx context.Context, input SendNotificationInput) (*SendNotificationResult, error)
 	SendPushToUsers(ctx context.Context, input SendPushInput) (*SendPushResult, error)
 }

--- a/backend/internal/application/notification/validator.go
+++ b/backend/internal/application/notification/validator.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"strings"
+	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 )
@@ -42,4 +43,59 @@ func validateSendPushInput(input SendPushInput) *domain.AppError {
 		return domain.ValidationError(details)
 	}
 	return nil
+}
+
+func validateSendNotificationInput(input SendNotificationInput) *domain.AppError {
+	details := map[string]string{}
+	if len(input.UserIDs) == 0 {
+		details["user_ids"] = "must contain at least one user id"
+	}
+	if strings.TrimSpace(input.Title) == "" {
+		details["title"] = "is required"
+	}
+	if strings.TrimSpace(input.Body) == "" {
+		details["body"] = "is required"
+	}
+	if strings.TrimSpace(input.IdempotencyKey) == "" {
+		details["idempotency_key"] = "is required"
+	}
+	if len(details) > 0 {
+		return domain.ValidationError(details)
+	}
+	return nil
+}
+
+func normalizeListNotificationsInput(input ListNotificationsInput, now time.Time) (ListNotificationsParams, error) {
+	params := ListNotificationsParams{
+		UserID:               input.UserID,
+		OnlyUnread:           input.OnlyUnread,
+		Limit:                DefaultNotificationLimit,
+		VisibleAfter:         now.UTC().AddDate(0, 0, -NotificationRetentionDays),
+		RepositoryFetchLimit: DefaultNotificationLimit + 1,
+	}
+
+	if input.Limit != nil {
+		if *input.Limit < 1 || *input.Limit > MaxNotificationLimit {
+			return ListNotificationsParams{}, domain.ValidationError(map[string]string{
+				"limit": "limit must be between 1 and 50",
+			})
+		}
+		params.Limit = *input.Limit
+		params.RepositoryFetchLimit = params.Limit + 1
+	}
+
+	if input.Cursor != nil {
+		cursorToken := strings.TrimSpace(*input.Cursor)
+		if cursorToken != "" {
+			cursor, err := decodeNotificationCursor(cursorToken)
+			if err != nil {
+				return ListNotificationsParams{}, domain.ValidationError(map[string]string{
+					"cursor": "cursor is invalid",
+				})
+			}
+			params.DecodedCursor = cursor
+		}
+	}
+
+	return params, nil
 }

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -60,6 +60,7 @@ type Container struct {
 	TicketService           ticket.UseCase
 	RatingService           rating.UseCase
 	NotificationService     notification.UseCase
+	NotificationBroker      *notification.Broker
 	CategoryService         category.UseCase
 	ProfileService          profile.UseCase
 	FavoriteLocationService favoritelocation.UseCase
@@ -102,6 +103,7 @@ func New(ctx context.Context) (*Container, error) {
 	container.ticketRepo = postgres.NewTicketRepository(container.DB)
 	container.ratingRepo = postgres.NewRatingRepository(container.DB)
 	container.notificationRepo = postgres.NewNotificationRepository(container.DB)
+	container.NotificationBroker = notification.NewBroker()
 	container.categoryRepo = postgres.NewCategoryRepository(container.DB)
 	container.profileRepo = postgres.NewProfileRepository(container.DB)
 	container.favoriteLocationRepo = postgres.NewFavoriteLocationRepository(container.DB)
@@ -141,6 +143,37 @@ func (c *Container) StartEventExpiryJob(ctx context.Context, interval time.Durat
 			select {
 			case <-ticker.C:
 				expire()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// StartNotificationRetentionJob deletes inbox notifications older than the
+// configured retention window, then repeats until ctx is cancelled.
+func (c *Container) StartNotificationRetentionJob(ctx context.Context, interval time.Duration) {
+	purge := func() {
+		deleted, err := c.NotificationService.DeleteExpiredNotifications(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "notification retention job failed", "error", err)
+			return
+		}
+		if deleted > 0 {
+			slog.InfoContext(ctx, "expired notifications deleted",
+				"operation", "notification.retention.delete_expired",
+				"deleted_count", deleted,
+			)
+		}
+	}
+	purge()
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				purge()
 			case <-ctx.Done():
 				return
 			}
@@ -253,7 +286,7 @@ func newNotificationService(ctx context.Context, c *Container) (notification.Use
 	if err != nil {
 		return nil, fmt.Errorf("build push sender: %w", err)
 	}
-	return notification.NewService(c.notificationRepo, sender, c.UnitOfWork), nil
+	return notification.NewService(c.notificationRepo, sender, c.UnitOfWork, c.NotificationBroker), nil
 }
 
 func newImageUploadService(c *Container, storage *spacesadapter.Storage) imageupload.UseCase {

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -69,6 +69,8 @@ const (
 	ErrorCodeTicketScanRejected       = "ticket_scan_rejected"
 	ErrorCodeTicketProximityRequired  = "ticket_proximity_required"
 	ErrorCodeTicketClientNotSupported = "ticket_client_not_supported"
+
+	ErrorCodeNotificationNotFound = "notification_not_found"
 )
 
 // ErrNotFound is a sentinel error returned when a queried entity does not exist.

--- a/backend/internal/domain/notification.go
+++ b/backend/internal/domain/notification.go
@@ -30,12 +30,73 @@ func (p PushDevicePlatform) String() string {
 	return string(p)
 }
 
-// Notification delivery method and status values stored in notification rows.
+// NotificationDeliveryMethod identifies how a notification delivery was attempted.
+type NotificationDeliveryMethod string
+
 const (
-	NotificationDeliveryMethodFCM = "FCM"
-	NotificationStatusSent        = "SENT"
-	NotificationStatusFailed      = "FAILED"
+	NotificationDeliveryMethodFCM NotificationDeliveryMethod = "FCM"
+	NotificationDeliveryMethodSSE NotificationDeliveryMethod = "SSE"
 )
+
+func ParseNotificationDeliveryMethod(value string) (NotificationDeliveryMethod, bool) {
+	switch NotificationDeliveryMethod(strings.ToUpper(strings.TrimSpace(value))) {
+	case NotificationDeliveryMethodFCM:
+		return NotificationDeliveryMethodFCM, true
+	case NotificationDeliveryMethodSSE:
+		return NotificationDeliveryMethodSSE, true
+	default:
+		return "", false
+	}
+}
+
+func (m NotificationDeliveryMethod) String() string {
+	return string(m)
+}
+
+// NotificationDeliveryStatus identifies the result of one delivery attempt.
+type NotificationDeliveryStatus string
+
+const (
+	NotificationDeliveryStatusSent    NotificationDeliveryStatus = "SENT"
+	NotificationDeliveryStatusFailed  NotificationDeliveryStatus = "FAILED"
+	NotificationDeliveryStatusSkipped NotificationDeliveryStatus = "SKIPPED"
+)
+
+func ParseNotificationDeliveryStatus(value string) (NotificationDeliveryStatus, bool) {
+	switch NotificationDeliveryStatus(strings.ToUpper(strings.TrimSpace(value))) {
+	case NotificationDeliveryStatusSent:
+		return NotificationDeliveryStatusSent, true
+	case NotificationDeliveryStatusFailed:
+		return NotificationDeliveryStatusFailed, true
+	case NotificationDeliveryStatusSkipped:
+		return NotificationDeliveryStatusSkipped, true
+	default:
+		return "", false
+	}
+}
+
+func (s NotificationDeliveryStatus) String() string {
+	return string(s)
+}
+
+// Notification is the user-facing in-app notification inbox item.
+type Notification struct {
+	ID             uuid.UUID
+	EventID        *uuid.UUID
+	ReceiverUserID uuid.UUID
+	Title          string
+	Type           *string
+	Body           string
+	DeepLink       *string
+	ImageURL       *string
+	Data           map[string]string
+	IsRead         bool
+	ReadAt         *time.Time
+	DeletedAt      *time.Time
+	IdempotencyKey string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
 
 // PushDevice stores the current push-token assignment for one app installation.
 type PushDevice struct {

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -67,7 +67,7 @@ func NewHTTP(container *bootstrap.Container) *fiber.App {
 	favorite_location_handler.RegisterRoutes(app, favoriteLocationHandler, auth)
 
 	// Push notification device routes (authenticated)
-	notificationHandler := notification_handler.NewHandler(container.NotificationService)
+	notificationHandler := notification_handler.NewHandler(container.NotificationService, container.NotificationBroker)
 	notification_handler.RegisterRoutes(app, notificationHandler, auth)
 
 	// Direct image upload routes (authenticated)

--- a/backend/migrations/000023_in_app_notifications.down.sql
+++ b/backend/migrations/000023_in_app_notifications.down.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS notification_delivery_attempt;
+
+DROP INDEX IF EXISTS idx_notification_created_at;
+DROP INDEX IF EXISTS idx_notification_user_unread_visible;
+DROP INDEX IF EXISTS idx_notification_user_unread_visible_created;
+DROP INDEX IF EXISTS idx_notification_user_visible_created;
+DROP INDEX IF EXISTS uq_notification_receiver_idempotency;
+
+ALTER TABLE notification
+    ALTER COLUMN is_read DROP NOT NULL,
+    ALTER COLUMN body DROP NOT NULL,
+    ALTER COLUMN title DROP NOT NULL;
+
+ALTER TABLE notification
+    DROP COLUMN IF EXISTS deleted_at,
+    DROP COLUMN IF EXISTS read_at,
+    DROP COLUMN IF EXISTS idempotency_key,
+    DROP COLUMN IF EXISTS data,
+    DROP COLUMN IF EXISTS image_url;

--- a/backend/migrations/000023_in_app_notifications.up.sql
+++ b/backend/migrations/000023_in_app_notifications.up.sql
@@ -1,0 +1,86 @@
+ALTER TABLE notification
+    ADD COLUMN image_url TEXT,
+    ADD COLUMN data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN idempotency_key TEXT,
+    ADD COLUMN read_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE notification
+SET idempotency_key = 'LEGACY:' || id::text,
+    title = COALESCE(title, ''),
+    body = COALESCE(body, ''),
+    is_read = COALESCE(is_read, FALSE),
+    read_at = CASE
+        WHEN is_read = TRUE THEN COALESCE(read_at, updated_at)
+        ELSE read_at
+    END;
+
+ALTER TABLE notification
+    ALTER COLUMN idempotency_key SET NOT NULL,
+    ALTER COLUMN title SET NOT NULL,
+    ALTER COLUMN body SET NOT NULL,
+    ALTER COLUMN is_read SET NOT NULL;
+
+CREATE UNIQUE INDEX uq_notification_receiver_idempotency
+    ON notification (receiver_user_id, idempotency_key);
+
+CREATE INDEX idx_notification_user_visible_created
+    ON notification (receiver_user_id, created_at DESC, id DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_notification_user_unread_visible_created
+    ON notification (receiver_user_id, created_at DESC, id DESC)
+    WHERE deleted_at IS NULL AND is_read = FALSE;
+
+CREATE INDEX idx_notification_user_unread_visible
+    ON notification (receiver_user_id)
+    WHERE deleted_at IS NULL AND is_read = FALSE;
+
+CREATE INDEX idx_notification_created_at
+    ON notification (created_at);
+
+CREATE TABLE notification_delivery_attempt
+(
+    id               UUID PRIMARY KEY                  DEFAULT gen_random_uuid(),
+    notification_id  UUID                     NOT NULL,
+    receiver_user_id UUID                     NOT NULL,
+    method           TEXT                     NOT NULL,
+    status           TEXT                     NOT NULL,
+    push_device_id   UUID,
+    error_summary    TEXT,
+    sent_at          TIMESTAMP WITH TIME ZONE,
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_notification_delivery_attempt_notification
+        FOREIGN KEY (notification_id) REFERENCES notification (id) ON DELETE CASCADE,
+    CONSTRAINT fk_notification_delivery_attempt_user
+        FOREIGN KEY (receiver_user_id) REFERENCES app_user (id) ON DELETE CASCADE,
+    CONSTRAINT fk_notification_delivery_attempt_push_device
+        FOREIGN KEY (push_device_id) REFERENCES user_push_device (id) ON DELETE SET NULL,
+    CONSTRAINT chk_notification_delivery_attempt_method CHECK (method IN ('FCM', 'SSE')),
+    CONSTRAINT chk_notification_delivery_attempt_status CHECK (status IN ('SENT', 'FAILED', 'SKIPPED'))
+);
+
+CREATE INDEX idx_notification_delivery_attempt_notification
+    ON notification_delivery_attempt (notification_id, created_at DESC);
+
+CREATE INDEX idx_notification_delivery_attempt_user
+    ON notification_delivery_attempt (receiver_user_id, created_at DESC);
+
+INSERT INTO notification_delivery_attempt (
+    notification_id,
+    receiver_user_id,
+    method,
+    status,
+    sent_at,
+    created_at
+)
+SELECT id,
+       receiver_user_id,
+       delivery_method,
+       status,
+       sent_at,
+       COALESCE(sent_at, created_at)
+FROM notification
+WHERE delivery_method IN ('FCM', 'SSE')
+  AND status IN ('SENT', 'FAILED', 'SKIPPED');

--- a/backend/tests_integration/notification_test.go
+++ b/backend/tests_integration/notification_test.go
@@ -5,6 +5,7 @@ package tests_integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
@@ -62,5 +63,123 @@ func TestNotificationRegisterDevicePersistsAndEnforcesDeviceLimit(t *testing.T) 
 		if device.InstallationID == firstInstallationID {
 			t.Fatal("expected oldest installation to be revoked")
 		}
+	}
+}
+
+func TestNotificationInboxLifecycleAndIdempotency(t *testing.T) {
+	// given
+	h := common.NewNotificationHarness(t)
+	user := common.GivenUser(t, h.AuthRepo)
+	ctx := context.Background()
+	key := "integration:" + uuid.NewString()
+
+	// when
+	firstSend, err := h.Service.SendNotificationToUsers(ctx, notificationapp.SendNotificationInput{
+		UserIDs:        []uuid.UUID{user.ID},
+		Title:          "Event update",
+		Body:           "A new update is available.",
+		IdempotencyKey: key,
+		Data:           map[string]string{"source": "integration"},
+	})
+	if err != nil {
+		t.Fatalf("SendNotificationToUsers(first) error = %v", err)
+	}
+	secondSend, err := h.Service.SendNotificationToUsers(ctx, notificationapp.SendNotificationInput{
+		UserIDs:        []uuid.UUID{user.ID},
+		Title:          "Event update",
+		Body:           "A new update is available.",
+		IdempotencyKey: key,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("SendNotificationToUsers(second) error = %v", err)
+	}
+	if firstSend.CreatedCount != 1 || secondSend.IdempotentCount != 1 {
+		t.Fatalf("unexpected send results first=%#v second=%#v", firstSend, secondSend)
+	}
+
+	list, err := h.Service.ListNotifications(ctx, notificationapp.ListNotificationsInput{UserID: user.ID})
+	if err != nil {
+		t.Fatalf("ListNotifications() error = %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(list.Items))
+	}
+	if list.Items[0].Data["source"] != "integration" {
+		t.Fatalf("expected notification data to round-trip, got %#v", list.Items[0].Data)
+	}
+
+	unread, err := h.Service.CountUnreadNotifications(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("CountUnreadNotifications() error = %v", err)
+	}
+	if unread.UnreadCount != 1 {
+		t.Fatalf("expected unread count 1, got %d", unread.UnreadCount)
+	}
+
+	if err := h.Service.MarkNotificationRead(ctx, user.ID, list.Items[0].ID); err != nil {
+		t.Fatalf("MarkNotificationRead() error = %v", err)
+	}
+	unread, err = h.Service.CountUnreadNotifications(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("CountUnreadNotifications(after read) error = %v", err)
+	}
+	if unread.UnreadCount != 0 {
+		t.Fatalf("expected unread count 0, got %d", unread.UnreadCount)
+	}
+
+	if err := h.Service.DeleteNotification(ctx, user.ID, list.Items[0].ID); err != nil {
+		t.Fatalf("DeleteNotification() error = %v", err)
+	}
+	list, err = h.Service.ListNotifications(ctx, notificationapp.ListNotificationsInput{UserID: user.ID})
+	if err != nil {
+		t.Fatalf("ListNotifications(after delete) error = %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected deleted notification to be hidden, got %d items", len(list.Items))
+	}
+}
+
+func TestNotificationRetentionDeletesExpiredRows(t *testing.T) {
+	// given
+	h := common.NewNotificationHarness(t)
+	user := common.GivenUser(t, h.AuthRepo)
+	ctx := context.Background()
+	expiredAt := time.Now().UTC().AddDate(0, 0, -(notificationapp.NotificationRetentionDays + 1))
+	var notificationID uuid.UUID
+	if err := h.Tx.QueryRow(ctx, `
+		INSERT INTO notification (
+			receiver_user_id,
+			title,
+			body,
+			is_read,
+			data,
+			idempotency_key,
+			created_at,
+			updated_at
+		)
+		VALUES ($1, 'Expired', 'Expired body', FALSE, '{}'::jsonb, $2, $3, $3)
+		RETURNING id
+	`, user.ID, "expired:"+uuid.NewString(), expiredAt).Scan(&notificationID); err != nil {
+		t.Fatalf("insert expired notification error = %v", err)
+	}
+
+	// when
+	deleted, err := h.Service.DeleteExpiredNotifications(ctx)
+
+	// then
+	if err != nil {
+		t.Fatalf("DeleteExpiredNotifications() error = %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected 1 deleted notification, got %d", deleted)
+	}
+	var exists bool
+	if err := h.Tx.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM notification WHERE id = $1)`, notificationID).Scan(&exists); err != nil {
+		t.Fatalf("lookup expired notification error = %v", err)
+	}
+	if exists {
+		t.Fatal("expected expired notification to be hard-deleted")
 	}
 }

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -370,11 +370,16 @@ CREATE TABLE notification (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     event_id UUID,
     receiver_user_id UUID NOT NULL,
-    title TEXT,
+    title TEXT NOT NULL,
     type VARCHAR,
-    body TEXT,
-    is_read BOOLEAN DEFAULT FALSE,
+    body TEXT NOT NULL,
+    is_read BOOLEAN NOT NULL DEFAULT FALSE,
+    read_at TIMESTAMP WITH TIME ZONE,
+    deleted_at TIMESTAMP WITH TIME ZONE,
     deep_link TEXT,
+    image_url TEXT,
+    data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    idempotency_key TEXT NOT NULL,
     delivery_method VARCHAR,
     status TEXT,  -- SENT, FAILED
     sent_at TIMESTAMP WITH TIME ZONE,
@@ -389,6 +394,11 @@ CREATE TABLE notification (
 CREATE INDEX idx_notification_user_id ON notification(receiver_user_id);
 CREATE INDEX idx_delivery_method_and_status ON notification(delivery_method, status);
 CREATE INDEX idx_notification_unread ON notification(receiver_user_id) WHERE is_read = false;
+CREATE UNIQUE INDEX uq_notification_receiver_idempotency ON notification(receiver_user_id, idempotency_key);
+CREATE INDEX idx_notification_user_visible_created ON notification(receiver_user_id, created_at DESC, id DESC) WHERE deleted_at IS NULL;
+CREATE INDEX idx_notification_user_unread_visible_created ON notification(receiver_user_id, created_at DESC, id DESC) WHERE deleted_at IS NULL AND is_read = false;
+CREATE INDEX idx_notification_user_unread_visible ON notification(receiver_user_id) WHERE deleted_at IS NULL AND is_read = false;
+CREATE INDEX idx_notification_created_at ON notification(created_at);
 
 -- =========================
 -- USER PUSH DEVICE
@@ -419,6 +429,30 @@ CREATE UNIQUE INDEX uq_user_push_device_active_fcm_token
 CREATE INDEX idx_user_push_device_user_active
     ON user_push_device(user_id, last_seen_at DESC)
     WHERE revoked_at IS NULL;
+
+-- =========================
+-- NOTIFICATION DELIVERY ATTEMPT
+-- =========================
+CREATE TABLE notification_delivery_attempt (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    notification_id UUID NOT NULL,
+    receiver_user_id UUID NOT NULL,
+    method TEXT NOT NULL,
+    status TEXT NOT NULL,
+    push_device_id UUID,
+    error_summary TEXT,
+    sent_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_notification_delivery_attempt_notification FOREIGN KEY (notification_id) REFERENCES notification(id) ON DELETE CASCADE,
+    CONSTRAINT fk_notification_delivery_attempt_user FOREIGN KEY (receiver_user_id) REFERENCES app_user(id) ON DELETE CASCADE,
+    CONSTRAINT fk_notification_delivery_attempt_push_device FOREIGN KEY (push_device_id) REFERENCES user_push_device(id) ON DELETE SET NULL,
+    CONSTRAINT chk_notification_delivery_attempt_method CHECK (method IN ('FCM', 'SSE')),
+    CONSTRAINT chk_notification_delivery_attempt_status CHECK (status IN ('SENT', 'FAILED', 'SKIPPED'))
+);
+
+CREATE INDEX idx_notification_delivery_attempt_notification ON notification_delivery_attempt(notification_id, created_at DESC);
+CREATE INDEX idx_notification_delivery_attempt_user ON notification_delivery_attempt(receiver_user_id, created_at DESC);
 
 -- =========================
 -- JOIN REQUEST

--- a/docs/openapi/notification.yaml
+++ b/docs/openapi/notification.yaml
@@ -1,8 +1,8 @@
 openapi: 3.1.0
 info:
-  title: Social Event Mapper - Push Notification API
-  version: 0.1.0
-  description: Authenticated endpoints for registering and unregistering mobile FCM push devices.
+  title: Social Event Mapper - Notification API
+  version: 0.2.0
+  description: Authenticated endpoints for mobile push-device registration and the in-app notification inbox.
 
 servers:
   - url: /api
@@ -10,6 +10,8 @@ servers:
 tags:
   - name: Push Notifications
     description: Mobile push-device registration endpoints.
+  - name: In-App Notifications
+    description: Notification inbox, unread counters, mutations, and SSE streaming.
 
 paths:
   /me/push-devices/{installation_id}:
@@ -25,24 +27,13 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - name: installation_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
+        - $ref: "#/components/parameters/InstallationID"
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/RegisterPushDeviceRequest"
-            examples:
-              ios:
-                value:
-                  fcm_token: dQw4w9WgXcQ:APA91b...
-                  platform: IOS
-                  device_info: ios 26.0
       responses:
         "200":
           description: Push device registered or updated.
@@ -61,17 +52,170 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - name: installation_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
+        - $ref: "#/components/parameters/InstallationID"
       responses:
         "204":
           description: Push device unregistered or already inactive.
         "400":
           $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+
+  /me/notifications:
+    get:
+      tags: [In-App Notifications]
+      summary: List the authenticated user's notifications
+      description: Returns non-deleted notifications created within the 90-day retention window, ordered by newest first.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: Notification page.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListNotificationsResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+    delete:
+      tags: [In-App Notifications]
+      summary: Delete all visible notifications
+      description: Soft-deletes all non-expired notifications for the authenticated user. Rows are physically removed by the 90-day retention cleanup.
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: All visible notifications are hidden.
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+
+  /me/notifications/unread:
+    get:
+      tags: [In-App Notifications]
+      summary: List unread notifications
+      description: Returns unread, non-deleted notifications created within the 90-day retention window, ordered by newest first.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: Unread notification page.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListNotificationsResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+
+  /me/notifications/unread-count:
+    get:
+      tags: [In-App Notifications]
+      summary: Get unread notification count
+      description: Counts unread, non-deleted notifications created within the 90-day retention window.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Unread count.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnreadCountResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+
+  /me/notifications/read:
+    patch:
+      tags: [In-App Notifications]
+      summary: Mark all notifications as read
+      description: Marks all visible unread notifications as read and returns the number of rows updated.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Updated count.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MarkAllReadResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+
+  /me/notifications/{notification_id}/read:
+    patch:
+      tags: [In-App Notifications]
+      summary: Mark one notification as read
+      description: Marks one owned, visible notification as read. Repeating the call is safe.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/NotificationID"
+      responses:
+        "204":
+          description: Notification is read.
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          $ref: "#/components/responses/NotificationNotFoundError"
+
+  /me/notifications/{notification_id}:
+    delete:
+      tags: [In-App Notifications]
+      summary: Delete one notification
+      description: Soft-deletes one owned notification. The operation is idempotent and does not reveal whether the notification existed.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/NotificationID"
+      responses:
+        "204":
+          description: Notification is hidden or was already absent.
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+
+  /me/notifications/stream:
+    get:
+      tags: [In-App Notifications]
+      summary: Stream in-app notifications
+      description: |
+        Opens a Server-Sent Events stream for active users. Clients must send the
+        normal Bearer access token in the `Authorization` header, typically with
+        a fetch-based SSE client because browser `EventSource` cannot set custom
+        headers. The server sends `event: heartbeat` every 20 seconds and
+        `event: notification` when a new notification is created for the user.
+        Notification events use `id: <notification_id>` and the same JSON shape
+        as the list endpoints. Clients should still call the HTTP list endpoints
+        after reconnecting to recover missed events.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: SSE stream.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                examples:
+                  - |
+                    event: heartbeat
+                    data: {}
+
+                    id: 2ca3f3d1-7d3c-4e4e-b1b9-78fe0d4c749d
+                    event: notification
+                    data: {"id":"2ca3f3d1-7d3c-4e4e-b1b9-78fe0d4c749d","event_id":null,"title":"Event update","body":"A new update is available.","type":null,"deep_link":null,"image_url":null,"data":{},"is_read":false,"read_at":null,"created_at":"2026-04-30T12:00:00Z"}
         "401":
           $ref: "#/components/responses/UnauthorizedError"
 
@@ -81,6 +225,38 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  parameters:
+    InstallationID:
+      name: installation_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    NotificationID:
+      name: notification_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    Limit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 50
+        default: 25
+      description: Maximum notifications to return.
+    Cursor:
+      name: cursor
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Opaque cursor returned in `page_info.next_cursor`.
   schemas:
     RegisterPushDeviceRequest:
       type: object
@@ -91,7 +267,6 @@ components:
           type: string
           minLength: 1
           maxLength: 4096
-          description: Firebase Cloud Messaging registration token for this app installation.
         platform:
           type: string
           enum: [IOS, ANDROID]
@@ -100,7 +275,6 @@ components:
             - string
             - "null"
           maxLength: 512
-          description: Optional low-sensitivity device summary for debugging.
     RegisterPushDeviceResponse:
       type: object
       additionalProperties: false
@@ -119,6 +293,88 @@ components:
         updated_at:
           type: string
           format: date-time
+    Notification:
+      type: object
+      additionalProperties: false
+      required: [id, event_id, title, body, type, deep_link, image_url, data, is_read, read_at, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        event_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+        title:
+          type: string
+        body:
+          type: string
+        type:
+          type:
+            - string
+            - "null"
+        deep_link:
+          type:
+            - string
+            - "null"
+        image_url:
+          type:
+            - string
+            - "null"
+          format: uri
+        data:
+          type: object
+          additionalProperties:
+            type: string
+        is_read:
+          type: boolean
+        read_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+    ListNotificationsResponse:
+      type: object
+      additionalProperties: false
+      required: [items, page_info]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Notification"
+        page_info:
+          $ref: "#/components/schemas/PageInfo"
+    PageInfo:
+      type: object
+      additionalProperties: false
+      required: [next_cursor, has_next]
+      properties:
+        next_cursor:
+          type:
+            - string
+            - "null"
+        has_next:
+          type: boolean
+    UnreadCountResponse:
+      type: object
+      additionalProperties: false
+      required: [unread_count]
+      properties:
+        unread_count:
+          type: integer
+          minimum: 0
+    MarkAllReadResponse:
+      type: object
+      additionalProperties: false
+      required: [updated_count]
+      properties:
+        updated_count:
+          type: integer
+          minimum: 0
     ErrorResponse:
       type: object
       required: [error]
@@ -137,13 +393,19 @@ components:
                 type: string
   responses:
     ValidationError:
-      description: The request body or path parameters failed validation.
+      description: The request body, path parameters, or query parameters failed validation.
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
     UnauthorizedError:
       description: Missing or invalid access token.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    NotificationNotFoundError:
+      description: Notification does not exist, is not owned by the caller, is deleted, or is expired.
       content:
         application/json:
           schema:

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -41,6 +41,7 @@ http {
 
     upstream backend_api {
         server backend:8080;
+        keepalive 32;
     }
 
     upstream frontend_web {
@@ -63,9 +64,26 @@ http {
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_prefer_server_ciphers on;
         
+        location = /api/me/notifications/stream {
+            proxy_pass http://backend_api/me/notifications/stream;
+            proxy_http_version 1.1;
+            proxy_read_timeout 1h;
+            proxy_send_timeout 1h;
+            proxy_buffering off;
+            proxy_cache off;
+            chunked_transfer_encoding off;
+            add_header X-Accel-Buffering no;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location /api/ {
             proxy_pass http://backend_api/;
             proxy_http_version 1.1;
+            proxy_set_header Connection "";
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/nginx.local.conf
+++ b/nginx/nginx.local.conf
@@ -15,6 +15,7 @@ http {
 
     upstream backend_api {
         server backend:8080;
+        keepalive 32;
     }
 
     upstream frontend_web {
@@ -40,9 +41,26 @@ http {
             try_files $uri $uri/ /api/docs/index.html;
         }
 
+        location = /api/me/notifications/stream {
+            proxy_pass http://backend_api/me/notifications/stream;
+            proxy_http_version 1.1;
+            proxy_read_timeout 1h;
+            proxy_send_timeout 1h;
+            proxy_buffering off;
+            proxy_cache off;
+            chunked_transfer_encoding off;
+            add_header X-Accel-Buffering no;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location /api/ {
             proxy_pass http://backend_api/;
             proxy_http_version 1.1;
+            proxy_set_header Connection "";
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 📋 Summary
Adds the backend in-app notification center with a canonical notification inbox, SSE real-time delivery for active users, FCM fallback for inactive users, idempotent notification creation, unread/read/delete APIs, and 90-day retention cleanup.

## 🔄 Changes
- Added notification inbox schema migration with `image_url`, `data`, `idempotency_key`, `read_at`, `deleted_at`, indexes, and `notification_delivery_attempt`.
- Added domain/application types for notifications and delivery methods/statuses.
- Implemented unified `SendNotificationToUsers` flow with SSE-first delivery and FCM fallback.
- Added in-memory SSE broker supporting multiple active connections per user and 20-second heartbeats.
- Added authenticated endpoints for listing, unread listing, unread count, mark read, mark all read, delete one, delete all, and SSE stream.
- Added daily retention cleanup for notifications older than 90 days.
- Updated Firebase push payloads to support `image_url`.
- Updated local/dev Nginx config for SSE proxy timeouts, keepalive, and buffering behavior.
- Expanded OpenAPI notification docs and DB schema docs.
- Added unit and integration coverage for inbox lifecycle, idempotency, SSE delivery, push fallback, read/delete behavior, and retention.

## 🧪 Testing
- `go test ./...`
- `go test -tags=integration ./tests_integration`
- `./shipcheck.sh`

## 🔗 Related
Closes #447
