### PR TITLE
feat(backend): emit notifications for join request approval/rejection and private event invitations

### DIFF
--- a/backend/internal/adapter/in/postgres/invitation_repo.go
+++ b/backend/internal/adapter/in/postgres/invitation_repo.go
@@ -246,6 +246,61 @@ func (r *InvitationRepository) DeclineInvitation(
 	return r.updateInvitationStatus(ctx, invitationID, domain.InvitationStatusDeclined)
 }
 
+func (r *InvitationRepository) GetInvitationNotificationContext(
+	ctx context.Context,
+	invitationID uuid.UUID,
+) (*invitationapp.InvitationNotificationContext, error) {
+	var (
+		record             invitationapp.InvitationNotificationContext
+		eventImageURL      pgtype.Text
+		hostDisplayName    pgtype.Text
+		invitedDisplayName pgtype.Text
+	)
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			inv.id,
+			inv.event_id,
+			e.title,
+			e.image_url,
+			e.start_time,
+			inv.host_id,
+			host.username,
+			host_profile.display_name,
+			inv.invited_user_id,
+			invited.username,
+			invited_profile.display_name
+		FROM invitation inv
+		JOIN event e ON e.id = inv.event_id
+		JOIN app_user host ON host.id = inv.host_id
+		LEFT JOIN profile host_profile ON host_profile.user_id = host.id
+		JOIN app_user invited ON invited.id = inv.invited_user_id
+		LEFT JOIN profile invited_profile ON invited_profile.user_id = invited.id
+		WHERE inv.id = $1
+	`, invitationID).Scan(
+		&record.InvitationID,
+		&record.EventID,
+		&record.EventTitle,
+		&eventImageURL,
+		&record.EventStartTime,
+		&record.HostUserID,
+		&record.HostUsername,
+		&hostDisplayName,
+		&record.InvitedUserID,
+		&record.InvitedUsername,
+		&invitedDisplayName,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.NotFoundError(domain.ErrorCodeInvitationNotFound, "The requested invitation does not exist.")
+		}
+		return nil, fmt.Errorf("load invitation notification context: %w", err)
+	}
+	record.EventImageURL = textPtr(eventImageURL)
+	record.HostDisplayName = textPtr(hostDisplayName)
+	record.InvitedDisplayName = textPtr(invitedDisplayName)
+	return &record, nil
+}
+
 func uniqueUsernames(usernames []string) ([]string, []string) {
 	seen := make(map[string]struct{}, len(usernames))
 	ordered := make([]string, 0, len(usernames))

--- a/backend/internal/adapter/in/postgres/join_request_repo.go
+++ b/backend/internal/adapter/in/postgres/join_request_repo.go
@@ -170,6 +170,61 @@ func (r *JoinRequestRepository) RejectJoinRequest(
 	}, nil
 }
 
+func (r *JoinRequestRepository) GetNotificationContext(
+	ctx context.Context,
+	joinRequestID uuid.UUID,
+) (*joinrequestapp.NotificationContext, error) {
+	var (
+		record               joinrequestapp.NotificationContext
+		eventImageURL        pgtype.Text
+		hostDisplayName      pgtype.Text
+		requesterDisplayName pgtype.Text
+	)
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			jr.id,
+			jr.event_id,
+			e.title,
+			e.image_url,
+			e.start_time,
+			jr.host_user_id,
+			host.username,
+			host_profile.display_name,
+			jr.user_id,
+			requester.username,
+			requester_profile.display_name
+		FROM join_request jr
+		JOIN event e ON e.id = jr.event_id
+		JOIN app_user host ON host.id = jr.host_user_id
+		LEFT JOIN profile host_profile ON host_profile.user_id = host.id
+		JOIN app_user requester ON requester.id = jr.user_id
+		LEFT JOIN profile requester_profile ON requester_profile.user_id = requester.id
+		WHERE jr.id = $1
+	`, joinRequestID).Scan(
+		&record.JoinRequestID,
+		&record.EventID,
+		&record.EventTitle,
+		&eventImageURL,
+		&record.EventStartTime,
+		&record.HostUserID,
+		&record.HostUsername,
+		&hostDisplayName,
+		&record.RequesterUserID,
+		&record.RequesterUsername,
+		&requesterDisplayName,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.NotFoundError(domain.ErrorCodeJoinRequestNotFound, "The requested join request does not exist.")
+		}
+		return nil, fmt.Errorf("load join request notification context: %w", err)
+	}
+	record.EventImageURL = textPtr(eventImageURL)
+	record.HostDisplayName = textPtr(hostDisplayName)
+	record.RequesterDisplayName = textPtr(requesterDisplayName)
+	return &record, nil
+}
+
 func (r *JoinRequestRepository) handleExistingJoinRequestForCreate(
 	ctx context.Context,
 	existing *domain.JoinRequest,

--- a/backend/internal/application/invitation/repository.go
+++ b/backend/internal/application/invitation/repository.go
@@ -12,4 +12,5 @@ type Repository interface {
 	ListReceivedPendingInvitations(ctx context.Context, userID uuid.UUID) ([]ReceivedInvitationRecord, error)
 	AcceptInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*AcceptInvitationRecord, error)
 	DeclineInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*domain.Invitation, error)
+	GetInvitationNotificationContext(ctx context.Context, invitationID uuid.UUID) (*InvitationNotificationContext, error)
 }

--- a/backend/internal/application/invitation/repository_dto.go
+++ b/backend/internal/application/invitation/repository_dto.go
@@ -40,6 +40,20 @@ type CreateInvitationsRecord struct {
 	Failed                []InvitationFailureRecord
 }
 
+type InvitationNotificationContext struct {
+	InvitationID       uuid.UUID
+	EventID            uuid.UUID
+	EventTitle         string
+	EventImageURL      *string
+	EventStartTime     time.Time
+	HostUserID         uuid.UUID
+	HostUsername       string
+	HostDisplayName    *string
+	InvitedUserID      uuid.UUID
+	InvitedUsername    string
+	InvitedDisplayName *string
+}
+
 type ReceivedInvitationRecord struct {
 	InvitationID uuid.UUID
 	Status       domain.InvitationStatus

--- a/backend/internal/application/invitation/service.go
+++ b/backend/internal/application/invitation/service.go
@@ -2,9 +2,12 @@ package invitation
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
+	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
@@ -14,10 +17,11 @@ import (
 const maxBatchInviteUsernames = 100
 
 type Service struct {
-	repo       Repository
-	unitOfWork uow.UnitOfWork
-	tickets    ticket.LifecycleUseCase
-	now        func() time.Time
+	repo          Repository
+	unitOfWork    uow.UnitOfWork
+	tickets       ticket.LifecycleUseCase
+	notifications notificationapp.UseCase
+	now           func() time.Time
 }
 
 var _ UseCase = (*Service)(nil)
@@ -32,6 +36,10 @@ func NewService(repo Repository, unitOfWork uow.UnitOfWork, ticketLifecycle ...t
 		service.tickets = ticketLifecycle[0]
 	}
 	return service
+}
+
+func (s *Service) SetNotificationService(notifications notificationapp.UseCase) {
+	s.notifications = notifications
 }
 
 func (s *Service) CreateInvitations(
@@ -59,6 +67,8 @@ func (s *Service) CreateInvitations(
 	if err != nil {
 		return nil, err
 	}
+
+	s.notifyCreatedInvitations(ctx, record)
 
 	return toCreateInvitationsResult(record), nil
 }
@@ -96,6 +106,8 @@ func (s *Service) AcceptInvitation(ctx context.Context, userID, invitationID uui
 		return nil, err
 	}
 
+	s.notifyInvitationResponse(ctx, record.Invitation.ID, domain.InvitationStatusAccepted)
+
 	return &AcceptInvitationResult{
 		InvitationID:        record.Invitation.ID.String(),
 		EventID:             record.Invitation.EventID.String(),
@@ -116,6 +128,8 @@ func (s *Service) DeclineInvitation(ctx context.Context, userID, invitationID uu
 	if err != nil {
 		return nil, err
 	}
+
+	s.notifyInvitationResponse(ctx, invitation.ID, domain.InvitationStatusDeclined)
 
 	return &DeclineInvitationResult{
 		InvitationID:   invitation.ID.String(),
@@ -153,4 +167,133 @@ func normalizeOptionalMessage(message *string) *string {
 		return nil
 	}
 	return &trimmed
+}
+
+func (s *Service) notifyCreatedInvitations(ctx context.Context, record *CreateInvitationsRecord) {
+	if s.notifications == nil || record == nil {
+		return
+	}
+	for _, item := range record.SuccessfulInvitations {
+		if item.Invitation == nil {
+			continue
+		}
+		notificationCtx, err := s.repo.GetInvitationNotificationContext(ctx, item.Invitation.ID)
+		if err != nil {
+			slog.ErrorContext(ctx, "invitation notification context load failed",
+				"operation", "invitation.notification.context",
+				"invitation_id", item.Invitation.ID.String(),
+				"error", err,
+			)
+			continue
+		}
+		s.sendInvitationReceivedNotification(ctx, notificationCtx)
+	}
+}
+
+func (s *Service) notifyInvitationResponse(ctx context.Context, invitationID uuid.UUID, status domain.InvitationStatus) {
+	if s.notifications == nil {
+		return
+	}
+	notificationCtx, err := s.repo.GetInvitationNotificationContext(ctx, invitationID)
+	if err != nil {
+		slog.ErrorContext(ctx, "invitation response notification context load failed",
+			"operation", "invitation.response.notification.context",
+			"invitation_id", invitationID.String(),
+			"status", status.String(),
+			"error", err,
+		)
+		return
+	}
+
+	notificationType := "PRIVATE_EVENT_INVITATION_ACCEPTED"
+	title := "Invitation accepted"
+	body := fmt.Sprintf("%s accepted your invitation to %s.", displayLabel(notificationCtx.InvitedDisplayName, notificationCtx.InvitedUsername), notificationCtx.EventTitle)
+	if status == domain.InvitationStatusDeclined {
+		notificationType = "PRIVATE_EVENT_INVITATION_DECLINED"
+		title = "Invitation declined"
+		body = fmt.Sprintf("%s declined your invitation to %s.", displayLabel(notificationCtx.InvitedDisplayName, notificationCtx.InvitedUsername), notificationCtx.EventTitle)
+	}
+
+	deepLink := fmt.Sprintf("/events/%s", notificationCtx.EventID.String())
+	_, err = s.notifications.SendNotificationToUsers(ctx, notificationapp.SendNotificationInput{
+		UserIDs:  []uuid.UUID{notificationCtx.HostUserID},
+		Title:    title,
+		Type:     &notificationType,
+		Body:     body,
+		DeepLink: &deepLink,
+		EventID:  &notificationCtx.EventID,
+		ImageURL: notificationCtx.EventImageURL,
+		Data: invitationNotificationData(notificationCtx, map[string]string{
+			"invitation_id":  notificationCtx.InvitationID.String(),
+			"actor_user_id":  notificationCtx.InvitedUserID.String(),
+			"actor_username": notificationCtx.InvitedUsername,
+			"status":         status.String(),
+		}, notificationCtx.InvitedDisplayName),
+		IdempotencyKey: fmt.Sprintf("INVITATION_%s:%s", status.String(), notificationCtx.InvitationID.String()),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "invitation response notification send failed",
+			"operation", "invitation.response.notification.send",
+			"invitation_id", notificationCtx.InvitationID.String(),
+			"event_id", notificationCtx.EventID.String(),
+			"receiver_user_id", notificationCtx.HostUserID.String(),
+			"status", status.String(),
+			"error", err,
+		)
+	}
+}
+
+func (s *Service) sendInvitationReceivedNotification(ctx context.Context, notificationCtx *InvitationNotificationContext) {
+	if notificationCtx == nil {
+		return
+	}
+	notificationType := "PRIVATE_EVENT_INVITATION_RECEIVED"
+	deepLink := fmt.Sprintf("/events/%s", notificationCtx.EventID.String())
+	_, err := s.notifications.SendNotificationToUsers(ctx, notificationapp.SendNotificationInput{
+		UserIDs:  []uuid.UUID{notificationCtx.InvitedUserID},
+		Title:    "Private event invitation",
+		Type:     &notificationType,
+		Body:     fmt.Sprintf("%s invited you to %s.", displayLabel(notificationCtx.HostDisplayName, notificationCtx.HostUsername), notificationCtx.EventTitle),
+		DeepLink: &deepLink,
+		EventID:  &notificationCtx.EventID,
+		ImageURL: notificationCtx.EventImageURL,
+		Data: invitationNotificationData(notificationCtx, map[string]string{
+			"invitation_id":  notificationCtx.InvitationID.String(),
+			"actor_user_id":  notificationCtx.HostUserID.String(),
+			"actor_username": notificationCtx.HostUsername,
+			"status":         domain.InvitationStatusPending.String(),
+		}, notificationCtx.HostDisplayName),
+		IdempotencyKey: fmt.Sprintf("INVITATION_RECEIVED:%s", notificationCtx.InvitationID.String()),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "invitation received notification send failed",
+			"operation", "invitation.received.notification.send",
+			"invitation_id", notificationCtx.InvitationID.String(),
+			"event_id", notificationCtx.EventID.String(),
+			"receiver_user_id", notificationCtx.InvitedUserID.String(),
+			"error", err,
+		)
+	}
+}
+
+func invitationNotificationData(notificationCtx *InvitationNotificationContext, extra map[string]string, actorDisplayName *string) map[string]string {
+	data := map[string]string{
+		"event_id":         notificationCtx.EventID.String(),
+		"event_title":      notificationCtx.EventTitle,
+		"event_start_time": notificationCtx.EventStartTime.UTC().Format(time.RFC3339),
+	}
+	for key, value := range extra {
+		data[key] = value
+	}
+	if actorDisplayName != nil && strings.TrimSpace(*actorDisplayName) != "" {
+		data["actor_display_name"] = strings.TrimSpace(*actorDisplayName)
+	}
+	return data
+}
+
+func displayLabel(displayName *string, username string) string {
+	if displayName != nil && strings.TrimSpace(*displayName) != "" {
+		return strings.TrimSpace(*displayName)
+	}
+	return username
 }

--- a/backend/internal/application/invitation/service_test.go
+++ b/backend/internal/application/invitation/service_test.go
@@ -2,9 +2,11 @@ package invitation
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
 )
@@ -16,8 +18,11 @@ func (u fakeUnitOfWork) RunInTx(ctx context.Context, fn func(context.Context) er
 }
 
 type fakeRepo struct {
-	lastParams CreateInvitationsParams
-	result     *CreateInvitationsRecord
+	lastParams    CreateInvitationsParams
+	result        *CreateInvitationsRecord
+	acceptResult  *AcceptInvitationRecord
+	declineResult *domain.Invitation
+	contexts      map[uuid.UUID]*InvitationNotificationContext
 }
 
 func (r *fakeRepo) CreateInvitations(_ context.Context, params CreateInvitationsParams) (*CreateInvitationsRecord, error) {
@@ -33,11 +38,18 @@ func (r *fakeRepo) ListReceivedPendingInvitations(context.Context, uuid.UUID) ([
 }
 
 func (r *fakeRepo) AcceptInvitation(context.Context, uuid.UUID, uuid.UUID) (*AcceptInvitationRecord, error) {
-	return nil, nil
+	return r.acceptResult, nil
 }
 
 func (r *fakeRepo) DeclineInvitation(context.Context, uuid.UUID, uuid.UUID) (*domain.Invitation, error) {
-	return nil, nil
+	return r.declineResult, nil
+}
+
+func (r *fakeRepo) GetInvitationNotificationContext(_ context.Context, invitationID uuid.UUID) (*InvitationNotificationContext, error) {
+	if r.contexts == nil {
+		return nil, domain.ErrNotFound
+	}
+	return r.contexts[invitationID], nil
 }
 
 func TestCreateInvitationsValidatesUsernameCount(t *testing.T) {
@@ -54,6 +66,217 @@ func TestCreateInvitationsValidatesUsernameCount(t *testing.T) {
 	if _, err := service.CreateInvitations(context.Background(), uuid.New(), uuid.New(), CreateInvitationsInput{Usernames: usernames}); err == nil {
 		t.Fatal("expected validation error for more than 100 usernames")
 	}
+}
+
+func TestCreateInvitationsNotifiesSuccessfulInvitedUsers(t *testing.T) {
+	// given
+	eventID := uuid.New()
+	hostID := uuid.New()
+	invitedID := uuid.New()
+	invitationID := uuid.New()
+	imageURL := "https://cdn.example.com/event.jpg"
+	startTime := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	repo := &fakeRepo{
+		result: &CreateInvitationsRecord{
+			SuccessfulInvitations: []CreatedInvitationRecord{{
+				Username: "valid_user",
+				Invitation: &domain.Invitation{
+					ID:            invitationID,
+					EventID:       eventID,
+					HostID:        hostID,
+					InvitedUserID: invitedID,
+					Status:        domain.InvitationStatusPending,
+					CreatedAt:     startTime,
+				},
+			}},
+			Failed: []InvitationFailureRecord{{Username: "blocked_user", Code: FailureAlreadyInvited}},
+		},
+		contexts: map[uuid.UUID]*InvitationNotificationContext{
+			invitationID: {
+				InvitationID:    invitationID,
+				EventID:         eventID,
+				EventTitle:      "Trail Run",
+				EventImageURL:   &imageURL,
+				EventStartTime:  startTime,
+				HostUserID:      hostID,
+				HostUsername:    "host",
+				InvitedUserID:   invitedID,
+				InvitedUsername: "valid_user",
+			},
+		},
+	}
+	notifications := &fakeNotificationUseCase{}
+	service := NewService(repo, fakeUnitOfWork{})
+	service.SetNotificationService(notifications)
+
+	// when
+	_, err := service.CreateInvitations(context.Background(), hostID, eventID, CreateInvitationsInput{Usernames: []string{"valid_user", "blocked_user"}})
+
+	// then
+	if err != nil {
+		t.Fatalf("CreateInvitations() error = %v", err)
+	}
+	if len(notifications.inputs) != 1 {
+		t.Fatalf("expected one notification, got %d", len(notifications.inputs))
+	}
+	input := notifications.inputs[0]
+	if input.UserIDs[0] != invitedID || input.EventID == nil || *input.EventID != eventID {
+		t.Fatalf("unexpected notification target/event: %#v", input)
+	}
+	if input.ImageURL == nil || *input.ImageURL != imageURL {
+		t.Fatalf("expected event image URL, got %#v", input.ImageURL)
+	}
+	if input.Type == nil || *input.Type != "PRIVATE_EVENT_INVITATION_RECEIVED" {
+		t.Fatalf("unexpected notification type %#v", input.Type)
+	}
+	if input.Data["invitation_id"] != invitationID.String() || input.Data["actor_user_id"] != hostID.String() {
+		t.Fatalf("unexpected notification data %#v", input.Data)
+	}
+}
+
+func TestAcceptInvitationNotifiesHostWithoutFailingAction(t *testing.T) {
+	// given
+	eventID := uuid.New()
+	hostID := uuid.New()
+	invitedID := uuid.New()
+	invitationID := uuid.New()
+	participationID := uuid.New()
+	imageURL := "https://cdn.example.com/event.jpg"
+	now := time.Now().UTC()
+	repo := &fakeRepo{
+		acceptResult: &AcceptInvitationRecord{
+			Invitation:    &domain.Invitation{ID: invitationID, EventID: eventID, HostID: hostID, InvitedUserID: invitedID, Status: domain.InvitationStatusAccepted, UpdatedAt: now},
+			Participation: &domain.Participation{ID: participationID, EventID: eventID, UserID: invitedID, Status: domain.ParticipationStatusApproved},
+		},
+		contexts: map[uuid.UUID]*InvitationNotificationContext{
+			invitationID: {
+				InvitationID:    invitationID,
+				EventID:         eventID,
+				EventTitle:      "Trail Run",
+				EventImageURL:   &imageURL,
+				EventStartTime:  now,
+				HostUserID:      hostID,
+				HostUsername:    "host",
+				InvitedUserID:   invitedID,
+				InvitedUsername: "guest",
+			},
+		},
+	}
+	notifications := &fakeNotificationUseCase{err: errors.New("send failed")}
+	service := NewService(repo, fakeUnitOfWork{})
+	service.SetNotificationService(notifications)
+
+	// when
+	result, err := service.AcceptInvitation(context.Background(), invitedID, invitationID)
+
+	// then
+	if err != nil {
+		t.Fatalf("AcceptInvitation() error = %v", err)
+	}
+	if result.InvitationID != invitationID.String() {
+		t.Fatalf("unexpected result %#v", result)
+	}
+	if len(notifications.inputs) != 1 {
+		t.Fatalf("expected one notification attempt, got %d", len(notifications.inputs))
+	}
+	input := notifications.inputs[0]
+	if input.UserIDs[0] != hostID || input.Type == nil || *input.Type != "PRIVATE_EVENT_INVITATION_ACCEPTED" {
+		t.Fatalf("unexpected notification input %#v", input)
+	}
+	if input.IdempotencyKey != "INVITATION_ACCEPTED:"+invitationID.String() {
+		t.Fatalf("unexpected idempotency key %q", input.IdempotencyKey)
+	}
+}
+
+func TestDeclineInvitationNotifiesHost(t *testing.T) {
+	// given
+	eventID := uuid.New()
+	hostID := uuid.New()
+	invitedID := uuid.New()
+	invitationID := uuid.New()
+	now := time.Now().UTC()
+	repo := &fakeRepo{
+		declineResult: &domain.Invitation{ID: invitationID, EventID: eventID, HostID: hostID, InvitedUserID: invitedID, Status: domain.InvitationStatusDeclined, UpdatedAt: now},
+		contexts: map[uuid.UUID]*InvitationNotificationContext{
+			invitationID: {
+				InvitationID:    invitationID,
+				EventID:         eventID,
+				EventTitle:      "Trail Run",
+				EventStartTime:  now,
+				HostUserID:      hostID,
+				HostUsername:    "host",
+				InvitedUserID:   invitedID,
+				InvitedUsername: "guest",
+			},
+		},
+	}
+	notifications := &fakeNotificationUseCase{}
+	service := NewService(repo, fakeUnitOfWork{})
+	service.SetNotificationService(notifications)
+
+	// when
+	_, err := service.DeclineInvitation(context.Background(), invitedID, invitationID)
+
+	// then
+	if err != nil {
+		t.Fatalf("DeclineInvitation() error = %v", err)
+	}
+	if len(notifications.inputs) != 1 {
+		t.Fatalf("expected one notification, got %d", len(notifications.inputs))
+	}
+	input := notifications.inputs[0]
+	if input.UserIDs[0] != hostID || input.Type == nil || *input.Type != "PRIVATE_EVENT_INVITATION_DECLINED" {
+		t.Fatalf("unexpected notification input %#v", input)
+	}
+	if input.Data["status"] != domain.InvitationStatusDeclined.String() {
+		t.Fatalf("unexpected notification data %#v", input.Data)
+	}
+}
+
+type fakeNotificationUseCase struct {
+	inputs []notificationapp.SendNotificationInput
+	err    error
+}
+
+func (f *fakeNotificationUseCase) RegisterDevice(context.Context, notificationapp.RegisterDeviceInput) (*notificationapp.RegisterDeviceResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) UnregisterDevice(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (f *fakeNotificationUseCase) ListNotifications(context.Context, notificationapp.ListNotificationsInput) (*notificationapp.ListNotificationsResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) CountUnreadNotifications(context.Context, uuid.UUID) (*notificationapp.UnreadCountResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) MarkNotificationRead(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (f *fakeNotificationUseCase) MarkAllNotificationsRead(context.Context, uuid.UUID) (*notificationapp.MarkAllReadResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) DeleteNotification(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (f *fakeNotificationUseCase) DeleteAllNotifications(context.Context, uuid.UUID) error {
+	return nil
+}
+func (f *fakeNotificationUseCase) DeleteExpiredNotifications(context.Context) (int, error) {
+	return 0, nil
+}
+func (f *fakeNotificationUseCase) SendNotificationToUsers(_ context.Context, input notificationapp.SendNotificationInput) (*notificationapp.SendNotificationResult, error) {
+	f.inputs = append(f.inputs, input)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &notificationapp.SendNotificationResult{TargetUserCount: len(input.UserIDs), CreatedCount: len(input.UserIDs)}, nil
+}
+func (f *fakeNotificationUseCase) SendCustomNotificationToUsers(context.Context, notificationapp.SendCustomNotificationInput) (*notificationapp.SendNotificationResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) SendPushToUsers(context.Context, notificationapp.SendPushInput) (*notificationapp.SendPushResult, error) {
+	return nil, nil
 }
 
 func TestCreateInvitationsReturnsPartialCounts(t *testing.T) {

--- a/backend/internal/application/join_request/repository.go
+++ b/backend/internal/application/join_request/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
 )
 
 // Repository is the application-layer persistence port for join requests.
@@ -11,4 +12,5 @@ type Repository interface {
 	CreateJoinRequest(ctx context.Context, params CreateJoinRequestParams) (*domain.JoinRequest, error)
 	ApproveJoinRequest(ctx context.Context, params ApproveJoinRequestParams) (*ApproveJoinRequestResult, error)
 	RejectJoinRequest(ctx context.Context, params RejectJoinRequestParams) (*RejectJoinRequestResult, error)
+	GetNotificationContext(ctx context.Context, joinRequestID uuid.UUID) (*NotificationContext, error)
 }

--- a/backend/internal/application/join_request/repository_dto.go
+++ b/backend/internal/application/join_request/repository_dto.go
@@ -1,6 +1,10 @@
 package join_request
 
-import "github.com/google/uuid"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // CreateJoinRequestParams carries the data needed to persist a join request.
 type CreateJoinRequestParams struct {
@@ -27,4 +31,18 @@ type RejectJoinRequestParams struct {
 	EventID       uuid.UUID
 	JoinRequestID uuid.UUID
 	HostUserID    uuid.UUID
+}
+
+type NotificationContext struct {
+	JoinRequestID        uuid.UUID
+	EventID              uuid.UUID
+	EventTitle           string
+	EventImageURL        *string
+	EventStartTime       time.Time
+	HostUserID           uuid.UUID
+	HostUsername         string
+	HostDisplayName      *string
+	RequesterUserID      uuid.UUID
+	RequesterUsername    string
+	RequesterDisplayName *string
 }

--- a/backend/internal/application/join_request/service.go
+++ b/backend/internal/application/join_request/service.go
@@ -3,8 +3,12 @@ package join_request
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"strings"
+	"time"
 
+	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
@@ -18,9 +22,10 @@ var tracer = otel.Tracer("github.com/bounswe/bounswe2026group11/backend/internal
 
 // Service owns join-request-specific application behavior.
 type Service struct {
-	repo       Repository
-	unitOfWork uow.UnitOfWork
-	tickets    ticket.LifecycleUseCase
+	repo          Repository
+	unitOfWork    uow.UnitOfWork
+	tickets       ticket.LifecycleUseCase
+	notifications notificationapp.UseCase
 }
 
 var _ UseCase = (*Service)(nil)
@@ -35,6 +40,10 @@ func NewService(repo Repository, unitOfWork uow.UnitOfWork, ticketLifecycle ...t
 		service.tickets = ticketLifecycle[0]
 	}
 	return service
+}
+
+func (s *Service) SetNotificationService(notifications notificationapp.UseCase) {
+	s.notifications = notifications
 }
 
 // CreatePendingJoinRequest persists a PENDING join request for the given event,
@@ -143,6 +152,7 @@ func (s *Service) ApproveJoinRequest(
 			attribute.String("participant_user_id", result.Participation.UserID.String()),
 		)
 	}
+	s.notifyModeratedJoinRequest(ctx, joinRequestID, domain.JoinRequestStatusApproved, nil)
 
 	return result, nil
 }
@@ -167,5 +177,84 @@ func (s *Service) RejectJoinRequest(
 		return nil, err
 	}
 
+	s.notifyModeratedJoinRequest(ctx, joinRequestID, domain.JoinRequestStatusRejected, &result.CooldownEndsAt)
+
 	return result, nil
+}
+
+func (s *Service) notifyModeratedJoinRequest(ctx context.Context, joinRequestID uuid.UUID, status domain.JoinRequestStatus, cooldownEndsAt *time.Time) {
+	if s.notifications == nil {
+		return
+	}
+	notificationCtx, err := s.repo.GetNotificationContext(ctx, joinRequestID)
+	if err != nil {
+		slog.ErrorContext(ctx, "join request notification context load failed",
+			"operation", "join_request.notification.context",
+			"join_request_id", joinRequestID.String(),
+			"status", string(status),
+			"error", err,
+		)
+		return
+	}
+
+	notificationType := "PROTECTED_EVENT_JOIN_REQUEST_APPROVED"
+	title := "Join request approved"
+	body := fmt.Sprintf("%s approved your request to join %s.", displayLabel(notificationCtx.HostDisplayName, notificationCtx.HostUsername), notificationCtx.EventTitle)
+	idempotencyKey := fmt.Sprintf("JOIN_REQUEST_APPROVED:%s", notificationCtx.JoinRequestID.String())
+	if status == domain.JoinRequestStatusRejected {
+		notificationType = "PROTECTED_EVENT_JOIN_REQUEST_REJECTED"
+		title = "Join request rejected"
+		body = fmt.Sprintf("%s rejected your request to join %s.", displayLabel(notificationCtx.HostDisplayName, notificationCtx.HostUsername), notificationCtx.EventTitle)
+		idempotencyKey = fmt.Sprintf("JOIN_REQUEST_REJECTED:%s", notificationCtx.JoinRequestID.String())
+	}
+
+	deepLink := fmt.Sprintf("/events/%s", notificationCtx.EventID.String())
+	data := joinRequestNotificationData(notificationCtx, status)
+	if cooldownEndsAt != nil {
+		data["cooldown_ends_at"] = cooldownEndsAt.UTC().Format(time.RFC3339)
+	}
+	_, err = s.notifications.SendNotificationToUsers(ctx, notificationapp.SendNotificationInput{
+		UserIDs:        []uuid.UUID{notificationCtx.RequesterUserID},
+		Title:          title,
+		Type:           &notificationType,
+		Body:           body,
+		DeepLink:       &deepLink,
+		EventID:        &notificationCtx.EventID,
+		ImageURL:       notificationCtx.EventImageURL,
+		Data:           data,
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "join request notification send failed",
+			"operation", "join_request.notification.send",
+			"join_request_id", notificationCtx.JoinRequestID.String(),
+			"event_id", notificationCtx.EventID.String(),
+			"receiver_user_id", notificationCtx.RequesterUserID.String(),
+			"status", string(status),
+			"error", err,
+		)
+	}
+}
+
+func joinRequestNotificationData(notificationCtx *NotificationContext, status domain.JoinRequestStatus) map[string]string {
+	data := map[string]string{
+		"event_id":         notificationCtx.EventID.String(),
+		"event_title":      notificationCtx.EventTitle,
+		"event_start_time": notificationCtx.EventStartTime.UTC().Format(time.RFC3339),
+		"join_request_id":  notificationCtx.JoinRequestID.String(),
+		"actor_user_id":    notificationCtx.HostUserID.String(),
+		"actor_username":   notificationCtx.HostUsername,
+		"status":           string(status),
+	}
+	if notificationCtx.HostDisplayName != nil && strings.TrimSpace(*notificationCtx.HostDisplayName) != "" {
+		data["actor_display_name"] = strings.TrimSpace(*notificationCtx.HostDisplayName)
+	}
+	return data
+}
+
+func displayLabel(displayName *string, username string) string {
+	if displayName != nil && strings.TrimSpace(*displayName) != "" {
+		return strings.TrimSpace(*displayName)
+	}
+	return username
 }

--- a/backend/internal/application/join_request/service_test.go
+++ b/backend/internal/application/join_request/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
 )
@@ -56,6 +57,7 @@ type fakeJoinRequestRepo struct {
 	result            *domain.JoinRequest
 	approveResult     *ApproveJoinRequestResult
 	rejectResult      *RejectJoinRequestResult
+	notificationCtx   *NotificationContext
 }
 
 func (r *fakeJoinRequestRepo) CreateJoinRequest(_ context.Context, params CreateJoinRequestParams) (*domain.JoinRequest, error) {
@@ -140,6 +142,13 @@ func (r *fakeJoinRequestRepo) RejectJoinRequest(_ context.Context, params Reject
 		},
 		CooldownEndsAt: now.Add(domain.JoinRequestCooldown),
 	}, nil
+}
+
+func (r *fakeJoinRequestRepo) GetNotificationContext(context.Context, uuid.UUID) (*NotificationContext, error) {
+	if r.notificationCtx == nil {
+		return nil, domain.ErrNotFound
+	}
+	return r.notificationCtx, nil
 }
 
 func TestCreatePendingJoinRequestDelegatesToRepo(t *testing.T) {
@@ -266,4 +275,163 @@ func TestRejectJoinRequestDelegatesToRepo(t *testing.T) {
 	if repo.lastRejectParams.EventID != eventID || repo.lastRejectParams.JoinRequestID != joinRequestID || repo.lastRejectParams.HostUserID != hostUserID {
 		t.Fatalf("expected reject params to match event %s, join request %s, host %s", eventID, joinRequestID, hostUserID)
 	}
+}
+
+func TestApproveJoinRequestNotifiesRequester(t *testing.T) {
+	// given
+	eventID := uuid.New()
+	joinRequestID := uuid.New()
+	hostUserID := uuid.New()
+	requesterID := uuid.New()
+	participationID := uuid.New()
+	imageURL := "https://cdn.example.com/event.jpg"
+	now := time.Now().UTC()
+	repo := &fakeJoinRequestRepo{
+		approveResult: &ApproveJoinRequestResult{
+			JoinRequest: &domain.JoinRequest{
+				ID:              joinRequestID,
+				EventID:         eventID,
+				UserID:          requesterID,
+				ParticipationID: &participationID,
+				HostUserID:      hostUserID,
+				Status:          domain.JoinRequestStatusApproved,
+				UpdatedAt:       now,
+			},
+			Participation: &domain.Participation{ID: participationID, EventID: eventID, UserID: requesterID, Status: domain.ParticipationStatusApproved},
+		},
+		notificationCtx: &NotificationContext{
+			JoinRequestID:     joinRequestID,
+			EventID:           eventID,
+			EventTitle:        "Trail Run",
+			EventImageURL:     &imageURL,
+			EventStartTime:    now,
+			HostUserID:        hostUserID,
+			HostUsername:      "host",
+			RequesterUserID:   requesterID,
+			RequesterUsername: "guest",
+		},
+	}
+	notifications := &fakeNotificationUseCase{}
+	service := NewService(repo, &fakeUnitOfWork{})
+	service.SetNotificationService(notifications)
+
+	// when
+	_, err := service.ApproveJoinRequest(context.Background(), eventID, joinRequestID, hostUserID)
+
+	// then
+	if err != nil {
+		t.Fatalf("ApproveJoinRequest() error = %v", err)
+	}
+	if len(notifications.inputs) != 1 {
+		t.Fatalf("expected one notification, got %d", len(notifications.inputs))
+	}
+	input := notifications.inputs[0]
+	if input.UserIDs[0] != requesterID || input.EventID == nil || *input.EventID != eventID {
+		t.Fatalf("unexpected notification target/event %#v", input)
+	}
+	if input.ImageURL == nil || *input.ImageURL != imageURL {
+		t.Fatalf("expected event image URL, got %#v", input.ImageURL)
+	}
+	if input.Type == nil || *input.Type != "PROTECTED_EVENT_JOIN_REQUEST_APPROVED" {
+		t.Fatalf("unexpected notification type %#v", input.Type)
+	}
+	if input.IdempotencyKey != "JOIN_REQUEST_APPROVED:"+joinRequestID.String() {
+		t.Fatalf("unexpected idempotency key %q", input.IdempotencyKey)
+	}
+}
+
+func TestRejectJoinRequestNotifiesRequesterWithoutFailingAction(t *testing.T) {
+	// given
+	eventID := uuid.New()
+	joinRequestID := uuid.New()
+	hostUserID := uuid.New()
+	requesterID := uuid.New()
+	now := time.Now().UTC()
+	cooldownEndsAt := now.Add(domain.JoinRequestCooldown)
+	repo := &fakeJoinRequestRepo{
+		rejectResult: &RejectJoinRequestResult{
+			JoinRequest:    &domain.JoinRequest{ID: joinRequestID, EventID: eventID, UserID: requesterID, HostUserID: hostUserID, Status: domain.JoinRequestStatusRejected, UpdatedAt: now},
+			CooldownEndsAt: cooldownEndsAt,
+		},
+		notificationCtx: &NotificationContext{
+			JoinRequestID:     joinRequestID,
+			EventID:           eventID,
+			EventTitle:        "Trail Run",
+			EventStartTime:    now,
+			HostUserID:        hostUserID,
+			HostUsername:      "host",
+			RequesterUserID:   requesterID,
+			RequesterUsername: "guest",
+		},
+	}
+	notifications := &fakeNotificationUseCase{err: errors.New("send failed")}
+	service := NewService(repo, &fakeUnitOfWork{})
+	service.SetNotificationService(notifications)
+
+	// when
+	result, err := service.RejectJoinRequest(context.Background(), eventID, joinRequestID, hostUserID)
+
+	// then
+	if err != nil {
+		t.Fatalf("RejectJoinRequest() error = %v", err)
+	}
+	if !result.CooldownEndsAt.Equal(cooldownEndsAt) {
+		t.Fatalf("unexpected cooldown %s", result.CooldownEndsAt)
+	}
+	if len(notifications.inputs) != 1 {
+		t.Fatalf("expected one notification attempt, got %d", len(notifications.inputs))
+	}
+	input := notifications.inputs[0]
+	if input.Type == nil || *input.Type != "PROTECTED_EVENT_JOIN_REQUEST_REJECTED" {
+		t.Fatalf("unexpected notification type %#v", input.Type)
+	}
+	if input.Data["status"] != string(domain.JoinRequestStatusRejected) || input.Data["cooldown_ends_at"] == "" {
+		t.Fatalf("unexpected notification data %#v", input.Data)
+	}
+}
+
+type fakeNotificationUseCase struct {
+	inputs []notificationapp.SendNotificationInput
+	err    error
+}
+
+func (f *fakeNotificationUseCase) RegisterDevice(context.Context, notificationapp.RegisterDeviceInput) (*notificationapp.RegisterDeviceResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) UnregisterDevice(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (f *fakeNotificationUseCase) ListNotifications(context.Context, notificationapp.ListNotificationsInput) (*notificationapp.ListNotificationsResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) CountUnreadNotifications(context.Context, uuid.UUID) (*notificationapp.UnreadCountResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) MarkNotificationRead(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (f *fakeNotificationUseCase) MarkAllNotificationsRead(context.Context, uuid.UUID) (*notificationapp.MarkAllReadResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) DeleteNotification(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (f *fakeNotificationUseCase) DeleteAllNotifications(context.Context, uuid.UUID) error {
+	return nil
+}
+func (f *fakeNotificationUseCase) DeleteExpiredNotifications(context.Context) (int, error) {
+	return 0, nil
+}
+func (f *fakeNotificationUseCase) SendNotificationToUsers(_ context.Context, input notificationapp.SendNotificationInput) (*notificationapp.SendNotificationResult, error) {
+	f.inputs = append(f.inputs, input)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &notificationapp.SendNotificationResult{TargetUserCount: len(input.UserIDs), CreatedCount: len(input.UserIDs)}, nil
+}
+func (f *fakeNotificationUseCase) SendCustomNotificationToUsers(context.Context, notificationapp.SendCustomNotificationInput) (*notificationapp.SendNotificationResult, error) {
+	return nil, nil
+}
+func (f *fakeNotificationUseCase) SendPushToUsers(context.Context, notificationapp.SendPushInput) (*notificationapp.SendPushResult, error) {
+	return nil, nil
 }

--- a/backend/internal/application/notification/service.go
+++ b/backend/internal/application/notification/service.go
@@ -381,6 +381,35 @@ func (s *Service) sendPushForNotification(ctx context.Context, notification doma
 	now := s.now().UTC()
 
 	for _, device := range devices {
+		sendResult, sendErr := s.sendPushWithRetries(ctx, notification, device, now)
+		if sendResult != nil && sendResult.InvalidToken {
+			result.InvalidTokenCount++
+			if err := s.repo.RevokeDeviceByID(ctx, device.ID, now); err != nil {
+				return nil, fmt.Errorf("revoke invalid push device: %w", err)
+			}
+		}
+		if sendErr != nil {
+			result.FailedCount++
+			continue
+		}
+		result.SentCount++
+	}
+
+	return result, nil
+}
+
+func (s *Service) sendPushWithRetries(
+	ctx context.Context,
+	notification domain.Notification,
+	device domain.PushDevice,
+	now time.Time,
+) (*PushSendResult, error) {
+	var (
+		lastResult *PushSendResult
+		lastErr    error
+	)
+
+	for attempt := 0; attempt <= MaxPushDeliveryRetries; attempt++ {
 		sendResult, sendErr := s.sender.Send(ctx, PushSendMessage{
 			Token:    device.FCMToken,
 			Title:    notification.Title,
@@ -398,20 +427,12 @@ func (s *Service) sendPushForNotification(ctx context.Context, notification doma
 				"operation", "notification.push.device_send",
 				"user_id", device.UserID.String(),
 				"device_id", device.ID.String(),
+				"attempt", attempt+1,
 				"error", sendErr,
 			)
 			status = domain.NotificationDeliveryStatusFailed
 			sentAt = nil
 			errorSummary = shortErrorSummary(sendErr)
-			result.FailedCount++
-		} else {
-			result.SentCount++
-		}
-		if sendResult != nil && sendResult.InvalidToken {
-			result.InvalidTokenCount++
-			if err := s.repo.RevokeDeviceByID(ctx, device.ID, now); err != nil {
-				return nil, fmt.Errorf("revoke invalid push device: %w", err)
-			}
 		}
 
 		if err := s.repo.CreateDeliveryAttempt(ctx, CreateDeliveryAttemptParams{
@@ -425,9 +446,15 @@ func (s *Service) sendPushForNotification(ctx context.Context, notification doma
 		}); err != nil {
 			return nil, fmt.Errorf("store push delivery attempt: %w", err)
 		}
+
+		lastResult = sendResult
+		lastErr = sendErr
+		if sendErr == nil || (sendResult != nil && sendResult.InvalidToken) {
+			return sendResult, sendErr
+		}
 	}
 
-	return result, nil
+	return lastResult, lastErr
 }
 
 func uniqueUserIDs(userIDs []uuid.UUID) map[uuid.UUID]struct{} {

--- a/backend/internal/application/notification/service_dto.go
+++ b/backend/internal/application/notification/service_dto.go
@@ -11,6 +11,7 @@ const MaxActiveDevicesPerUser = 2
 const DefaultNotificationLimit = 25
 const MaxNotificationLimit = 50
 const NotificationRetentionDays = 90
+const MaxPushDeliveryRetries = 2
 
 type RegisterDeviceInput struct {
 	UserID         uuid.UUID

--- a/backend/internal/application/notification/service_test.go
+++ b/backend/internal/application/notification/service_test.go
@@ -188,6 +188,73 @@ func TestSendNotificationToUsersIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestSendNotificationRetriesPushUntilSuccess(t *testing.T) {
+	// given
+	repo := newFakeNotificationRepo()
+	sender := &flakyPushSender{failuresBeforeSuccess: 2}
+	svc := NewService(repo, sender, fakeUnitOfWork{})
+	svc.now = func() time.Time { return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC) }
+	userID := uuid.New()
+	repo.addDevice(userID, uuid.New(), "push-token", svc.now())
+
+	// when
+	result, err := svc.SendNotificationToUsers(context.Background(), SendNotificationInput{
+		UserIDs:        []uuid.UUID{userID},
+		Title:          "Event update",
+		Body:           "A new update is available.",
+		IdempotencyKey: "event:update:retry-success",
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("SendNotificationToUsers() error = %v", err)
+	}
+	if result.PushSentCount != 1 || result.PushFailedCount != 0 {
+		t.Fatalf("expected final push success, got %#v", result)
+	}
+	if sender.sentCount != 3 {
+		t.Fatalf("expected three send attempts, got %d", sender.sentCount)
+	}
+	if len(repo.deliveryAttempts) != 3 {
+		t.Fatalf("expected three delivery attempt rows, got %d", len(repo.deliveryAttempts))
+	}
+	if repo.deliveryAttempts[2].Status != domain.NotificationDeliveryStatusSent {
+		t.Fatalf("expected final delivery attempt SENT, got %q", repo.deliveryAttempts[2].Status)
+	}
+}
+
+func TestSendNotificationStopsAfterTwoPushRetries(t *testing.T) {
+	// given
+	repo := newFakeNotificationRepo()
+	sender := &flakyPushSender{failuresBeforeSuccess: 99}
+	svc := NewService(repo, sender, fakeUnitOfWork{})
+	svc.now = func() time.Time { return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC) }
+	userID := uuid.New()
+	repo.addDevice(userID, uuid.New(), "push-token", svc.now())
+
+	// when
+	result, err := svc.SendNotificationToUsers(context.Background(), SendNotificationInput{
+		UserIDs:        []uuid.UUID{userID},
+		Title:          "Event update",
+		Body:           "A new update is available.",
+		IdempotencyKey: "event:update:retry-fail",
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("SendNotificationToUsers() error = %v", err)
+	}
+	if result.PushSentCount != 0 || result.PushFailedCount != 1 {
+		t.Fatalf("expected one final push failure, got %#v", result)
+	}
+	if sender.sentCount != 3 {
+		t.Fatalf("expected three send attempts, got %d", sender.sentCount)
+	}
+	if len(repo.deliveryAttempts) != 3 {
+		t.Fatalf("expected three delivery attempt rows, got %d", len(repo.deliveryAttempts))
+	}
+}
+
 func TestSendCustomNotificationBothUsesSSEAndPush(t *testing.T) {
 	// given
 	repo := newFakeNotificationRepo()
@@ -540,6 +607,19 @@ type recordingPushSender struct {
 
 func (s *recordingPushSender) Send(_ context.Context, _ PushSendMessage) (*PushSendResult, error) {
 	s.sentCount++
+	return &PushSendResult{}, nil
+}
+
+type flakyPushSender struct {
+	sentCount             int
+	failuresBeforeSuccess int
+}
+
+func (s *flakyPushSender) Send(context.Context, PushSendMessage) (*PushSendResult, error) {
+	s.sentCount++
+	if s.sentCount <= s.failuresBeforeSuccess {
+		return &PushSendResult{}, errors.New("temporary push failure")
+	}
 	return &PushSendResult{}, nil
 }
 

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -115,17 +115,17 @@ func New(ctx context.Context) (*Container, error) {
 	container.categoryRepo = postgres.NewCategoryRepository(container.DB)
 	container.profileRepo = postgres.NewProfileRepository(container.DB)
 	container.favoriteLocationRepo = postgres.NewFavoriteLocationRepository(container.DB)
-	container.ParticipationService = newParticipationService(container)
-	container.TicketService = newTicketService(container)
-	container.InvitationService = newInvitationService(container)
-	container.JoinRequestService = newJoinRequestService(container)
-	container.RatingService = newRatingService(container)
 	notificationService, err := newNotificationService(ctx, container)
 	if err != nil {
 		db.Close()
 		return nil, err
 	}
 	container.NotificationService = notificationService
+	container.ParticipationService = newParticipationService(container)
+	container.TicketService = newTicketService(container)
+	container.InvitationService = newInvitationService(container)
+	container.JoinRequestService = newJoinRequestService(container)
+	container.RatingService = newRatingService(container)
 	container.AuthService = newAuthService(container)
 	container.AdminService = newAdminService(container)
 	container.EventService = newEventService(container)
@@ -263,13 +263,17 @@ func newParticipationService(c *Container) participation.UseCase {
 }
 
 func newInvitationService(c *Container) invitation.UseCase {
-	return invitation.NewService(c.invitationRepo, c.UnitOfWork, c.TicketService)
+	service := invitation.NewService(c.invitationRepo, c.UnitOfWork, c.TicketService)
+	service.SetNotificationService(c.NotificationService)
+	return service
 }
 
 // newJoinRequestService wires the join request use-case service with its
 // driven adapter.
 func newJoinRequestService(c *Container) join_request.UseCase {
-	return join_request.NewService(c.joinRequestRepo, c.UnitOfWork, c.TicketService)
+	service := join_request.NewService(c.joinRequestRepo, c.UnitOfWork, c.TicketService)
+	service.SetNotificationService(c.NotificationService)
+	return service
 }
 
 // newTicketService wires the ticket use-case service with its driven adapters.

--- a/backend/tests_integration/common/harness.go
+++ b/backend/tests_integration/common/harness.go
@@ -85,13 +85,14 @@ func NewAuthHarness(t *testing.T) *AuthHarness {
 
 // EventHarness bundles the shared wiring used by event integration tests.
 type EventHarness struct {
-	Service           eventapp.UseCase
-	InvitationService invitationapp.UseCase
-	EventRepo         *postgresrepo.EventRepository
-	TicketService     ticketapp.UseCase
-	RatingService     ratingapp.UseCase
-	ProfileService    profileapp.UseCase
-	AuthRepo          authapp.Repository
+	Service             eventapp.UseCase
+	InvitationService   invitationapp.UseCase
+	NotificationService notificationapp.UseCase
+	EventRepo           *postgresrepo.EventRepository
+	TicketService       ticketapp.UseCase
+	RatingService       ratingapp.UseCase
+	ProfileService      profileapp.UseCase
+	AuthRepo            authapp.Repository
 }
 
 // FavoriteLocationHarness bundles the shared wiring used by favorite-location integration tests.
@@ -121,8 +122,10 @@ func NewEventHarness(t *testing.T) *EventHarness {
 	ticketRepo := postgresrepo.NewTicketRepository(pool)
 	ratingRepo := postgresrepo.NewRatingRepository(pool)
 	profileRepo := postgresrepo.NewProfileRepository(pool)
+	notificationRepo := postgresrepo.NewNotificationRepository(pool)
 	unitOfWork := postgresrepo.NewUnitOfWork(pool)
 	participationService := participationapp.NewService(participationRepo)
+	notificationService := notificationapp.NewService(notificationRepo, pushadapter.MockSender{}, unitOfWork)
 	ticketService := ticketapp.NewService(
 		ticketRepo,
 		unitOfWork,
@@ -133,13 +136,16 @@ func NewEventHarness(t *testing.T) *EventHarness {
 		},
 	)
 	joinRequestService := joinrequestapp.NewService(joinRequestRepo, unitOfWork, ticketService)
+	joinRequestService.SetNotificationService(notificationService)
 	invitationService := invitationapp.NewService(invitationRepo, unitOfWork, ticketService)
+	invitationService.SetNotificationService(notificationService)
 
 	return &EventHarness{
-		Service:           eventapp.NewService(eventRepo, participationService, joinRequestService, unitOfWork, ticketService),
-		InvitationService: invitationService,
-		EventRepo:         eventRepo,
-		TicketService:     ticketService,
+		Service:             eventapp.NewService(eventRepo, participationService, joinRequestService, unitOfWork, ticketService),
+		InvitationService:   invitationService,
+		NotificationService: notificationService,
+		EventRepo:           eventRepo,
+		TicketService:       ticketService,
 		RatingService: ratingapp.NewService(ratingRepo, unitOfWork, ratingapp.Settings{
 			GlobalPrior: 4.0,
 			BayesianM:   5,

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -10,6 +10,7 @@ import (
 
 	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
 	invitationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/invitation"
+	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
 	"github.com/google/uuid"
@@ -1468,6 +1469,78 @@ func TestCreateInvitationsCreatesValidAndReportsInvalidAndFailed(t *testing.T) {
 	}
 }
 
+func TestInvitationFlowCreatesEventNotifications(t *testing.T) {
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("notif_host_"+uuid.NewString()[:8]))
+	invited := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("notif_guest_"+uuid.NewString()[:8]))
+	categoryID := common.GivenEventCategory(t)
+	imageURL := "https://cdn.example.com/integration-event.jpg"
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Notification Private Event",
+		Description:  "private notification event",
+		CategoryID:   categoryID,
+		Lat:          41,
+		Lon:          29,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPrivate,
+	})
+	setEventImageURL(t, eventID, imageURL)
+
+	// when
+	invitations, err := harness.InvitationService.CreateInvitations(context.Background(), host.ID, eventID, invitationapp.CreateInvitationsInput{
+		Usernames: []string{invited.Username},
+	})
+	if err != nil {
+		t.Fatalf("CreateInvitations() error = %v", err)
+	}
+	invitationID := uuid.MustParse(invitations.SuccessfulInvitations[0].InvitationID)
+	if _, err := harness.InvitationService.AcceptInvitation(context.Background(), invited.ID, invitationID); err != nil {
+		t.Fatalf("AcceptInvitation() error = %v", err)
+	}
+
+	// then
+	invitedNotifications, err := harness.NotificationService.ListNotifications(context.Background(), notificationapp.ListNotificationsInput{UserID: invited.ID})
+	if err != nil {
+		t.Fatalf("ListNotifications(invited) error = %v", err)
+	}
+	if len(invitedNotifications.Items) != 1 {
+		t.Fatalf("expected one invited-user notification, got %d", len(invitedNotifications.Items))
+	}
+	received := invitedNotifications.Items[0]
+	if received.Type == nil || *received.Type != "PRIVATE_EVENT_INVITATION_RECEIVED" {
+		t.Fatalf("unexpected invitation notification type %#v", received.Type)
+	}
+	if received.EventID == nil || *received.EventID != eventID || received.ImageURL == nil || *received.ImageURL != imageURL {
+		t.Fatalf("unexpected invitation notification event/image: %#v", received)
+	}
+	if received.Data["invitation_id"] != invitationID.String() || received.Data["actor_user_id"] != host.ID.String() {
+		t.Fatalf("unexpected invitation notification data %#v", received.Data)
+	}
+	if received.IdempotencyKey != "INVITATION_RECEIVED:"+invitationID.String() {
+		t.Fatalf("unexpected invitation idempotency key %q", received.IdempotencyKey)
+	}
+
+	hostNotifications, err := harness.NotificationService.ListNotifications(context.Background(), notificationapp.ListNotificationsInput{UserID: host.ID})
+	if err != nil {
+		t.Fatalf("ListNotifications(host) error = %v", err)
+	}
+	if len(hostNotifications.Items) != 1 {
+		t.Fatalf("expected one host notification, got %d", len(hostNotifications.Items))
+	}
+	accepted := hostNotifications.Items[0]
+	if accepted.Type == nil || *accepted.Type != "PRIVATE_EVENT_INVITATION_ACCEPTED" {
+		t.Fatalf("unexpected accepted notification type %#v", accepted.Type)
+	}
+	if accepted.ImageURL == nil || *accepted.ImageURL != imageURL {
+		t.Fatalf("expected accepted notification image URL %q, got %#v", imageURL, accepted.ImageURL)
+	}
+	if accepted.Data["status"] != domain.InvitationStatusAccepted.String() || accepted.Data["actor_user_id"] != invited.ID.String() {
+		t.Fatalf("unexpected accepted notification data %#v", accepted.Data)
+	}
+}
+
 func TestAcceptInvitationCreatesParticipationAndAllowsPrivateDetail(t *testing.T) {
 	t.Parallel()
 
@@ -2242,6 +2315,48 @@ func TestApproveJoinRequestSuccessPath(t *testing.T) {
 	}
 }
 
+func TestApproveJoinRequestCreatesRequesterNotification(t *testing.T) {
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("join_host_"+uuid.NewString()[:8]))
+	requester := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("join_guest_"+uuid.NewString()[:8]))
+	event := common.GivenProtectedEvent(t, harness.Service, host.ID)
+	imageURL := "https://cdn.example.com/protected-event.jpg"
+	setEventImageURL(t, event.ID, imageURL)
+	createdRequest, err := harness.Service.RequestJoin(context.Background(), requester.ID, event.ID, eventapp.RequestJoinInput{})
+	if err != nil {
+		t.Fatalf("RequestJoin() error = %v", err)
+	}
+	joinRequestID := uuid.MustParse(createdRequest.JoinRequestID)
+
+	// when
+	if _, err := harness.Service.ApproveJoinRequest(context.Background(), host.ID, event.ID, joinRequestID); err != nil {
+		t.Fatalf("ApproveJoinRequest() error = %v", err)
+	}
+
+	// then
+	notifications, err := harness.NotificationService.ListNotifications(context.Background(), notificationapp.ListNotificationsInput{UserID: requester.ID})
+	if err != nil {
+		t.Fatalf("ListNotifications() error = %v", err)
+	}
+	if len(notifications.Items) != 1 {
+		t.Fatalf("expected one requester notification, got %d", len(notifications.Items))
+	}
+	item := notifications.Items[0]
+	if item.Type == nil || *item.Type != "PROTECTED_EVENT_JOIN_REQUEST_APPROVED" {
+		t.Fatalf("unexpected join request notification type %#v", item.Type)
+	}
+	if item.EventID == nil || *item.EventID != event.ID || item.ImageURL == nil || *item.ImageURL != imageURL {
+		t.Fatalf("unexpected join request notification event/image: %#v", item)
+	}
+	if item.Data["join_request_id"] != joinRequestID.String() || item.Data["actor_user_id"] != host.ID.String() || item.Data["status"] != string(domain.JoinRequestStatusApproved) {
+		t.Fatalf("unexpected join request notification data %#v", item.Data)
+	}
+	if item.IdempotencyKey != "JOIN_REQUEST_APPROVED:"+joinRequestID.String() {
+		t.Fatalf("unexpected join request idempotency key %q", item.IdempotencyKey)
+	}
+}
+
 func TestRejectJoinRequestSuccessPath(t *testing.T) {
 	t.Parallel()
 
@@ -2823,6 +2938,19 @@ func setJoinRequestUpdatedAt(t *testing.T, joinRequestID uuid.UUID, updatedAt ti
 		updatedAt,
 	); err != nil {
 		t.Fatalf("update join_request updated_at error = %v", err)
+	}
+}
+
+func setEventImageURL(t *testing.T, eventID uuid.UUID, imageURL string) {
+	t.Helper()
+
+	if _, err := common.RequirePool(t).Exec(
+		context.Background(),
+		`UPDATE event SET image_url = $2, updated_at = now() WHERE id = $1`,
+		eventID,
+		imageURL,
+	); err != nil {
+		t.Fatalf("set event image_url error = %v", err)
 	}
 }
 

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -421,6 +421,9 @@ paths:
         for per-username business outcomes: unknown or syntactically invalid usernames are
         returned in `invalid_usernames`, and known but ineligible usernames are returned in
         `failed` with a stable reason code. System errors still fail the whole request.
+        Each successfully created invitation creates a notification for the invited user with
+        the event image URL when present. Notification delivery failures do not fail the
+        invitation batch.
       operationId: createEventInvitations
       security:
         - bearerAuth: []
@@ -1371,7 +1374,8 @@ paths:
         **PROTECTED** event. Approval updates the join request to `APPROVED` and creates an
         `APPROVED` participation row atomically. If the requester had left before
         `start_time`, approval reactivates the same participation row instead of creating a
-        second one.
+        second one. After success, the requester receives an event notification with the
+        event image URL when present; notification delivery failures do not fail approval.
       operationId: approveJoinRequest
       security:
         - bearerAuth: []
@@ -1494,7 +1498,9 @@ paths:
       description: |
         Allows the authenticated event host to reject a **PENDING** join request for a
         **PROTECTED** event. Rejection updates the join request to `REJECTED` and starts a
-        **3-day** re-request cooldown for the same user and event.
+        **3-day** re-request cooldown for the same user and event. After success, the
+        requester receives an event notification with the event image URL when present;
+        notification delivery failures do not fail rejection.
       operationId: rejectJoinRequest
       security:
         - bearerAuth: []

--- a/docs/openapi/notification.yaml
+++ b/docs/openapi/notification.yaml
@@ -2,7 +2,10 @@ openapi: 3.1.0
 info:
   title: Social Event Mapper - Notification API
   version: 0.2.0
-  description: Authenticated endpoints for mobile push-device registration and the in-app notification inbox.
+  description: |
+    Authenticated endpoints for mobile push-device registration and the in-app notification inbox.
+    Event-related system notifications include `event_id`, the event `image_url` when present,
+    and stable string metadata in `data` so clients can route without an extra lookup.
 
 servers:
   - url: /api
@@ -314,6 +317,13 @@ components:
           type:
             - string
             - "null"
+          description: |
+            Notification category. Event workflow notifications currently use:
+            `PRIVATE_EVENT_INVITATION_RECEIVED`,
+            `PRIVATE_EVENT_INVITATION_ACCEPTED`,
+            `PRIVATE_EVENT_INVITATION_DECLINED`,
+            `PROTECTED_EVENT_JOIN_REQUEST_APPROVED`, and
+            `PROTECTED_EVENT_JOIN_REQUEST_REJECTED`.
         deep_link:
           type:
             - string
@@ -323,10 +333,18 @@ components:
             - string
             - "null"
           format: uri
+          description: Event image URL for event-related notifications when the event has one.
         data:
           type: object
           additionalProperties:
             type: string
+          description: |
+            String metadata for routing and UI labels. Event workflow notifications include
+            `event_id`, `event_title`, `event_start_time`, `actor_user_id`,
+            `actor_username`, optional `actor_display_name`, and `status`.
+            Invitation notifications also include `invitation_id`; join-request
+            notifications include `join_request_id`, and rejection notifications include
+            `cooldown_ends_at`.
         is_read:
           type: boolean
         read_at:

--- a/docs/openapi/profile.yaml
+++ b/docs/openapi/profile.yaml
@@ -148,7 +148,7 @@ paths:
   /me/invitations/{invitation_id}/accept:
     post:
       summary: Accept a private-event invitation
-      description: Accepts a `PENDING` invitation owned by the authenticated user and creates an approved participation.
+      description: Accepts a `PENDING` invitation owned by the authenticated user and creates an approved participation. After success, the event host receives an event notification with the event image URL when present; notification delivery failures do not fail acceptance.
       tags:
         - Profile
       security:
@@ -174,7 +174,7 @@ paths:
   /me/invitations/{invitation_id}/decline:
     post:
       summary: Decline a private-event invitation
-      description: Declines a `PENDING` invitation owned by the authenticated user. No participation is created.
+      description: Declines a `PENDING` invitation owned by the authenticated user. No participation is created. After success, the event host receives an event notification with the event image URL when present; notification delivery failures do not fail decline.
       tags:
         - Profile
       security:


### PR DESCRIPTION
## 📋 Summary
Adds automatic backend notifications for private event invitations, invitation responses, and protected event join-request moderation, with event image URLs and related routing metadata included in notification payloads.

## 🔄 Changes
- Emits notifications when private invitations are created for invited users.
- Emits host notifications when an invited user accepts or declines.
- Emits requester notifications when protected join requests are approved or rejected.
- Adds event/image/user/status metadata to notification `data`.
- Keeps core invitation and moderation actions successful even if notification delivery fails.
- Retries failed push sends up to two additional times and records each delivery attempt.
- Updates OpenAPI docs for notification payloads and affected event/profile flows.
- Adds unit and integration coverage for notification emission and retry behavior.

## 🧪 Testing
- Ran `go test ./...`
- Ran targeted integration tests for invitation and join-request notifications.
- Ran `./shipcheck.sh`; all backend checks passed.

## 🔗 Related
Closes #449
