### PR TITLE
feat(backend): add admin role authorization and backoffice read APIs

### DIFF
--- a/backend/internal/adapter/in/jwt/issuer.go
+++ b/backend/internal/adapter/in/jwt/issuer.go
@@ -14,13 +14,14 @@ type Issuer struct {
 }
 
 // IssueAccessToken creates a signed HS256 JWT containing the user's ID, username,
-// and email as claims, valid for the configured TTL.
+// email, and role as claims, valid for the configured TTL.
 func (j Issuer) IssueAccessToken(user domain.User, issuedAt time.Time) (string, int64, error) {
 	expiresAt := issuedAt.Add(j.TTL)
 	claims := gojwt.MapClaims{
 		"sub":      user.ID.String(),
 		"username": user.Username,
 		"email":    user.Email,
+		"role":     string(user.Role),
 		"iat":      issuedAt.Unix(),
 		"exp":      expiresAt.Unix(),
 	}

--- a/backend/internal/adapter/in/jwt/verifier.go
+++ b/backend/internal/adapter/in/jwt/verifier.go
@@ -39,10 +39,16 @@ func (v Verifier) VerifyAccessToken(token string) (*domain.AuthClaims, error) {
 
 	username, _ := claims["username"].(string)
 	email, _ := claims["email"].(string)
+	roleValue, _ := claims["role"].(string)
+	role, ok := domain.ParseUserRole(roleValue)
+	if !ok {
+		return nil, fmt.Errorf("invalid role claim")
+	}
 
 	return &domain.AuthClaims{
 		UserID:   userID,
 		Username: username,
 		Email:    email,
+		Role:     role,
 	}, nil
 }

--- a/backend/internal/adapter/in/postgres/admin_repo.go
+++ b/backend/internal/adapter/in/postgres/admin_repo.go
@@ -1,0 +1,372 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	adminapp "github.com/bounswe/bounswe2026group11/backend/internal/application/admin"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// AdminRepository is the Postgres-backed implementation of admin.Repository.
+type AdminRepository struct {
+	pool *pgxpool.Pool
+	db   execer
+}
+
+var _ adminapp.Repository = (*AdminRepository)(nil)
+
+// NewAdminRepository returns a repository that executes read-only admin queries.
+func NewAdminRepository(pool *pgxpool.Pool) *AdminRepository {
+	return &AdminRepository{
+		pool: pool,
+		db:   contextualRunner{fallback: pool},
+	}
+}
+
+func (r *AdminRepository) ListUsers(ctx context.Context, input adminapp.ListUsersInput) (*adminapp.ListUsersResult, error) {
+	args := []any{}
+	where := []string{"TRUE"}
+	add := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if input.Query != nil {
+		placeholder := add("%" + *input.Query + "%")
+		where = append(where, "(username ILIKE "+placeholder+" OR email ILIKE "+placeholder+" OR phone_number ILIKE "+placeholder+")")
+	}
+	if input.Status != nil {
+		where = append(where, "status = "+add(input.Status.String()))
+	}
+	if input.Role != nil {
+		where = append(where, "role = "+add(input.Role.String()))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "created_at <= "+add(*input.CreatedTo))
+	}
+
+	limitPlaceholder := add(input.Limit)
+	offsetPlaceholder := add(input.Offset)
+	query := `
+		SELECT id, username, email, phone_number, email_verified_at IS NOT NULL, last_login, status, role, created_at, updated_at, COUNT(*) OVER()
+		FROM app_user
+		WHERE ` + strings.Join(where, " AND ") + `
+		ORDER BY created_at DESC, id DESC
+		LIMIT ` + limitPlaceholder + ` OFFSET ` + offsetPlaceholder
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list users: %w", err)
+	}
+	defer rows.Close()
+
+	items := []adminapp.AdminUserItem{}
+	totalCount := 0
+	for rows.Next() {
+		var item adminapp.AdminUserItem
+		var phone pgtype.Text
+		var lastLogin pgtype.Timestamptz
+		var status string
+		var role string
+		if err := rows.Scan(
+			&item.ID,
+			&item.Username,
+			&item.Email,
+			&phone,
+			&item.EmailVerified,
+			&lastLogin,
+			&status,
+			&role,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+			&totalCount,
+		); err != nil {
+			return nil, fmt.Errorf("admin scan user: %w", err)
+		}
+		item.PhoneNumber = textPtr(phone)
+		item.LastLogin = timestamptzPtr(lastLogin)
+		item.Status = status
+		item.Role = role
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list users rows: %w", err)
+	}
+
+	return &adminapp.ListUsersResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
+}
+
+func (r *AdminRepository) ListEvents(ctx context.Context, input adminapp.ListEventsInput) (*adminapp.ListEventsResult, error) {
+	args := []any{}
+	where := []string{"TRUE"}
+	add := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if input.Query != nil {
+		placeholder := add("%" + *input.Query + "%")
+		where = append(where, "(e.title ILIKE "+placeholder+" OR e.description ILIKE "+placeholder+" OR u.username ILIKE "+placeholder+")")
+	}
+	if input.HostID != nil {
+		where = append(where, "e.host_id = "+add(*input.HostID))
+	}
+	if input.CategoryID != nil {
+		where = append(where, "e.category_id = "+add(*input.CategoryID))
+	}
+	if input.PrivacyLevel != nil {
+		where = append(where, "e.privacy_level = "+add(string(*input.PrivacyLevel)))
+	}
+	if input.Status != nil {
+		where = append(where, "e.status = "+add(string(*input.Status)))
+	}
+	if input.StartFrom != nil {
+		where = append(where, "e.start_time >= "+add(*input.StartFrom))
+	}
+	if input.StartTo != nil {
+		where = append(where, "e.start_time <= "+add(*input.StartTo))
+	}
+
+	limitPlaceholder := add(input.Limit)
+	offsetPlaceholder := add(input.Offset)
+	query := `
+		SELECT e.id, e.host_id, u.username, e.title, e.category_id, c.name, e.start_time, e.end_time,
+		       e.privacy_level, e.status, e.capacity, e.approved_participant_count, e.pending_participant_count,
+		       e.created_at, e.updated_at, COUNT(*) OVER()
+		FROM event e
+		JOIN app_user u ON u.id = e.host_id
+		LEFT JOIN event_category c ON c.id = e.category_id
+		WHERE ` + strings.Join(where, " AND ") + `
+		ORDER BY e.created_at DESC, e.id DESC
+		LIMIT ` + limitPlaceholder + ` OFFSET ` + offsetPlaceholder
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list events: %w", err)
+	}
+	defer rows.Close()
+
+	items := []adminapp.AdminEventItem{}
+	totalCount := 0
+	for rows.Next() {
+		var item adminapp.AdminEventItem
+		var categoryID pgtype.Int4
+		var categoryName pgtype.Text
+		var endTime pgtype.Timestamptz
+		var capacity pgtype.Int4
+		if err := rows.Scan(
+			&item.ID,
+			&item.HostID,
+			&item.HostUsername,
+			&item.Title,
+			&categoryID,
+			&categoryName,
+			&item.StartTime,
+			&endTime,
+			&item.PrivacyLevel,
+			&item.Status,
+			&capacity,
+			&item.ApprovedParticipantCount,
+			&item.PendingParticipantCount,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+			&totalCount,
+		); err != nil {
+			return nil, fmt.Errorf("admin scan event: %w", err)
+		}
+		item.CategoryID = intPtr(categoryID)
+		item.CategoryName = textPtr(categoryName)
+		item.EndTime = timestamptzPtr(endTime)
+		item.Capacity = intPtr(capacity)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list events rows: %w", err)
+	}
+
+	return &adminapp.ListEventsResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
+}
+
+func (r *AdminRepository) ListParticipations(ctx context.Context, input adminapp.ListParticipationsInput) (*adminapp.ListParticipationsResult, error) {
+	args := []any{}
+	where := []string{"TRUE"}
+	add := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if input.Query != nil {
+		placeholder := add("%" + *input.Query + "%")
+		where = append(where, "(e.title ILIKE "+placeholder+" OR u.username ILIKE "+placeholder+" OR u.email ILIKE "+placeholder+")")
+	}
+	if input.Status != nil {
+		where = append(where, "p.status = "+add(input.Status.String()))
+	}
+	if input.EventID != nil {
+		where = append(where, "p.event_id = "+add(*input.EventID))
+	}
+	if input.UserID != nil {
+		where = append(where, "p.user_id = "+add(*input.UserID))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "p.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "p.created_at <= "+add(*input.CreatedTo))
+	}
+
+	limitPlaceholder := add(input.Limit)
+	offsetPlaceholder := add(input.Offset)
+	query := `
+		SELECT p.id, p.event_id, e.title, p.user_id, u.username, u.email, p.status, p.reconfirmed_at,
+		       p.created_at, p.updated_at, COUNT(*) OVER()
+		FROM participation p
+		JOIN event e ON e.id = p.event_id
+		JOIN app_user u ON u.id = p.user_id
+		WHERE ` + strings.Join(where, " AND ") + `
+		ORDER BY p.created_at DESC, p.id DESC
+		LIMIT ` + limitPlaceholder + ` OFFSET ` + offsetPlaceholder
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list participations: %w", err)
+	}
+	defer rows.Close()
+
+	items := []adminapp.AdminParticipationItem{}
+	totalCount := 0
+	for rows.Next() {
+		var item adminapp.AdminParticipationItem
+		var reconfirmedAt pgtype.Timestamptz
+		if err := rows.Scan(
+			&item.ID,
+			&item.EventID,
+			&item.EventTitle,
+			&item.UserID,
+			&item.Username,
+			&item.UserEmail,
+			&item.Status,
+			&reconfirmedAt,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+			&totalCount,
+		); err != nil {
+			return nil, fmt.Errorf("admin scan participation: %w", err)
+		}
+		item.ReconfirmedAt = timestamptzPtr(reconfirmedAt)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list participations rows: %w", err)
+	}
+
+	return &adminapp.ListParticipationsResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
+}
+
+func (r *AdminRepository) ListTickets(ctx context.Context, input adminapp.ListTicketsInput) (*adminapp.ListTicketsResult, error) {
+	args := []any{}
+	where := []string{"TRUE"}
+	add := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if input.Query != nil {
+		placeholder := add("%" + *input.Query + "%")
+		where = append(where, "(e.title ILIKE "+placeholder+" OR u.username ILIKE "+placeholder+" OR u.email ILIKE "+placeholder+")")
+	}
+	if input.Status != nil {
+		where = append(where, "t.status = "+add(input.Status.String()))
+	}
+	if input.EventID != nil {
+		where = append(where, "p.event_id = "+add(*input.EventID))
+	}
+	if input.UserID != nil {
+		where = append(where, "p.user_id = "+add(*input.UserID))
+	}
+	if input.ParticipationID != nil {
+		where = append(where, "t.participation_id = "+add(*input.ParticipationID))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "t.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "t.created_at <= "+add(*input.CreatedTo))
+	}
+
+	limitPlaceholder := add(input.Limit)
+	offsetPlaceholder := add(input.Offset)
+	query := `
+		SELECT t.id, t.participation_id, p.event_id, e.title, p.user_id, u.username, u.email,
+		       t.status, t.expires_at, t.used_at, t.canceled_at, t.created_at, t.updated_at, COUNT(*) OVER()
+		FROM ticket t
+		JOIN participation p ON p.id = t.participation_id
+		JOIN event e ON e.id = p.event_id
+		JOIN app_user u ON u.id = p.user_id
+		WHERE ` + strings.Join(where, " AND ") + `
+		ORDER BY t.created_at DESC, t.id DESC
+		LIMIT ` + limitPlaceholder + ` OFFSET ` + offsetPlaceholder
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list tickets: %w", err)
+	}
+	defer rows.Close()
+
+	items := []adminapp.AdminTicketItem{}
+	totalCount := 0
+	for rows.Next() {
+		var item adminapp.AdminTicketItem
+		var usedAt pgtype.Timestamptz
+		var canceledAt pgtype.Timestamptz
+		if err := rows.Scan(
+			&item.ID,
+			&item.ParticipationID,
+			&item.EventID,
+			&item.EventTitle,
+			&item.UserID,
+			&item.Username,
+			&item.UserEmail,
+			&item.Status,
+			&item.ExpiresAt,
+			&usedAt,
+			&canceledAt,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+			&totalCount,
+		); err != nil {
+			return nil, fmt.Errorf("admin scan ticket: %w", err)
+		}
+		item.UsedAt = timestamptzPtr(usedAt)
+		item.CanceledAt = timestamptzPtr(canceledAt)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list tickets rows: %w", err)
+	}
+
+	return &adminapp.ListTicketsResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
+}
+
+func pageMeta(page adminapp.PageInput, totalCount, itemCount int) adminapp.PageMeta {
+	return adminapp.PageMeta{
+		Limit:      page.Limit,
+		Offset:     page.Offset,
+		TotalCount: totalCount,
+		HasNext:    page.Offset+itemCount < totalCount,
+	}
+}
+
+func intPtr(value pgtype.Int4) *int {
+	if !value.Valid {
+		return nil
+	}
+	converted := int(value.Int32)
+	return &converted
+}

--- a/backend/internal/adapter/in/postgres/auth_repo.go
+++ b/backend/internal/adapter/in/postgres/auth_repo.go
@@ -41,7 +41,7 @@ func NewAuthRepositoryWithTx(pool *pgxpool.Pool, tx pgx.Tx) *AuthRepository {
 
 func (r *AuthRepository) GetUserByEmail(ctx context.Context, email string) (*domain.User, error) {
 	row := r.db.QueryRow(ctx, `
-		SELECT id, username, email, phone_number, gender, birth_date, password_hash, email_verified_at, last_login, status, created_at, updated_at
+		SELECT id, username, email, phone_number, gender, birth_date, password_hash, email_verified_at, last_login, status, role, created_at, updated_at
 		FROM app_user
 		WHERE email = $1
 	`, email)
@@ -50,7 +50,7 @@ func (r *AuthRepository) GetUserByEmail(ctx context.Context, email string) (*dom
 
 func (r *AuthRepository) GetUserByUsername(ctx context.Context, username string) (*domain.User, error) {
 	row := r.db.QueryRow(ctx, `
-		SELECT id, username, email, phone_number, gender, birth_date, password_hash, email_verified_at, last_login, status, created_at, updated_at
+		SELECT id, username, email, phone_number, gender, birth_date, password_hash, email_verified_at, last_login, status, role, created_at, updated_at
 		FROM app_user
 		WHERE username = $1
 	`, username)
@@ -59,7 +59,7 @@ func (r *AuthRepository) GetUserByUsername(ctx context.Context, username string)
 
 func (r *AuthRepository) GetUserByID(ctx context.Context, userID uuid.UUID) (*domain.User, error) {
 	row := r.db.QueryRow(ctx, `
-		SELECT id, username, email, phone_number, gender, birth_date, password_hash, email_verified_at, last_login, status, created_at, updated_at
+		SELECT id, username, email, phone_number, gender, birth_date, password_hash, email_verified_at, last_login, status, role, created_at, updated_at
 		FROM app_user
 		WHERE id = $1
 	`, userID)
@@ -68,10 +68,10 @@ func (r *AuthRepository) GetUserByID(ctx context.Context, userID uuid.UUID) (*do
 
 func (r *AuthRepository) CreateUser(ctx context.Context, params authapp.CreateUserParams) (*domain.User, error) {
 	row := r.db.QueryRow(ctx, `
-		INSERT INTO app_user (username, email, phone_number, gender, birth_date, password_hash, email_verified_at, status)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-		RETURNING id, username, email, phone_number, gender, birth_date, password_hash, email_verified_at, last_login, status, created_at, updated_at
-	`, params.Username, params.Email, params.PhoneNumber, params.Gender, params.BirthDate, params.PasswordHash, params.EmailVerifiedAt, params.Status)
+		INSERT INTO app_user (username, email, phone_number, gender, birth_date, password_hash, email_verified_at, status, role)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING id, username, email, phone_number, gender, birth_date, password_hash, email_verified_at, last_login, status, role, created_at, updated_at
+	`, params.Username, params.Email, params.PhoneNumber, params.Gender, params.BirthDate, params.PasswordHash, params.EmailVerifiedAt, params.Status, domain.UserRoleUser)
 
 	user, err := scanUser(row)
 	if err != nil {

--- a/backend/internal/adapter/in/postgres/helpers.go
+++ b/backend/internal/adapter/in/postgres/helpers.go
@@ -22,6 +22,7 @@ func scanUser(row pgx.Row) (*domain.User, error) {
 		emailVerifiedAt pgtype.Timestamptz
 		lastLogin       pgtype.Timestamptz
 		status          pgtype.Text
+		role            string
 	)
 
 	if err := row.Scan(
@@ -35,6 +36,7 @@ func scanUser(row pgx.Row) (*domain.User, error) {
 		&emailVerifiedAt,
 		&lastLogin,
 		&status,
+		&role,
 		&user.CreatedAt,
 		&user.UpdatedAt,
 	); err != nil {
@@ -50,7 +52,8 @@ func scanUser(row pgx.Row) (*domain.User, error) {
 	user.PasswordHash = textValue(passwordHash)
 	user.EmailVerifiedAt = timestamptzPtr(emailVerifiedAt)
 	user.LastLogin = timestamptzPtr(lastLogin)
-	user.Status = textValue(status)
+	user.Status = domain.UserStatus(textValue(status))
+	user.Role = domain.UserRole(role)
 	return &user, nil
 }
 

--- a/backend/internal/adapter/out/httpapi/admin_handler/admin_handler.go
+++ b/backend/internal/adapter/out/httpapi/admin_handler/admin_handler.go
@@ -1,0 +1,341 @@
+package admin_handler
+
+import (
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/admin"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// Handler groups web-only admin backoffice handlers.
+type Handler struct {
+	service admin.UseCase
+}
+
+// NewHandler creates an admin handler backed by the given use case.
+func NewHandler(service admin.UseCase) *Handler {
+	return &Handler{service: service}
+}
+
+// RegisterRoutes mounts admin-only read endpoints.
+func RegisterRoutes(router fiber.Router, handler *Handler, adminAuth fiber.Handler) {
+	group := router.Group("/admin", adminAuth)
+	group.Get("/users", handler.ListUsers)
+	group.Get("/events", handler.ListEvents)
+	group.Get("/participations", handler.ListParticipations)
+	group.Get("/tickets", handler.ListTickets)
+}
+
+func (h *Handler) ListUsers(c *fiber.Ctx) error {
+	input, errs := parseListUsersInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListUsers(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	logAdminList(c, "admin.users.list", len(result.Items), result.PageMeta, summarizeUsers(input))
+	return c.JSON(result)
+}
+
+func (h *Handler) ListEvents(c *fiber.Ctx) error {
+	input, errs := parseListEventsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListEvents(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	logAdminList(c, "admin.events.list", len(result.Items), result.PageMeta, summarizeEvents(input))
+	return c.JSON(result)
+}
+
+func (h *Handler) ListParticipations(c *fiber.Ctx) error {
+	input, errs := parseListParticipationsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListParticipations(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	logAdminList(c, "admin.participations.list", len(result.Items), result.PageMeta, summarizeParticipations(input))
+	return c.JSON(result)
+}
+
+func (h *Handler) ListTickets(c *fiber.Ctx) error {
+	input, errs := parseListTicketsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListTickets(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	logAdminList(c, "admin.tickets.list", len(result.Items), result.PageMeta, summarizeTickets(input))
+	return c.JSON(result)
+}
+
+func parseListUsersInput(c *fiber.Ctx) (admin.ListUsersInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListUsersInput{PageInput: page}
+	input.Query = optionalTrimmed(c.Query("q"))
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	if raw := strings.TrimSpace(c.Query("status")); raw != "" {
+		status, ok := domain.ParseUserStatus(raw)
+		if !ok {
+			errs["status"] = "must be one of: active"
+		} else {
+			input.Status = &status
+		}
+	}
+	if raw := strings.TrimSpace(c.Query("role")); raw != "" {
+		role, ok := domain.ParseUserRole(raw)
+		if !ok {
+			errs["role"] = "must be one of: USER, ADMIN"
+		} else {
+			input.Role = &role
+		}
+	}
+	return input, errs
+}
+
+func parseListEventsInput(c *fiber.Ctx) (admin.ListEventsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListEventsInput{PageInput: page}
+	input.Query = optionalTrimmed(c.Query("q"))
+	input.HostID = parseOptionalUUID(c, "host_id", errs)
+	input.CategoryID = parseOptionalInt(c, "category_id", errs)
+	input.StartFrom = parseOptionalTime(c, "start_from", errs)
+	input.StartTo = parseOptionalTime(c, "start_to", errs)
+	if raw := strings.TrimSpace(c.Query("privacy_level")); raw != "" {
+		level, ok := domain.ParseEventPrivacyLevel(raw)
+		if !ok {
+			errs["privacy_level"] = "must be one of: PUBLIC, PROTECTED, PRIVATE"
+		} else {
+			input.PrivacyLevel = &level
+		}
+	}
+	if raw := strings.TrimSpace(c.Query("status")); raw != "" {
+		status, ok := domain.ParseEventStatus(raw)
+		if !ok {
+			errs["status"] = "must be one of: ACTIVE, IN_PROGRESS, CANCELED, COMPLETED"
+		} else {
+			input.Status = &status
+		}
+	}
+	return input, errs
+}
+
+func parseListParticipationsInput(c *fiber.Ctx) (admin.ListParticipationsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListParticipationsInput{PageInput: page}
+	input.Query = optionalTrimmed(c.Query("q"))
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	if raw := strings.TrimSpace(c.Query("status")); raw != "" {
+		status, ok := domain.ParseParticipationStatus(raw)
+		if !ok {
+			errs["status"] = "must be one of: APPROVED, PENDING, CANCELED, LEAVED"
+		} else {
+			input.Status = &status
+		}
+	}
+	return input, errs
+}
+
+func parseListTicketsInput(c *fiber.Ctx) (admin.ListTicketsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListTicketsInput{PageInput: page}
+	input.Query = optionalTrimmed(c.Query("q"))
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.ParticipationID = parseOptionalUUID(c, "participation_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	if raw := strings.TrimSpace(c.Query("status")); raw != "" {
+		status, ok := domain.ParseTicketStatus(raw)
+		if !ok {
+			errs["status"] = "must be one of: ACTIVE, PENDING, EXPIRED, USED, CANCELED"
+		} else {
+			input.Status = &status
+		}
+	}
+	return input, errs
+}
+
+func parsePage(c *fiber.Ctx) (admin.PageInput, map[string]string) {
+	errs := map[string]string{}
+	page := admin.PageInput{Limit: admin.DefaultLimit}
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		limit, err := strconv.Atoi(raw)
+		if err != nil || limit < 1 || limit > admin.MaxLimit {
+			errs["limit"] = "must be an integer between 1 and 100"
+		} else {
+			page.Limit = limit
+		}
+	}
+	if raw := strings.TrimSpace(c.Query("offset")); raw != "" {
+		offset, err := strconv.Atoi(raw)
+		if err != nil || offset < 0 {
+			errs["offset"] = "must be a non-negative integer"
+		} else {
+			page.Offset = offset
+		}
+	}
+	return page, errs
+}
+
+func optionalTrimmed(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func parseOptionalUUID(c *fiber.Ctx, key string, errs map[string]string) *uuid.UUID {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return nil
+	}
+	value, err := uuid.Parse(raw)
+	if err != nil {
+		errs[key] = "must be a valid UUID"
+		return nil
+	}
+	return &value
+}
+
+func parseOptionalInt(c *fiber.Ctx, key string, errs map[string]string) *int {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		errs[key] = "must be an integer"
+		return nil
+	}
+	return &value
+}
+
+func parseOptionalTime(c *fiber.Ctx, key string, errs map[string]string) *time.Time {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return nil
+	}
+	value, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		errs[key] = "must be an RFC3339 timestamp"
+		return nil
+	}
+	value = value.UTC()
+	return &value
+}
+
+func logAdminList(c *fiber.Ctx, operation string, resultCount int, page admin.PageMeta, summary string) {
+	httpapi.LogInfo(
+		c.UserContext(),
+		"admin list query completed",
+		httpapi.OperationAttr(operation),
+		httpapi.UserIDAttr(httpapi.UserClaims(c).UserID),
+		slog.Int("result_count", resultCount),
+		slog.Int("limit", page.Limit),
+		slog.Int("offset", page.Offset),
+		slog.Bool("has_next", page.HasNext),
+		httpapi.QuerySummaryAttr(summary),
+	)
+}
+
+func summarizeUsers(input admin.ListUsersInput) string {
+	return httpapi.JoinSummary(
+		httpapi.CountSummary("limit", input.Limit),
+		httpapi.CountSummary("offset", input.Offset),
+		httpapi.StringPtrSummary("q", input.Query),
+		pointerSummary("status", input.Status),
+		pointerSummary("role", input.Role),
+		timePointerSummary("created_from", input.CreatedFrom),
+		timePointerSummary("created_to", input.CreatedTo),
+	)
+}
+
+func summarizeEvents(input admin.ListEventsInput) string {
+	return httpapi.JoinSummary(
+		httpapi.CountSummary("limit", input.Limit),
+		httpapi.CountSummary("offset", input.Offset),
+		httpapi.StringPtrSummary("q", input.Query),
+		uuidPointerSummary("host_id", input.HostID),
+		intPointerSummary("category_id", input.CategoryID),
+		pointerSummary("privacy_level", input.PrivacyLevel),
+		pointerSummary("status", input.Status),
+		timePointerSummary("start_from", input.StartFrom),
+		timePointerSummary("start_to", input.StartTo),
+	)
+}
+
+func summarizeParticipations(input admin.ListParticipationsInput) string {
+	return httpapi.JoinSummary(
+		httpapi.CountSummary("limit", input.Limit),
+		httpapi.CountSummary("offset", input.Offset),
+		httpapi.StringPtrSummary("q", input.Query),
+		pointerSummary("status", input.Status),
+		uuidPointerSummary("event_id", input.EventID),
+		uuidPointerSummary("user_id", input.UserID),
+		timePointerSummary("created_from", input.CreatedFrom),
+		timePointerSummary("created_to", input.CreatedTo),
+	)
+}
+
+func summarizeTickets(input admin.ListTicketsInput) string {
+	return httpapi.JoinSummary(
+		httpapi.CountSummary("limit", input.Limit),
+		httpapi.CountSummary("offset", input.Offset),
+		httpapi.StringPtrSummary("q", input.Query),
+		pointerSummary("status", input.Status),
+		uuidPointerSummary("event_id", input.EventID),
+		uuidPointerSummary("user_id", input.UserID),
+		uuidPointerSummary("participation_id", input.ParticipationID),
+		timePointerSummary("created_from", input.CreatedFrom),
+		timePointerSummary("created_to", input.CreatedTo),
+	)
+}
+
+func pointerSummary[T ~string](label string, value *T) string {
+	if value == nil {
+		return label + "=<nil>"
+	}
+	return httpapi.StringSummary(label, string(*value))
+}
+
+func uuidPointerSummary(label string, value *uuid.UUID) string {
+	if value == nil {
+		return label + "=<nil>"
+	}
+	return httpapi.StringSummary(label, value.String())
+}
+
+func intPointerSummary(label string, value *int) string {
+	if value == nil {
+		return label + "=<nil>"
+	}
+	return httpapi.CountSummary(label, *value)
+}
+
+func timePointerSummary(label string, value *time.Time) string {
+	if value == nil {
+		return label + "=<nil>"
+	}
+	return httpapi.StringSummary(label, value.Format(time.RFC3339))
+}

--- a/backend/internal/adapter/out/httpapi/admin_handler/admin_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/admin_handler/admin_handler_test.go
@@ -1,0 +1,166 @@
+package admin_handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/admin"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+type stubAdminService struct {
+	lastUsers          admin.ListUsersInput
+	lastEvents         admin.ListEventsInput
+	lastParticipations admin.ListParticipationsInput
+	lastTickets        admin.ListTicketsInput
+}
+
+func (s *stubAdminService) ListUsers(_ context.Context, input admin.ListUsersInput) (*admin.ListUsersResult, error) {
+	s.lastUsers = input
+	return &admin.ListUsersResult{Items: []admin.AdminUserItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+
+func (s *stubAdminService) ListEvents(_ context.Context, input admin.ListEventsInput) (*admin.ListEventsResult, error) {
+	s.lastEvents = input
+	return &admin.ListEventsResult{Items: []admin.AdminEventItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+
+func (s *stubAdminService) ListParticipations(_ context.Context, input admin.ListParticipationsInput) (*admin.ListParticipationsResult, error) {
+	s.lastParticipations = input
+	return &admin.ListParticipationsResult{Items: []admin.AdminParticipationItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+
+func (s *stubAdminService) ListTickets(_ context.Context, input admin.ListTicketsInput) (*admin.ListTicketsResult, error) {
+	s.lastTickets = input
+	return &admin.ListTicketsResult{Items: []admin.AdminTicketItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+
+func adminHandlerTestApp(service admin.UseCase) *fiber.App {
+	app := fiber.New()
+	RegisterRoutes(app, NewHandler(service), func(c *fiber.Ctx) error {
+		c.Locals("user_claims", &domain.AuthClaims{UserID: uuid.New(), Role: domain.UserRoleAdmin})
+		return c.Next()
+	})
+	return app
+}
+
+func TestListUsersValidatesPagination(t *testing.T) {
+	// given
+	app := adminHandlerTestApp(&stubAdminService{})
+	req := httptest.NewRequest(fiber.MethodGet, "/admin/users?limit=101&offset=-1", nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var body struct {
+		Error struct {
+			Details map[string]string `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.Error.Details["limit"] == "" || body.Error.Details["offset"] == "" {
+		t.Fatalf("expected limit and offset validation details, got %#v", body.Error.Details)
+	}
+}
+
+func TestListUsersParsesFilters(t *testing.T) {
+	// given
+	service := &stubAdminService{}
+	app := adminHandlerTestApp(service)
+	from := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	req := httptest.NewRequest(fiber.MethodGet, "/admin/users?limit=25&offset=50&q=ali&status=active&role=ADMIN&created_from="+from.Format(time.RFC3339), nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if service.lastUsers.Limit != 25 || service.lastUsers.Offset != 50 {
+		t.Fatalf("unexpected pagination: %#v", service.lastUsers.PageInput)
+	}
+	if service.lastUsers.Query == nil || *service.lastUsers.Query != "ali" {
+		t.Fatalf("expected query ali, got %#v", service.lastUsers.Query)
+	}
+	if service.lastUsers.Status == nil || *service.lastUsers.Status != domain.UserStatusActive {
+		t.Fatalf("expected active status, got %#v", service.lastUsers.Status)
+	}
+	if service.lastUsers.Role == nil || *service.lastUsers.Role != domain.UserRoleAdmin {
+		t.Fatalf("expected admin role, got %#v", service.lastUsers.Role)
+	}
+	if service.lastUsers.CreatedFrom == nil || !service.lastUsers.CreatedFrom.Equal(from) {
+		t.Fatalf("expected created_from %s, got %#v", from, service.lastUsers.CreatedFrom)
+	}
+}
+
+func TestListEventsValidatesEnumFilters(t *testing.T) {
+	// given
+	app := adminHandlerTestApp(&stubAdminService{})
+	req := httptest.NewRequest(fiber.MethodGet, "/admin/events?privacy_level=FRIENDS&status=DRAFT", nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestListTicketsParsesIDsAndStatus(t *testing.T) {
+	// given
+	service := &stubAdminService{}
+	app := adminHandlerTestApp(service)
+	eventID := uuid.New()
+	userID := uuid.New()
+	participationID := uuid.New()
+	req := httptest.NewRequest(fiber.MethodGet, "/admin/tickets?event_id="+eventID.String()+"&user_id="+userID.String()+"&participation_id="+participationID.String()+"&status=ACTIVE", nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if service.lastTickets.EventID == nil || *service.lastTickets.EventID != eventID {
+		t.Fatalf("expected event_id %s, got %#v", eventID, service.lastTickets.EventID)
+	}
+	if service.lastTickets.UserID == nil || *service.lastTickets.UserID != userID {
+		t.Fatalf("expected user_id %s, got %#v", userID, service.lastTickets.UserID)
+	}
+	if service.lastTickets.ParticipationID == nil || *service.lastTickets.ParticipationID != participationID {
+		t.Fatalf("expected participation_id %s, got %#v", participationID, service.lastTickets.ParticipationID)
+	}
+	if service.lastTickets.Status == nil || *service.lastTickets.Status != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE status, got %#v", service.lastTickets.Status)
+	}
+}

--- a/backend/internal/adapter/out/httpapi/middleware.go
+++ b/backend/internal/adapter/out/httpapi/middleware.go
@@ -41,6 +41,45 @@ func RequireAuth(verifier domain.TokenVerifier) fiber.Handler {
 	}
 }
 
+// RequireAdmin returns middleware that first authenticates the request and then
+// requires the caller's role claim to be ADMIN. Authentication failures keep the
+// standard 401 behavior from RequireAuth; authenticated non-admins receive 403.
+func RequireAdmin(verifier domain.TokenVerifier) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		header := c.Get(fiber.HeaderAuthorization)
+		token, ok := extractBearer(header)
+		if !ok {
+			return c.Status(fiber.StatusUnauthorized).JSON(ErrorEnvelope{
+				Error: ErrorBody{
+					Code:    "missing_token",
+					Message: "Authorization header with Bearer token is required.",
+				},
+			})
+		}
+
+		claims, err := verifier.VerifyAccessToken(token)
+		if err != nil {
+			return c.Status(fiber.StatusUnauthorized).JSON(ErrorEnvelope{
+				Error: ErrorBody{
+					Code:    "invalid_token",
+					Message: "The access token is invalid or expired.",
+				},
+			})
+		}
+		if claims.Role != domain.UserRoleAdmin {
+			return c.Status(fiber.StatusForbidden).JSON(ErrorEnvelope{
+				Error: ErrorBody{
+					Code:    domain.ErrorCodeAdminAccessRequired,
+					Message: "Admin access is required for this endpoint.",
+				},
+			})
+		}
+
+		c.Locals(contextKeyUserClaims, claims)
+		return c.Next()
+	}
+}
+
 // OptionalAuth returns a middleware that parses the Bearer token if present
 // and stores the claims in the request context. If the header is absent the
 // request proceeds unauthenticated (UserClaims will return nil). If a token
@@ -73,6 +112,29 @@ func OptionalAuth(verifier domain.TokenVerifier) fiber.Handler {
 func UserClaims(c *fiber.Ctx) *domain.AuthClaims {
 	claims, _ := c.Locals(contextKeyUserClaims).(*domain.AuthClaims)
 	return claims
+}
+
+// RequireAdminRole is intended to be mounted after RequireAuth when route
+// groups need to compose authentication separately from authorization.
+func RequireAdminRole(c *fiber.Ctx) error {
+	claims := UserClaims(c)
+	if claims == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(ErrorEnvelope{
+			Error: ErrorBody{
+				Code:    "missing_token",
+				Message: "Authorization header with Bearer token is required.",
+			},
+		})
+	}
+	if claims.Role != domain.UserRoleAdmin {
+		return c.Status(fiber.StatusForbidden).JSON(ErrorEnvelope{
+			Error: ErrorBody{
+				Code:    domain.ErrorCodeAdminAccessRequired,
+				Message: "Admin access is required for this endpoint.",
+			},
+		})
+	}
+	return c.Next()
 }
 
 // extractBearer parses "Bearer <token>" from an Authorization header value.

--- a/backend/internal/adapter/out/httpapi/middleware_test.go
+++ b/backend/internal/adapter/out/httpapi/middleware_test.go
@@ -33,6 +33,18 @@ func testApp(verifier domain.TokenVerifier) *fiber.App {
 	return app
 }
 
+func adminTestApp(verifier domain.TokenVerifier) *fiber.App {
+	app := fiber.New()
+	app.Get("/admin", RequireAdmin(verifier), func(c *fiber.Ctx) error {
+		claims := UserClaims(c)
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{
+			"user_id": claims.UserID.String(),
+			"role":    claims.Role.String(),
+		})
+	})
+	return app
+}
+
 func TestRequireAuthMissingHeader(t *testing.T) {
 	// given
 	app := testApp(&fakeVerifier{})
@@ -117,5 +129,77 @@ func TestRequireAuthValidToken(t *testing.T) {
 	if resp.StatusCode != fiber.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 200, got %d — body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestRequireAdminMissingHeader(t *testing.T) {
+	// given
+	app := adminTestApp(&fakeVerifier{})
+	req := httptest.NewRequest(fiber.MethodGet, "/admin", nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestRequireAdminRejectsNonAdmin(t *testing.T) {
+	// given
+	app := adminTestApp(&fakeVerifier{
+		claims: &domain.AuthClaims{
+			UserID:   uuid.New(),
+			Username: "regular",
+			Email:    "regular@example.com",
+			Role:     domain.UserRoleUser,
+		},
+	})
+	req := httptest.NewRequest(fiber.MethodGet, "/admin", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token.here")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403, got %d body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestRequireAdminAllowsAdmin(t *testing.T) {
+	// given
+	app := adminTestApp(&fakeVerifier{
+		claims: &domain.AuthClaims{
+			UserID:   uuid.New(),
+			Username: "admin",
+			Email:    "admin@example.com",
+			Role:     domain.UserRoleAdmin,
+		},
+	})
+	req := httptest.NewRequest(fiber.MethodGet, "/admin", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token.here")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d body=%s", resp.StatusCode, body)
 	}
 }

--- a/backend/internal/application/admin/repository.go
+++ b/backend/internal/application/admin/repository.go
@@ -1,0 +1,11 @@
+package admin
+
+import "context"
+
+// Repository is the persistence port for read-only backoffice list queries.
+type Repository interface {
+	ListUsers(ctx context.Context, input ListUsersInput) (*ListUsersResult, error)
+	ListEvents(ctx context.Context, input ListEventsInput) (*ListEventsResult, error)
+	ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error)
+	ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error)
+}

--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -1,0 +1,13 @@
+package admin
+
+// Service implements read-only admin backoffice use cases.
+type Service struct {
+	repo Repository
+}
+
+var _ UseCase = (*Service)(nil)
+
+// NewService constructs an admin service with the given repository.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}

--- a/backend/internal/application/admin/service_dto.go
+++ b/backend/internal/application/admin/service_dto.go
@@ -1,0 +1,171 @@
+package admin
+
+import (
+	"context"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+const (
+	DefaultLimit = 50
+	MaxLimit     = 100
+)
+
+// PageInput carries offset pagination controls.
+type PageInput struct {
+	Limit  int
+	Offset int
+}
+
+// PageMeta describes offset pagination state for table clients.
+type PageMeta struct {
+	Limit      int  `json:"limit"`
+	Offset     int  `json:"offset"`
+	TotalCount int  `json:"total_count"`
+	HasNext    bool `json:"has_next"`
+}
+
+type CreatedRange struct {
+	CreatedFrom *time.Time
+	CreatedTo   *time.Time
+}
+
+type StartRange struct {
+	StartFrom *time.Time
+	StartTo   *time.Time
+}
+
+type ListUsersInput struct {
+	PageInput
+	CreatedRange
+	Query  *string
+	Status *domain.UserStatus
+	Role   *domain.UserRole
+}
+
+type AdminUserItem struct {
+	ID            uuid.UUID  `json:"id"`
+	Username      string     `json:"username"`
+	Email         string     `json:"email"`
+	PhoneNumber   *string    `json:"phone_number"`
+	EmailVerified bool       `json:"email_verified"`
+	LastLogin     *time.Time `json:"last_login"`
+	Status        string     `json:"status"`
+	Role          string     `json:"role"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+type ListUsersResult struct {
+	Items []AdminUserItem `json:"items"`
+	PageMeta
+}
+
+type ListEventsInput struct {
+	PageInput
+	StartRange
+	Query        *string
+	HostID       *uuid.UUID
+	CategoryID   *int
+	PrivacyLevel *domain.EventPrivacyLevel
+	Status       *domain.EventStatus
+}
+
+type AdminEventItem struct {
+	ID                       uuid.UUID  `json:"id"`
+	HostID                   uuid.UUID  `json:"host_id"`
+	HostUsername             string     `json:"host_username"`
+	Title                    string     `json:"title"`
+	CategoryID               *int       `json:"category_id"`
+	CategoryName             *string    `json:"category_name"`
+	StartTime                time.Time  `json:"start_time"`
+	EndTime                  *time.Time `json:"end_time"`
+	PrivacyLevel             string     `json:"privacy_level"`
+	Status                   string     `json:"status"`
+	Capacity                 *int       `json:"capacity"`
+	ApprovedParticipantCount int        `json:"approved_participant_count"`
+	PendingParticipantCount  int        `json:"pending_participant_count"`
+	CreatedAt                time.Time  `json:"created_at"`
+	UpdatedAt                time.Time  `json:"updated_at"`
+}
+
+type ListEventsResult struct {
+	Items []AdminEventItem `json:"items"`
+	PageMeta
+}
+
+type ListParticipationsInput struct {
+	PageInput
+	CreatedRange
+	Query   *string
+	Status  *domain.ParticipationStatus
+	EventID *uuid.UUID
+	UserID  *uuid.UUID
+}
+
+type AdminParticipationItem struct {
+	ID            uuid.UUID  `json:"id"`
+	EventID       uuid.UUID  `json:"event_id"`
+	EventTitle    string     `json:"event_title"`
+	UserID        uuid.UUID  `json:"user_id"`
+	Username      string     `json:"username"`
+	UserEmail     string     `json:"user_email"`
+	Status        string     `json:"status"`
+	ReconfirmedAt *time.Time `json:"reconfirmed_at"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+type ListParticipationsResult struct {
+	Items []AdminParticipationItem `json:"items"`
+	PageMeta
+}
+
+type ListTicketsInput struct {
+	PageInput
+	CreatedRange
+	Query           *string
+	Status          *domain.TicketStatus
+	EventID         *uuid.UUID
+	UserID          *uuid.UUID
+	ParticipationID *uuid.UUID
+}
+
+type AdminTicketItem struct {
+	ID              uuid.UUID  `json:"id"`
+	ParticipationID uuid.UUID  `json:"participation_id"`
+	EventID         uuid.UUID  `json:"event_id"`
+	EventTitle      string     `json:"event_title"`
+	UserID          uuid.UUID  `json:"user_id"`
+	Username        string     `json:"username"`
+	UserEmail       string     `json:"user_email"`
+	Status          string     `json:"status"`
+	ExpiresAt       time.Time  `json:"expires_at"`
+	UsedAt          *time.Time `json:"used_at"`
+	CanceledAt      *time.Time `json:"canceled_at"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+}
+
+type ListTicketsResult struct {
+	Items []AdminTicketItem `json:"items"`
+	PageMeta
+}
+
+func (s *Service) ListUsers(ctx context.Context, input ListUsersInput) (*ListUsersResult, error) {
+	return s.repo.ListUsers(ctx, input)
+}
+
+func (s *Service) ListEvents(ctx context.Context, input ListEventsInput) (*ListEventsResult, error) {
+	return s.repo.ListEvents(ctx, input)
+}
+
+func (s *Service) ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error) {
+	return s.repo.ListParticipations(ctx, input)
+}
+
+func (s *Service) ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error) {
+	return s.repo.ListTickets(ctx, input)
+}

--- a/backend/internal/application/admin/usecase.go
+++ b/backend/internal/application/admin/usecase.go
@@ -1,0 +1,11 @@
+package admin
+
+import "context"
+
+// UseCase exposes read-only backoffice list operations.
+type UseCase interface {
+	ListUsers(ctx context.Context, input ListUsersInput) (*ListUsersResult, error)
+	ListEvents(ctx context.Context, input ListEventsInput) (*ListEventsResult, error)
+	ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error)
+	ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error)
+}

--- a/backend/internal/application/auth/repository_dto.go
+++ b/backend/internal/application/auth/repository_dto.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"time"
 
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
 )
 
@@ -15,7 +16,7 @@ type CreateUserParams struct {
 	BirthDate       *time.Time
 	PasswordHash    string
 	EmailVerifiedAt time.Time
-	Status          string
+	Status          domain.UserStatus
 }
 
 // UpsertOTPChallengeParams carries the fields needed to insert or update an

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/ratelimit"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/security"
 	spacesadapter "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/spaces"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/admin"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/auth"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/category"
 	emailapp "github.com/bounswe/bounswe2026group11/backend/internal/application/email"
@@ -44,6 +45,7 @@ type Container struct {
 	TokenIssuer             auth.TokenIssuer
 	TokenVerifier           domain.TokenVerifier
 	authRepo                *postgres.AuthRepository
+	adminRepo               *postgres.AdminRepository
 	eventRepo               *postgres.EventRepository
 	participationRepo       *postgres.ParticipationRepository
 	joinRequestRepo         *postgres.JoinRequestRepository
@@ -54,6 +56,7 @@ type Container struct {
 	profileRepo             *postgres.ProfileRepository
 	favoriteLocationRepo    *postgres.FavoriteLocationRepository
 	AuthService             auth.UseCase
+	AdminService            admin.UseCase
 	EventService            event.UseCase
 	ParticipationService    participation.UseCase
 	JoinRequestService      join_request.UseCase
@@ -97,6 +100,7 @@ func New(ctx context.Context) (*Container, error) {
 		TokenVerifier: buildTokenVerifier(cfg),
 	}
 	container.authRepo = postgres.NewAuthRepository(container.DB)
+	container.adminRepo = postgres.NewAdminRepository(container.DB)
 	container.eventRepo = postgres.NewEventRepository(container.DB)
 	container.participationRepo = postgres.NewParticipationRepository(container.DB)
 	container.joinRequestRepo = postgres.NewJoinRequestRepository(container.DB)
@@ -118,6 +122,7 @@ func New(ctx context.Context) (*Container, error) {
 	}
 	container.NotificationService = notificationService
 	container.AuthService = newAuthService(container)
+	container.AdminService = newAdminService(container)
 	container.EventService = newEventService(container)
 	container.CategoryService = newCategoryService(container)
 	container.ProfileService = newProfileService(container)
@@ -234,6 +239,11 @@ func buildPushSender(ctx context.Context, cfg *config.Config) (notification.Push
 	default:
 		return nil, fmt.Errorf("unsupported push provider %q", cfg.PushProvider)
 	}
+}
+
+// newAdminService wires the admin backoffice use case with its read repository.
+func newAdminService(c *Container) admin.UseCase {
+	return admin.NewService(c.adminRepo)
 }
 
 // newEventService wires the event use case with its driven adapters.

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -71,6 +71,8 @@ const (
 	ErrorCodeTicketClientNotSupported = "ticket_client_not_supported"
 
 	ErrorCodeNotificationNotFound = "notification_not_found"
+
+	ErrorCodeAdminAccessRequired = "admin_access_required"
 )
 
 // ErrNotFound is a sentinel error returned when a queried entity does not exist.

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -89,6 +89,13 @@ var eventDiscoverySorts = map[string]EventDiscoverySort{
 	string(EventDiscoverySortRelevance): EventDiscoverySortRelevance,
 }
 
+var eventStatuses = map[string]EventStatus{
+	string(EventStatusActive):     EventStatusActive,
+	string(EventStatusInProgress): EventStatusInProgress,
+	string(EventStatusCanceled):   EventStatusCanceled,
+	string(EventStatusCompleted):  EventStatusCompleted,
+}
+
 // ParseEventPrivacyLevel converts a wire string to an EventPrivacyLevel.
 func ParseEventPrivacyLevel(value string) (EventPrivacyLevel, bool) {
 	level, ok := eventPrivacyLevels[value]
@@ -111,6 +118,12 @@ func ParseEventParticipantGender(value string) (EventParticipantGender, bool) {
 func ParseEventDiscoverySort(value string) (EventDiscoverySort, bool) {
 	sort, ok := eventDiscoverySorts[value]
 	return sort, ok
+}
+
+// ParseEventStatus converts a wire string to an EventStatus.
+func ParseEventStatus(value string) (EventStatus, bool) {
+	status, ok := eventStatuses[value]
+	return status, ok
 }
 
 // GeoPoint is a single WGS84 coordinate used for event locations.

--- a/backend/internal/domain/token.go
+++ b/backend/internal/domain/token.go
@@ -27,6 +27,7 @@ type AuthClaims struct {
 	UserID   uuid.UUID
 	Username string
 	Email    string
+	Role     UserRole
 }
 
 // TokenVerifier parses and validates access tokens, returning the embedded claims.

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -1,13 +1,58 @@
 package domain
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
 
-// UserStatusActive is the default status assigned to newly registered users.
-const UserStatusActive = "active"
+// UserStatus is the lifecycle state of an application account.
+type UserStatus string
+
+// UserRole is the authorization role attached to an application account.
+type UserRole string
+
+const (
+	// UserStatusActive is the default status assigned to newly registered users.
+	UserStatusActive = "active"
+
+	// UserRoleUser is the default non-admin role for regular accounts.
+	UserRoleUser UserRole = "USER"
+	// UserRoleAdmin allows access to web-only admin backoffice endpoints.
+	UserRoleAdmin UserRole = "ADMIN"
+)
+
+var userRoles = map[string]UserRole{
+	string(UserRoleUser):  UserRoleUser,
+	string(UserRoleAdmin): UserRoleAdmin,
+}
+
+var userStatuses = map[string]UserStatus{
+	UserStatusActive: UserStatus(UserStatusActive),
+}
+
+// ParseUserRole converts a wire string into a UserRole.
+func ParseUserRole(value string) (UserRole, bool) {
+	role, ok := userRoles[strings.ToUpper(strings.TrimSpace(value))]
+	return role, ok
+}
+
+// ParseUserStatus converts a wire string into a UserStatus.
+func ParseUserStatus(value string) (UserStatus, bool) {
+	status, ok := userStatuses[strings.TrimSpace(value)]
+	return status, ok
+}
+
+// String returns the serialized wire value of the role.
+func (r UserRole) String() string {
+	return string(r)
+}
+
+// String returns the serialized persistence value of the status.
+func (s UserStatus) String() string {
+	return string(s)
+}
 
 // User is the core identity entity representing a registered account.
 type User struct {
@@ -20,7 +65,8 @@ type User struct {
 	PasswordHash    string
 	EmailVerifiedAt *time.Time
 	LastLogin       *time.Time
-	Status          string
+	Status          UserStatus
+	Role            UserRole
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
@@ -34,6 +80,7 @@ type UserSummary struct {
 	PhoneNumber   *string   `json:"phone_number"`
 	EmailVerified bool      `json:"email_verified"`
 	Status        string    `json:"status"`
+	Role          string    `json:"role"`
 	Gender        *string   `json:"gender"`
 	BirthDate     *string   `json:"birth_date"`
 }
@@ -47,7 +94,8 @@ func (u User) Summary() UserSummary {
 		Email:         u.Email,
 		PhoneNumber:   u.PhoneNumber,
 		EmailVerified: u.EmailVerifiedAt != nil,
-		Status:        u.Status,
+		Status:        string(u.Status),
+		Role:          string(u.Role),
 		Gender:        u.Gender,
 	}
 	if u.BirthDate != nil {

--- a/backend/internal/domain/user_test.go
+++ b/backend/internal/domain/user_test.go
@@ -1,0 +1,29 @@
+package domain
+
+import "testing"
+
+func TestParseUserRole(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want UserRole
+		ok   bool
+	}{
+		{name: "user", raw: "USER", want: UserRoleUser, ok: true},
+		{name: "admin", raw: "ADMIN", want: UserRoleAdmin, ok: true},
+		{name: "trims and uppercases", raw: " admin ", want: UserRoleAdmin, ok: true},
+		{name: "rejects unknown", raw: "OWNER", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseUserRole(tt.raw)
+			if ok != tt.ok {
+				t.Fatalf("expected ok=%v, got %v", tt.ok, ok)
+			}
+			if got != tt.want {
+				t.Fatalf("expected role %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/admin_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/auth_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/category_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/event_handler"
@@ -42,7 +43,13 @@ func NewHTTP(container *bootstrap.Container) *fiber.App {
 
 	// Event routes
 	auth := httpapi.RequireAuth(container.TokenVerifier)
+	adminAuth := httpapi.RequireAdmin(container.TokenVerifier)
 	optionalAuth := httpapi.OptionalAuth(container.TokenVerifier)
+
+	// Admin backoffice routes (authenticated ADMIN role only)
+	adminHandler := admin_handler.NewHandler(container.AdminService)
+	admin_handler.RegisterRoutes(app, adminHandler, adminAuth)
+
 	eventHandler := event_handler.NewEventHandler(container.EventService)
 	event_handler.RegisterEventRoutes(app, eventHandler, auth, optionalAuth)
 

--- a/backend/migrations/000024_user_role.down.sql
+++ b/backend/migrations/000024_user_role.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_app_user_role;
+
+ALTER TABLE app_user
+    DROP CONSTRAINT IF EXISTS chk_app_user_role;
+
+ALTER TABLE app_user
+    DROP COLUMN IF EXISTS role;

--- a/backend/migrations/000024_user_role.up.sql
+++ b/backend/migrations/000024_user_role.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE app_user
+    ADD COLUMN role TEXT NOT NULL DEFAULT 'USER';
+
+UPDATE app_user
+SET role = 'USER'
+WHERE role IS NULL OR role = '';
+
+ALTER TABLE app_user
+    ADD CONSTRAINT chk_app_user_role
+        CHECK (role IN ('USER', 'ADMIN'));
+
+CREATE INDEX idx_app_user_role ON app_user (role);

--- a/backend/tests_integration/admin_test.go
+++ b/backend/tests_integration/admin_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+package tests_integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jwtadapter "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/jwt"
+	postgresrepo "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/postgres"
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/admin_handler"
+	adminapp "github.com/bounswe/bounswe2026group11/backend/internal/application/admin"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+func TestAdminUsersEndpointAuthorizationAndFiltering(t *testing.T) {
+	t.Parallel()
+
+	// given
+	pool := common.RequirePool(t)
+	authRepo := postgresrepo.NewAuthRepository(pool)
+	adminRepo := postgresrepo.NewAdminRepository(pool)
+	app, issuer := adminIntegrationApp(adminapp.NewService(adminRepo))
+
+	adminUser := common.GivenUser(t, authRepo, common.WithUserUsername("admin_"+uuid.NewString()[:8]))
+	regularUser := common.GivenUser(t, authRepo, common.WithUserUsername("regular_"+uuid.NewString()[:8]))
+	promoteUser(t, adminUser.ID)
+	adminUser.Role = domain.UserRoleAdmin
+	regularUser.Role = domain.UserRoleUser
+
+	adminToken := issueAccessToken(t, issuer, *adminUser)
+	regularToken := issueAccessToken(t, issuer, *regularUser)
+
+	// when
+	anonymousResp := performAdminRequest(t, app, "/admin/users", "")
+	nonAdminResp := performAdminRequest(t, app, "/admin/users", regularToken)
+	adminResp := performAdminRequest(t, app, "/admin/users?role=USER&q="+regularUser.Username+"&limit=1&offset=0", adminToken)
+	defer func() { _ = anonymousResp.Body.Close() }()
+	defer func() { _ = nonAdminResp.Body.Close() }()
+	defer func() { _ = adminResp.Body.Close() }()
+
+	// then
+	if anonymousResp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("expected anonymous request to return 401, got %d", anonymousResp.StatusCode)
+	}
+	if nonAdminResp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("expected non-admin request to return 403, got %d", nonAdminResp.StatusCode)
+	}
+	if adminResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected admin request to return 200, got %d", adminResp.StatusCode)
+	}
+
+	var body struct {
+		Items      []adminapp.AdminUserItem `json:"items"`
+		Limit      int                      `json:"limit"`
+		Offset     int                      `json:"offset"`
+		TotalCount int                      `json:"total_count"`
+		HasNext    bool                     `json:"has_next"`
+	}
+	if err := json.NewDecoder(adminResp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.Limit != 1 || body.Offset != 0 {
+		t.Fatalf("unexpected pagination metadata: limit=%d offset=%d", body.Limit, body.Offset)
+	}
+	if body.TotalCount != 1 || len(body.Items) != 1 {
+		t.Fatalf("expected one filtered user, got total=%d items=%d", body.TotalCount, len(body.Items))
+	}
+	if body.Items[0].ID != regularUser.ID || body.Items[0].Role != string(domain.UserRoleUser) {
+		t.Fatalf("unexpected filtered user item: %#v", body.Items[0])
+	}
+}
+
+func TestAdminEventsParticipationsAndTicketsFiltering(t *testing.T) {
+	t.Parallel()
+
+	// given
+	pool := common.RequirePool(t)
+	authRepo := postgresrepo.NewAuthRepository(pool)
+	eventHarness := common.NewEventHarness(t)
+	adminRepo := postgresrepo.NewAdminRepository(pool)
+	app, issuer := adminIntegrationApp(adminapp.NewService(adminRepo))
+
+	adminUser := common.GivenUser(t, authRepo, common.WithUserUsername("admin_"+uuid.NewString()[:8]))
+	host := common.GivenUser(t, authRepo, common.WithUserUsername("host_"+uuid.NewString()[:8]))
+	participant := common.GivenUser(t, authRepo, common.WithUserUsername("participant_"+uuid.NewString()[:8]))
+	promoteUser(t, adminUser.ID)
+	adminUser.Role = domain.UserRoleAdmin
+
+	eventRef := common.GivenProtectedEvent(t, eventHarness.Service, host.ID)
+	participationID := createParticipationAndTicket(t, eventRef.ID, participant.ID)
+	adminToken := issueAccessToken(t, issuer, *adminUser)
+
+	// when
+	eventsResp := performAdminRequest(t, app, "/admin/events?host_id="+host.ID.String()+"&privacy_level=PROTECTED&status=ACTIVE&limit=5", adminToken)
+	participationsResp := performAdminRequest(t, app, "/admin/participations?event_id="+eventRef.ID.String()+"&user_id="+participant.ID.String()+"&status=APPROVED", adminToken)
+	ticketsResp := performAdminRequest(t, app, "/admin/tickets?event_id="+eventRef.ID.String()+"&user_id="+participant.ID.String()+"&participation_id="+participationID.String()+"&status=ACTIVE", adminToken)
+	defer func() { _ = eventsResp.Body.Close() }()
+	defer func() { _ = participationsResp.Body.Close() }()
+	defer func() { _ = ticketsResp.Body.Close() }()
+
+	// then
+	assertAdminListHasOne(t, eventsResp, "events")
+	assertAdminListHasOne(t, participationsResp, "participations")
+	assertAdminListHasOne(t, ticketsResp, "tickets")
+}
+
+func adminIntegrationApp(service adminapp.UseCase) (*fiber.App, jwtadapter.Issuer) {
+	secret := []byte("admin-integration-secret")
+	issuer := jwtadapter.Issuer{Secret: secret, TTL: 15 * time.Minute}
+	verifier := jwtadapter.Verifier{Secret: secret}
+
+	app := fiber.New()
+	admin_handler.RegisterRoutes(app, admin_handler.NewHandler(service), httpapi.RequireAdmin(verifier))
+	return app, issuer
+}
+
+func issueAccessToken(t *testing.T, issuer jwtadapter.Issuer, user domain.User) string {
+	t.Helper()
+	token, _, err := issuer.IssueAccessToken(user, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("IssueAccessToken() error = %v", err)
+	}
+	return token
+}
+
+func performAdminRequest(t *testing.T, app *fiber.App, path, token string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodGet, path, nil)
+	if token != "" {
+		req.Header.Set(fiber.HeaderAuthorization, "Bearer "+token)
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test(%s) error = %v", path, err)
+	}
+	return resp
+}
+
+func promoteUser(t *testing.T, userID uuid.UUID) {
+	t.Helper()
+	_, err := common.RequirePool(t).Exec(context.Background(), `UPDATE app_user SET role = 'ADMIN' WHERE id = $1`, userID)
+	if err != nil {
+		t.Fatalf("promote user error = %v", err)
+	}
+}
+
+func createParticipationAndTicket(t *testing.T, eventID, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	pool := common.RequirePool(t)
+	var participationID uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO participation (event_id, user_id, status)
+		VALUES ($1, $2, 'APPROVED')
+		RETURNING id
+	`, eventID, userID).Scan(&participationID)
+	if err != nil {
+		t.Fatalf("insert participation error = %v", err)
+	}
+	_, err = pool.Exec(context.Background(), `
+		INSERT INTO ticket (participation_id, status, expires_at)
+		VALUES ($1, 'ACTIVE', NOW() + INTERVAL '1 day')
+	`, participationID)
+	if err != nil {
+		t.Fatalf("insert ticket error = %v", err)
+	}
+	return participationID
+}
+
+func assertAdminListHasOne(t *testing.T, resp *http.Response, label string) {
+	t.Helper()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected %s request to return 200, got %d", label, resp.StatusCode)
+	}
+	var body struct {
+		Items      []json.RawMessage `json:"items"`
+		TotalCount int               `json:"total_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode(%s) error = %v", label, err)
+	}
+	if body.TotalCount != 1 || len(body.Items) != 1 {
+		t.Fatalf("expected one %s item, got total=%d items=%d", label, body.TotalCount, len(body.Items))
+	}
+}

--- a/backend/tests_integration/common/fixtures.go
+++ b/backend/tests_integration/common/fixtures.go
@@ -25,7 +25,7 @@ type userFixture struct {
 	gender          *string
 	birthDate       *time.Time
 	emailVerifiedAt time.Time
-	status          string
+	status          domain.UserStatus
 }
 
 // WithUserUsername overrides the default username for the fixture.

--- a/docs/admin-panel.md
+++ b/docs/admin-panel.md
@@ -1,0 +1,118 @@
+# Admin Panel Analysis
+
+## Purpose
+
+The admin panel is a web-only backoffice surface for users with the `ADMIN` role. Admin users should see an `Admin Panel` button in the top-right web header next to the profile button. The button routes to `/backoffice`. Mobile must not expose this entry point.
+
+The panel should let admins inspect operational data with simple, image-free row lists and perform two controlled operations:
+
+- send custom in-app or push notifications to selected users
+- create, cancel, and inspect manual participations
+
+## Current Repository State
+
+### Backend
+
+- The backend is a Go/Fiber service using clean/hexagonal layers:
+  - domain models under `backend/internal/domain/`
+  - application services under `backend/internal/application/`
+  - Postgres adapters under `backend/internal/adapter/in/postgres/`
+  - HTTP handlers under `backend/internal/adapter/out/httpapi/`
+  - route registration in `backend/internal/server/http.go`
+- Authentication currently verifies JWTs through `httpapi.RequireAuth`.
+- Access token claims currently include user id, username, and email, but not a role.
+- `app_user` has no role column today. Admin authorization needs a persisted role, preferably uppercase values such as `USER` and `ADMIN`.
+- Existing notification application service already supports `SendNotificationToUsers` and `SendPushToUsers`, which can be reused by an admin HTTP endpoint after authorization and validation.
+- Existing participation logic supports direct public joins and leave/cancel flows, but admin manual participation creation/cancellation needs separate application behavior so normal user join restrictions are not accidentally reused or bypassed in unclear ways.
+- Existing OpenAPI specs live under `docs/openapi/`; admin contract changes should be documented there.
+
+### Frontend
+
+- The web app is React with React Router.
+- Main routes are registered in `frontend/src/App.tsx`.
+- The shared web shell/header is `frontend/src/components/AppShell.tsx`.
+- Auth state is held in `frontend/src/contexts/AuthContext.tsx`; it currently stores token, refresh token, username, avatar URL, and display name, but not user role.
+- API helpers live in `frontend/src/services/api.ts`; domain service wrappers are in `frontend/src/services/*Service.ts`.
+- Mobile is a separate app under `mobile/` and should not be changed for this feature.
+
+## Proposed Backend Shape
+
+Add an admin/backoffice HTTP surface under an authenticated admin-only route group such as `/admin` or `/backoffice/api`. The public frontend route remains `/backoffice`; API paths should be documented in OpenAPI.
+
+Recommended backend work:
+
+- Add a `role` field to `app_user` with default `USER`.
+- Add domain role constants with uppercase serialized values: `USER`, `ADMIN`.
+- Include role in auth session responses and JWT access-token claims.
+- Add `RequireAdmin` middleware or an equivalent route wrapper that verifies authenticated claims carry `ADMIN`.
+- Add offset pagination for admin list endpoints using `limit` and `offset`.
+- Keep responses lightweight and row-oriented; do not return image payloads except existing URL strings when needed for identification.
+- Add OpenAPI documentation under `docs/openapi/`.
+- Add unit and integration tests for authorization, filters, pagination, and admin mutations.
+
+Recommended admin list endpoints:
+
+- `GET /admin/users`
+  - Filters: query text, status, role, created date range.
+  - Rows: id, username, email, phone number, role, status, email verified flag, created_at, updated_at.
+- `GET /admin/events`
+  - Filters: query text, host id, category id, privacy level, status, start date range.
+  - Rows: id, title, host id/username, category, privacy level, status, start_time, end_time, capacity, approved/pending counts, created_at.
+- `GET /admin/tickets`
+  - Filters: query text, status, event id, user id, participation id, created date range.
+  - Rows: ticket id, status, participation id, event id/title, user id/username, expires_at, used_at, created_at.
+- `GET /admin/participations`
+  - Filters: query text, status, event id, user id, created date range.
+  - Rows: participation id, status, event id/title, user id/username, created_at, updated_at.
+
+Recommended admin mutation endpoints:
+
+- `POST /admin/notifications`
+  - Inputs: user_ids, delivery target (`IN_APP`, `PUSH`, or `BOTH`), title, body, optional type, optional deep_link, optional data.
+  - Behavior: create in-app notifications and/or trigger push delivery for the selected users through the existing notification service.
+  - Response: target user count, created count, SSE count, push sent/failed counts, invalid-token count.
+- `POST /admin/participations`
+  - Inputs: event_id, user_id, optional status defaulting to `APPROVED`, optional reason/note for auditability if audit logging is added.
+  - Behavior: creates or reactivates a participation according to explicit admin rules. It should validate that event and user exist, prevent duplicate active participation, update participant counters consistently, and create/cancel protected-event tickets when required by existing ticket lifecycle rules.
+- `POST /admin/participations/{participation_id}/cancel`
+  - Inputs: optional reason.
+  - Behavior: marks the participation `CANCELED`, updates event counters, cancels linked active/pending tickets, and is idempotent for already-canceled rows where possible.
+
+## Proposed Frontend Shape
+
+Add a web-only backoffice route under `/backoffice` inside the React frontend.
+
+Recommended frontend work:
+
+- Extend auth models/context to store the authenticated user role from auth responses.
+- Show `Admin Panel` next to the profile button in the top-right web header only when `role === 'ADMIN'`.
+- Add a protected admin route guard so non-admin users cannot access `/backoffice`.
+- Add a fixed left sidebar in the backoffice with these sections:
+  - Users
+  - Events
+  - Participations
+  - Tickets
+  - Notifications
+- Use dense, simple list views with table rows and no images.
+- Use offset pagination controls backed by backend `limit` and `offset` parameters.
+- Add basic filters per entity matching the backend filters.
+- Keep the panel isolated from mobile and from regular user-facing navigation.
+
+Recommended pages:
+
+- `/backoffice/users`: filterable user table.
+- `/backoffice/events`: filterable event table.
+- `/backoffice/participations`: filterable participation table plus create/cancel actions.
+- `/backoffice/tickets`: filterable ticket table.
+- `/backoffice/notifications`: user targeting controls and custom notification form for in-app or push delivery.
+
+## Delivery Plan
+
+The work should be split by deployable surface:
+
+1. Backend admin foundation and read-only list APIs.
+2. Backend admin notification and manual participation mutations.
+3. Frontend admin entry point, route guard, shell, sidebar, and read-only list views.
+4. Frontend admin notification and participation action pages.
+
+This sequencing lets backend contracts land first, then the read-only panel, then operational admin actions.

--- a/docs/openapi/admin.yaml
+++ b/docs/openapi/admin.yaml
@@ -1,0 +1,311 @@
+openapi: 3.1.0
+info:
+  title: Social Event Mapper Admin Backoffice API
+  version: 0.1.0
+  description: |
+    Web-only read APIs for the admin backoffice.
+
+    All endpoints require a bearer access token whose `role` claim is `ADMIN`.
+    Anonymous callers receive `401`; authenticated non-admin callers receive `403`.
+servers:
+  - url: /api
+security:
+  - bearerAuth: []
+tags:
+  - name: Admin
+    description: Read-only admin table endpoints.
+paths:
+  /admin/users:
+    get:
+      tags: [Admin]
+      summary: List users
+      operationId: adminListUsers
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/TextQuery'
+        - name: status
+          in: query
+          schema: { type: string, enum: [active] }
+        - name: role
+          in: query
+          schema: { type: string, enum: [USER, ADMIN] }
+        - name: created_from
+          in: query
+          schema: { type: string, format: date-time }
+        - name: created_to
+          in: query
+          schema: { type: string, format: date-time }
+      responses:
+        '200':
+          description: Offset-paginated users.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminUser' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/events:
+    get:
+      tags: [Admin]
+      summary: List events
+      operationId: adminListEvents
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/TextQuery'
+        - name: host_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: category_id
+          in: query
+          schema: { type: integer }
+        - name: privacy_level
+          in: query
+          schema: { type: string, enum: [PUBLIC, PROTECTED, PRIVATE] }
+        - name: status
+          in: query
+          schema: { type: string, enum: [ACTIVE, IN_PROGRESS, CANCELED, COMPLETED] }
+        - name: start_from
+          in: query
+          schema: { type: string, format: date-time }
+        - name: start_to
+          in: query
+          schema: { type: string, format: date-time }
+      responses:
+        '200':
+          description: Offset-paginated events.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminEvent' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/participations:
+    get:
+      tags: [Admin]
+      summary: List participations
+      operationId: adminListParticipations
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/TextQuery'
+        - name: status
+          in: query
+          schema: { type: string, enum: [APPROVED, PENDING, CANCELED, LEAVED] }
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: created_from
+          in: query
+          schema: { type: string, format: date-time }
+        - name: created_to
+          in: query
+          schema: { type: string, format: date-time }
+      responses:
+        '200':
+          description: Offset-paginated participations.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminParticipation' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/tickets:
+    get:
+      tags: [Admin]
+      summary: List tickets
+      operationId: adminListTickets
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/TextQuery'
+        - name: status
+          in: query
+          schema: { type: string, enum: [ACTIVE, PENDING, EXPIRED, USED, CANCELED] }
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: participation_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: created_from
+          in: query
+          schema: { type: string, format: date-time }
+        - name: created_to
+          in: query
+          schema: { type: string, format: date-time }
+      responses:
+        '200':
+          description: Offset-paginated tickets.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminTicket' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    Limit:
+      name: limit
+      in: query
+      description: Page size. Defaults to 50 and may not exceed 100.
+      schema: { type: integer, minimum: 1, maximum: 100, default: 50 }
+    Offset:
+      name: offset
+      in: query
+      description: Zero-based row offset. Defaults to 0.
+      schema: { type: integer, minimum: 0, default: 0 }
+    TextQuery:
+      name: q
+      in: query
+      description: Case-insensitive text search over table-friendly identifying fields.
+      schema: { type: string }
+  schemas:
+    PageMeta:
+      type: object
+      additionalProperties: false
+      required: [limit, offset, total_count, has_next]
+      properties:
+        limit: { type: integer, example: 50 }
+        offset: { type: integer, example: 0 }
+        total_count: { type: integer, example: 125 }
+        has_next: { type: boolean, example: true }
+    AdminUser:
+      type: object
+      additionalProperties: false
+      required: [id, username, email, email_verified, status, role, created_at, updated_at]
+      properties:
+        id: { type: string, format: uuid }
+        username: { type: string }
+        email: { type: string, format: email }
+        phone_number: { type: [string, 'null'] }
+        email_verified: { type: boolean }
+        last_login: { type: [string, 'null'], format: date-time }
+        status: { type: string, example: active }
+        role: { type: string, enum: [USER, ADMIN] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminEvent:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        host_id: { type: string, format: uuid }
+        host_username: { type: string }
+        title: { type: string }
+        category_id: { type: [integer, 'null'] }
+        category_name: { type: [string, 'null'] }
+        start_time: { type: string, format: date-time }
+        end_time: { type: [string, 'null'], format: date-time }
+        privacy_level: { type: string, enum: [PUBLIC, PROTECTED, PRIVATE] }
+        status: { type: string, enum: [ACTIVE, IN_PROGRESS, CANCELED, COMPLETED] }
+        capacity: { type: [integer, 'null'] }
+        approved_participant_count: { type: integer }
+        pending_participant_count: { type: integer }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminParticipation:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        event_title: { type: string }
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        status: { type: string, enum: [APPROVED, PENDING, CANCELED, LEAVED] }
+        reconfirmed_at: { type: [string, 'null'], format: date-time }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminTicket:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        participation_id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        event_title: { type: string }
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        status: { type: string, enum: [ACTIVE, PENDING, EXPIRED, USED, CANCELED] }
+        expires_at: { type: string, format: date-time }
+        used_at: { type: [string, 'null'], format: date-time }
+        canceled_at: { type: [string, 'null'], format: date-time }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    ErrorResponse:
+      type: object
+      additionalProperties: false
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code: { type: string }
+            message: { type: string }
+            details:
+              type: object
+              additionalProperties: { type: string }
+  responses:
+    ValidationError:
+      description: Invalid query parameter. `error.details` identifies the field.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ErrorResponse' }
+    Unauthorized:
+      description: Missing, invalid, or expired bearer token.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ErrorResponse' }
+    Forbidden:
+      description: The bearer token is valid, but the user role is not ADMIN.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/docs/openapi/auth.yaml
+++ b/docs/openapi/auth.yaml
@@ -264,6 +264,7 @@ paths:
                       phone_number: "+905551112233"
                       email_verified: true
                       status: active
+                      role: USER
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
@@ -318,6 +319,7 @@ paths:
                       phone_number: "+905551112233"
                       email_verified: true
                       status: active
+                      role: USER
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
@@ -371,6 +373,7 @@ paths:
                       phone_number: "+905551112233"
                       email_verified: true
                       status: active
+                      role: USER
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
@@ -823,7 +826,7 @@ components:
       type: object
       description: Public-facing summary of the authenticated user.
       additionalProperties: false
-      required: [id, username, email, phone_number, email_verified, status]
+      required: [id, username, email, phone_number, email_verified, status, role]
       properties:
         id:
           type: string
@@ -853,6 +856,11 @@ components:
           type: string
           description: Current account status.
           example: active
+        role:
+          type: string
+          enum: [USER, ADMIN]
+          description: Authorization role embedded in access tokens and session responses. Newly registered users receive USER.
+          example: USER
         gender:
           type:
             - string


### PR DESCRIPTION
## 📋 Summary
Adds the backend foundation for the web-only admin backoffice, including persisted user roles, admin-only authorization, and read-only paginated admin list APIs.

## 🔄 Changes
- Added `USER` / `ADMIN` user roles persisted on `app_user`, defaulting users to `USER`.
- Included user role in auth session responses and JWT access token claims.
- Added admin-only middleware that returns `401` for unauthenticated callers and `403` for non-admin users.
- Added read-only admin endpoints for users, events, participations, and tickets with offset pagination and filters.
- Added a dedicated admin application service/port and Postgres repository.
- Updated OpenAPI docs for auth role exposure and new admin contracts.
- Added unit and integration tests for role parsing, admin authorization, pagination/filter validation, and representative admin list requests.

## 🧪 Testing
- `go test ./...`
- `go test -tags=integration ./tests_integration -run 'TestAdmin'`
- `./shipcheck.sh`

## 🔗 Related
Closes #524
