### PR TITLE
feat(frontend): add backoffice shell and admin list views

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -20,6 +20,11 @@ vi.mock('./components/AppShell', () => {
 vi.mock('./views/auth/LoginView', () => ({ default: () => <div>Login</div> }));
 vi.mock('./views/auth/RegisterView', () => ({ default: () => <div>Register</div> }));
 vi.mock('./views/auth/ForgotPasswordView', () => ({ default: () => <div>Forgot Password</div> }));
+vi.mock('./views/backoffice/UsersAdminPage', () => ({ default: () => <div>Users Admin Page</div> }));
+vi.mock('./views/backoffice/EventsAdminPage', () => ({ default: () => <div>Events Admin Page</div> }));
+vi.mock('./views/backoffice/ParticipationsAdminPage', () => ({ default: () => <div>Participations Admin Page</div> }));
+vi.mock('./views/backoffice/TicketsAdminPage', () => ({ default: () => <div>Tickets Admin Page</div> }));
+vi.mock('./views/backoffice/NotificationsAdminPage', () => ({ default: () => <div>Notifications Admin Page</div> }));
 vi.mock('./components/ProtectedRoute', () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -78,5 +83,23 @@ describe('App / route', () => {
     // App returns null while loading; only CurrentPath should be in the DOM
     expect(container.querySelector('[data-testid="path"]')).toBeDefined();
     expect(screen.queryByText('Landing Page')).toBeNull();
+  });
+
+  it('denies /admin-panel child pages to non-admin users', () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, token: 'valid-token', role: 'USER' });
+
+    renderAt('/admin-panel/users');
+
+    expect(screen.getByText('Admin Access Required')).toBeDefined();
+    expect(screen.queryByText('Users Admin Page')).toBeNull();
+  });
+
+  it('renders /admin-panel child pages for admins', () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, token: 'valid-token', role: 'ADMIN' });
+
+    renderAt('/admin-panel/users');
+
+    expect(screen.getByText('Users Admin Page')).toBeDefined();
+    expect(screen.getByRole('link', { name: 'Users' })).toBeDefined();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import RegisterView from './views/auth/RegisterView';
 import ForgotPasswordView from './views/auth/ForgotPasswordView';
 import AppShell from './components/AppShell';
 import ProtectedRoute from './components/ProtectedRoute';
+import AdminRoute from './components/AdminRoute';
 import DiscoverPage from './views/discover/DiscoverPage';
 import CreateEventPage from './views/events/CreateEventPage';
 import EventDetailPage from './views/events/EventDetailPage';
@@ -14,6 +15,12 @@ import InvitationsPage from './views/invitations/InvitationsPage';
 import FavoritesPage from './views/favorites/FavoritesPage';
 import ProfilePage from './views/profile/ProfilePage';
 import NotFoundView from './views/fallback/NotFoundView';
+import BackofficeLayout from './views/backoffice/BackofficeLayout';
+import UsersAdminPage from './views/backoffice/UsersAdminPage';
+import EventsAdminPage from './views/backoffice/EventsAdminPage';
+import ParticipationsAdminPage from './views/backoffice/ParticipationsAdminPage';
+import TicketsAdminPage from './views/backoffice/TicketsAdminPage';
+import NotificationsAdminPage from './views/backoffice/NotificationsAdminPage';
 
 export default function App() {
   const { isLoading, token } = useAuth();
@@ -38,6 +45,19 @@ export default function App() {
         <Route path="/invitations" element={<ProtectedRoute><InvitationsPage /></ProtectedRoute>} />
         <Route path="/favorites" element={<ProtectedRoute><FavoritesPage /></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
+        <Route
+          path="/admin-panel"
+          element={<AdminRoute><BackofficeLayout /></AdminRoute>}
+        >
+          <Route index element={<Navigate to="/admin-panel/users" replace />} />
+          <Route path="users" element={<UsersAdminPage />} />
+          <Route path="events" element={<EventsAdminPage />} />
+          <Route path="participations" element={<ParticipationsAdminPage />} />
+          <Route path="tickets" element={<TicketsAdminPage />} />
+          <Route path="notifications" element={<NotificationsAdminPage />} />
+        </Route>
+        <Route path="/backoffice" element={<Navigate to="/admin-panel" replace />} />
+        <Route path="/backoffice/*" element={<Navigate to="/admin-panel" replace />} />
       </Route>
 
       {/* Auth pages (no shell) */}

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,0 +1,31 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import AccessDeniedView from '@/views/fallback/AccessDeniedView';
+
+export default function AdminRoute({ children }: { children: React.ReactNode }) {
+  const { token, role, isLoading } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    return (
+      <div className="auth-page">
+        <div className="spinner" style={{ borderTopColor: '#111827', borderColor: 'rgba(17,24,39,0.2)' }} />
+      </div>
+    );
+  }
+
+  if (!token) {
+    return <Navigate to="/" state={{ from: location.pathname }} replace />;
+  }
+
+  if (role !== 'ADMIN') {
+    return (
+      <AccessDeniedView
+        title="Admin Access Required"
+        message="This admin panel area is only available to administrators."
+      />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AppShell from './AppShell';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/authService', () => ({
+  logout: vi.fn(),
+}));
+
+import { useAuth } from '@/contexts/AuthContext';
+
+const mockUseAuth = useAuth as ReturnType<typeof vi.fn>;
+
+function renderShell() {
+  return render(
+    <MemoryRouter initialEntries={['/discover']}>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/discover" element={<div>Discover</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AppShell admin entry', () => {
+  it('shows Admin Panel for authenticated admins', () => {
+    mockUseAuth.mockReturnValue({
+      token: 'token',
+      refreshToken: 'refresh',
+      username: 'admin',
+      role: 'ADMIN',
+      avatarUrl: null,
+      displayName: null,
+      clearAuth: vi.fn(),
+    });
+
+    renderShell();
+
+    expect(screen.getByRole('link', { name: 'Admin Panel' }).getAttribute('href')).toBe('/admin-panel');
+  });
+
+  it('hides Admin Panel for regular authenticated users', () => {
+    mockUseAuth.mockReturnValue({
+      token: 'token',
+      refreshToken: 'refresh',
+      username: 'user',
+      role: 'USER',
+      avatarUrl: null,
+      displayName: null,
+      clearAuth: vi.fn(),
+    });
+
+    renderShell();
+
+    expect(screen.queryByRole('link', { name: 'Admin Panel' })).toBeNull();
+  });
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { UserAvatar } from '@/components/UserAvatar';
 import { logout } from '@/services/authService';
@@ -14,14 +14,16 @@ const AUTH_NAV = [
 ];
 
 export default function AppShell() {
-  const { token, username, avatarUrl, displayName, refreshToken, clearAuth } = useAuth();
+  const { token, username, role, avatarUrl, displayName, refreshToken, clearAuth } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [menuOpen, setMenuOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
 
   const isLoggedIn = !!token;
   const navItems = isLoggedIn ? AUTH_NAV : [];
+  const isAdminPanel = location.pathname.startsWith('/admin-panel');
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -78,6 +80,14 @@ export default function AppShell() {
                 <NavLink to="/events/create" className="shell-create-btn">
                   + Create Event
                 </NavLink>
+                {role === 'ADMIN' && (
+                  <NavLink to="/admin-panel" className="shell-admin-btn">
+                    <svg className="shell-admin-icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M12 3.5 18 6v5.2c0 3.9-2.4 7.4-6 8.8-3.6-1.4-6-4.9-6-8.8V6l6-2.5Z" />
+                    </svg>
+                    <span>Admin Panel</span>
+                  </NavLink>
+                )}
                 <div className="shell-user-menu" ref={userMenuRef}>
                   <button
                     className="shell-user-btn"
@@ -146,7 +156,7 @@ export default function AppShell() {
         />
       )}
 
-      <main className="shell-main">
+      <main className={`shell-main ${isAdminPanel ? 'admin-panel-main' : ''}`}>
         <Outlet />
       </main>
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,12 +1,32 @@
 import { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import { setTokenRefreshManager } from '@/services/api';
 import { profileService } from '@/services/profileService';
+import type { UserRole } from '@/models/auth';
 
 const STORAGE_KEY_TOKEN = 'sem_access_token';
 const STORAGE_KEY_REFRESH = 'sem_refresh_token';
 const STORAGE_KEY_USERNAME = 'sem_username';
 const STORAGE_KEY_AVATAR_URL = 'sem_avatar_url';
 const STORAGE_KEY_DISPLAY_NAME = 'sem_display_name';
+const STORAGE_KEY_ROLE = 'sem_role';
+
+function normalizeRole(value: string | null | undefined): UserRole | null {
+  return value === 'ADMIN' || value === 'USER' ? value : null;
+}
+
+function readRoleFromAccessToken(accessToken: string): UserRole | null {
+  const payload = accessToken.split('.')[1];
+  if (!payload) return null;
+
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    const decoded = JSON.parse(window.atob(padded)) as { role?: string };
+    return normalizeRole(decoded.role);
+  } catch {
+    return null;
+  }
+}
 
 export interface ProfileSummary {
   avatarUrl: string | null;
@@ -17,10 +37,11 @@ interface AuthContextType {
   token: string | null;
   refreshToken: string | null;
   username: string | null;
+  role: UserRole | null;
   avatarUrl: string | null;
   displayName: string | null;
   isLoading: boolean;
-  setSession: (accessToken: string, refreshToken: string, username: string) => void;
+  setSession: (accessToken: string, refreshToken: string, username: string, role?: UserRole) => void;
   setProfileSummary: (data: ProfileSummary) => void;
   clearAuth: () => void;
 }
@@ -31,6 +52,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState<string | null>(null);
   const [username, setUsername] = useState<string | null>(null);
+  const [role, setRole] = useState<UserRole | null>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [displayName, setDisplayName] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -58,6 +80,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setToken(storedToken);
       setRefreshToken(storedRefresh);
       setUsername(storedUsername);
+      const storedRole = normalizeRole(localStorage.getItem(STORAGE_KEY_ROLE)) ?? readRoleFromAccessToken(storedToken) ?? 'USER';
+      setRole(storedRole);
+      localStorage.setItem(STORAGE_KEY_ROLE, storedRole);
       const storedAvatar = localStorage.getItem(STORAGE_KEY_AVATAR_URL);
       const storedDisplayName = localStorage.getItem(STORAGE_KEY_DISPLAY_NAME);
       setAvatarUrl(storedAvatar);
@@ -67,15 +92,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const setSession = useCallback(
-    (accessToken: string, refresh: string, user: string) => {
+    (accessToken: string, refresh: string, user: string, nextRole: UserRole = 'USER') => {
       localStorage.setItem(STORAGE_KEY_TOKEN, accessToken);
       localStorage.setItem(STORAGE_KEY_REFRESH, refresh);
       localStorage.setItem(STORAGE_KEY_USERNAME, user);
+      localStorage.setItem(STORAGE_KEY_ROLE, nextRole);
       localStorage.removeItem(STORAGE_KEY_AVATAR_URL);
       localStorage.removeItem(STORAGE_KEY_DISPLAY_NAME);
       setToken(accessToken);
       setRefreshToken(refresh);
       setUsername(user);
+      setRole(nextRole);
       setAvatarUrl(null);
       setDisplayName(null);
     },
@@ -86,11 +113,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.removeItem(STORAGE_KEY_TOKEN);
     localStorage.removeItem(STORAGE_KEY_REFRESH);
     localStorage.removeItem(STORAGE_KEY_USERNAME);
+    localStorage.removeItem(STORAGE_KEY_ROLE);
     localStorage.removeItem(STORAGE_KEY_AVATAR_URL);
     localStorage.removeItem(STORAGE_KEY_DISPLAY_NAME);
     setToken(null);
     setRefreshToken(null);
     setUsername(null);
+    setRole(null);
     setAvatarUrl(null);
     setDisplayName(null);
   }, []);
@@ -119,8 +148,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     setTokenRefreshManager({
       getRefreshToken: () => localStorage.getItem(STORAGE_KEY_REFRESH),
-      onRefreshSuccess: (accessToken, newRefreshToken, newUsername) => {
-        setSession(accessToken, newRefreshToken, newUsername);
+      onRefreshSuccess: (accessToken, newRefreshToken, newUsername, newRole) => {
+        setSession(accessToken, newRefreshToken, newUsername, newRole);
       },
       onRefreshFailure: clearAuth,
     });
@@ -136,6 +165,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         token,
         refreshToken,
         username,
+        role,
         avatarUrl,
         displayName,
         isLoading,

--- a/frontend/src/models/admin.ts
+++ b/frontend/src/models/admin.ts
@@ -1,0 +1,114 @@
+import type { UserRole } from '@/models/auth';
+
+export interface AdminPageMeta {
+  limit: number;
+  offset: number;
+  total_count: number;
+  has_next: boolean;
+}
+
+export interface AdminListResponse<T> extends AdminPageMeta {
+  items: T[];
+}
+
+export interface AdminPageParams {
+  limit: number;
+  offset: number;
+}
+
+export interface AdminUserFilters {
+  q?: string;
+  status?: string;
+  role?: UserRole;
+  created_from?: string;
+  created_to?: string;
+}
+
+export interface AdminEventFilters {
+  q?: string;
+  host_id?: string;
+  category_id?: string;
+  privacy_level?: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+  status?: 'ACTIVE' | 'IN_PROGRESS' | 'CANCELED' | 'COMPLETED';
+  start_from?: string;
+  start_to?: string;
+}
+
+export interface AdminParticipationFilters {
+  q?: string;
+  status?: 'APPROVED' | 'PENDING' | 'CANCELED' | 'LEAVED';
+  event_id?: string;
+  user_id?: string;
+  created_from?: string;
+  created_to?: string;
+}
+
+export interface AdminTicketFilters {
+  q?: string;
+  status?: 'ACTIVE' | 'PENDING' | 'EXPIRED' | 'USED' | 'CANCELED';
+  event_id?: string;
+  user_id?: string;
+  participation_id?: string;
+  created_from?: string;
+  created_to?: string;
+}
+
+export interface AdminUser {
+  id: string;
+  username: string;
+  email: string;
+  phone_number: string | null;
+  email_verified: boolean;
+  last_login: string | null;
+  status: string;
+  role: UserRole;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminEvent {
+  id: string;
+  host_id: string;
+  host_username: string;
+  title: string;
+  category_id: number | null;
+  category_name: string | null;
+  start_time: string;
+  end_time: string | null;
+  privacy_level: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+  status: 'ACTIVE' | 'IN_PROGRESS' | 'CANCELED' | 'COMPLETED';
+  capacity: number | null;
+  approved_participant_count: number;
+  pending_participant_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminParticipation {
+  id: string;
+  event_id: string;
+  event_title: string;
+  user_id: string;
+  username: string;
+  user_email: string;
+  status: 'APPROVED' | 'PENDING' | 'CANCELED' | 'LEAVED';
+  reconfirmed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminTicket {
+  id: string;
+  participation_id: string;
+  event_id: string;
+  event_title: string;
+  user_id: string;
+  username: string;
+  user_email: string;
+  status: 'ACTIVE' | 'PENDING' | 'EXPIRED' | 'USED' | 'CANCELED';
+  expires_at: string;
+  used_at: string | null;
+  canceled_at: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -1,4 +1,5 @@
 export type AvailabilityStatus = 'AVAILABLE' | 'TAKEN';
+export type UserRole = 'USER' | 'ADMIN';
 
 export interface CheckAvailabilityRequest {
   username: string;
@@ -41,6 +42,7 @@ export interface UserSummary {
   phone_number: string | null;
   email_verified: boolean;
   status: string;
+  role: UserRole;
 }
 
 export interface AuthSessionResponse {

--- a/frontend/src/services/adminService.test.ts
+++ b/frontend/src/services/adminService.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { buildAdminListPath } from './adminService';
+
+describe('buildAdminListPath', () => {
+  it('serializes filters and pagination while skipping empty values', () => {
+    const path = buildAdminListPath('/admin/users', {
+      q: 'ali',
+      role: 'ADMIN',
+      status: '',
+      created_from: '2026-05-06T10:00',
+      created_to: undefined,
+      limit: 25,
+      offset: 50,
+    });
+
+    const url = new URL(path, 'http://localhost');
+    expect(url.pathname).toBe('/admin/users');
+    expect(url.searchParams.get('q')).toBe('ali');
+    expect(url.searchParams.get('role')).toBe('ADMIN');
+    expect(url.searchParams.get('status')).toBeNull();
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('offset')).toBe('50');
+
+    const createdFrom = url.searchParams.get('created_from');
+    expect(createdFrom).toBeTruthy();
+    expect(createdFrom).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00\.000Z$/);
+    expect(Number.isNaN(new Date(createdFrom as string).getTime())).toBe(false);
+  });
+});

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -1,0 +1,73 @@
+import { apiGetAuth } from '@/services/api';
+import type {
+  AdminEvent,
+  AdminEventFilters,
+  AdminListResponse,
+  AdminPageParams,
+  AdminParticipation,
+  AdminParticipationFilters,
+  AdminTicket,
+  AdminTicketFilters,
+  AdminUser,
+  AdminUserFilters,
+} from '@/models/admin';
+
+const RFC3339_FILTER_KEYS = new Set([
+  'created_from',
+  'created_to',
+  'start_from',
+  'start_to',
+]);
+
+function serializeAdminQueryValue(key: string, value: string | number | boolean): string {
+  if (typeof value === 'string' && RFC3339_FILTER_KEYS.has(key)) {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return String(value);
+}
+
+export function buildAdminListPath(path: string, params: object): string {
+  const qs = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    qs.set(key, serializeAdminQueryValue(key, value));
+  });
+
+  const query = qs.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+export function listAdminUsers(
+  token: string,
+  params: AdminPageParams & AdminUserFilters,
+): Promise<AdminListResponse<AdminUser>> {
+  return apiGetAuth<AdminListResponse<AdminUser>>(buildAdminListPath('/admin/users', params), token);
+}
+
+export function listAdminEvents(
+  token: string,
+  params: AdminPageParams & AdminEventFilters,
+): Promise<AdminListResponse<AdminEvent>> {
+  return apiGetAuth<AdminListResponse<AdminEvent>>(buildAdminListPath('/admin/events', params), token);
+}
+
+export function listAdminParticipations(
+  token: string,
+  params: AdminPageParams & AdminParticipationFilters,
+): Promise<AdminListResponse<AdminParticipation>> {
+  return apiGetAuth<AdminListResponse<AdminParticipation>>(
+    buildAdminListPath('/admin/participations', params),
+    token,
+  );
+}
+
+export function listAdminTickets(
+  token: string,
+  params: AdminPageParams & AdminTicketFilters,
+): Promise<AdminListResponse<AdminTicket>> {
+  return apiGetAuth<AdminListResponse<AdminTicket>>(buildAdminListPath('/admin/tickets', params), token);
+}

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -16,7 +16,7 @@ const SESSION_RESPONSE = {
   refresh_token: 'new-refresh-token',
   token_type: 'Bearer' as const,
   expires_in_seconds: 900,
-  user: { id: '1', username: 'testuser', email: 'test@example.com', phone_number: null, email_verified: true, status: 'active' },
+  user: { id: '1', username: 'testuser', email: 'test@example.com', phone_number: null, email_verified: true, status: 'active', role: 'ADMIN' },
 };
 
 const onRefreshSuccess = vi.fn();
@@ -83,6 +83,7 @@ describe('apiGetAuth', () => {
       'new-access-token',
       'new-refresh-token',
       'testuser',
+      'ADMIN',
     );
   });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -31,7 +31,7 @@ async function handleErrorResponse(response: Response): Promise<never> {
 
 interface TokenRefreshManager {
   getRefreshToken: () => string | null;
-  onRefreshSuccess: (accessToken: string, refreshToken: string, username: string) => void;
+  onRefreshSuccess: (accessToken: string, refreshToken: string, username: string, role: AuthSessionResponse['user']['role']) => void;
   onRefreshFailure: () => void;
 }
 
@@ -65,6 +65,7 @@ async function attemptTokenRefresh(): Promise<string> {
       session.access_token,
       session.refresh_token,
       session.user.username,
+      session.user.role,
     );
     return session.access_token;
   };

--- a/frontend/src/styles/backoffice.css
+++ b/frontend/src/styles/backoffice.css
@@ -1,0 +1,245 @@
+.bo-layout {
+  min-height: calc(100vh - 64px);
+}
+
+.bo-sidebar {
+  position: fixed;
+  top: 64px;
+  left: 0;
+  bottom: 0;
+  width: 248px;
+  padding: 24px 14px;
+  border-right: 1px solid #e5e7eb;
+  background: #ffffff;
+  z-index: 50;
+}
+
+.bo-sidebar-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 4px 14px;
+  padding: 0 6px 16px;
+  border-bottom: 1px solid #e5e7eb;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0;
+  color: #111827;
+}
+
+.bo-sidebar-title-icon {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  flex-shrink: 0;
+}
+
+.bo-sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bo-sidebar-link {
+  padding: 9px 10px;
+  border-radius: 6px;
+  color: #4b5563;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.bo-sidebar-link:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.bo-sidebar-link.active {
+  background: #111827;
+  color: #ffffff;
+}
+
+.bo-content {
+  margin-left: 248px;
+  padding: 32px 40px 48px 36px;
+  min-width: 0;
+}
+
+.bo-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.bo-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.bo-page-header h1 {
+  margin: 0 0 4px;
+  font-size: 24px;
+  line-height: 1.2;
+  color: #111827;
+}
+
+.bo-page-header p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.bo-filter-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #f9fafb;
+}
+
+.bo-filter-bar:empty {
+  display: none;
+}
+
+.bo-filter-bar input,
+.bo-filter-bar select,
+.bo-pagination select {
+  min-height: 34px;
+  padding: 6px 9px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111827;
+  font-size: 13px;
+}
+
+.bo-filter-bar input {
+  min-width: 150px;
+}
+
+.bo-filter-bar button,
+.bo-pagination button,
+.bo-state button {
+  min-height: 34px;
+  padding: 6px 12px;
+  border: 1px solid #111827;
+  border-radius: 6px;
+  background: #111827;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.bo-filter-bar .bo-secondary-button {
+  border-color: #d1d5db;
+  background: #ffffff;
+  color: #374151;
+}
+
+.bo-pagination button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.bo-table-wrap {
+  overflow-x: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.bo-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.bo-table th,
+.bo-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.bo-table th {
+  background: #f9fafb;
+  color: #374151;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.bo-table tbody tr:hover {
+  background: #f9fafb;
+}
+
+.bo-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.bo-state {
+  padding: 14px 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.bo-state-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
+.bo-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+}
+
+.bo-pagination-summary {
+  color: #4b5563;
+  font-size: 13px;
+}
+
+.bo-pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bo-pagination-controls label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #4b5563;
+  font-size: 13px;
+}
+
+@media (max-width: 900px) {
+  .bo-sidebar {
+    width: 210px;
+  }
+
+  .bo-content {
+    margin-left: 210px;
+    padding: 24px;
+  }
+}

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -16,7 +16,7 @@
 }
 
 .shell-header-inner {
-  max-width: 1200px;
+  max-width: 1440px;
   margin: 0 auto;
   padding: 0 24px;
   height: 64px;
@@ -85,6 +85,40 @@
 
 .shell-create-btn:hover {
   background-color: #0F172A;
+}
+
+.shell-admin-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  text-decoration: none;
+  border-radius: 8px;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+
+.shell-admin-icon {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  flex-shrink: 0;
+}
+
+.shell-admin-btn:hover,
+.shell-admin-btn.active {
+  color: #ffffff;
+  background-color: #111827;
+  border-color: #111827;
 }
 
 /* User menu */
@@ -246,10 +280,16 @@
 /* Main content */
 .shell-main {
   flex: 1;
-  max-width: 1200px;
+  max-width: 1440px;
   width: 100%;
   margin: 0 auto;
   padding: 32px 24px;
+}
+
+.shell-main.admin-panel-main {
+  max-width: none;
+  margin: 0;
+  padding: 0;
 }
 
 /* Responsive */
@@ -316,6 +356,10 @@
 
   /* Hide header create button on mobile */
   .shell-create-btn {
+    display: none;
+  }
+
+  .shell-admin-btn {
     display: none;
   }
 

--- a/frontend/src/viewmodels/admin/useAdminListViewModel.test.tsx
+++ b/frontend/src/viewmodels/admin/useAdminListViewModel.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useAdminListViewModel } from './useAdminListViewModel';
+import type { AdminListResponse } from '@/models/admin';
+
+interface Row {
+  id: string;
+}
+
+interface Filters {
+  q?: string;
+}
+
+function Harness({ fetchPage }: { fetchPage: ReturnType<typeof vi.fn> }) {
+  const vm = useAdminListViewModel<Row, Filters>({
+    token: 'token',
+    initialFilters: { q: '' },
+    fetchPage,
+  });
+
+  return (
+    <div>
+      <input aria-label="Search" value={vm.filters.q ?? ''} onChange={(event) => vm.setFilter('q', event.target.value)} />
+      <button type="button" onClick={vm.applyFilters}>Apply</button>
+      <button type="button" onClick={vm.nextPage}>Next</button>
+      <button type="button" onClick={vm.previousPage}>Previous</button>
+      <div data-testid="offset">{vm.offset}</div>
+      <div data-testid="count">{vm.items.length}</div>
+    </div>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useAdminListViewModel', () => {
+  it('applies filters and advances offset pagination', async () => {
+    const fetchPage = vi.fn<[], Promise<AdminListResponse<Row>>>().mockResolvedValue({
+      items: [{ id: '1' }],
+      limit: 25,
+      offset: 0,
+      total_count: 60,
+      has_next: true,
+    });
+
+    render(<Harness fetchPage={fetchPage} />);
+
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledWith('token', { q: '', limit: 25, offset: 0 }));
+
+    fireEvent.change(screen.getByLabelText('Search'), { target: { value: 'alice' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledWith('token', { q: 'alice', limit: 25, offset: 0 }));
+
+    fireEvent.click(screen.getByText('Next'));
+
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledWith('token', { q: 'alice', limit: 25, offset: 25 }));
+    expect(screen.getByTestId('offset').textContent).toBe('25');
+
+    fireEvent.click(screen.getByText('Previous'));
+
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledWith('token', { q: 'alice', limit: 25, offset: 0 }));
+  });
+});

--- a/frontend/src/viewmodels/admin/useAdminListViewModel.ts
+++ b/frontend/src/viewmodels/admin/useAdminListViewModel.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ApiError } from '@/services/api';
+import type { AdminListResponse, AdminPageParams } from '@/models/admin';
+
+const DEFAULT_LIMIT = 25;
+
+export type AdminFilters = object;
+
+interface UseAdminListOptions<TItem, TFilters extends AdminFilters> {
+  token: string | null;
+  initialFilters: TFilters;
+  fetchPage: (
+    token: string,
+    params: AdminPageParams & TFilters,
+  ) => Promise<AdminListResponse<TItem>>;
+}
+
+export function useAdminListViewModel<TItem, TFilters extends AdminFilters>({
+  token,
+  initialFilters,
+  fetchPage,
+}: UseAdminListOptions<TItem, TFilters>) {
+  const [filters, setFilters] = useState<TFilters>(initialFilters);
+  const [appliedFilters, setAppliedFilters] = useState<TFilters>(initialFilters);
+  const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [offset, setOffset] = useState(0);
+  const [items, setItems] = useState<TItem[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const params = useMemo(
+    () => ({ ...appliedFilters, limit, offset }) as AdminPageParams & TFilters,
+    [appliedFilters, limit, offset],
+  );
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchPage(token, params);
+      setItems(data.items ?? []);
+      setTotalCount(data.total_count ?? 0);
+      setHasNext(Boolean(data.has_next));
+    } catch (err) {
+      setItems([]);
+      setTotalCount(0);
+      setHasNext(false);
+      setError(err instanceof ApiError ? err.message : 'Failed to load admin data.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchPage, params, token]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const setFilter = useCallback(<K extends keyof TFilters>(key: K, value: TFilters[K]) => {
+    setFilters((current) => ({ ...current, [key]: value }));
+  }, []);
+
+  const applyFilters = useCallback(() => {
+    setOffset(0);
+    setAppliedFilters(filters);
+  }, [filters]);
+
+  const clearFilters = useCallback(() => {
+    setFilters(initialFilters);
+    setAppliedFilters(initialFilters);
+    setOffset(0);
+  }, [initialFilters]);
+
+  const nextPage = useCallback(() => {
+    if (hasNext) setOffset((current) => current + limit);
+  }, [hasNext, limit]);
+
+  const previousPage = useCallback(() => {
+    setOffset((current) => Math.max(0, current - limit));
+  }, [limit]);
+
+  const changeLimit = useCallback((nextLimit: number) => {
+    setLimit(nextLimit);
+    setOffset(0);
+  }, []);
+
+  return {
+    filters,
+    items,
+    totalCount,
+    hasNext,
+    isLoading,
+    error,
+    limit,
+    offset,
+    setFilter,
+    applyFilters,
+    clearFilters,
+    nextPage,
+    previousPage,
+    changeLimit,
+    retry: load,
+  };
+}

--- a/frontend/src/views/auth/LoginView.tsx
+++ b/frontend/src/views/auth/LoginView.tsx
@@ -14,7 +14,7 @@ export default function LoginView() {
     e.preventDefault();
     const session = await vm.handleLogin();
     if (session) {
-      setSession(session.access_token, session.refresh_token, session.user.username);
+      setSession(session.access_token, session.refresh_token, session.user.username, session.user.role);
       navigate('/discover', { replace: true });
     }
   };

--- a/frontend/src/views/auth/RegisterView.tsx
+++ b/frontend/src/views/auth/RegisterView.tsx
@@ -33,7 +33,7 @@ export default function RegisterView() {
     } else {
       const session = await vm.handleVerifyOtp();
       if (session) {
-        setSession(session.access_token, session.refresh_token, session.user.username);
+        setSession(session.access_token, session.refresh_token, session.user.username, session.user.role);
         navigate('/discover', { replace: true });
       }
     }

--- a/frontend/src/views/backoffice/BackofficeLayout.tsx
+++ b/frontend/src/views/backoffice/BackofficeLayout.tsx
@@ -1,0 +1,39 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import '@/styles/backoffice.css';
+
+const SIDEBAR_ITEMS = [
+  { to: '/admin-panel/users', label: 'Users' },
+  { to: '/admin-panel/events', label: 'Events' },
+  { to: '/admin-panel/participations', label: 'Participations' },
+  { to: '/admin-panel/tickets', label: 'Tickets' },
+  { to: '/admin-panel/notifications', label: 'Notifications' },
+];
+
+export default function BackofficeLayout() {
+  return (
+    <div className="bo-layout">
+      <aside className="bo-sidebar" aria-label="Admin Panel navigation">
+        <div className="bo-sidebar-title">
+          <svg className="bo-sidebar-title-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 3.5 18 6v5.2c0 3.9-2.4 7.4-6 8.8-3.6-1.4-6-4.9-6-8.8V6l6-2.5Z" />
+          </svg>
+          <span>Admin Panel</span>
+        </div>
+        <nav className="bo-sidebar-nav">
+          {SIDEBAR_ITEMS.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) => `bo-sidebar-link ${isActive ? 'active' : ''}`}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+      <section className="bo-content">
+        <Outlet />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/views/backoffice/BackofficeListParts.tsx
+++ b/frontend/src/views/backoffice/BackofficeListParts.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from 'react';
+
+export function formatAdminDate(value: string | null | undefined): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+interface ShellProps {
+  title: string;
+  subtitle: string;
+  filters: ReactNode;
+  children: ReactNode;
+}
+
+export function BackofficePageShell({ title, subtitle, filters, children }: ShellProps) {
+  return (
+    <div className="bo-page">
+      <div className="bo-page-header">
+        <div>
+          <h1>{title}</h1>
+          <p>{subtitle}</p>
+        </div>
+      </div>
+      <div className="bo-filter-bar">{filters}</div>
+      {children}
+    </div>
+  );
+}
+
+interface PaginationProps {
+  offset: number;
+  limit: number;
+  totalCount: number;
+  hasNext: boolean;
+  isLoading: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+  onLimitChange: (limit: number) => void;
+}
+
+export function BackofficePagination({
+  offset,
+  limit,
+  totalCount,
+  hasNext,
+  isLoading,
+  onPrevious,
+  onNext,
+  onLimitChange,
+}: PaginationProps) {
+  const first = totalCount === 0 ? 0 : offset + 1;
+  const last = Math.min(offset + limit, totalCount);
+
+  return (
+    <div className="bo-pagination">
+      <div className="bo-pagination-summary">
+        Showing {first}-{last} of {totalCount}
+      </div>
+      <div className="bo-pagination-controls">
+        <label>
+          Rows
+          <select
+            value={limit}
+            onChange={(event) => onLimitChange(Number(event.target.value))}
+            disabled={isLoading}
+          >
+            <option value={10}>10</option>
+            <option value={25}>25</option>
+            <option value={50}>50</option>
+            <option value={100}>100</option>
+          </select>
+        </label>
+        <button type="button" onClick={onPrevious} disabled={isLoading || offset === 0}>
+          Previous
+        </button>
+        <button type="button" onClick={onNext} disabled={isLoading || !hasNext}>
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface StateProps {
+  isLoading: boolean;
+  error: string | null;
+  empty: boolean;
+  onRetry: () => void;
+}
+
+export function BackofficeTableState({ isLoading, error, empty, onRetry }: StateProps) {
+  if (isLoading) {
+    return <div className="bo-state">Loading...</div>;
+  }
+  if (error) {
+    return (
+      <div className="bo-state bo-state-error">
+        <span>{error}</span>
+        <button type="button" onClick={onRetry}>Retry</button>
+      </div>
+    );
+  }
+  if (empty) {
+    return <div className="bo-state">No rows match the current filters.</div>;
+  }
+  return null;
+}

--- a/frontend/src/views/backoffice/EventsAdminPage.tsx
+++ b/frontend/src/views/backoffice/EventsAdminPage.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminEventFilters } from '@/models/admin';
+import { listAdminEvents } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminEventFilters = {
+  q: '',
+  host_id: '',
+  category_id: undefined,
+  privacy_level: undefined,
+  status: undefined,
+  start_from: '',
+  start_to: '',
+};
+
+export default function EventsAdminPage() {
+  const { token } = useAuth();
+  const initialFilters = useMemo(() => INITIAL_FILTERS, []);
+  const vm = useAdminListViewModel({ token, initialFilters, fetchPage: listAdminEvents });
+
+  return (
+    <BackofficePageShell
+      title="Events"
+      subtitle="Inspect event rows by host, category, privacy, lifecycle, and start time."
+      filters={(
+        <>
+          <input aria-label="Search events" placeholder="Search title or host" value={vm.filters.q ?? ''} onChange={(event) => vm.setFilter('q', event.target.value)} />
+          <input aria-label="Host ID" placeholder="Host ID" value={vm.filters.host_id ?? ''} onChange={(event) => vm.setFilter('host_id', event.target.value)} />
+          <input aria-label="Category ID" type="number" placeholder="Category ID" value={vm.filters.category_id ?? ''} onChange={(event) => vm.setFilter('category_id', event.target.value === '' ? undefined : event.target.value)} />
+          <select aria-label="Privacy level" value={vm.filters.privacy_level ?? ''} onChange={(event) => vm.setFilter('privacy_level', event.target.value === '' ? undefined : event.target.value as AdminEventFilters['privacy_level'])}>
+            <option value="">Any privacy</option>
+            <option value="PUBLIC">PUBLIC</option>
+            <option value="PROTECTED">PROTECTED</option>
+            <option value="PRIVATE">PRIVATE</option>
+          </select>
+          <select aria-label="Event status" value={vm.filters.status ?? ''} onChange={(event) => vm.setFilter('status', event.target.value === '' ? undefined : event.target.value as AdminEventFilters['status'])}>
+            <option value="">Any status</option>
+            <option value="ACTIVE">ACTIVE</option>
+            <option value="IN_PROGRESS">IN_PROGRESS</option>
+            <option value="CANCELED">CANCELED</option>
+            <option value="COMPLETED">COMPLETED</option>
+          </select>
+          <input aria-label="Start from" type="datetime-local" value={vm.filters.start_from ?? ''} onChange={(event) => vm.setFilter('start_from', event.target.value)} />
+          <input aria-label="Start to" type="datetime-local" value={vm.filters.start_to ?? ''} onChange={(event) => vm.setFilter('start_to', event.target.value)} />
+          <button type="button" onClick={vm.applyFilters}>Apply</button>
+          <button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+        </>
+      )}
+    >
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap">
+        <table className="bo-table">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Host</th>
+              <th>Category</th>
+              <th>Privacy</th>
+              <th>Status</th>
+              <th>Start</th>
+              <th>End</th>
+              <th>Capacity</th>
+              <th>Approved</th>
+              <th>Pending</th>
+            </tr>
+          </thead>
+          <tbody>
+            {vm.items.map((event) => (
+              <tr key={event.id}>
+                <td>{event.title}</td>
+                <td>{event.host_username}</td>
+                <td>{event.category_name ?? event.category_id ?? '-'}</td>
+                <td>{event.privacy_level}</td>
+                <td>{event.status}</td>
+                <td>{formatAdminDate(event.start_time)}</td>
+                <td>{formatAdminDate(event.end_time)}</td>
+                <td>{event.capacity ?? '-'}</td>
+                <td>{event.approved_participant_count}</td>
+                <td>{event.pending_participant_count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/NotificationsAdminPage.tsx
+++ b/frontend/src/views/backoffice/NotificationsAdminPage.tsx
@@ -1,0 +1,13 @@
+import { BackofficePageShell } from './BackofficeListParts';
+
+export default function NotificationsAdminPage() {
+  return (
+    <BackofficePageShell
+      title="Notifications"
+      subtitle="Notification sending controls are tracked in the separate admin actions issue."
+      filters={null}
+    >
+      <div className="bo-state">No read-only notification list is available yet.</div>
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/ParticipationsAdminPage.tsx
+++ b/frontend/src/views/backoffice/ParticipationsAdminPage.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminParticipationFilters } from '@/models/admin';
+import { listAdminParticipations } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminParticipationFilters = {
+  q: '',
+  status: undefined,
+  event_id: '',
+  user_id: '',
+  created_from: '',
+  created_to: '',
+};
+
+export default function ParticipationsAdminPage() {
+  const { token } = useAuth();
+  const initialFilters = useMemo(() => INITIAL_FILTERS, []);
+  const vm = useAdminListViewModel({ token, initialFilters, fetchPage: listAdminParticipations });
+
+  return (
+    <BackofficePageShell
+      title="Participations"
+      subtitle="Review user-event participation rows and current lifecycle status."
+      filters={(
+        <>
+          <input aria-label="Search participations" placeholder="Search event or user" value={vm.filters.q ?? ''} onChange={(event) => vm.setFilter('q', event.target.value)} />
+          <select aria-label="Participation status" value={vm.filters.status ?? ''} onChange={(event) => vm.setFilter('status', event.target.value === '' ? undefined : event.target.value as AdminParticipationFilters['status'])}>
+            <option value="">Any status</option>
+            <option value="APPROVED">APPROVED</option>
+            <option value="PENDING">PENDING</option>
+            <option value="CANCELED">CANCELED</option>
+            <option value="LEAVED">LEAVED</option>
+          </select>
+          <input aria-label="Event ID" placeholder="Event ID" value={vm.filters.event_id ?? ''} onChange={(event) => vm.setFilter('event_id', event.target.value)} />
+          <input aria-label="User ID" placeholder="User ID" value={vm.filters.user_id ?? ''} onChange={(event) => vm.setFilter('user_id', event.target.value)} />
+          <input aria-label="Created from" type="datetime-local" value={vm.filters.created_from ?? ''} onChange={(event) => vm.setFilter('created_from', event.target.value)} />
+          <input aria-label="Created to" type="datetime-local" value={vm.filters.created_to ?? ''} onChange={(event) => vm.setFilter('created_to', event.target.value)} />
+          <button type="button" onClick={vm.applyFilters}>Apply</button>
+          <button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+        </>
+      )}
+    >
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap">
+        <table className="bo-table">
+          <thead>
+            <tr>
+              <th>Event</th>
+              <th>User</th>
+              <th>Email</th>
+              <th>Status</th>
+              <th>Reconfirmed</th>
+              <th>Created</th>
+              <th>Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {vm.items.map((participation) => (
+              <tr key={participation.id}>
+                <td>{participation.event_title}</td>
+                <td>{participation.username}</td>
+                <td>{participation.user_email}</td>
+                <td>{participation.status}</td>
+                <td>{formatAdminDate(participation.reconfirmed_at)}</td>
+                <td>{formatAdminDate(participation.created_at)}</td>
+                <td>{formatAdminDate(participation.updated_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/TicketsAdminPage.tsx
+++ b/frontend/src/views/backoffice/TicketsAdminPage.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminTicketFilters } from '@/models/admin';
+import { listAdminTickets } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminTicketFilters = {
+  q: '',
+  status: undefined,
+  event_id: '',
+  user_id: '',
+  participation_id: '',
+  created_from: '',
+  created_to: '',
+};
+
+export default function TicketsAdminPage() {
+  const { token } = useAuth();
+  const initialFilters = useMemo(() => INITIAL_FILTERS, []);
+  const vm = useAdminListViewModel({ token, initialFilters, fetchPage: listAdminTickets });
+
+  return (
+    <BackofficePageShell
+      title="Tickets"
+      subtitle="Inspect ticket state across events, users, and participations."
+      filters={(
+        <>
+          <input aria-label="Search tickets" placeholder="Search event or user" value={vm.filters.q ?? ''} onChange={(event) => vm.setFilter('q', event.target.value)} />
+          <select aria-label="Ticket status" value={vm.filters.status ?? ''} onChange={(event) => vm.setFilter('status', event.target.value === '' ? undefined : event.target.value as AdminTicketFilters['status'])}>
+            <option value="">Any status</option>
+            <option value="ACTIVE">ACTIVE</option>
+            <option value="PENDING">PENDING</option>
+            <option value="EXPIRED">EXPIRED</option>
+            <option value="USED">USED</option>
+            <option value="CANCELED">CANCELED</option>
+          </select>
+          <input aria-label="Event ID" placeholder="Event ID" value={vm.filters.event_id ?? ''} onChange={(event) => vm.setFilter('event_id', event.target.value)} />
+          <input aria-label="User ID" placeholder="User ID" value={vm.filters.user_id ?? ''} onChange={(event) => vm.setFilter('user_id', event.target.value)} />
+          <input aria-label="Participation ID" placeholder="Participation ID" value={vm.filters.participation_id ?? ''} onChange={(event) => vm.setFilter('participation_id', event.target.value)} />
+          <input aria-label="Created from" type="datetime-local" value={vm.filters.created_from ?? ''} onChange={(event) => vm.setFilter('created_from', event.target.value)} />
+          <input aria-label="Created to" type="datetime-local" value={vm.filters.created_to ?? ''} onChange={(event) => vm.setFilter('created_to', event.target.value)} />
+          <button type="button" onClick={vm.applyFilters}>Apply</button>
+          <button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+        </>
+      )}
+    >
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap">
+        <table className="bo-table">
+          <thead>
+            <tr>
+              <th>Event</th>
+              <th>User</th>
+              <th>Email</th>
+              <th>Status</th>
+              <th>Expires</th>
+              <th>Used</th>
+              <th>Canceled</th>
+              <th>Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {vm.items.map((ticket) => (
+              <tr key={ticket.id}>
+                <td>{ticket.event_title}</td>
+                <td>{ticket.username}</td>
+                <td>{ticket.user_email}</td>
+                <td>{ticket.status}</td>
+                <td>{formatAdminDate(ticket.expires_at)}</td>
+                <td>{formatAdminDate(ticket.used_at)}</td>
+                <td>{formatAdminDate(ticket.canceled_at)}</td>
+                <td>{formatAdminDate(ticket.created_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/UsersAdminPage.tsx
+++ b/frontend/src/views/backoffice/UsersAdminPage.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminUserFilters } from '@/models/admin';
+import { listAdminUsers } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminUserFilters = {
+  q: '',
+  status: '',
+  role: undefined,
+  created_from: '',
+  created_to: '',
+};
+
+export default function UsersAdminPage() {
+  const { token } = useAuth();
+  const initialFilters = useMemo(() => INITIAL_FILTERS, []);
+  const vm = useAdminListViewModel({
+    token,
+    initialFilters,
+    fetchPage: listAdminUsers,
+  });
+
+  return (
+    <BackofficePageShell
+      title="Users"
+      subtitle="Search accounts by identity, status, role, and creation window."
+      filters={(
+        <>
+          <input aria-label="Search users" placeholder="Search username, email, phone" value={vm.filters.q ?? ''} onChange={(event) => vm.setFilter('q', event.target.value)} />
+          <select aria-label="User status" value={vm.filters.status ?? ''} onChange={(event) => vm.setFilter('status', event.target.value)}>
+            <option value="">Any status</option>
+            <option value="active">active</option>
+          </select>
+          <select aria-label="User role" value={vm.filters.role ?? ''} onChange={(event) => vm.setFilter('role', event.target.value === '' ? undefined : event.target.value as AdminUserFilters['role'])}>
+            <option value="">Any role</option>
+            <option value="USER">USER</option>
+            <option value="ADMIN">ADMIN</option>
+          </select>
+          <input aria-label="Created from" type="datetime-local" value={vm.filters.created_from ?? ''} onChange={(event) => vm.setFilter('created_from', event.target.value)} />
+          <input aria-label="Created to" type="datetime-local" value={vm.filters.created_to ?? ''} onChange={(event) => vm.setFilter('created_to', event.target.value)} />
+          <button type="button" onClick={vm.applyFilters}>Apply</button>
+          <button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+        </>
+      )}
+    >
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap">
+        <table className="bo-table">
+          <thead>
+            <tr>
+              <th>Username</th>
+              <th>Email</th>
+              <th>Phone</th>
+              <th>Role</th>
+              <th>Status</th>
+              <th>Verified</th>
+              <th>Created</th>
+              <th>Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {vm.items.map((user) => (
+              <tr key={user.id}>
+                <td>{user.username}</td>
+                <td>{user.email}</td>
+                <td>{user.phone_number ?? '-'}</td>
+                <td>{user.role}</td>
+                <td>{user.status}</td>
+                <td>{user.email_verified ? 'Yes' : 'No'}</td>
+                <td>{formatAdminDate(user.created_at)}</td>
+                <td>{formatAdminDate(user.updated_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}


### PR DESCRIPTION
## 📋 Summary
Adds the web-only Admin Panel entry point, admin route protection, fixed sidebar layout, and read-only admin list views for Users, Events, Participations, and Tickets. The panel consumes the backend admin read APIs and keeps the mobile app untouched.

## 🔄 Changes
- Extended frontend auth session state to store and persist authenticated user role.
- Updated login, registration, and refresh-token handling to preserve `USER` / `ADMIN` role values.
- Added role-gated `Admin Panel` header button for authenticated `ADMIN` users only.
- Added `/admin-panel` route tree with admin-only access control.
- Added redirect compatibility from old `/backoffice` paths to `/admin-panel`.
- Added fixed left Admin Panel sidebar with Users, Events, Participations, Tickets, and Notifications entries.
- Added read-only admin table views for:
  - Users
  - Events
  - Participations
  - Tickets
- Added admin model, service, and viewmodel code for offset-paginated list APIs.
- Added basic filters for admin list pages matching backend query contracts.
- Converted admin date filters to RFC3339 timestamps before sending requests.
- Kept admin tables image-free and row-oriented.
- Adjusted web layout width for better desktop use and made Admin Panel use full-width operational layout.
- Added frontend tests for admin button visibility, route protection, query parameter construction, and pagination behavior.

## 🧪 Testing
- `npm test`
- `npm run build`
- `git diff --check`

## 🔗 Related
Closes #526 