### PR TITLE
feat(backend): add admin notification and manual participation actions

### DIFF
--- a/backend/internal/adapter/in/postgres/admin_repo.go
+++ b/backend/internal/adapter/in/postgres/admin_repo.go
@@ -2,10 +2,14 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	adminapp "github.com/bounswe/bounswe2026group11/backend/internal/application/admin"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -352,6 +356,166 @@ func (r *AdminRepository) ListTickets(ctx context.Context, input adminapp.ListTi
 	}
 
 	return &adminapp.ListTicketsResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
+}
+
+func (r *AdminRepository) CountExistingUsers(ctx context.Context, userIDs []uuid.UUID) (int, error) {
+	if len(userIDs) == 0 {
+		return 0, nil
+	}
+	var count int
+	if err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM app_user
+		WHERE id = ANY($1)
+	`, userIDs).Scan(&count); err != nil {
+		return 0, fmt.Errorf("admin count existing users: %w", err)
+	}
+	return count, nil
+}
+
+func (r *AdminRepository) GetEventState(ctx context.Context, eventID uuid.UUID, forUpdate bool) (*adminapp.AdminEventState, error) {
+	query := `
+		SELECT id, privacy_level
+		FROM event
+		WHERE id = $1
+	`
+	if forUpdate {
+		query += ` FOR UPDATE`
+	}
+
+	var (
+		state        adminapp.AdminEventState
+		privacyLevel string
+	)
+	err := r.db.QueryRow(ctx, query, eventID).Scan(&state.ID, &privacyLevel)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("admin get event state: %w", err)
+	}
+	parsed, ok := domain.ParseEventPrivacyLevel(privacyLevel)
+	if !ok {
+		return nil, fmt.Errorf("admin get event state: unknown privacy level %q", privacyLevel)
+	}
+	state.PrivacyLevel = parsed
+	return &state, nil
+}
+
+func (r *AdminRepository) CreateManualParticipation(ctx context.Context, eventID, userID uuid.UUID, status domain.ParticipationStatus) (*domain.Participation, error) {
+	existing, err := loadParticipation(ctx, r.db, eventID, userID, true)
+	if err != nil {
+		return nil, fmt.Errorf("admin load existing participation: %w", err)
+	}
+	if existing != nil && (existing.Status == domain.ParticipationStatusApproved || existing.Status == domain.ParticipationStatusPending) {
+		return nil, domain.ConflictError(domain.ErrorCodeAlreadyParticipating, "The user already has an active participation for this event.")
+	}
+
+	if existing != nil {
+		participation, err := scanParticipation(r.db.QueryRow(ctx, `
+			UPDATE participation
+			SET status = $3,
+			    reconfirmed_at = NULL,
+			    updated_at = NOW()
+			WHERE event_id = $1
+			  AND user_id = $2
+			RETURNING id, status, created_at, updated_at
+		`, eventID, userID, status), eventID, userID, "admin reactivate participation")
+		if err != nil {
+			return nil, err
+		}
+		return participation, nil
+	}
+
+	participation, err := scanParticipation(r.db.QueryRow(ctx, `
+		INSERT INTO participation (event_id, user_id, status)
+		VALUES ($1, $2, $3)
+		RETURNING id, status, created_at, updated_at
+	`, eventID, userID, status), eventID, userID, "admin create participation")
+	if err != nil {
+		return nil, mapAdminParticipationMutationError(err)
+	}
+	if participation == nil {
+		return nil, fmt.Errorf("admin create participation: no row returned")
+	}
+	return participation, nil
+}
+
+func (r *AdminRepository) GetParticipationByID(ctx context.Context, participationID uuid.UUID, forUpdate bool) (*domain.Participation, error) {
+	query := `
+		SELECT id, event_id, user_id, status, created_at, updated_at
+		FROM participation
+		WHERE id = $1
+	`
+	if forUpdate {
+		query += ` FOR UPDATE`
+	}
+	return scanAdminParticipation(r.db.QueryRow(ctx, query, participationID), "admin get participation")
+}
+
+func (r *AdminRepository) CancelParticipation(ctx context.Context, participationID uuid.UUID) (*domain.Participation, bool, error) {
+	existing, err := r.GetParticipationByID(ctx, participationID, true)
+	if err != nil {
+		return nil, false, err
+	}
+	if existing == nil {
+		return nil, false, domain.NotFoundError(domain.ErrorCodeParticipationNotFound, "The requested participation does not exist.")
+	}
+	if existing.Status == domain.ParticipationStatusCanceled {
+		return existing, true, nil
+	}
+
+	participation, err := scanAdminParticipation(r.db.QueryRow(ctx, `
+		UPDATE participation
+		SET status = $2,
+		    updated_at = NOW()
+		WHERE id = $1
+		RETURNING id, event_id, user_id, status, created_at, updated_at
+	`, participationID, domain.ParticipationStatusCanceled), "admin cancel participation")
+	if err != nil {
+		return nil, false, err
+	}
+	return participation, false, nil
+}
+
+func scanAdminParticipation(row pgx.Row, operation string) (*domain.Participation, error) {
+	var (
+		participation domain.Participation
+		status        string
+	)
+	err := row.Scan(
+		&participation.ID,
+		&participation.EventID,
+		&participation.UserID,
+		&status,
+		&participation.CreatedAt,
+		&participation.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s: %w", operation, err)
+	}
+	parsed, ok := domain.ParseParticipationStatus(status)
+	if !ok {
+		return nil, fmt.Errorf("%s: unknown participation status %q", operation, status)
+	}
+	participation.Status = parsed
+	return &participation, nil
+}
+
+func mapAdminParticipationMutationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "fk_participation_event") {
+		return domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+	}
+	if strings.Contains(err.Error(), "fk_participation_user") {
+		return domain.NotFoundError(domain.ErrorCodeUserNotFound, "The requested user does not exist.")
+	}
+	return err
 }
 
 func pageMeta(page adminapp.PageInput, totalCount, itemCount int) adminapp.PageMeta {

--- a/backend/internal/adapter/out/httpapi/admin_handler/admin_handler.go
+++ b/backend/internal/adapter/out/httpapi/admin_handler/admin_handler.go
@@ -29,7 +29,10 @@ func RegisterRoutes(router fiber.Router, handler *Handler, adminAuth fiber.Handl
 	group.Get("/users", handler.ListUsers)
 	group.Get("/events", handler.ListEvents)
 	group.Get("/participations", handler.ListParticipations)
+	group.Post("/participations", handler.CreateParticipation)
+	group.Post("/participations/:participation_id/cancel", handler.CancelParticipation)
 	group.Get("/tickets", handler.ListTickets)
+	group.Post("/notifications", handler.CreateNotification)
 }
 
 func (h *Handler) ListUsers(c *fiber.Ctx) error {
@@ -82,6 +85,178 @@ func (h *Handler) ListTickets(c *fiber.Ctx) error {
 	}
 	logAdminList(c, "admin.tickets.list", len(result.Items), result.PageMeta, summarizeTickets(input))
 	return c.JSON(result)
+}
+
+func (h *Handler) CreateNotification(c *fiber.Ctx) error {
+	input, errs := parseCreateNotificationInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.SendCustomNotification(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.Status(fiber.StatusCreated).JSON(result)
+}
+
+func (h *Handler) CreateParticipation(c *fiber.Ctx) error {
+	input, errs := parseCreateParticipationInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.CreateManualParticipation(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.Status(fiber.StatusCreated).JSON(result)
+}
+
+func (h *Handler) CancelParticipation(c *fiber.Ctx) error {
+	input, errs := parseCancelParticipationInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.CancelParticipation(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+type createNotificationRequest struct {
+	UserIDs        []string          `json:"user_ids"`
+	DeliveryMode   string            `json:"delivery_mode"`
+	Title          string            `json:"title"`
+	Body           string            `json:"body"`
+	Type           *string           `json:"type"`
+	DeepLink       *string           `json:"deep_link"`
+	EventID        *string           `json:"event_id"`
+	Data           map[string]string `json:"data"`
+	IdempotencyKey *string           `json:"idempotency_key"`
+}
+
+type createParticipationRequest struct {
+	EventID string  `json:"event_id"`
+	UserID  string  `json:"user_id"`
+	Status  *string `json:"status"`
+	Reason  *string `json:"reason"`
+}
+
+type cancelParticipationRequest struct {
+	Reason *string `json:"reason"`
+}
+
+func parseCreateNotificationInput(c *fiber.Ctx) (admin.SendCustomNotificationInput, map[string]string) {
+	var body createNotificationRequest
+	errs := map[string]string{}
+	if err := c.BodyParser(&body); err != nil {
+		errs["body"] = "must be a valid JSON object"
+		return admin.SendCustomNotificationInput{}, errs
+	}
+
+	input := admin.SendCustomNotificationInput{
+		AdminUserID:    httpapi.UserClaims(c).UserID,
+		Title:          body.Title,
+		Body:           body.Body,
+		Type:           optionalTrimmedPtr(body.Type),
+		DeepLink:       optionalTrimmedPtr(body.DeepLink),
+		Data:           body.Data,
+		IdempotencyKey: optionalTrimmedPtr(body.IdempotencyKey),
+	}
+	if len(body.UserIDs) == 0 {
+		errs["user_ids"] = "must contain at least one user id"
+	} else {
+		input.UserIDs = make([]uuid.UUID, 0, len(body.UserIDs))
+		for _, raw := range body.UserIDs {
+			value, err := uuid.Parse(strings.TrimSpace(raw))
+			if err != nil {
+				errs["user_ids"] = "must contain only valid UUIDs"
+				break
+			}
+			if value == uuid.Nil {
+				errs["user_ids"] = "must contain only valid UUIDs"
+				break
+			}
+			input.UserIDs = append(input.UserIDs, value)
+		}
+	}
+	mode, ok := domain.ParseNotificationDeliveryMode(body.DeliveryMode)
+	if !ok {
+		errs["delivery_mode"] = "must be one of: IN_APP, PUSH, BOTH"
+	} else {
+		input.DeliveryMode = mode
+	}
+	if strings.TrimSpace(body.Title) == "" {
+		errs["title"] = "is required"
+	}
+	if strings.TrimSpace(body.Body) == "" {
+		errs["body"] = "is required"
+	}
+	if body.EventID != nil && strings.TrimSpace(*body.EventID) != "" {
+		eventID, err := uuid.Parse(strings.TrimSpace(*body.EventID))
+		if err != nil || eventID == uuid.Nil {
+			errs["event_id"] = "must be a valid UUID"
+		} else {
+			input.EventID = &eventID
+		}
+	}
+	return input, errs
+}
+
+func parseCreateParticipationInput(c *fiber.Ctx) (admin.CreateManualParticipationInput, map[string]string) {
+	var body createParticipationRequest
+	errs := map[string]string{}
+	if err := c.BodyParser(&body); err != nil {
+		errs["body"] = "must be a valid JSON object"
+		return admin.CreateManualParticipationInput{}, errs
+	}
+
+	input := admin.CreateManualParticipationInput{
+		AdminUserID: httpapi.UserClaims(c).UserID,
+		Status:      domain.ParticipationStatusApproved,
+		Reason:      optionalTrimmedPtr(body.Reason),
+	}
+	eventID, err := uuid.Parse(strings.TrimSpace(body.EventID))
+	if err != nil || eventID == uuid.Nil {
+		errs["event_id"] = "must be a valid UUID"
+	} else {
+		input.EventID = eventID
+	}
+	userID, err := uuid.Parse(strings.TrimSpace(body.UserID))
+	if err != nil || userID == uuid.Nil {
+		errs["user_id"] = "must be a valid UUID"
+	} else {
+		input.UserID = userID
+	}
+	if body.Status != nil && strings.TrimSpace(*body.Status) != "" {
+		status, ok := domain.ParseParticipationStatus(strings.TrimSpace(*body.Status))
+		if !ok || (status != domain.ParticipationStatusApproved && status != domain.ParticipationStatusPending) {
+			errs["status"] = "must be one of: APPROVED, PENDING"
+		} else {
+			input.Status = status
+		}
+	}
+	return input, errs
+}
+
+func parseCancelParticipationInput(c *fiber.Ctx) (admin.CancelParticipationInput, map[string]string) {
+	errs := map[string]string{}
+	participationID, err := uuid.Parse(strings.TrimSpace(c.Params("participation_id")))
+	if err != nil || participationID == uuid.Nil {
+		errs["participation_id"] = "must be a valid UUID"
+	}
+
+	var body cancelParticipationRequest
+	if len(c.Body()) > 0 {
+		if err := c.BodyParser(&body); err != nil {
+			errs["body"] = "must be a valid JSON object"
+		}
+	}
+	return admin.CancelParticipationInput{
+		AdminUserID:     httpapi.UserClaims(c).UserID,
+		ParticipationID: participationID,
+		Reason:          optionalTrimmedPtr(body.Reason),
+	}, errs
 }
 
 func parseListUsersInput(c *fiber.Ctx) (admin.ListUsersInput, map[string]string) {
@@ -203,6 +378,13 @@ func optionalTrimmed(value string) *string {
 		return nil
 	}
 	return &trimmed
+}
+
+func optionalTrimmedPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	return optionalTrimmed(*value)
 }
 
 func parseOptionalUUID(c *fiber.Ctx, key string, errs map[string]string) *uuid.UUID {

--- a/backend/internal/adapter/out/httpapi/admin_handler/admin_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/admin_handler/admin_handler_test.go
@@ -1,6 +1,7 @@
 package admin_handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http/httptest"
@@ -18,6 +19,9 @@ type stubAdminService struct {
 	lastEvents         admin.ListEventsInput
 	lastParticipations admin.ListParticipationsInput
 	lastTickets        admin.ListTicketsInput
+	lastNotification   admin.SendCustomNotificationInput
+	lastCreate         admin.CreateManualParticipationInput
+	lastCancel         admin.CancelParticipationInput
 }
 
 func (s *stubAdminService) ListUsers(_ context.Context, input admin.ListUsersInput) (*admin.ListUsersResult, error) {
@@ -38,6 +42,21 @@ func (s *stubAdminService) ListParticipations(_ context.Context, input admin.Lis
 func (s *stubAdminService) ListTickets(_ context.Context, input admin.ListTicketsInput) (*admin.ListTicketsResult, error) {
 	s.lastTickets = input
 	return &admin.ListTicketsResult{Items: []admin.AdminTicketItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+
+func (s *stubAdminService) SendCustomNotification(_ context.Context, input admin.SendCustomNotificationInput) (*admin.SendCustomNotificationResult, error) {
+	s.lastNotification = input
+	return &admin.SendCustomNotificationResult{TargetUserCount: len(input.UserIDs), CreatedCount: len(input.UserIDs)}, nil
+}
+
+func (s *stubAdminService) CreateManualParticipation(_ context.Context, input admin.CreateManualParticipationInput) (*admin.CreateManualParticipationResult, error) {
+	s.lastCreate = input
+	return &admin.CreateManualParticipationResult{ParticipationID: uuid.New(), EventID: input.EventID, UserID: input.UserID, Status: input.Status}, nil
+}
+
+func (s *stubAdminService) CancelParticipation(_ context.Context, input admin.CancelParticipationInput) (*admin.CancelParticipationResult, error) {
+	s.lastCancel = input
+	return &admin.CancelParticipationResult{ParticipationID: input.ParticipationID, Status: domain.ParticipationStatusCanceled}, nil
 }
 
 func adminHandlerTestApp(service admin.UseCase) *fiber.App {
@@ -162,5 +181,124 @@ func TestListTicketsParsesIDsAndStatus(t *testing.T) {
 	}
 	if service.lastTickets.Status == nil || *service.lastTickets.Status != domain.TicketStatusActive {
 		t.Fatalf("expected ACTIVE status, got %#v", service.lastTickets.Status)
+	}
+}
+
+func TestCreateNotificationValidatesBody(t *testing.T) {
+	// given
+	app := adminHandlerTestApp(&stubAdminService{})
+	req := httptest.NewRequest(fiber.MethodPost, "/admin/notifications", bytes.NewBufferString(`{"user_ids":[],"delivery_mode":"EMAIL","title":"","body":""}`))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var body struct {
+		Error struct {
+			Details map[string]string `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	for _, field := range []string{"user_ids", "delivery_mode", "title", "body"} {
+		if body.Error.Details[field] == "" {
+			t.Fatalf("expected %s validation detail, got %#v", field, body.Error.Details)
+		}
+	}
+}
+
+func TestCreateNotificationParsesInput(t *testing.T) {
+	// given
+	service := &stubAdminService{}
+	app := adminHandlerTestApp(service)
+	userID := uuid.New()
+	eventID := uuid.New()
+	payload := `{"user_ids":["` + userID.String() + `"],"delivery_mode":"BOTH","title":"Ops","body":"Update","type":"ADMIN","deep_link":"sem://events/1","event_id":"` + eventID.String() + `","data":{"k":"v"},"idempotency_key":"custom-key"}`
+	req := httptest.NewRequest(fiber.MethodPost, "/admin/notifications", bytes.NewBufferString(payload))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	if len(service.lastNotification.UserIDs) != 1 || service.lastNotification.UserIDs[0] != userID {
+		t.Fatalf("unexpected user IDs: %#v", service.lastNotification.UserIDs)
+	}
+	if service.lastNotification.DeliveryMode != domain.NotificationDeliveryModeBoth {
+		t.Fatalf("unexpected delivery mode %q", service.lastNotification.DeliveryMode)
+	}
+	if service.lastNotification.EventID == nil || *service.lastNotification.EventID != eventID {
+		t.Fatalf("expected event id %s, got %#v", eventID, service.lastNotification.EventID)
+	}
+	if service.lastNotification.Data["k"] != "v" {
+		t.Fatalf("expected data payload, got %#v", service.lastNotification.Data)
+	}
+}
+
+func TestCreateParticipationDefaultsApproved(t *testing.T) {
+	// given
+	service := &stubAdminService{}
+	app := adminHandlerTestApp(service)
+	eventID := uuid.New()
+	userID := uuid.New()
+	payload := `{"event_id":"` + eventID.String() + `","user_id":"` + userID.String() + `"}`
+	req := httptest.NewRequest(fiber.MethodPost, "/admin/participations", bytes.NewBufferString(payload))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	if service.lastCreate.EventID != eventID || service.lastCreate.UserID != userID {
+		t.Fatalf("unexpected create input %#v", service.lastCreate)
+	}
+	if service.lastCreate.Status != domain.ParticipationStatusApproved {
+		t.Fatalf("expected APPROVED default, got %q", service.lastCreate.Status)
+	}
+}
+
+func TestCancelParticipationParsesID(t *testing.T) {
+	// given
+	service := &stubAdminService{}
+	app := adminHandlerTestApp(service)
+	participationID := uuid.New()
+	req := httptest.NewRequest(fiber.MethodPost, "/admin/participations/"+participationID.String()+"/cancel", nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if service.lastCancel.ParticipationID != participationID {
+		t.Fatalf("expected participation id %s, got %s", participationID, service.lastCancel.ParticipationID)
 	}
 }

--- a/backend/internal/adapter/out/httpapi/notification_handler/notification_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/notification_handler/notification_handler_test.go
@@ -245,6 +245,10 @@ func (s *stubNotificationService) SendNotificationToUsers(_ context.Context, _ n
 	return &notificationapp.SendNotificationResult{}, nil
 }
 
+func (s *stubNotificationService) SendCustomNotificationToUsers(_ context.Context, _ notificationapp.SendCustomNotificationInput) (*notificationapp.SendNotificationResult, error) {
+	return &notificationapp.SendNotificationResult{}, nil
+}
+
 func (s *stubNotificationService) SendPushToUsers(_ context.Context, _ notificationapp.SendPushInput) (*notificationapp.SendPushResult, error) {
 	return &notificationapp.SendPushResult{}, nil
 }

--- a/backend/internal/application/admin/repository.go
+++ b/backend/internal/application/admin/repository.go
@@ -1,6 +1,11 @@
 package admin
 
-import "context"
+import (
+	"context"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
 
 // Repository is the persistence port for read-only backoffice list queries.
 type Repository interface {
@@ -8,4 +13,9 @@ type Repository interface {
 	ListEvents(ctx context.Context, input ListEventsInput) (*ListEventsResult, error)
 	ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error)
 	ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error)
+	CountExistingUsers(ctx context.Context, userIDs []uuid.UUID) (int, error)
+	GetEventState(ctx context.Context, eventID uuid.UUID, forUpdate bool) (*AdminEventState, error)
+	CreateManualParticipation(ctx context.Context, eventID, userID uuid.UUID, status domain.ParticipationStatus) (*domain.Participation, error)
+	GetParticipationByID(ctx context.Context, participationID uuid.UUID, forUpdate bool) (*domain.Participation, error)
+	CancelParticipation(ctx context.Context, participationID uuid.UUID) (*domain.Participation, bool, error)
 }

--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -1,13 +1,291 @@
 package admin
 
-// Service implements read-only admin backoffice use cases.
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// Service implements admin backoffice use cases.
 type Service struct {
-	repo Repository
+	repo               Repository
+	notifications      notification.UseCase
+	tickets            ticket.LifecycleUseCase
+	unitOfWork         uow.UnitOfWork
+	idempotencyKeyFunc func() string
 }
 
 var _ UseCase = (*Service)(nil)
 
+type Option func(*Service)
+
+func WithMutationDependencies(notifications notification.UseCase, tickets ticket.LifecycleUseCase, unitOfWork uow.UnitOfWork) Option {
+	return func(s *Service) {
+		s.notifications = notifications
+		s.tickets = tickets
+		s.unitOfWork = unitOfWork
+	}
+}
+
 // NewService constructs an admin service with the given repository.
-func NewService(repo Repository) *Service {
-	return &Service{repo: repo}
+func NewService(repo Repository, options ...Option) *Service {
+	service := &Service{
+		repo:               repo,
+		idempotencyKeyFunc: uuid.NewString,
+	}
+	for _, option := range options {
+		option(service)
+	}
+	return service
+}
+
+func (s *Service) SendCustomNotification(ctx context.Context, input SendCustomNotificationInput) (*SendCustomNotificationResult, error) {
+	if s.notifications == nil {
+		return nil, domain.ConflictError(domain.ErrorCodeAdminDependencyUnavailable, "Admin notification mutations are not configured.")
+	}
+	if err := s.validateCustomNotification(ctx, input); err != nil {
+		return nil, err
+	}
+
+	idempotencyKey := ""
+	if input.IdempotencyKey != nil {
+		idempotencyKey = strings.TrimSpace(*input.IdempotencyKey)
+	}
+	if idempotencyKey == "" {
+		idempotencyKey = "ADMIN:" + s.idempotencyKeyFunc()
+	}
+
+	result, err := s.notifications.SendCustomNotificationToUsers(ctx, notification.SendCustomNotificationInput{
+		UserIDs:        input.UserIDs,
+		DeliveryMode:   input.DeliveryMode,
+		Title:          input.Title,
+		Body:           input.Body,
+		Type:           input.Type,
+		DeepLink:       input.DeepLink,
+		Data:           input.Data,
+		EventID:        input.EventID,
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slog.InfoContext(ctx, "admin notification mutation completed",
+		"operation", "admin.notifications.create",
+		"admin_user_id", input.AdminUserID.String(),
+		"delivery_mode", input.DeliveryMode.String(),
+		"target_user_count", result.TargetUserCount,
+		"created_count", result.CreatedCount,
+		"idempotent_count", result.IdempotentCount,
+		"sse_delivery_count", result.SSEDeliveryCount,
+		"push_active_device_count", result.PushActiveDeviceCount,
+		"push_sent_count", result.PushSentCount,
+		"push_failed_count", result.PushFailedCount,
+		"invalid_token_count", result.InvalidTokenCount,
+	)
+
+	return &SendCustomNotificationResult{
+		TargetUserCount:       result.TargetUserCount,
+		CreatedCount:          result.CreatedCount,
+		IdempotentCount:       result.IdempotentCount,
+		SSEDeliveryCount:      result.SSEDeliveryCount,
+		PushActiveDeviceCount: result.PushActiveDeviceCount,
+		PushSentCount:         result.PushSentCount,
+		PushFailedCount:       result.PushFailedCount,
+		InvalidTokenCount:     result.InvalidTokenCount,
+	}, nil
+}
+
+func (s *Service) CreateManualParticipation(ctx context.Context, input CreateManualParticipationInput) (*CreateManualParticipationResult, error) {
+	if s.unitOfWork == nil || s.tickets == nil {
+		return nil, domain.ConflictError(domain.ErrorCodeAdminDependencyUnavailable, "Admin participation mutations are not configured.")
+	}
+	if err := validateManualParticipationInput(input); err != nil {
+		return nil, err
+	}
+
+	var result *CreateManualParticipationResult
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		eventState, err := s.repo.GetEventState(ctx, input.EventID, true)
+		if err != nil {
+			return fmt.Errorf("load admin participation event: %w", err)
+		}
+		if eventState == nil {
+			return domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+		if err := s.requireUsersExist(ctx, []uuid.UUID{input.UserID}); err != nil {
+			return err
+		}
+
+		participation, err := s.repo.CreateManualParticipation(ctx, input.EventID, input.UserID, input.Status)
+		if err != nil {
+			return err
+		}
+
+		result = &CreateManualParticipationResult{
+			ParticipationID: participation.ID,
+			EventID:         participation.EventID,
+			UserID:          participation.UserID,
+			Status:          participation.Status,
+		}
+
+		if eventState.PrivacyLevel == domain.PrivacyProtected && participation.Status == domain.ParticipationStatusApproved {
+			createdTicket, err := s.tickets.CreateTicketForParticipation(ctx, participation, domain.TicketStatusActive)
+			if err != nil {
+				return err
+			}
+			result.TicketID = &createdTicket.ID
+			result.TicketStatus = &createdTicket.Status
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slog.InfoContext(ctx, "admin participation created",
+		"operation", "admin.participations.create",
+		"admin_user_id", input.AdminUserID.String(),
+		"event_id", result.EventID.String(),
+		"participant_user_id", result.UserID.String(),
+		"participation_id", result.ParticipationID.String(),
+		"participation_status", result.Status.String(),
+		"ticket_created", result.TicketID != nil,
+		"has_reason", input.Reason != nil && strings.TrimSpace(*input.Reason) != "",
+	)
+	return result, nil
+}
+
+func (s *Service) CancelParticipation(ctx context.Context, input CancelParticipationInput) (*CancelParticipationResult, error) {
+	if s.unitOfWork == nil || s.tickets == nil {
+		return nil, domain.ConflictError(domain.ErrorCodeAdminDependencyUnavailable, "Admin participation mutations are not configured.")
+	}
+	if input.ParticipationID == uuid.Nil {
+		return nil, domain.ValidationError(map[string]string{"participation_id": "is required"})
+	}
+
+	var result *CancelParticipationResult
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		existing, err := s.repo.GetParticipationByID(ctx, input.ParticipationID, true)
+		if err != nil {
+			return fmt.Errorf("load admin participation: %w", err)
+		}
+		if existing == nil {
+			return domain.NotFoundError(domain.ErrorCodeParticipationNotFound, "The requested participation does not exist.")
+		}
+
+		participation, alreadyCanceled, err := s.repo.CancelParticipation(ctx, input.ParticipationID)
+		if err != nil {
+			return err
+		}
+		if !alreadyCanceled {
+			if err := s.tickets.CancelTicketForParticipation(ctx, input.ParticipationID); err != nil {
+				return err
+			}
+		}
+
+		result = &CancelParticipationResult{
+			ParticipationID: participation.ID,
+			EventID:         participation.EventID,
+			UserID:          participation.UserID,
+			Status:          participation.Status,
+			AlreadyCanceled: alreadyCanceled,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slog.InfoContext(ctx, "admin participation canceled",
+		"operation", "admin.participations.cancel",
+		"admin_user_id", input.AdminUserID.String(),
+		"event_id", result.EventID.String(),
+		"participant_user_id", result.UserID.String(),
+		"participation_id", result.ParticipationID.String(),
+		"already_canceled", result.AlreadyCanceled,
+		"has_reason", input.Reason != nil && strings.TrimSpace(*input.Reason) != "",
+	)
+	return result, nil
+}
+
+func (s *Service) validateCustomNotification(ctx context.Context, input SendCustomNotificationInput) error {
+	details := map[string]string{}
+	if len(input.UserIDs) == 0 {
+		details["user_ids"] = "must contain at least one user id"
+	}
+	if input.DeliveryMode == "" {
+		details["delivery_mode"] = "must be one of: IN_APP, PUSH, BOTH"
+	}
+	if strings.TrimSpace(input.Title) == "" {
+		details["title"] = "is required"
+	}
+	if strings.TrimSpace(input.Body) == "" {
+		details["body"] = "is required"
+	}
+	if len(details) > 0 {
+		return domain.ValidationError(details)
+	}
+	if err := s.requireUsersExist(ctx, input.UserIDs); err != nil {
+		return err
+	}
+	if input.EventID != nil {
+		eventState, err := s.repo.GetEventState(ctx, *input.EventID, false)
+		if err != nil {
+			return fmt.Errorf("load admin notification event: %w", err)
+		}
+		if eventState == nil {
+			return domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+	}
+	return nil
+}
+
+func validateManualParticipationInput(input CreateManualParticipationInput) error {
+	details := map[string]string{}
+	if input.EventID == uuid.Nil {
+		details["event_id"] = "is required"
+	}
+	if input.UserID == uuid.Nil {
+		details["user_id"] = "is required"
+	}
+	switch input.Status {
+	case domain.ParticipationStatusApproved, domain.ParticipationStatusPending:
+	default:
+		details["status"] = "must be one of: APPROVED, PENDING"
+	}
+	if len(details) > 0 {
+		return domain.ValidationError(details)
+	}
+	return nil
+}
+
+func (s *Service) requireUsersExist(ctx context.Context, userIDs []uuid.UUID) error {
+	unique := make([]uuid.UUID, 0, len(userIDs))
+	seen := map[uuid.UUID]struct{}{}
+	for _, userID := range userIDs {
+		if userID == uuid.Nil {
+			return domain.ValidationError(map[string]string{"user_ids": "must contain valid UUIDs"})
+		}
+		if _, ok := seen[userID]; ok {
+			continue
+		}
+		seen[userID] = struct{}{}
+		unique = append(unique, userID)
+	}
+	count, err := s.repo.CountExistingUsers(ctx, unique)
+	if err != nil {
+		return fmt.Errorf("count admin target users: %w", err)
+	}
+	if count != len(unique) {
+		return domain.NotFoundError(domain.ErrorCodeUserNotFound, "One or more requested users do not exist.")
+	}
+	return nil
 }

--- a/backend/internal/application/admin/service_dto.go
+++ b/backend/internal/application/admin/service_dto.go
@@ -154,6 +154,66 @@ type ListTicketsResult struct {
 	PageMeta
 }
 
+type SendCustomNotificationInput struct {
+	AdminUserID    uuid.UUID
+	UserIDs        []uuid.UUID
+	DeliveryMode   domain.NotificationDeliveryMode
+	Title          string
+	Body           string
+	Type           *string
+	DeepLink       *string
+	EventID        *uuid.UUID
+	Data           map[string]string
+	IdempotencyKey *string
+}
+
+type SendCustomNotificationResult struct {
+	TargetUserCount       int `json:"target_user_count"`
+	CreatedCount          int `json:"created_count"`
+	IdempotentCount       int `json:"idempotent_count"`
+	SSEDeliveryCount      int `json:"sse_delivery_count"`
+	PushActiveDeviceCount int `json:"push_active_device_count"`
+	PushSentCount         int `json:"push_sent_count"`
+	PushFailedCount       int `json:"push_failed_count"`
+	InvalidTokenCount     int `json:"invalid_token_count"`
+}
+
+type CreateManualParticipationInput struct {
+	AdminUserID uuid.UUID
+	EventID     uuid.UUID
+	UserID      uuid.UUID
+	Status      domain.ParticipationStatus
+	Reason      *string
+}
+
+type CreateManualParticipationResult struct {
+	ParticipationID uuid.UUID                  `json:"participation_id"`
+	EventID         uuid.UUID                  `json:"event_id"`
+	UserID          uuid.UUID                  `json:"user_id"`
+	Status          domain.ParticipationStatus `json:"status"`
+	TicketID        *uuid.UUID                 `json:"ticket_id,omitempty"`
+	TicketStatus    *domain.TicketStatus       `json:"ticket_status,omitempty"`
+}
+
+type CancelParticipationInput struct {
+	AdminUserID     uuid.UUID
+	ParticipationID uuid.UUID
+	Reason          *string
+}
+
+type CancelParticipationResult struct {
+	ParticipationID uuid.UUID                  `json:"participation_id"`
+	EventID         uuid.UUID                  `json:"event_id"`
+	UserID          uuid.UUID                  `json:"user_id"`
+	Status          domain.ParticipationStatus `json:"status"`
+	AlreadyCanceled bool                       `json:"already_canceled"`
+}
+
+type AdminEventState struct {
+	ID           uuid.UUID
+	PrivacyLevel domain.EventPrivacyLevel
+}
+
 func (s *Service) ListUsers(ctx context.Context, input ListUsersInput) (*ListUsersResult, error) {
 	return s.repo.ListUsers(ctx, input)
 }

--- a/backend/internal/application/admin/usecase.go
+++ b/backend/internal/application/admin/usecase.go
@@ -8,4 +8,7 @@ type UseCase interface {
 	ListEvents(ctx context.Context, input ListEventsInput) (*ListEventsResult, error)
 	ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error)
 	ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error)
+	SendCustomNotification(ctx context.Context, input SendCustomNotificationInput) (*SendCustomNotificationResult, error)
+	CreateManualParticipation(ctx context.Context, input CreateManualParticipationInput) (*CreateManualParticipationResult, error)
+	CancelParticipation(ctx context.Context, input CancelParticipationInput) (*CancelParticipationResult, error)
 }

--- a/backend/internal/application/notification/service.go
+++ b/backend/internal/application/notification/service.go
@@ -255,6 +255,91 @@ func (s *Service) SendNotificationToUsers(ctx context.Context, input SendNotific
 	return result, nil
 }
 
+// SendCustomNotificationToUsers sends an admin-triggered notification through
+// the requested channels while sharing inbox persistence, realtime attempts,
+// push attempts, invalid-token handling, and delivery metrics.
+func (s *Service) SendCustomNotificationToUsers(ctx context.Context, input SendCustomNotificationInput) (*SendNotificationResult, error) {
+	if appErr := validateSendCustomNotificationInput(input); appErr != nil {
+		return nil, appErr
+	}
+
+	now := s.now().UTC()
+	result := &SendNotificationResult{
+		TargetUserCount: len(uniqueUserIDs(input.UserIDs)),
+	}
+
+	for userID := range uniqueUserIDs(input.UserIDs) {
+		createResult, err := s.repo.CreateNotificationIfAbsent(ctx, CreateNotificationParams{
+			UserID:         userID,
+			EventID:        input.EventID,
+			Title:          strings.TrimSpace(input.Title),
+			Type:           input.Type,
+			Body:           strings.TrimSpace(input.Body),
+			DeepLink:       input.DeepLink,
+			ImageURL:       input.ImageURL,
+			Data:           input.Data,
+			IdempotencyKey: strings.TrimSpace(input.IdempotencyKey),
+			CreatedAt:      now,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create custom notification: %w", err)
+		}
+		if !createResult.Created {
+			result.IdempotentCount++
+			continue
+		}
+		result.CreatedCount++
+
+		if input.DeliveryMode == domain.NotificationDeliveryModeInApp || input.DeliveryMode == domain.NotificationDeliveryModeBoth {
+			delivered := 0
+			if s.realtime != nil {
+				delivered = s.realtime.Publish(ctx, userID, createResult.Notification)
+			}
+			if delivered > 0 {
+				result.SSEDeliveryCount += delivered
+				for i := 0; i < delivered; i++ {
+					sentAt := now
+					if err := s.repo.CreateDeliveryAttempt(ctx, CreateDeliveryAttemptParams{
+						NotificationID: createResult.Notification.ID,
+						UserID:         userID,
+						Method:         domain.NotificationDeliveryMethodSSE,
+						Status:         domain.NotificationDeliveryStatusSent,
+						SentAt:         &sentAt,
+					}); err != nil {
+						return nil, fmt.Errorf("store custom sse delivery attempt: %w", err)
+					}
+				}
+			}
+		}
+
+		if input.DeliveryMode == domain.NotificationDeliveryModePush || input.DeliveryMode == domain.NotificationDeliveryModeBoth {
+			pushResult, err := s.sendPushForNotification(ctx, createResult.Notification)
+			if err != nil {
+				return nil, err
+			}
+			result.PushActiveDeviceCount += pushResult.ActiveDeviceCount
+			result.PushSentCount += pushResult.SentCount
+			result.PushFailedCount += pushResult.FailedCount
+			result.InvalidTokenCount += pushResult.InvalidTokenCount
+		}
+	}
+
+	slog.InfoContext(ctx, "admin custom notifications sent",
+		"operation", "admin.notifications.send",
+		"delivery_mode", input.DeliveryMode.String(),
+		"target_user_count", result.TargetUserCount,
+		"created_count", result.CreatedCount,
+		"idempotent_count", result.IdempotentCount,
+		"sse_delivery_count", result.SSEDeliveryCount,
+		"push_active_device_count", result.PushActiveDeviceCount,
+		"push_sent_count", result.PushSentCount,
+		"push_failed_count", result.PushFailedCount,
+		"invalid_token_count", result.InvalidTokenCount,
+	)
+
+	return result, nil
+}
+
 func (s *Service) SendPushToUsers(ctx context.Context, input SendPushInput) (*SendPushResult, error) {
 	if appErr := validateSendPushInput(input); appErr != nil {
 		return nil, appErr

--- a/backend/internal/application/notification/service_dto.go
+++ b/backend/internal/application/notification/service_dto.go
@@ -49,6 +49,19 @@ type SendNotificationInput struct {
 	IdempotencyKey string
 }
 
+type SendCustomNotificationInput struct {
+	UserIDs        []uuid.UUID
+	DeliveryMode   domain.NotificationDeliveryMode
+	Title          string
+	Body           string
+	Type           *string
+	DeepLink       *string
+	Data           map[string]string
+	EventID        *uuid.UUID
+	ImageURL       *string
+	IdempotencyKey string
+}
+
 type SendPushResult struct {
 	TargetUserCount   int
 	ActiveDeviceCount int

--- a/backend/internal/application/notification/service_test.go
+++ b/backend/internal/application/notification/service_test.go
@@ -188,6 +188,77 @@ func TestSendNotificationToUsersIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestSendCustomNotificationBothUsesSSEAndPush(t *testing.T) {
+	// given
+	repo := newFakeNotificationRepo()
+	broker := NewBroker()
+	sender := &recordingPushSender{}
+	svc := NewService(repo, sender, fakeUnitOfWork{}, broker)
+	svc.now = func() time.Time { return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC) }
+	userID := uuid.New()
+	repo.addDevice(userID, uuid.New(), "push-token", svc.now())
+	sub := broker.Subscribe(userID)
+	defer sub.Cancel()
+
+	// when
+	result, err := svc.SendCustomNotificationToUsers(context.Background(), SendCustomNotificationInput{
+		UserIDs:        []uuid.UUID{userID},
+		DeliveryMode:   domain.NotificationDeliveryModeBoth,
+		Title:          "Admin update",
+		Body:           "Please check this.",
+		IdempotencyKey: "admin:update:1",
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("SendCustomNotificationToUsers() error = %v", err)
+	}
+	if result.SSEDeliveryCount != 1 || result.PushSentCount != 1 {
+		t.Fatalf("expected SSE and push delivery, got %#v", result)
+	}
+	if sender.sentCount != 1 {
+		t.Fatalf("expected one push send, got %d", sender.sentCount)
+	}
+	select {
+	case notification := <-sub.Events:
+		if notification.Title != "Admin update" {
+			t.Fatalf("unexpected notification title %q", notification.Title)
+		}
+	default:
+		t.Fatal("expected notification on SSE subscription")
+	}
+}
+
+func TestSendCustomNotificationInAppSkipsPush(t *testing.T) {
+	// given
+	repo := newFakeNotificationRepo()
+	sender := &recordingPushSender{}
+	svc := NewService(repo, sender, fakeUnitOfWork{})
+	svc.now = func() time.Time { return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC) }
+	userID := uuid.New()
+	repo.addDevice(userID, uuid.New(), "push-token", svc.now())
+
+	// when
+	result, err := svc.SendCustomNotificationToUsers(context.Background(), SendCustomNotificationInput{
+		UserIDs:        []uuid.UUID{userID},
+		DeliveryMode:   domain.NotificationDeliveryModeInApp,
+		Title:          "Admin update",
+		Body:           "Please check this.",
+		IdempotencyKey: "admin:update:2",
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("SendCustomNotificationToUsers() error = %v", err)
+	}
+	if result.PushActiveDeviceCount != 0 || result.PushSentCount != 0 || sender.sentCount != 0 {
+		t.Fatalf("expected no push delivery, result=%#v sends=%d", result, sender.sentCount)
+	}
+	if len(repo.notifications) != 1 {
+		t.Fatalf("expected one inbox notification, got %d", len(repo.notifications))
+	}
+}
+
 type fakeNotificationRepo struct {
 	devices          map[uuid.UUID]*domain.PushDevice
 	notifications    map[uuid.UUID]*domain.Notification

--- a/backend/internal/application/notification/usecase.go
+++ b/backend/internal/application/notification/usecase.go
@@ -18,5 +18,6 @@ type UseCase interface {
 	DeleteAllNotifications(ctx context.Context, userID uuid.UUID) error
 	DeleteExpiredNotifications(ctx context.Context) (int, error)
 	SendNotificationToUsers(ctx context.Context, input SendNotificationInput) (*SendNotificationResult, error)
+	SendCustomNotificationToUsers(ctx context.Context, input SendCustomNotificationInput) (*SendNotificationResult, error)
 	SendPushToUsers(ctx context.Context, input SendPushInput) (*SendPushResult, error)
 }

--- a/backend/internal/application/notification/validator.go
+++ b/backend/internal/application/notification/validator.go
@@ -65,6 +65,36 @@ func validateSendNotificationInput(input SendNotificationInput) *domain.AppError
 	return nil
 }
 
+func validateSendCustomNotificationInput(input SendCustomNotificationInput) *domain.AppError {
+	details := map[string]string{}
+	if len(input.UserIDs) == 0 {
+		details["user_ids"] = "must contain at least one user id"
+	}
+	if input.DeliveryMode == "" {
+		details["delivery_mode"] = "must be one of: IN_APP, PUSH, BOTH"
+	}
+	if input.DeliveryMode != "" {
+		switch input.DeliveryMode {
+		case domain.NotificationDeliveryModeInApp, domain.NotificationDeliveryModePush, domain.NotificationDeliveryModeBoth:
+		default:
+			details["delivery_mode"] = "must be one of: IN_APP, PUSH, BOTH"
+		}
+	}
+	if strings.TrimSpace(input.Title) == "" {
+		details["title"] = "is required"
+	}
+	if strings.TrimSpace(input.Body) == "" {
+		details["body"] = "is required"
+	}
+	if strings.TrimSpace(input.IdempotencyKey) == "" {
+		details["idempotency_key"] = "is required"
+	}
+	if len(details) > 0 {
+		return domain.ValidationError(details)
+	}
+	return nil
+}
+
 func normalizeListNotificationsInput(input ListNotificationsInput, now time.Time) (ListNotificationsParams, error) {
 	params := ListNotificationsParams{
 		UserID:               input.UserID,

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -243,7 +243,7 @@ func buildPushSender(ctx context.Context, cfg *config.Config) (notification.Push
 
 // newAdminService wires the admin backoffice use case with its read repository.
 func newAdminService(c *Container) admin.UseCase {
-	return admin.NewService(c.adminRepo)
+	return admin.NewService(c.adminRepo, admin.WithMutationDependencies(c.NotificationService, c.TicketService, c.UnitOfWork))
 }
 
 // newEventService wires the event use case with its driven adapters.

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -31,9 +31,11 @@ const (
 	ErrorCodeUsernameExists    = "username_already_exists"
 	ErrorCodePhoneExists       = "phone_number_already_exists"
 	ErrorCodeEventTitleExists  = "event_title_already_exists"
+	ErrorCodeUserNotFound      = "user_not_found"
 
 	ErrorCodeEventNotFound                   = "event_not_found"
 	ErrorCodeAlreadyParticipating            = "already_participating"
+	ErrorCodeParticipationNotFound           = "participation_not_found"
 	ErrorCodeAlreadyRequested                = "already_requested"
 	ErrorCodeEventJoinNotAllowed             = "event_join_not_allowed"
 	ErrorCodeHostCannotJoin                  = "host_cannot_join"
@@ -72,7 +74,8 @@ const (
 
 	ErrorCodeNotificationNotFound = "notification_not_found"
 
-	ErrorCodeAdminAccessRequired = "admin_access_required"
+	ErrorCodeAdminAccessRequired        = "admin_access_required"
+	ErrorCodeAdminDependencyUnavailable = "admin_dependency_unavailable"
 )
 
 // ErrNotFound is a sentinel error returned when a queried entity does not exist.

--- a/backend/internal/domain/notification.go
+++ b/backend/internal/domain/notification.go
@@ -56,10 +56,20 @@ func (m NotificationDeliveryMethod) String() string {
 // NotificationDeliveryStatus identifies the result of one delivery attempt.
 type NotificationDeliveryStatus string
 
+// NotificationDeliveryMode identifies which admin-triggered delivery channels
+// should be attempted for a custom notification.
+type NotificationDeliveryMode string
+
 const (
 	NotificationDeliveryStatusSent    NotificationDeliveryStatus = "SENT"
 	NotificationDeliveryStatusFailed  NotificationDeliveryStatus = "FAILED"
 	NotificationDeliveryStatusSkipped NotificationDeliveryStatus = "SKIPPED"
+)
+
+const (
+	NotificationDeliveryModeInApp NotificationDeliveryMode = "IN_APP"
+	NotificationDeliveryModePush  NotificationDeliveryMode = "PUSH"
+	NotificationDeliveryModeBoth  NotificationDeliveryMode = "BOTH"
 )
 
 func ParseNotificationDeliveryStatus(value string) (NotificationDeliveryStatus, bool) {
@@ -77,6 +87,23 @@ func ParseNotificationDeliveryStatus(value string) (NotificationDeliveryStatus, 
 
 func (s NotificationDeliveryStatus) String() string {
 	return string(s)
+}
+
+func ParseNotificationDeliveryMode(value string) (NotificationDeliveryMode, bool) {
+	switch NotificationDeliveryMode(strings.ToUpper(strings.TrimSpace(value))) {
+	case NotificationDeliveryModeInApp:
+		return NotificationDeliveryModeInApp, true
+	case NotificationDeliveryModePush:
+		return NotificationDeliveryModePush, true
+	case NotificationDeliveryModeBoth:
+		return NotificationDeliveryModeBoth, true
+	default:
+		return "", false
+	}
+}
+
+func (m NotificationDeliveryMode) String() string {
+	return string(m)
 }
 
 // Notification is the user-facing in-app notification inbox item.

--- a/backend/tests_integration/admin_test.go
+++ b/backend/tests_integration/admin_test.go
@@ -3,6 +3,7 @@
 package tests_integration
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -10,11 +11,14 @@ import (
 	"testing"
 	"time"
 
+	pushadapter "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/firebasepush"
 	jwtadapter "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/jwt"
 	postgresrepo "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/postgres"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/admin_handler"
 	adminapp "github.com/bounswe/bounswe2026group11/backend/internal/application/admin"
+	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
+	ticketapp "github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
 	"github.com/gofiber/fiber/v2"
@@ -113,6 +117,108 @@ func TestAdminEventsParticipationsAndTicketsFiltering(t *testing.T) {
 	assertAdminListHasOne(t, ticketsResp, "tickets")
 }
 
+func TestAdminCreateNotificationMutation(t *testing.T) {
+	t.Parallel()
+
+	// given
+	pool := common.RequirePool(t)
+	authRepo := postgresrepo.NewAuthRepository(pool)
+	service := newAdminMutationService(t)
+	app, issuer := adminIntegrationApp(service)
+
+	adminUser := common.GivenUser(t, authRepo, common.WithUserUsername("admin_notify_"+uuid.NewString()[:8]))
+	targetUser := common.GivenUser(t, authRepo, common.WithUserUsername("target_notify_"+uuid.NewString()[:8]))
+	promoteUser(t, adminUser.ID)
+	adminUser.Role = domain.UserRoleAdmin
+	adminToken := issueAccessToken(t, issuer, *adminUser)
+	payload := `{"user_ids":["` + targetUser.ID.String() + `"],"delivery_mode":"IN_APP","title":"Backoffice update","body":"Check your inbox","idempotency_key":"admin-it-` + uuid.NewString() + `"}`
+
+	// when
+	resp := performAdminJSONRequest(t, app, fiber.MethodPost, "/admin/notifications", adminToken, payload)
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("expected admin notification request to return 201, got %d", resp.StatusCode)
+	}
+	var body adminapp.SendCustomNotificationResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.TargetUserCount != 1 || body.CreatedCount != 1 {
+		t.Fatalf("unexpected notification result: %#v", body)
+	}
+}
+
+func TestAdminCreateAndCancelParticipationMutationCreatesAndCancelsTicket(t *testing.T) {
+	t.Parallel()
+
+	// given
+	pool := common.RequirePool(t)
+	authRepo := postgresrepo.NewAuthRepository(pool)
+	eventHarness := common.NewEventHarness(t)
+	service := newAdminMutationService(t)
+	app, issuer := adminIntegrationApp(service)
+
+	adminUser := common.GivenUser(t, authRepo, common.WithUserUsername("admin_part_"+uuid.NewString()[:8]))
+	host := common.GivenUser(t, authRepo, common.WithUserUsername("host_part_"+uuid.NewString()[:8]))
+	participant := common.GivenUser(t, authRepo, common.WithUserUsername("manual_part_"+uuid.NewString()[:8]))
+	promoteUser(t, adminUser.ID)
+	adminUser.Role = domain.UserRoleAdmin
+	adminToken := issueAccessToken(t, issuer, *adminUser)
+	eventRef := common.GivenProtectedEvent(t, eventHarness.Service, host.ID)
+	createPayload := `{"event_id":"` + eventRef.ID.String() + `","user_id":"` + participant.ID.String() + `"}`
+
+	// when
+	createResp := performAdminJSONRequest(t, app, fiber.MethodPost, "/admin/participations", adminToken, createPayload)
+	defer func() { _ = createResp.Body.Close() }()
+
+	// then
+	if createResp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("expected participation create to return 201, got %d", createResp.StatusCode)
+	}
+	var createBody adminapp.CreateManualParticipationResult
+	if err := json.NewDecoder(createResp.Body).Decode(&createBody); err != nil {
+		t.Fatalf("Decode(create) error = %v", err)
+	}
+	if createBody.TicketID == nil || createBody.TicketStatus == nil || *createBody.TicketStatus != domain.TicketStatusActive {
+		t.Fatalf("expected active ticket for protected event, got %#v", createBody)
+	}
+
+	duplicateResp := performAdminJSONRequest(t, app, fiber.MethodPost, "/admin/participations", adminToken, createPayload)
+	defer func() { _ = duplicateResp.Body.Close() }()
+	if duplicateResp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("expected duplicate participation to return 409, got %d", duplicateResp.StatusCode)
+	}
+
+	cancelResp := performAdminJSONRequest(t, app, fiber.MethodPost, "/admin/participations/"+createBody.ParticipationID.String()+"/cancel", adminToken, `{}`)
+	defer func() { _ = cancelResp.Body.Close() }()
+	if cancelResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected participation cancel to return 200, got %d", cancelResp.StatusCode)
+	}
+
+	var ticketStatus string
+	if err := pool.QueryRow(context.Background(), `SELECT status FROM ticket WHERE participation_id = $1`, createBody.ParticipationID).Scan(&ticketStatus); err != nil {
+		t.Fatalf("query ticket status error = %v", err)
+	}
+	if ticketStatus != string(domain.TicketStatusCanceled) {
+		t.Fatalf("expected ticket to be canceled, got %q", ticketStatus)
+	}
+
+	cancelAgainResp := performAdminJSONRequest(t, app, fiber.MethodPost, "/admin/participations/"+createBody.ParticipationID.String()+"/cancel", adminToken, `{}`)
+	defer func() { _ = cancelAgainResp.Body.Close() }()
+	if cancelAgainResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected idempotent cancel to return 200, got %d", cancelAgainResp.StatusCode)
+	}
+	var cancelAgainBody adminapp.CancelParticipationResult
+	if err := json.NewDecoder(cancelAgainResp.Body).Decode(&cancelAgainBody); err != nil {
+		t.Fatalf("Decode(cancel again) error = %v", err)
+	}
+	if !cancelAgainBody.AlreadyCanceled {
+		t.Fatalf("expected already_canceled=true, got %#v", cancelAgainBody)
+	}
+}
+
 func adminIntegrationApp(service adminapp.UseCase) (*fiber.App, jwtadapter.Issuer) {
 	secret := []byte("admin-integration-secret")
 	issuer := jwtadapter.Issuer{Secret: secret, TTL: 15 * time.Minute}
@@ -143,6 +249,37 @@ func performAdminRequest(t *testing.T, app *fiber.App, path, token string) *http
 		t.Fatalf("app.Test(%s) error = %v", path, err)
 	}
 	return resp
+}
+
+func performAdminJSONRequest(t *testing.T, app *fiber.App, method, path, token, payload string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(payload))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	if token != "" {
+		req.Header.Set(fiber.HeaderAuthorization, "Bearer "+token)
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test(%s %s) error = %v", method, path, err)
+	}
+	return resp
+}
+
+func newAdminMutationService(t *testing.T) adminapp.UseCase {
+	t.Helper()
+	pool := common.RequirePool(t)
+	unitOfWork := postgresrepo.NewUnitOfWork(pool)
+	ticketService := ticketapp.NewService(
+		postgresrepo.NewTicketRepository(pool),
+		unitOfWork,
+		jwtadapter.TicketTokenManager{Secret: []byte("admin-integration-secret")},
+		ticketapp.Settings{QRTokenTTL: 10 * time.Second, ProximityMeters: 200},
+	)
+	notificationService := notificationapp.NewService(postgresrepo.NewNotificationRepository(pool), pushadapter.MockSender{}, unitOfWork)
+	return adminapp.NewService(
+		postgresrepo.NewAdminRepository(pool),
+		adminapp.WithMutationDependencies(notificationService, ticketService, unitOfWork),
+	)
 }
 
 func promoteUser(t *testing.T, userID uuid.UUID) {

--- a/docs/openapi/admin.yaml
+++ b/docs/openapi/admin.yaml
@@ -3,7 +3,7 @@ info:
   title: Social Event Mapper Admin Backoffice API
   version: 0.1.0
   description: |
-    Web-only read APIs for the admin backoffice.
+    Web-only admin backoffice APIs for read tables and privileged mutations.
 
     All endpoints require a bearer access token whose `role` claim is `ADMIN`.
     Anonymous callers receive `401`; authenticated non-admin callers receive `403`.
@@ -13,7 +13,7 @@ security:
   - bearerAuth: []
 tags:
   - name: Admin
-    description: Read-only admin table endpoints.
+    description: Admin table and mutation endpoints.
 paths:
   /admin/users:
     get:
@@ -138,6 +138,77 @@ paths:
         '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+    post:
+      tags: [Admin]
+      summary: Create a manual participation
+      operationId: adminCreateParticipation
+      description: |
+        Creates or reactivates a manual participation for the selected event/user pair.
+        `status` defaults to `APPROVED`. Only `APPROVED` and `PENDING` are accepted.
+
+        The event and user must exist. If the user already has an active
+        `APPROVED` or `PENDING` participation for the event, the API returns `409`.
+        For `PROTECTED` events, creating an `APPROVED` participation also creates
+        or reactivates the linked `ACTIVE` ticket in the same application mutation.
+        Event participant counts are maintained by the existing participation count triggers.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminCreateParticipationRequest' }
+      responses:
+        '201':
+          description: Manual participation created or reactivated.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminCreateParticipationResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404':
+          description: The event or user does not exist.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '409':
+          description: The user already has an active participation for this event.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /admin/participations/{participation_id}/cancel:
+    post:
+      tags: [Admin]
+      summary: Cancel a participation
+      operationId: adminCancelParticipation
+      description: |
+        Marks the participation `CANCELED` and cancels linked `ACTIVE` or `PENDING`
+        tickets in the same application mutation. If the participation is already
+        `CANCELED`, the endpoint is idempotent: it returns `200` with
+        `already_canceled: true` and does not perform another ticket mutation.
+      parameters:
+        - name: participation_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminCancelParticipationRequest' }
+      responses:
+        '200':
+          description: Participation is canceled.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminCancelParticipationResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404':
+          description: The participation does not exist.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /admin/tickets:
     get:
       tags: [Admin]
@@ -182,6 +253,40 @@ paths:
         '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/notifications:
+    post:
+      tags: [Admin]
+      summary: Send a custom notification
+      operationId: adminCreateNotification
+      description: |
+        Sends a custom notification to explicit user IDs selected by an admin.
+        `delivery_mode` controls delivery attempts: `IN_APP` creates inbox rows
+        and attempts SSE delivery, `PUSH` creates inbox rows and attempts push
+        delivery to active devices, and `BOTH` attempts both SSE and push.
+
+        The API does not log notification body text or other sensitive free-form
+        content. `idempotency_key` is optional; when supplied, duplicate calls with
+        the same key for the same receiver return existing rows and increment
+        `idempotent_count`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminCreateNotificationRequest' }
+      responses:
+        '201':
+          description: Notification processing summary.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminCreateNotificationResponse' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404':
+          description: A target user or referenced event does not exist.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 components:
   securitySchemes:
     bearerAuth:
@@ -279,6 +384,90 @@ components:
         canceled_at: { type: [string, 'null'], format: date-time }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+    AdminCreateNotificationRequest:
+      type: object
+      additionalProperties: false
+      required: [user_ids, delivery_mode, title, body]
+      properties:
+        user_ids:
+          type: array
+          minItems: 1
+          items: { type: string, format: uuid }
+        delivery_mode: { type: string, enum: [IN_APP, PUSH, BOTH] }
+        title: { type: string, minLength: 1 }
+        body: { type: string, minLength: 1 }
+        type: { type: [string, 'null'] }
+        deep_link: { type: [string, 'null'] }
+        event_id: { type: [string, 'null'], format: uuid }
+        data:
+          type: object
+          additionalProperties: { type: string }
+        idempotency_key:
+          type: [string, 'null']
+          description: Optional caller-provided key for receiver-level idempotency.
+    AdminCreateNotificationResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - target_user_count
+        - created_count
+        - idempotent_count
+        - sse_delivery_count
+        - push_active_device_count
+        - push_sent_count
+        - push_failed_count
+        - invalid_token_count
+      properties:
+        target_user_count: { type: integer }
+        created_count: { type: integer }
+        idempotent_count: { type: integer }
+        sse_delivery_count: { type: integer }
+        push_active_device_count: { type: integer }
+        push_sent_count: { type: integer }
+        push_failed_count: { type: integer }
+        invalid_token_count: { type: integer }
+    AdminCreateParticipationRequest:
+      type: object
+      additionalProperties: false
+      required: [event_id, user_id]
+      properties:
+        event_id: { type: string, format: uuid }
+        user_id: { type: string, format: uuid }
+        status:
+          type: string
+          enum: [APPROVED, PENDING]
+          default: APPROVED
+        reason:
+          type: [string, 'null']
+          description: Optional admin note/reason. It is accepted for audit-aware clients but is not persisted yet.
+    AdminCreateParticipationResponse:
+      type: object
+      additionalProperties: false
+      required: [participation_id, event_id, user_id, status]
+      properties:
+        participation_id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        user_id: { type: string, format: uuid }
+        status: { type: string, enum: [APPROVED, PENDING] }
+        ticket_id: { type: string, format: uuid }
+        ticket_status: { type: string, enum: [ACTIVE, PENDING, EXPIRED, USED, CANCELED] }
+    AdminCancelParticipationRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        reason:
+          type: [string, 'null']
+          description: Optional admin note/reason. It is accepted for audit-aware clients but is not persisted yet.
+    AdminCancelParticipationResponse:
+      type: object
+      additionalProperties: false
+      required: [participation_id, event_id, user_id, status, already_canceled]
+      properties:
+        participation_id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        user_id: { type: string, format: uuid }
+        status: { type: string, enum: [CANCELED] }
+        already_canceled: { type: boolean }
     ErrorResponse:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## 📋 Summary
Adds backend-only admin mutation APIs for the backoffice Notifications and Participations pages, including custom notification delivery and manual participation lifecycle management.

## 🔄 Changes
- Added `POST /admin/notifications` for admin-triggered custom notifications to explicit user IDs.
- Supports `IN_APP`, `PUSH`, and `BOTH` delivery modes.
- Reuses existing notification persistence, SSE delivery attempts, push delivery attempts, invalid-token handling, and delivery metrics.
- Added `POST /admin/participations` for manual admin participation creation.
- Added `POST /admin/participations/{participation_id}/cancel` for idempotent admin cancellation.
- Creates protected-event tickets for approved manual participations and cancels linked active/pending tickets on participation cancellation.
- Added validation, conflict, not-found, and authorization behavior for the new endpoints.
- Updated `docs/openapi/admin.yaml` with the new mutation contracts and side effects.
- Added unit and integration test coverage for the new admin mutation flows.

## 🧪 Testing
- `go test ./...`
- `go test -tags=integration ./tests_integration -run 'TestAdmin'`
- `./shipcheck.sh`

## 🔗 Related
Closes #525