### PR TITLE
feat(frontend): add admin notifications and participation management pages

### DIFF
--- a/backend/internal/adapter/in/postgres/admin_repo.go
+++ b/backend/internal/adapter/in/postgres/admin_repo.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -356,6 +357,122 @@ func (r *AdminRepository) ListTickets(ctx context.Context, input adminapp.ListTi
 	}
 
 	return &adminapp.ListTicketsResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
+}
+
+func (r *AdminRepository) ListNotifications(ctx context.Context, input adminapp.ListNotificationsInput) (*adminapp.ListNotificationsResult, error) {
+	args := []any{}
+	where := []string{"TRUE"}
+	add := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if input.Query != nil {
+		placeholder := add("%" + *input.Query + "%")
+		where = append(where, "(n.title ILIKE "+placeholder+" OR n.body ILIKE "+placeholder+" OR u.username ILIKE "+placeholder+" OR u.email ILIKE "+placeholder+")")
+	}
+	if input.UserID != nil {
+		where = append(where, "n.receiver_user_id = "+add(*input.UserID))
+	}
+	if input.EventID != nil {
+		where = append(where, "n.event_id = "+add(*input.EventID))
+	}
+	if input.Type != nil {
+		where = append(where, "n.type = "+add(*input.Type))
+	}
+	if input.IsRead != nil {
+		where = append(where, "n.is_read = "+add(*input.IsRead))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "n.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "n.created_at <= "+add(*input.CreatedTo))
+	}
+
+	limitPlaceholder := add(input.Limit)
+	offsetPlaceholder := add(input.Offset)
+	query := `
+		SELECT n.id, n.receiver_user_id, u.username, u.email, n.event_id, e.title, n.title, n.type,
+		       n.body, n.deep_link, n.data, n.is_read, n.read_at, n.deleted_at,
+		       COUNT(a.id) FILTER (WHERE a.method = 'SSE' AND a.status = 'SENT') AS sse_sent_count,
+		       COUNT(a.id) FILTER (WHERE a.method = 'FCM' AND a.status = 'SENT') AS push_sent_count,
+		       COUNT(a.id) FILTER (WHERE a.method = 'FCM' AND a.status = 'FAILED') AS push_failed_count,
+		       n.created_at, n.updated_at, COUNT(*) OVER()
+		FROM notification n
+		JOIN app_user u ON u.id = n.receiver_user_id
+		LEFT JOIN event e ON e.id = n.event_id
+		LEFT JOIN notification_delivery_attempt a ON a.notification_id = n.id
+		WHERE ` + strings.Join(where, " AND ") + `
+		GROUP BY n.id, u.username, u.email, e.title
+		ORDER BY n.created_at DESC, n.id DESC
+		LIMIT ` + limitPlaceholder + ` OFFSET ` + offsetPlaceholder
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list notifications: %w", err)
+	}
+	defer rows.Close()
+
+	items := []adminapp.AdminNotificationItem{}
+	totalCount := 0
+	for rows.Next() {
+		var (
+			item       adminapp.AdminNotificationItem
+			eventID    pgtype.UUID
+			eventTitle pgtype.Text
+			typ        pgtype.Text
+			deepLink   pgtype.Text
+			data       []byte
+			readAt     pgtype.Timestamptz
+			deletedAt  pgtype.Timestamptz
+		)
+		if err := rows.Scan(
+			&item.ID,
+			&item.ReceiverUserID,
+			&item.Username,
+			&item.UserEmail,
+			&eventID,
+			&eventTitle,
+			&item.Title,
+			&typ,
+			&item.Body,
+			&deepLink,
+			&data,
+			&item.IsRead,
+			&readAt,
+			&deletedAt,
+			&item.SSESentCount,
+			&item.PushSentCount,
+			&item.PushFailedCount,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+			&totalCount,
+		); err != nil {
+			return nil, fmt.Errorf("admin scan notification: %w", err)
+		}
+		item.EventID = uuidPtr(eventID)
+		item.EventTitle = textPtr(eventTitle)
+		item.Type = textPtr(typ)
+		item.DeepLink = textPtr(deepLink)
+		item.ReadAt = timestamptzPtr(readAt)
+		item.DeletedAt = timestamptzPtr(deletedAt)
+		item.Data = map[string]string{}
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &item.Data); err != nil {
+				return nil, fmt.Errorf("admin unmarshal notification data: %w", err)
+			}
+		}
+		if item.Data == nil {
+			item.Data = map[string]string{}
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list notifications rows: %w", err)
+	}
+
+	return &adminapp.ListNotificationsResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
 }
 
 func (r *AdminRepository) CountExistingUsers(ctx context.Context, userIDs []uuid.UUID) (int, error) {

--- a/backend/internal/adapter/out/httpapi/admin_handler/admin_handler.go
+++ b/backend/internal/adapter/out/httpapi/admin_handler/admin_handler.go
@@ -32,6 +32,7 @@ func RegisterRoutes(router fiber.Router, handler *Handler, adminAuth fiber.Handl
 	group.Post("/participations", handler.CreateParticipation)
 	group.Post("/participations/:participation_id/cancel", handler.CancelParticipation)
 	group.Get("/tickets", handler.ListTickets)
+	group.Get("/notifications", handler.ListNotifications)
 	group.Post("/notifications", handler.CreateNotification)
 }
 
@@ -84,6 +85,19 @@ func (h *Handler) ListTickets(c *fiber.Ctx) error {
 		return httpapi.WriteError(c, err)
 	}
 	logAdminList(c, "admin.tickets.list", len(result.Items), result.PageMeta, summarizeTickets(input))
+	return c.JSON(result)
+}
+
+func (h *Handler) ListNotifications(c *fiber.Ctx) error {
+	input, errs := parseListNotificationsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListNotifications(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	logAdminList(c, "admin.notifications.list", len(result.Items), result.PageMeta, summarizeNotifications(input))
 	return c.JSON(result)
 }
 
@@ -350,6 +364,26 @@ func parseListTicketsInput(c *fiber.Ctx) (admin.ListTicketsInput, map[string]str
 	return input, errs
 }
 
+func parseListNotificationsInput(c *fiber.Ctx) (admin.ListNotificationsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListNotificationsInput{PageInput: page}
+	input.Query = optionalTrimmed(c.Query("q"))
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	input.Type = optionalTrimmed(c.Query("type"))
+	if raw := strings.TrimSpace(c.Query("is_read")); raw != "" {
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			errs["is_read"] = "must be true or false"
+		} else {
+			input.IsRead = &value
+		}
+	}
+	return input, errs
+}
+
 func parsePage(c *fiber.Ctx) (admin.PageInput, map[string]string) {
 	errs := map[string]string{}
 	page := admin.PageInput{Limit: admin.DefaultLimit}
@@ -494,6 +528,20 @@ func summarizeTickets(input admin.ListTicketsInput) string {
 	)
 }
 
+func summarizeNotifications(input admin.ListNotificationsInput) string {
+	return httpapi.JoinSummary(
+		httpapi.CountSummary("limit", input.Limit),
+		httpapi.CountSummary("offset", input.Offset),
+		httpapi.StringPtrSummary("q", input.Query),
+		uuidPointerSummary("user_id", input.UserID),
+		uuidPointerSummary("event_id", input.EventID),
+		httpapi.StringPtrSummary("type", input.Type),
+		boolPointerSummary("is_read", input.IsRead),
+		timePointerSummary("created_from", input.CreatedFrom),
+		timePointerSummary("created_to", input.CreatedTo),
+	)
+}
+
 func pointerSummary[T ~string](label string, value *T) string {
 	if value == nil {
 		return label + "=<nil>"
@@ -513,6 +561,13 @@ func intPointerSummary(label string, value *int) string {
 		return label + "=<nil>"
 	}
 	return httpapi.CountSummary(label, *value)
+}
+
+func boolPointerSummary(label string, value *bool) string {
+	if value == nil {
+		return label + "=<nil>"
+	}
+	return httpapi.BoolSummary(label, *value)
 }
 
 func timePointerSummary(label string, value *time.Time) string {

--- a/backend/internal/adapter/out/httpapi/admin_handler/admin_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/admin_handler/admin_handler_test.go
@@ -19,6 +19,7 @@ type stubAdminService struct {
 	lastEvents         admin.ListEventsInput
 	lastParticipations admin.ListParticipationsInput
 	lastTickets        admin.ListTicketsInput
+	lastNotifications  admin.ListNotificationsInput
 	lastNotification   admin.SendCustomNotificationInput
 	lastCreate         admin.CreateManualParticipationInput
 	lastCancel         admin.CancelParticipationInput
@@ -42,6 +43,11 @@ func (s *stubAdminService) ListParticipations(_ context.Context, input admin.Lis
 func (s *stubAdminService) ListTickets(_ context.Context, input admin.ListTicketsInput) (*admin.ListTicketsResult, error) {
 	s.lastTickets = input
 	return &admin.ListTicketsResult{Items: []admin.AdminTicketItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+
+func (s *stubAdminService) ListNotifications(_ context.Context, input admin.ListNotificationsInput) (*admin.ListNotificationsResult, error) {
+	s.lastNotifications = input
+	return &admin.ListNotificationsResult{Items: []admin.AdminNotificationItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
 }
 
 func (s *stubAdminService) SendCustomNotification(_ context.Context, input admin.SendCustomNotificationInput) (*admin.SendCustomNotificationResult, error) {
@@ -213,6 +219,67 @@ func TestCreateNotificationValidatesBody(t *testing.T) {
 		if body.Error.Details[field] == "" {
 			t.Fatalf("expected %s validation detail, got %#v", field, body.Error.Details)
 		}
+	}
+}
+
+func TestListNotificationsParsesFilters(t *testing.T) {
+	// given
+	service := &stubAdminService{}
+	app := adminHandlerTestApp(service)
+	userID := uuid.New()
+	eventID := uuid.New()
+	from := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	req := httptest.NewRequest(fiber.MethodGet, "/admin/notifications?limit=10&offset=20&q=ops&user_id="+userID.String()+"&event_id="+eventID.String()+"&type=ADMIN&is_read=false&created_from="+from.Format(time.RFC3339), nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if service.lastNotifications.Limit != 10 || service.lastNotifications.Offset != 20 {
+		t.Fatalf("unexpected pagination: %#v", service.lastNotifications.PageInput)
+	}
+	if service.lastNotifications.Query == nil || *service.lastNotifications.Query != "ops" {
+		t.Fatalf("expected query ops, got %#v", service.lastNotifications.Query)
+	}
+	if service.lastNotifications.UserID == nil || *service.lastNotifications.UserID != userID {
+		t.Fatalf("expected user_id %s, got %#v", userID, service.lastNotifications.UserID)
+	}
+	if service.lastNotifications.EventID == nil || *service.lastNotifications.EventID != eventID {
+		t.Fatalf("expected event_id %s, got %#v", eventID, service.lastNotifications.EventID)
+	}
+	if service.lastNotifications.Type == nil || *service.lastNotifications.Type != "ADMIN" {
+		t.Fatalf("expected type ADMIN, got %#v", service.lastNotifications.Type)
+	}
+	if service.lastNotifications.IsRead == nil || *service.lastNotifications.IsRead {
+		t.Fatalf("expected is_read false, got %#v", service.lastNotifications.IsRead)
+	}
+	if service.lastNotifications.CreatedFrom == nil || !service.lastNotifications.CreatedFrom.Equal(from) {
+		t.Fatalf("expected created_from %s, got %#v", from, service.lastNotifications.CreatedFrom)
+	}
+}
+
+func TestListNotificationsValidatesFilters(t *testing.T) {
+	// given
+	app := adminHandlerTestApp(&stubAdminService{})
+	req := httptest.NewRequest(fiber.MethodGet, "/admin/notifications?user_id=nope&is_read=maybe", nil)
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
 	}
 }
 

--- a/backend/internal/application/admin/repository.go
+++ b/backend/internal/application/admin/repository.go
@@ -13,6 +13,7 @@ type Repository interface {
 	ListEvents(ctx context.Context, input ListEventsInput) (*ListEventsResult, error)
 	ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error)
 	ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error)
+	ListNotifications(ctx context.Context, input ListNotificationsInput) (*ListNotificationsResult, error)
 	CountExistingUsers(ctx context.Context, userIDs []uuid.UUID) (int, error)
 	GetEventState(ctx context.Context, eventID uuid.UUID, forUpdate bool) (*AdminEventState, error)
 	CreateManualParticipation(ctx context.Context, eventID, userID uuid.UUID, status domain.ParticipationStatus) (*domain.Participation, error)

--- a/backend/internal/application/admin/service_dto.go
+++ b/backend/internal/application/admin/service_dto.go
@@ -154,6 +154,43 @@ type ListTicketsResult struct {
 	PageMeta
 }
 
+type ListNotificationsInput struct {
+	PageInput
+	CreatedRange
+	Query   *string
+	UserID  *uuid.UUID
+	EventID *uuid.UUID
+	Type    *string
+	IsRead  *bool
+}
+
+type AdminNotificationItem struct {
+	ID              uuid.UUID         `json:"id"`
+	ReceiverUserID  uuid.UUID         `json:"receiver_user_id"`
+	Username        string            `json:"username"`
+	UserEmail       string            `json:"user_email"`
+	EventID         *uuid.UUID        `json:"event_id"`
+	EventTitle      *string           `json:"event_title"`
+	Title           string            `json:"title"`
+	Type            *string           `json:"type"`
+	Body            string            `json:"body"`
+	DeepLink        *string           `json:"deep_link"`
+	Data            map[string]string `json:"data"`
+	IsRead          bool              `json:"is_read"`
+	ReadAt          *time.Time        `json:"read_at"`
+	DeletedAt       *time.Time        `json:"deleted_at"`
+	SSESentCount    int               `json:"sse_sent_count"`
+	PushSentCount   int               `json:"push_sent_count"`
+	PushFailedCount int               `json:"push_failed_count"`
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+}
+
+type ListNotificationsResult struct {
+	Items []AdminNotificationItem `json:"items"`
+	PageMeta
+}
+
 type SendCustomNotificationInput struct {
 	AdminUserID    uuid.UUID
 	UserIDs        []uuid.UUID
@@ -228,4 +265,8 @@ func (s *Service) ListParticipations(ctx context.Context, input ListParticipatio
 
 func (s *Service) ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error) {
 	return s.repo.ListTickets(ctx, input)
+}
+
+func (s *Service) ListNotifications(ctx context.Context, input ListNotificationsInput) (*ListNotificationsResult, error) {
+	return s.repo.ListNotifications(ctx, input)
 }

--- a/backend/internal/application/admin/usecase.go
+++ b/backend/internal/application/admin/usecase.go
@@ -8,6 +8,7 @@ type UseCase interface {
 	ListEvents(ctx context.Context, input ListEventsInput) (*ListEventsResult, error)
 	ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error)
 	ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error)
+	ListNotifications(ctx context.Context, input ListNotificationsInput) (*ListNotificationsResult, error)
 	SendCustomNotification(ctx context.Context, input SendCustomNotificationInput) (*SendCustomNotificationResult, error)
 	CreateManualParticipation(ctx context.Context, input CreateManualParticipationInput) (*CreateManualParticipationResult, error)
 	CancelParticipation(ctx context.Context, input CancelParticipationInput) (*CancelParticipationResult, error)

--- a/docs/openapi/admin.yaml
+++ b/docs/openapi/admin.yaml
@@ -254,6 +254,50 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
   /admin/notifications:
+    get:
+      tags: [Admin]
+      summary: List sent notifications
+      operationId: adminListNotifications
+      description: Lists notification inbox rows for backoffice review, including delivery-attempt summary counts.
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/TextQuery'
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: type
+          in: query
+          schema: { type: string }
+        - name: is_read
+          in: query
+          schema: { type: boolean }
+        - name: created_from
+          in: query
+          schema: { type: string, format: date-time }
+        - name: created_to
+          in: query
+          schema: { type: string, format: date-time }
+      responses:
+        '200':
+          description: Offset-paginated notifications.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminNotification' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
     post:
       tags: [Admin]
       summary: Send a custom notification
@@ -382,6 +426,31 @@ components:
         expires_at: { type: string, format: date-time }
         used_at: { type: [string, 'null'], format: date-time }
         canceled_at: { type: [string, 'null'], format: date-time }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminNotification:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        receiver_user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        event_id: { type: [string, 'null'], format: uuid }
+        event_title: { type: [string, 'null'] }
+        title: { type: string }
+        type: { type: [string, 'null'] }
+        body: { type: string }
+        deep_link: { type: [string, 'null'] }
+        data:
+          type: object
+          additionalProperties: { type: string }
+        is_read: { type: boolean }
+        read_at: { type: [string, 'null'], format: date-time }
+        deleted_at: { type: [string, 'null'], format: date-time }
+        sse_sent_count: { type: integer }
+        push_sent_count: { type: integer }
+        push_failed_count: { type: integer }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
     AdminCreateNotificationRequest:

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -85,19 +85,19 @@ describe('App / route', () => {
     expect(screen.queryByText('Landing Page')).toBeNull();
   });
 
-  it('denies /admin-panel child pages to non-admin users', () => {
+  it('denies /backoffice child pages to non-admin users', () => {
     mockUseAuth.mockReturnValue({ isLoading: false, token: 'valid-token', role: 'USER' });
 
-    renderAt('/admin-panel/users');
+    renderAt('/backoffice/users');
 
     expect(screen.getByText('Admin Access Required')).toBeDefined();
     expect(screen.queryByText('Users Admin Page')).toBeNull();
   });
 
-  it('renders /admin-panel child pages for admins', () => {
+  it('renders /backoffice child pages for admins', () => {
     mockUseAuth.mockReturnValue({ isLoading: false, token: 'valid-token', role: 'ADMIN' });
 
-    renderAt('/admin-panel/users');
+    renderAt('/backoffice/users');
 
     expect(screen.getByText('Users Admin Page')).toBeDefined();
     expect(screen.getByRole('link', { name: 'Users' })).toBeDefined();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,18 +46,18 @@ export default function App() {
         <Route path="/favorites" element={<ProtectedRoute><FavoritesPage /></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
         <Route
-          path="/admin-panel"
+          path="/backoffice"
           element={<AdminRoute><BackofficeLayout /></AdminRoute>}
         >
-          <Route index element={<Navigate to="/admin-panel/users" replace />} />
+          <Route index element={<Navigate to="/backoffice/users" replace />} />
           <Route path="users" element={<UsersAdminPage />} />
           <Route path="events" element={<EventsAdminPage />} />
           <Route path="participations" element={<ParticipationsAdminPage />} />
           <Route path="tickets" element={<TicketsAdminPage />} />
           <Route path="notifications" element={<NotificationsAdminPage />} />
         </Route>
-        <Route path="/backoffice" element={<Navigate to="/admin-panel" replace />} />
-        <Route path="/backoffice/*" element={<Navigate to="/admin-panel" replace />} />
+        <Route path="/admin-panel" element={<Navigate to="/backoffice" replace />} />
+        <Route path="/admin-panel/*" element={<Navigate to="/backoffice" replace />} />
       </Route>
 
       {/* Auth pages (no shell) */}

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -50,7 +50,7 @@ describe('AppShell admin entry', () => {
 
     renderShell();
 
-    expect(screen.getByRole('link', { name: 'Admin Panel' }).getAttribute('href')).toBe('/admin-panel');
+    expect(screen.getByRole('link', { name: 'Admin Panel' }).getAttribute('href')).toBe('/backoffice');
   });
 
   it('hides Admin Panel for regular authenticated users', () => {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -23,7 +23,7 @@ export default function AppShell() {
 
   const isLoggedIn = !!token;
   const navItems = isLoggedIn ? AUTH_NAV : [];
-  const isAdminPanel = location.pathname.startsWith('/admin-panel');
+  const isAdminPanel = location.pathname.startsWith('/backoffice') || location.pathname.startsWith('/admin-panel');
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -81,7 +81,7 @@ export default function AppShell() {
                   + Create Event
                 </NavLink>
                 {role === 'ADMIN' && (
-                  <NavLink to="/admin-panel" className="shell-admin-btn">
+                  <NavLink to="/backoffice" className="shell-admin-btn">
                     <svg className="shell-admin-icon" viewBox="0 0 24 24" aria-hidden="true">
                       <path d="M12 3.5 18 6v5.2c0 3.9-2.4 7.4-6 8.8-3.6-1.4-6-4.9-6-8.8V6l6-2.5Z" />
                     </svg>

--- a/frontend/src/models/admin.ts
+++ b/frontend/src/models/admin.ts
@@ -53,6 +53,16 @@ export interface AdminTicketFilters {
   created_to?: string;
 }
 
+export interface AdminNotificationFilters {
+  q?: string;
+  user_id?: string;
+  event_id?: string;
+  type?: string;
+  is_read?: string;
+  created_from?: string;
+  created_to?: string;
+}
+
 export interface AdminUser {
   id: string;
   username: string;
@@ -111,4 +121,78 @@ export interface AdminTicket {
   canceled_at: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface AdminNotification {
+  id: string;
+  receiver_user_id: string;
+  username: string;
+  user_email: string;
+  event_id: string | null;
+  event_title: string | null;
+  title: string;
+  type: string | null;
+  body: string;
+  deep_link: string | null;
+  data: Record<string, string>;
+  is_read: boolean;
+  read_at: string | null;
+  deleted_at: string | null;
+  sse_sent_count: number;
+  push_sent_count: number;
+  push_failed_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type AdminNotificationDeliveryMode = 'IN_APP' | 'PUSH' | 'BOTH';
+
+export interface AdminCreateNotificationRequest {
+  user_ids: string[];
+  delivery_mode: AdminNotificationDeliveryMode;
+  title: string;
+  body: string;
+  type?: string | null;
+  deep_link?: string | null;
+  event_id?: string | null;
+  data?: Record<string, string>;
+}
+
+export interface AdminCreateNotificationResponse {
+  target_user_count: number;
+  created_count: number;
+  idempotent_count: number;
+  sse_delivery_count: number;
+  push_active_device_count: number;
+  push_sent_count: number;
+  push_failed_count: number;
+  invalid_token_count: number;
+}
+
+export interface AdminCreateParticipationRequest {
+  event_id: string;
+  user_id: string;
+  status?: 'APPROVED' | 'PENDING';
+  reason?: string | null;
+}
+
+export interface AdminCreateParticipationResponse {
+  participation_id: string;
+  event_id: string;
+  user_id: string;
+  status: 'APPROVED' | 'PENDING';
+  ticket_id?: string;
+  ticket_status?: 'ACTIVE' | 'PENDING' | 'EXPIRED' | 'USED' | 'CANCELED';
+}
+
+export interface AdminCancelParticipationRequest {
+  reason?: string | null;
+}
+
+export interface AdminCancelParticipationResponse {
+  participation_id: string;
+  event_id: string;
+  user_id: string;
+  status: 'CANCELED';
+  already_canceled: boolean;
 }

--- a/frontend/src/services/adminService.test.ts
+++ b/frontend/src/services/adminService.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from 'vitest';
-import { buildAdminListPath } from './adminService';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildAdminListPath,
+  cancelAdminParticipation,
+  createAdminNotification,
+  createAdminParticipation,
+} from './adminService';
+
+vi.mock('@/config/api', () => ({
+  API_BASE_URL: 'http://api.test',
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('buildAdminListPath', () => {
   it('serializes filters and pagination while skipping empty values', () => {
@@ -25,5 +38,69 @@ describe('buildAdminListPath', () => {
     expect(createdFrom).toBeTruthy();
     expect(createdFrom).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00\.000Z$/);
     expect(Number.isNaN(new Date(createdFrom as string).getTime())).toBe(false);
+  });
+});
+
+describe('admin mutation services', () => {
+  it('posts notification payloads with delivery mode', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      target_user_count: 1,
+      created_count: 1,
+      idempotent_count: 0,
+      sse_delivery_count: 1,
+      push_active_device_count: 0,
+      push_sent_count: 0,
+      push_failed_count: 0,
+      invalid_token_count: 0,
+    }), { status: 201 }));
+
+    await createAdminNotification('token', {
+      user_ids: ['11111111-1111-4111-8111-111111111111'],
+      delivery_mode: 'BOTH',
+      title: 'Title',
+      body: 'Body',
+    });
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/admin/notifications', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({
+        user_ids: ['11111111-1111-4111-8111-111111111111'],
+        delivery_mode: 'BOTH',
+        title: 'Title',
+        body: 'Body',
+      }),
+    }));
+  });
+
+  it('posts participation create and cancel actions', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        participation_id: '33333333-3333-4333-8333-333333333333',
+        event_id: '11111111-1111-4111-8111-111111111111',
+        user_id: '22222222-2222-4222-8222-222222222222',
+        status: 'APPROVED',
+      }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        participation_id: '33333333-3333-4333-8333-333333333333',
+        event_id: '11111111-1111-4111-8111-111111111111',
+        user_id: '22222222-2222-4222-8222-222222222222',
+        status: 'CANCELED',
+        already_canceled: false,
+      }), { status: 200 }));
+
+    await createAdminParticipation('token', {
+      event_id: '11111111-1111-4111-8111-111111111111',
+      user_id: '22222222-2222-4222-8222-222222222222',
+      status: 'APPROVED',
+    });
+    await cancelAdminParticipation('token', '33333333-3333-4333-8333-333333333333');
+
+    expect(fetch).toHaveBeenNthCalledWith(1, 'http://api.test/admin/participations', expect.objectContaining({
+      method: 'POST',
+    }));
+    expect(fetch).toHaveBeenNthCalledWith(2, 'http://api.test/admin/participations/33333333-3333-4333-8333-333333333333/cancel', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({}),
+    }));
   });
 });

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -1,8 +1,16 @@
-import { apiGetAuth } from '@/services/api';
+import { apiGetAuth, apiPostAuth } from '@/services/api';
 import type {
+  AdminCancelParticipationRequest,
+  AdminCancelParticipationResponse,
+  AdminCreateNotificationRequest,
+  AdminCreateNotificationResponse,
+  AdminCreateParticipationRequest,
+  AdminCreateParticipationResponse,
   AdminEvent,
   AdminEventFilters,
   AdminListResponse,
+  AdminNotification,
+  AdminNotificationFilters,
   AdminPageParams,
   AdminParticipation,
   AdminParticipationFilters,
@@ -70,4 +78,37 @@ export function listAdminTickets(
   params: AdminPageParams & AdminTicketFilters,
 ): Promise<AdminListResponse<AdminTicket>> {
   return apiGetAuth<AdminListResponse<AdminTicket>>(buildAdminListPath('/admin/tickets', params), token);
+}
+
+export function listAdminNotifications(
+  token: string,
+  params: AdminPageParams & AdminNotificationFilters,
+): Promise<AdminListResponse<AdminNotification>> {
+  return apiGetAuth<AdminListResponse<AdminNotification>>(buildAdminListPath('/admin/notifications', params), token);
+}
+
+export function createAdminNotification(
+  token: string,
+  body: AdminCreateNotificationRequest,
+): Promise<AdminCreateNotificationResponse> {
+  return apiPostAuth<AdminCreateNotificationResponse>('/admin/notifications', body, token);
+}
+
+export function createAdminParticipation(
+  token: string,
+  body: AdminCreateParticipationRequest,
+): Promise<AdminCreateParticipationResponse> {
+  return apiPostAuth<AdminCreateParticipationResponse>('/admin/participations', body, token);
+}
+
+export function cancelAdminParticipation(
+  token: string,
+  participationId: string,
+  body: AdminCancelParticipationRequest = {},
+): Promise<AdminCancelParticipationResponse> {
+  return apiPostAuth<AdminCancelParticipationResponse>(
+    `/admin/participations/${encodeURIComponent(participationId)}/cancel`,
+    body,
+    token,
+  );
 }

--- a/frontend/src/styles/backoffice.css
+++ b/frontend/src/styles/backoffice.css
@@ -114,12 +114,39 @@
 .bo-filter-bar select,
 .bo-pagination select {
   min-height: 34px;
+  height: 36px;
   padding: 6px 9px;
   border: 1px solid #d1d5db;
   border-radius: 6px;
   background: #ffffff;
   color: #111827;
   font-size: 13px;
+}
+
+.bo-filter-bar select,
+.bo-pagination select,
+.bo-field select {
+  appearance: none;
+  min-width: 150px;
+  padding-right: 32px;
+  background-color: #ffffff;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #6b7280 50%),
+    linear-gradient(135deg, #6b7280 50%, transparent 50%);
+  background-position:
+    calc(100% - 16px) 15px,
+    calc(100% - 11px) 15px;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  line-height: 1.2;
+}
+
+.bo-filter-bar select:focus,
+.bo-pagination select:focus,
+.bo-field select:focus {
+  outline: 2px solid rgba(17, 24, 39, 0.16);
+  outline-offset: 1px;
+  border-color: #111827;
 }
 
 .bo-filter-bar input {
@@ -180,6 +207,48 @@
   font-weight: 700;
 }
 
+.bo-id-cell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+}
+
+.bo-id-cell button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111827;
+  cursor: pointer;
+}
+
+.bo-id-cell svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.bo-copy-check {
+  color: #166534;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.bo-id-cell button:hover {
+  border-color: #111827;
+  background: #f9fafb;
+}
+
 .bo-table tbody tr:hover {
   background: #f9fafb;
 }
@@ -204,6 +273,280 @@
   gap: 12px;
   border-color: #fecaca;
   color: #991b1b;
+}
+
+.bo-action-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.bo-notification-composer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  padding: 14px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.bo-composer-targets,
+.bo-body-field,
+.bo-advanced-fields,
+.bo-inline-state,
+.bo-result,
+.bo-form-actions {
+  grid-column: 1 / -1;
+}
+
+.bo-composer-targets {
+  grid-column: 1;
+}
+
+.bo-composer-main-fields {
+  grid-column: 2;
+  display: grid;
+  grid-template-columns: 148px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.bo-delivery-field select {
+  min-width: 0;
+}
+
+.bo-add-row {
+  display: flex;
+  gap: 8px;
+}
+
+.bo-add-row input {
+  flex: 1;
+}
+
+.bo-add-row button {
+  width: 36px;
+  min-height: 36px;
+  border: 1px solid #111827;
+  border-radius: 6px;
+  background: #111827;
+  color: #ffffff;
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.bo-target-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 30px;
+  margin-top: 8px;
+}
+
+.bo-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 5px 7px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #f9fafb;
+  color: #374151;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.bo-chip button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 0;
+  border-radius: 50%;
+  background: #e5e7eb;
+  color: #111827;
+  cursor: pointer;
+}
+
+.bo-muted {
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.bo-advanced-fields {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 10px;
+}
+
+.bo-advanced-fields summary {
+  width: max-content;
+  cursor: pointer;
+  color: #374151;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.bo-advanced-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.bo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  color: #374151;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.bo-field-wide {
+  grid-column: 1 / -1;
+}
+
+.bo-field input,
+.bo-field select,
+.bo-field textarea {
+  width: 100%;
+  min-height: 36px;
+  padding: 7px 9px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111827;
+  font: inherit;
+  font-weight: 500;
+  resize: vertical;
+}
+
+.bo-field select {
+  height: 36px;
+}
+
+.bo-field small {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.bo-field strong {
+  color: #991b1b;
+  font-size: 12px;
+}
+
+.bo-form-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.bo-form-actions button,
+.bo-row-action {
+  min-height: 34px;
+  padding: 6px 12px;
+  border: 1px solid #111827;
+  border-radius: 6px;
+  background: #111827;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.bo-form-actions button:disabled,
+.bo-row-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.bo-result {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  background: #f0fdf4;
+  color: #166534;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.bo-result span {
+  padding-right: 8px;
+  border-right: 1px solid #86efac;
+}
+
+.bo-result span:last-child {
+  border-right: 0;
+}
+
+.bo-history-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bo-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.bo-section-heading h2 {
+  margin: 0;
+  color: #111827;
+  font-size: 18px;
+}
+
+.bo-secondary-button {
+  min-height: 34px;
+  padding: 6px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #374151;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.bo-cell-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 320px;
+  white-space: normal;
+}
+
+.bo-cell-stack strong {
+  color: #111827;
+  font-weight: 700;
+}
+
+.bo-cell-stack span {
+  color: #6b7280;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.bo-message-cell span {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .bo-pagination {
@@ -241,5 +584,23 @@
   .bo-content {
     margin-left: 210px;
     padding: 24px;
+  }
+
+  .bo-action-form {
+    grid-template-columns: 1fr;
+  }
+
+  .bo-notification-composer,
+  .bo-advanced-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bo-composer-targets,
+  .bo-composer-main-fields {
+    grid-column: 1;
+  }
+
+  .bo-composer-main-fields {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/viewmodels/admin/useAdminNotificationViewModel.ts
+++ b/frontend/src/viewmodels/admin/useAdminNotificationViewModel.ts
@@ -1,0 +1,176 @@
+import { useMemo, useState } from 'react';
+import type {
+  AdminCreateNotificationResponse,
+  AdminNotificationDeliveryMode,
+} from '@/models/admin';
+import { ApiError } from '@/services/api';
+import { createAdminNotification } from '@/services/adminService';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface NotificationForm {
+  targetUserInput: string;
+  targetUserIds: string[];
+  deliveryMode: AdminNotificationDeliveryMode;
+  title: string;
+  body: string;
+  type: string;
+  deepLink: string;
+  eventId: string;
+  dataText: string;
+}
+
+const INITIAL_FORM: NotificationForm = {
+  targetUserInput: '',
+  targetUserIds: [],
+  deliveryMode: 'IN_APP',
+  title: '',
+  body: '',
+  type: '',
+  deepLink: '',
+  eventId: '',
+  dataText: '',
+};
+
+type NotificationField = keyof NotificationForm;
+type FieldErrors = Partial<Record<NotificationField, string>>;
+
+function parseUserIds(value: string): string[] {
+  return Array.from(new Set(value.split(/[\s,]+/).map((item) => item.trim()).filter(Boolean)));
+}
+
+function parseData(value: string): Record<string, string> | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = JSON.parse(trimmed) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Data must be a JSON object.');
+  }
+  const data: Record<string, string> = {};
+  Object.entries(parsed).forEach(([key, entry]) => {
+    if (typeof entry !== 'string') {
+      throw new Error('Data values must be strings.');
+    }
+    data[key] = entry;
+  });
+  return data;
+}
+
+function apiErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) {
+    const details = err.details ? Object.values(err.details).filter(Boolean).join(' ') : '';
+    return details ? `${err.message} ${details}` : err.message;
+  }
+  return fallback;
+}
+
+export function useAdminNotificationViewModel(token: string | null) {
+  const [form, setForm] = useState<NotificationForm>(INITIAL_FORM);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [result, setResult] = useState<AdminCreateNotificationResponse | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const targetUserIds = useMemo(() => form.targetUserIds, [form.targetUserIds]);
+
+  function setField<K extends NotificationField>(field: K, value: NotificationForm[K]) {
+    setForm((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => ({ ...current, [field]: undefined }));
+    setSubmitError(null);
+  }
+
+  function addTargetUser() {
+    const values = parseUserIds(form.targetUserInput);
+    if (values.length === 0) {
+      setFieldErrors((current) => ({ ...current, targetUserInput: 'Enter a user ID.' }));
+      return;
+    }
+    const invalid = values.find((id) => !UUID_RE.test(id));
+    if (invalid) {
+      setFieldErrors((current) => ({ ...current, targetUserInput: 'User IDs must be valid UUIDs.' }));
+      return;
+    }
+    setForm((current) => ({
+      ...current,
+      targetUserInput: '',
+      targetUserIds: Array.from(new Set([...current.targetUserIds, ...values])),
+    }));
+    setFieldErrors((current) => ({ ...current, targetUserInput: undefined }));
+    setSubmitError(null);
+  }
+
+  function removeTargetUser(userId: string) {
+    setForm((current) => ({
+      ...current,
+      targetUserIds: current.targetUserIds.filter((id) => id !== userId),
+    }));
+    setFieldErrors((current) => ({ ...current, targetUserInput: undefined }));
+  }
+
+  async function submit(): Promise<boolean> {
+    const errors: FieldErrors = {};
+    if (targetUserIds.length === 0) {
+      const pendingTargets = parseUserIds(form.targetUserInput);
+      errors.targetUserInput = pendingTargets.some((id) => !UUID_RE.test(id))
+        ? 'User IDs must be valid UUIDs.'
+        : 'Add at least one user ID.';
+    } else if (targetUserIds.some((id) => !UUID_RE.test(id))) {
+      errors.targetUserInput = 'User IDs must be valid UUIDs.';
+    }
+    if (!form.title.trim()) errors.title = 'Title is required.';
+    if (!form.body.trim()) errors.body = 'Body is required.';
+    if (form.eventId.trim() && !UUID_RE.test(form.eventId.trim())) {
+      errors.eventId = 'Event ID must be a valid UUID.';
+    }
+
+    let data: Record<string, string> | undefined;
+    try {
+      data = parseData(form.dataText);
+    } catch (err) {
+      errors.dataText = err instanceof Error ? err.message : 'Data must be valid JSON.';
+    }
+
+    setFieldErrors(errors);
+    setResult(null);
+    if (Object.keys(errors).length > 0) return false;
+    if (!token) {
+      setSubmitError('Admin session is not available.');
+      return false;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      const response = await createAdminNotification(token, {
+        user_ids: targetUserIds,
+        delivery_mode: form.deliveryMode,
+        title: form.title.trim(),
+        body: form.body.trim(),
+        type: form.type.trim() || null,
+        deep_link: form.deepLink.trim() || null,
+        event_id: form.eventId.trim() || null,
+        data,
+      });
+      setResult(response);
+      return true;
+    } catch (err) {
+      setSubmitError(apiErrorMessage(err, 'Failed to send notification.'));
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return {
+    form,
+    fieldErrors,
+    submitError,
+    result,
+    isSubmitting,
+    targetUserIds,
+    setField,
+    addTargetUser,
+    removeTargetUser,
+    submit,
+  };
+}

--- a/frontend/src/viewmodels/admin/useAdminParticipationActionsViewModel.ts
+++ b/frontend/src/viewmodels/admin/useAdminParticipationActionsViewModel.ts
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import type {
+  AdminCancelParticipationResponse,
+  AdminCreateParticipationResponse,
+} from '@/models/admin';
+import { ApiError } from '@/services/api';
+import { cancelAdminParticipation, createAdminParticipation } from '@/services/adminService';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface CreateForm {
+  eventId: string;
+  userId: string;
+  reason: string;
+}
+
+const INITIAL_CREATE_FORM: CreateForm = {
+  eventId: '',
+  userId: '',
+  reason: '',
+};
+
+type CreateField = keyof CreateForm;
+type CreateErrors = Partial<Record<CreateField, string>>;
+
+function apiErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) {
+    const details = err.details ? Object.values(err.details).filter(Boolean).join(' ') : '';
+    return details ? `${err.message} ${details}` : err.message;
+  }
+  return fallback;
+}
+
+export function useAdminParticipationActionsViewModel(
+  token: string | null,
+  onMutationSuccess: () => Promise<unknown> | void,
+) {
+  const [createForm, setCreateForm] = useState<CreateForm>(INITIAL_CREATE_FORM);
+  const [createErrors, setCreateErrors] = useState<CreateErrors>({});
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [createResult, setCreateResult] = useState<AdminCreateParticipationResponse | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [cancelingId, setCancelingId] = useState<string | null>(null);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  const [cancelResult, setCancelResult] = useState<AdminCancelParticipationResponse | null>(null);
+
+  function setCreateField<K extends CreateField>(field: K, value: CreateForm[K]) {
+    setCreateForm((current) => ({ ...current, [field]: value }));
+    setCreateErrors((current) => ({ ...current, [field]: undefined }));
+    setCreateError(null);
+  }
+
+  async function submitCreate() {
+    const errors: CreateErrors = {};
+    const eventId = createForm.eventId.trim();
+    const userId = createForm.userId.trim();
+    if (!UUID_RE.test(eventId)) errors.eventId = 'Event ID must be a valid UUID.';
+    if (!UUID_RE.test(userId)) errors.userId = 'User ID must be a valid UUID.';
+    setCreateErrors(errors);
+    setCreateResult(null);
+    if (Object.keys(errors).length > 0) return;
+    if (!token) {
+      setCreateError('Admin session is not available.');
+      return;
+    }
+
+    setIsCreating(true);
+    setCreateError(null);
+    try {
+      const result = await createAdminParticipation(token, {
+        event_id: eventId,
+        user_id: userId,
+        status: 'APPROVED',
+        reason: createForm.reason.trim() || null,
+      });
+      setCreateResult(result);
+      setCreateForm(INITIAL_CREATE_FORM);
+      await onMutationSuccess();
+    } catch (err) {
+      setCreateError(apiErrorMessage(err, 'Failed to create participation.'));
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  async function cancelParticipation(participationId: string) {
+    if (!token) {
+      setCancelError('Admin session is not available.');
+      return;
+    }
+    if (!window.confirm('Cancel this participation?')) return;
+
+    setCancelingId(participationId);
+    setCancelError(null);
+    setCancelResult(null);
+    try {
+      const result = await cancelAdminParticipation(token, participationId);
+      setCancelResult(result);
+      await onMutationSuccess();
+    } catch (err) {
+      setCancelError(apiErrorMessage(err, 'Failed to cancel participation.'));
+    } finally {
+      setCancelingId(null);
+    }
+  }
+
+  return {
+    createForm,
+    createErrors,
+    createError,
+    createResult,
+    isCreating,
+    cancelingId,
+    cancelError,
+    cancelResult,
+    setCreateField,
+    submitCreate,
+    cancelParticipation,
+  };
+}

--- a/frontend/src/views/backoffice/BackofficeLayout.tsx
+++ b/frontend/src/views/backoffice/BackofficeLayout.tsx
@@ -2,11 +2,11 @@ import { NavLink, Outlet } from 'react-router-dom';
 import '@/styles/backoffice.css';
 
 const SIDEBAR_ITEMS = [
-  { to: '/admin-panel/users', label: 'Users' },
-  { to: '/admin-panel/events', label: 'Events' },
-  { to: '/admin-panel/participations', label: 'Participations' },
-  { to: '/admin-panel/tickets', label: 'Tickets' },
-  { to: '/admin-panel/notifications', label: 'Notifications' },
+  { to: '/backoffice/users', label: 'Users' },
+  { to: '/backoffice/events', label: 'Events' },
+  { to: '/backoffice/participations', label: 'Participations' },
+  { to: '/backoffice/tickets', label: 'Tickets' },
+  { to: '/backoffice/notifications', label: 'Notifications' },
 ];
 
 export default function BackofficeLayout() {

--- a/frontend/src/views/backoffice/BackofficeListParts.tsx
+++ b/frontend/src/views/backoffice/BackofficeListParts.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 
 export function formatAdminDate(value: string | null | undefined): string {
   if (!value) return '-';
@@ -31,6 +31,35 @@ export function BackofficePageShell({ title, subtitle, filters, children }: Shel
       </div>
       <div className="bo-filter-bar">{filters}</div>
       {children}
+    </div>
+  );
+}
+
+export function BackofficeIdCell({ id }: { id: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copyId() {
+    try {
+      await navigator.clipboard.writeText(id);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="bo-id-cell">
+      <button type="button" onClick={copyId} aria-label={`Copy ID ${id}`} title={id}>
+        {copied ? (
+          <span className="bo-copy-check" aria-hidden="true">✓</span>
+        ) : (
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="9" y="9" width="10" height="10" rx="2" />
+            <path d="M5 15V7a2 2 0 0 1 2-2h8" />
+          </svg>
+        )}
+      </button>
     </div>
   );
 }

--- a/frontend/src/views/backoffice/EventsAdminPage.tsx
+++ b/frontend/src/views/backoffice/EventsAdminPage.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { AdminEventFilters } from '@/models/admin';
 import { listAdminEvents } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
-import { BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminEventFilters = {
   q: '',
@@ -54,6 +54,7 @@ export default function EventsAdminPage() {
         <table className="bo-table">
           <thead>
             <tr>
+              <th>ID</th>
               <th>Title</th>
               <th>Host</th>
               <th>Category</th>
@@ -69,6 +70,7 @@ export default function EventsAdminPage() {
           <tbody>
             {vm.items.map((event) => (
               <tr key={event.id}>
+                <td><BackofficeIdCell id={event.id} /></td>
                 <td>{event.title}</td>
                 <td>{event.host_username}</td>
                 <td>{event.category_name ?? event.category_id ?? '-'}</td>

--- a/frontend/src/views/backoffice/NotificationsAdminPage.test.tsx
+++ b/frontend/src/views/backoffice/NotificationsAdminPage.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import NotificationsAdminPage from './NotificationsAdminPage';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'admin-token' }),
+}));
+
+vi.mock('@/services/adminService', () => ({
+  createAdminNotification: vi.fn(),
+  listAdminNotifications: vi.fn(),
+}));
+
+import { createAdminNotification, listAdminNotifications } from '@/services/adminService';
+
+const mockCreateNotification = createAdminNotification as ReturnType<typeof vi.fn>;
+const mockListNotifications = listAdminNotifications as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListNotifications.mockResolvedValue({
+    items: [],
+    limit: 25,
+    offset: 0,
+    total_count: 0,
+    has_next: false,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('NotificationsAdminPage', () => {
+  it('validates required fields without clearing typed state', async () => {
+    render(<NotificationsAdminPage />);
+
+    fireEvent.change(screen.getByLabelText('Target user ID'), { target: { value: 'not-a-uuid' } });
+    fireEvent.click(screen.getByLabelText('Add target user'));
+    fireEvent.change(screen.getByLabelText('Notification body'), { target: { value: 'Body stays here' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send notification' }));
+
+    expect(await screen.findByText('User IDs must be valid UUIDs.')).toBeDefined();
+    expect(screen.getByLabelText('Notification body')).toHaveProperty('value', 'Body stays here');
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it('submits selected delivery mode and displays backend result counts', async () => {
+    mockCreateNotification.mockResolvedValue({
+      target_user_count: 2,
+      created_count: 2,
+      idempotent_count: 0,
+      sse_delivery_count: 2,
+      push_active_device_count: 2,
+      push_sent_count: 1,
+      push_failed_count: 1,
+      invalid_token_count: 0,
+    });
+
+    render(<NotificationsAdminPage />);
+
+    fireEvent.change(screen.getByLabelText('Target user ID'), { target: { value: '11111111-1111-4111-8111-111111111111' } });
+    fireEvent.click(screen.getByLabelText('Add target user'));
+    fireEvent.change(screen.getByLabelText('Target user ID'), { target: { value: '22222222-2222-4222-8222-222222222222' } });
+    fireEvent.click(screen.getByLabelText('Add target user'));
+    fireEvent.change(screen.getByLabelText('Delivery mode'), { target: { value: 'BOTH' } });
+    fireEvent.change(screen.getByLabelText('Notification title'), { target: { value: 'Ops update' } });
+    fireEvent.change(screen.getByLabelText('Notification body'), { target: { value: 'Doors open at 18:00.' } });
+    fireEvent.change(screen.getByLabelText('Notification data JSON'), { target: { value: '{"source":"test"}' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send notification' }));
+
+    await waitFor(() => expect(mockCreateNotification).toHaveBeenCalledWith('admin-token', {
+      user_ids: [
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+      ],
+      delivery_mode: 'BOTH',
+      title: 'Ops update',
+      body: 'Doors open at 18:00.',
+      type: null,
+      deep_link: null,
+      event_id: null,
+      data: { source: 'test' },
+    }));
+    expect(screen.getByText('Created: 2')).toBeDefined();
+    expect(screen.getByText('Push failed: 1')).toBeDefined();
+  });
+
+  it('loads sent notifications and filters by user', async () => {
+    mockListNotifications.mockResolvedValue({
+      items: [{
+        id: '99999999-9999-4999-8999-999999999999',
+        receiver_user_id: '11111111-1111-4111-8111-111111111111',
+        username: 'alice',
+        user_email: 'alice@example.com',
+        event_id: null,
+        event_title: null,
+        title: 'Welcome',
+        type: 'ADMIN',
+        body: 'Hello there',
+        deep_link: null,
+        data: {},
+        is_read: false,
+        read_at: null,
+        deleted_at: null,
+        sse_sent_count: 1,
+        push_sent_count: 0,
+        push_failed_count: 0,
+        created_at: '2026-05-01T10:00:00Z',
+        updated_at: '2026-05-01T10:00:00Z',
+      }],
+      limit: 25,
+      offset: 0,
+      total_count: 1,
+      has_next: false,
+    });
+
+    render(<NotificationsAdminPage />);
+
+    expect(await screen.findByText('alice')).toBeDefined();
+    fireEvent.change(screen.getByLabelText('Notification user filter'), { target: { value: '11111111-1111-4111-8111-111111111111' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => expect(mockListNotifications).toHaveBeenCalledWith('admin-token', expect.objectContaining({
+      user_id: '11111111-1111-4111-8111-111111111111',
+    })));
+  });
+});

--- a/frontend/src/views/backoffice/NotificationsAdminPage.tsx
+++ b/frontend/src/views/backoffice/NotificationsAdminPage.tsx
@@ -1,13 +1,247 @@
 import { BackofficePageShell } from './BackofficeListParts';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminNotificationFilters } from '@/models/admin';
+import { listAdminNotifications } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { useAdminNotificationViewModel } from '@/viewmodels/admin/useAdminNotificationViewModel';
+import { BackofficeIdCell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { useMemo } from 'react';
+
+const INITIAL_FILTERS: AdminNotificationFilters = {
+  q: '',
+  user_id: '',
+  event_id: '',
+  type: '',
+  is_read: '',
+  created_from: '',
+  created_to: '',
+};
 
 export default function NotificationsAdminPage() {
+  const { token } = useAuth();
+  const vm = useAdminNotificationViewModel(token);
+  const initialFilters = useMemo(() => INITIAL_FILTERS, []);
+  const list = useAdminListViewModel({ token, initialFilters, fetchPage: listAdminNotifications });
+
   return (
     <BackofficePageShell
       title="Notifications"
-      subtitle="Notification sending controls are tracked in the separate admin actions issue."
-      filters={null}
+      subtitle="Send targeted notifications and inspect recent notification inbox rows."
+      filters={(
+        <>
+          <input aria-label="Search notifications" placeholder="Search title, body, user" value={list.filters.q ?? ''} onChange={(event) => list.setFilter('q', event.target.value)} />
+          <input aria-label="Notification user filter" placeholder="User ID" value={list.filters.user_id ?? ''} onChange={(event) => list.setFilter('user_id', event.target.value)} />
+          <input aria-label="Notification event filter" placeholder="Event ID" value={list.filters.event_id ?? ''} onChange={(event) => list.setFilter('event_id', event.target.value)} />
+          <input aria-label="Notification type filter" placeholder="Type" value={list.filters.type ?? ''} onChange={(event) => list.setFilter('type', event.target.value)} />
+          <select aria-label="Notification read filter" value={list.filters.is_read ?? ''} onChange={(event) => list.setFilter('is_read', event.target.value)}>
+            <option value="">Any read state</option>
+            <option value="false">Unread</option>
+            <option value="true">Read</option>
+          </select>
+          <input aria-label="Notification created from" type="datetime-local" value={list.filters.created_from ?? ''} onChange={(event) => list.setFilter('created_from', event.target.value)} />
+          <input aria-label="Notification created to" type="datetime-local" value={list.filters.created_to ?? ''} onChange={(event) => list.setFilter('created_to', event.target.value)} />
+          <button type="button" onClick={list.applyFilters}>Apply</button>
+          <button type="button" className="bo-secondary-button" onClick={list.clearFilters}>Clear</button>
+        </>
+      )}
     >
-      <div className="bo-state">No read-only notification list is available yet.</div>
+      <form
+        className="bo-notification-composer"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void vm.submit().then((sent) => {
+            if (sent) void list.retry();
+          });
+        }}
+      >
+        <div className="bo-composer-targets">
+          <label className="bo-field">
+            <span>Target user</span>
+            <div className="bo-add-row">
+              <input
+                aria-label="Target user ID"
+                value={vm.form.targetUserInput}
+                onChange={(event) => vm.setField('targetUserInput', event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    vm.addTargetUser();
+                  }
+                }}
+                placeholder="User UUID"
+              />
+              <button type="button" onClick={vm.addTargetUser} aria-label="Add target user">+</button>
+            </div>
+            {vm.fieldErrors.targetUserInput && <strong>{vm.fieldErrors.targetUserInput}</strong>}
+          </label>
+
+          <div className="bo-target-list" aria-label="Selected target users">
+            {vm.targetUserIds.length === 0 ? (
+              <span className="bo-muted">No users selected</span>
+            ) : vm.targetUserIds.map((userId, index) => (
+              <span className="bo-chip" key={userId} title={userId}>
+                User {index + 1}
+                <button type="button" aria-label={`Remove ${userId}`} onClick={() => vm.removeTargetUser(userId)}>x</button>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="bo-composer-main-fields">
+          <label className="bo-field bo-delivery-field">
+          <span>Delivery mode</span>
+          <select
+            aria-label="Delivery mode"
+            value={vm.form.deliveryMode}
+            onChange={(event) => vm.setField('deliveryMode', event.target.value as typeof vm.form.deliveryMode)}
+          >
+            <option value="IN_APP">IN_APP</option>
+            <option value="PUSH">PUSH</option>
+            <option value="BOTH">BOTH</option>
+          </select>
+        </label>
+
+          <label className="bo-field bo-title-field">
+          <span>Title</span>
+          <input
+            aria-label="Notification title"
+            value={vm.form.title}
+            onChange={(event) => vm.setField('title', event.target.value)}
+          />
+          {vm.fieldErrors.title && <strong>{vm.fieldErrors.title}</strong>}
+        </label>
+        </div>
+
+        <label className="bo-field bo-body-field">
+          <span>Body</span>
+          <textarea
+            aria-label="Notification body"
+            value={vm.form.body}
+            onChange={(event) => vm.setField('body', event.target.value)}
+            rows={3}
+          />
+          {vm.fieldErrors.body && <strong>{vm.fieldErrors.body}</strong>}
+        </label>
+
+        <details className="bo-advanced-fields">
+          <summary>Optional metadata</summary>
+          <div className="bo-advanced-grid">
+            <label className="bo-field">
+          <span>Type</span>
+          <input
+            aria-label="Notification type"
+            value={vm.form.type}
+            onChange={(event) => vm.setField('type', event.target.value)}
+          />
+        </label>
+
+        <label className="bo-field">
+          <span>Deep link</span>
+          <input
+            aria-label="Deep link"
+            value={vm.form.deepLink}
+            onChange={(event) => vm.setField('deepLink', event.target.value)}
+          />
+        </label>
+
+        <label className="bo-field">
+          <span>Event ID</span>
+          <input
+            aria-label="Notification event ID"
+            value={vm.form.eventId}
+            onChange={(event) => vm.setField('eventId', event.target.value)}
+          />
+          {vm.fieldErrors.eventId && <strong>{vm.fieldErrors.eventId}</strong>}
+        </label>
+
+        <label className="bo-field bo-field-wide">
+          <span>Data JSON</span>
+          <textarea
+            aria-label="Notification data JSON"
+            value={vm.form.dataText}
+            onChange={(event) => vm.setField('dataText', event.target.value)}
+            placeholder='{"source":"backoffice"}'
+            rows={3}
+          />
+          {vm.fieldErrors.dataText && <strong>{vm.fieldErrors.dataText}</strong>}
+        </label>
+          </div>
+        </details>
+
+        {vm.submitError && <div className="bo-state bo-state-error bo-inline-state">{vm.submitError}</div>}
+
+        {vm.result && (
+          <div className="bo-result" role="status">
+            <span>Targets: {vm.result.target_user_count}</span>
+            <span>Created: {vm.result.created_count}</span>
+            <span>Idempotent: {vm.result.idempotent_count}</span>
+            <span>SSE: {vm.result.sse_delivery_count}</span>
+            <span>Push sent: {vm.result.push_sent_count}</span>
+            <span>Push failed: {vm.result.push_failed_count}</span>
+            <span>Invalid tokens: {vm.result.invalid_token_count}</span>
+          </div>
+        )}
+
+        <div className="bo-form-actions">
+          <button type="submit" disabled={vm.isSubmitting}>
+            {vm.isSubmitting ? 'Sending...' : 'Send notification'}
+          </button>
+        </div>
+      </form>
+
+      <section className="bo-history-section" aria-label="Sent notifications">
+        <div className="bo-section-heading">
+          <h2>Sent notifications</h2>
+          <button type="button" className="bo-secondary-button" onClick={list.retry}>Refresh</button>
+        </div>
+        <BackofficeTableState isLoading={list.isLoading} error={list.error} empty={list.items.length === 0} onRetry={list.retry} />
+        <div className="bo-table-wrap">
+          <table className="bo-table bo-notification-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>User</th>
+                <th>Title</th>
+                <th>Type</th>
+                <th>Read</th>
+                <th>Delivery</th>
+                <th>Event</th>
+                <th>Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.items.map((notification) => (
+                <tr key={notification.id}>
+                  <td><BackofficeIdCell id={notification.id} /></td>
+                  <td>
+                    <div className="bo-cell-stack">
+                      <strong>{notification.username}</strong>
+                      <span>{notification.user_email}</span>
+                    </div>
+                  </td>
+                  <td>
+                    <div className="bo-cell-stack bo-message-cell">
+                      <strong>{notification.title}</strong>
+                      <span>{notification.body}</span>
+                    </div>
+                  </td>
+                  <td>{notification.type ?? '-'}</td>
+                  <td>{notification.is_read ? 'Read' : 'Unread'}</td>
+                  <td>
+                    <div className="bo-cell-stack">
+                      <span>SSE {notification.sse_sent_count}</span>
+                      <span>Push {notification.push_sent_count}/{notification.push_failed_count}</span>
+                    </div>
+                  </td>
+                  <td>{notification.event_title ?? (notification.event_id ? <BackofficeIdCell id={notification.event_id} /> : '-')}</td>
+                  <td>{formatAdminDate(notification.created_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <BackofficePagination {...list} onPrevious={list.previousPage} onNext={list.nextPage} onLimitChange={list.changeLimit} />
+      </section>
     </BackofficePageShell>
   );
 }

--- a/frontend/src/views/backoffice/ParticipationsAdminPage.test.tsx
+++ b/frontend/src/views/backoffice/ParticipationsAdminPage.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ParticipationsAdminPage from './ParticipationsAdminPage';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'admin-token' }),
+}));
+
+vi.mock('@/services/adminService', async () => {
+  const actual = await vi.importActual<typeof import('@/services/adminService')>('@/services/adminService');
+  return {
+    ...actual,
+    listAdminParticipations: vi.fn(),
+    createAdminParticipation: vi.fn(),
+    cancelAdminParticipation: vi.fn(),
+  };
+});
+
+import {
+  cancelAdminParticipation,
+  createAdminParticipation,
+  listAdminParticipations,
+} from '@/services/adminService';
+
+const mockListParticipations = listAdminParticipations as ReturnType<typeof vi.fn>;
+const mockCreateParticipation = createAdminParticipation as ReturnType<typeof vi.fn>;
+const mockCancelParticipation = cancelAdminParticipation as ReturnType<typeof vi.fn>;
+
+const baseRows = [{
+  id: '33333333-3333-4333-8333-333333333333',
+  event_id: '11111111-1111-4111-8111-111111111111',
+  event_title: 'Launch Party',
+  user_id: '22222222-2222-4222-8222-222222222222',
+  username: 'alice',
+  user_email: 'alice@example.com',
+  status: 'APPROVED',
+  reconfirmed_at: null,
+  created_at: '2026-05-01T10:00:00Z',
+  updated_at: '2026-05-01T10:00:00Z',
+}];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListParticipations.mockResolvedValue({
+    items: baseRows,
+    limit: 25,
+    offset: 0,
+    total_count: 1,
+    has_next: false,
+  });
+  vi.spyOn(window, 'confirm').mockReturnValue(true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ParticipationsAdminPage', () => {
+  it('creates an approved manual participation and refreshes the table', async () => {
+    mockCreateParticipation.mockResolvedValue({
+      participation_id: '44444444-4444-4444-8444-444444444444',
+      event_id: '11111111-1111-4111-8111-111111111111',
+      user_id: '22222222-2222-4222-8222-222222222222',
+      status: 'APPROVED',
+    });
+
+    render(<ParticipationsAdminPage />);
+    await screen.findByText('Launch Party');
+
+    fireEvent.change(screen.getByLabelText('Manual event ID'), { target: { value: '11111111-1111-4111-8111-111111111111' } });
+    fireEvent.change(screen.getByLabelText('Manual user ID'), { target: { value: '22222222-2222-4222-8222-222222222222' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create approved participation' }));
+
+    await waitFor(() => expect(mockCreateParticipation).toHaveBeenCalledWith('admin-token', {
+      event_id: '11111111-1111-4111-8111-111111111111',
+      user_id: '22222222-2222-4222-8222-222222222222',
+      status: 'APPROVED',
+      reason: null,
+    }));
+    await waitFor(() => expect(mockListParticipations).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Created participation: 44444444-4444-4444-8444-444444444444')).toBeDefined();
+  });
+
+  it('shows create validation and backend failures without refreshing', async () => {
+    render(<ParticipationsAdminPage />);
+    await screen.findByText('Launch Party');
+
+    fireEvent.change(screen.getByLabelText('Manual event ID'), { target: { value: 'bad' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create approved participation' }));
+
+    expect(await screen.findByText('Event ID must be a valid UUID.')).toBeDefined();
+    expect(mockCreateParticipation).not.toHaveBeenCalled();
+
+    mockCreateParticipation.mockRejectedValue(new Error('duplicate active participation'));
+    fireEvent.change(screen.getByLabelText('Manual event ID'), { target: { value: '11111111-1111-4111-8111-111111111111' } });
+    fireEvent.change(screen.getByLabelText('Manual user ID'), { target: { value: '22222222-2222-4222-8222-222222222222' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create approved participation' }));
+
+    expect(await screen.findByText('Failed to create participation.')).toBeDefined();
+    expect(mockListParticipations).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirms cancellation, sends the cancel action, and refreshes the table', async () => {
+    mockCancelParticipation.mockResolvedValue({
+      participation_id: '33333333-3333-4333-8333-333333333333',
+      event_id: '11111111-1111-4111-8111-111111111111',
+      user_id: '22222222-2222-4222-8222-222222222222',
+      status: 'CANCELED',
+      already_canceled: false,
+    });
+
+    render(<ParticipationsAdminPage />);
+    await screen.findByText('Launch Party');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(window.confirm).toHaveBeenCalledWith('Cancel this participation?');
+    await waitFor(() => expect(mockCancelParticipation).toHaveBeenCalledWith(
+      'admin-token',
+      '33333333-3333-4333-8333-333333333333',
+    ));
+    await waitFor(() => expect(mockListParticipations).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Canceled participation: 33333333-3333-4333-8333-333333333333')).toBeDefined();
+  });
+});

--- a/frontend/src/views/backoffice/ParticipationsAdminPage.tsx
+++ b/frontend/src/views/backoffice/ParticipationsAdminPage.tsx
@@ -3,7 +3,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { AdminParticipationFilters } from '@/models/admin';
 import { listAdminParticipations } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
-import { BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { useAdminParticipationActionsViewModel } from '@/viewmodels/admin/useAdminParticipationActionsViewModel';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminParticipationFilters = {
   q: '',
@@ -18,6 +19,7 @@ export default function ParticipationsAdminPage() {
   const { token } = useAuth();
   const initialFilters = useMemo(() => INITIAL_FILTERS, []);
   const vm = useAdminListViewModel({ token, initialFilters, fetchPage: listAdminParticipations });
+  const actions = useAdminParticipationActionsViewModel(token, vm.retry);
 
   return (
     <BackofficePageShell
@@ -42,11 +44,69 @@ export default function ParticipationsAdminPage() {
         </>
       )}
     >
+      <form
+        className="bo-action-form bo-participation-form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void actions.submitCreate();
+        }}
+      >
+        <label className="bo-field">
+          <span>Event ID</span>
+          <input
+            aria-label="Manual event ID"
+            value={actions.createForm.eventId}
+            onChange={(event) => actions.setCreateField('eventId', event.target.value)}
+          />
+          {actions.createErrors.eventId && <strong>{actions.createErrors.eventId}</strong>}
+        </label>
+        <label className="bo-field">
+          <span>User ID</span>
+          <input
+            aria-label="Manual user ID"
+            value={actions.createForm.userId}
+            onChange={(event) => actions.setCreateField('userId', event.target.value)}
+          />
+          {actions.createErrors.userId && <strong>{actions.createErrors.userId}</strong>}
+        </label>
+        <label className="bo-field bo-field-wide">
+          <span>Reason</span>
+          <input
+            aria-label="Manual participation reason"
+            value={actions.createForm.reason}
+            onChange={(event) => actions.setCreateField('reason', event.target.value)}
+            placeholder="Optional admin note"
+          />
+        </label>
+        {actions.createError && <div className="bo-state bo-state-error bo-inline-state">{actions.createError}</div>}
+        {actions.createResult && (
+          <div className="bo-result" role="status">
+            <span>Created participation: {actions.createResult.participation_id}</span>
+            <span>Status: {actions.createResult.status}</span>
+            {actions.createResult.ticket_status && <span>Ticket: {actions.createResult.ticket_status}</span>}
+          </div>
+        )}
+        <div className="bo-form-actions">
+          <button type="submit" disabled={actions.isCreating}>
+            {actions.isCreating ? 'Creating...' : 'Create approved participation'}
+          </button>
+        </div>
+      </form>
+
+      {actions.cancelError && <div className="bo-state bo-state-error">{actions.cancelError}</div>}
+      {actions.cancelResult && (
+        <div className="bo-result" role="status">
+          <span>Canceled participation: {actions.cancelResult.participation_id}</span>
+          <span>{actions.cancelResult.already_canceled ? 'Already canceled' : 'Status updated'}</span>
+        </div>
+      )}
+
       <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
       <div className="bo-table-wrap">
         <table className="bo-table">
           <thead>
             <tr>
+              <th>ID</th>
               <th>Event</th>
               <th>User</th>
               <th>Email</th>
@@ -54,20 +114,35 @@ export default function ParticipationsAdminPage() {
               <th>Reconfirmed</th>
               <th>Created</th>
               <th>Updated</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
-            {vm.items.map((participation) => (
-              <tr key={participation.id}>
-                <td>{participation.event_title}</td>
-                <td>{participation.username}</td>
-                <td>{participation.user_email}</td>
-                <td>{participation.status}</td>
-                <td>{formatAdminDate(participation.reconfirmed_at)}</td>
-                <td>{formatAdminDate(participation.created_at)}</td>
-                <td>{formatAdminDate(participation.updated_at)}</td>
-              </tr>
-            ))}
+            {vm.items.map((participation) => {
+              const cancelable = participation.status === 'APPROVED' || participation.status === 'PENDING';
+              return (
+                <tr key={participation.id}>
+                  <td><BackofficeIdCell id={participation.id} /></td>
+                  <td>{participation.event_title}</td>
+                  <td>{participation.username}</td>
+                  <td>{participation.user_email}</td>
+                  <td>{participation.status}</td>
+                  <td>{formatAdminDate(participation.reconfirmed_at)}</td>
+                  <td>{formatAdminDate(participation.created_at)}</td>
+                  <td>{formatAdminDate(participation.updated_at)}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="bo-row-action"
+                      disabled={!cancelable || actions.cancelingId === participation.id}
+                      onClick={() => void actions.cancelParticipation(participation.id)}
+                    >
+                      {actions.cancelingId === participation.id ? 'Canceling...' : 'Cancel'}
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/frontend/src/views/backoffice/TicketsAdminPage.tsx
+++ b/frontend/src/views/backoffice/TicketsAdminPage.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { AdminTicketFilters } from '@/models/admin';
 import { listAdminTickets } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
-import { BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminTicketFilters = {
   q: '',
@@ -50,6 +50,7 @@ export default function TicketsAdminPage() {
         <table className="bo-table">
           <thead>
             <tr>
+              <th>ID</th>
               <th>Event</th>
               <th>User</th>
               <th>Email</th>
@@ -63,6 +64,7 @@ export default function TicketsAdminPage() {
           <tbody>
             {vm.items.map((ticket) => (
               <tr key={ticket.id}>
+                <td><BackofficeIdCell id={ticket.id} /></td>
                 <td>{ticket.event_title}</td>
                 <td>{ticket.username}</td>
                 <td>{ticket.user_email}</td>

--- a/frontend/src/views/backoffice/UsersAdminPage.tsx
+++ b/frontend/src/views/backoffice/UsersAdminPage.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { AdminUserFilters } from '@/models/admin';
 import { listAdminUsers } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
-import { BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminUserFilters = {
   q: '',
@@ -50,6 +50,7 @@ export default function UsersAdminPage() {
         <table className="bo-table">
           <thead>
             <tr>
+              <th>ID</th>
               <th>Username</th>
               <th>Email</th>
               <th>Phone</th>
@@ -63,6 +64,7 @@ export default function UsersAdminPage() {
           <tbody>
             {vm.items.map((user) => (
               <tr key={user.id}>
+                <td><BackofficeIdCell id={user.id} /></td>
                 <td>{user.username}</td>
                 <td>{user.email}</td>
                 <td>{user.phone_number ?? '-'}</td>


### PR DESCRIPTION
## 📋 Summary
Completes the web backoffice operational workflow by adding admin notification sending/history and manual participation create/cancel actions. Also improves the backoffice UX with compact notification targeting, copy-only ID controls, and consistent admin filter styling.

## 🔄 Changes
- Added `/backoffice/notifications` notification composer with target user add/remove flow, delivery mode selection, title/body, optional metadata, validation, backend error display, and result counts.
- Added sent notification history to the Notifications page with filters for text, user ID, event ID, type, read state, and created date range.
- Added backend `GET /admin/notifications` endpoint and OpenAPI documentation for admin notification history.
- Extended frontend admin models and service wrappers for notification listing and admin mutation APIs.
- Enhanced `/backoffice/participations` with manual approved participation creation and row-level cancel action with confirmation.
- Refreshes relevant admin tables after notification send, participation create, and participation cancel.
- Added ID columns to all backoffice entity/relation tables with icon-only copy controls and hover tooltip for full UUIDs.
- Updated admin select/filter styling for a more consistent, modern UI.
- Added/updated tests for notification validation/submission/history filtering and participation create/cancel flows.

## 🧪 Testing
- `npm test` in `frontend/` passed.
- `npm run build` in `frontend/` passed.
- `go test ./internal/application/admin ./internal/adapter/out/httpapi/admin_handler` in `backend/` passed.
- `./shipcheck.sh` in `backend/` passed.

## 🔗 Related
Closes #527