### PR TITLE
feat(mobile): adds a full in-app notification center to the mobile client

### DIFF
--- a/mobile/jest/mocks/react-native-firebase-messaging.js
+++ b/mobile/jest/mocks/react-native-firebase-messaging.js
@@ -10,6 +10,7 @@ const messagingStub = {
   onMessage: jest.fn(() => unsub),
   onNotificationOpenedApp: jest.fn(() => unsub),
   getInitialNotification: jest.fn(() => Promise.resolve(null)),
+  setBackgroundMessageHandler: jest.fn(),
 };
 
 module.exports = {
@@ -30,4 +31,6 @@ module.exports = {
   onNotificationOpenedApp: (messaging, listener) =>
     messaging.onNotificationOpenedApp(listener),
   getInitialNotification: (messaging) => messaging.getInitialNotification(),
+  setBackgroundMessageHandler: (messaging, listener) =>
+    messaging.setBackgroundMessageHandler(listener),
 };

--- a/mobile/jest/mocks/react-native.js
+++ b/mobile/jest/mocks/react-native.js
@@ -231,6 +231,25 @@ const ActivityIndicator = React.forwardRef(function MockActivityIndicator(
   });
 });
 
+const Switch = React.forwardRef(function MockSwitch(
+  { value, onValueChange, accessibilityLabel, testID, disabled, style, ...props },
+  ref,
+) {
+  return React.createElement('input', {
+    ref,
+    type: 'checkbox',
+    checked: Boolean(value),
+    'aria-label': accessibilityLabel,
+    'data-testid': testID,
+    style: mergeStyle(style),
+    disabled,
+    onChange: disabled
+      ? undefined
+      : (event) => onValueChange?.(event.target.checked),
+    ...stripReactNativeOnlyProps(props),
+  });
+});
+
 module.exports = {
   Alert: {
     alert: jest.fn(),
@@ -261,4 +280,5 @@ module.exports = {
   KeyboardAvoidingView,
   Modal,
   Image,
+  Switch,
 };

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -4183,34 +4183,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/@jest/transform": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
-      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/types": "30.3.0",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
-        "chalk": "^4.1.2",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.3.0",
-        "pirates": "^4.0.7",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/types": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
@@ -5800,67 +5772,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
-    "node_modules/babel-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/transform": "30.3.0",
-        "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.3.0",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/babel-plugin-istanbul": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "workspaces": [
-        "test/babel-8"
-      ],
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-instrument": "^6.0.2",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
-      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/babel__core": "^7.20.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
@@ -6014,25 +5925,6 @@
         "expo-widgets": {
           "optional": true
         }
-      }
-    },
-    "node_modules/babel-preset-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
-      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "babel-plugin-jest-hoist": "30.3.0",
-        "babel-preset-current-node-syntax": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "node_modules/balanced-match": {
@@ -9994,33 +9886,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-haste-map": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
-      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "anymatch": "^3.1.3",
-        "fb-watchman": "^2.0.2",
-        "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.3.0",
-        "jest-worker": "30.3.0",
-        "picomatch": "^4.0.3",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -11763,43 +11628,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-worker": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
-      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.3.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/@jest/schemas": {
@@ -16024,37 +15852,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/write-file-atomic": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/ws": {
       "version": "8.20.0",

--- a/mobile/src/app/notifications.tsx
+++ b/mobile/src/app/notifications.tsx
@@ -1,0 +1,3 @@
+import NotificationsView from '@/views/notifications/NotificationsView';
+
+export default NotificationsView;

--- a/mobile/src/components/common/PushMessagingHost.tsx
+++ b/mobile/src/components/common/PushMessagingHost.tsx
@@ -1,11 +1,32 @@
 import { usePushMessaging } from '@/firebase/usePushMessaging';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePushNotificationPreference } from '@/viewmodels/notifications/usePushNotificationPreference';
+import { resolveNotificationRoute } from '@/utils/notificationRouting';
+import { router, type Href } from 'expo-router';
+import { useCallback } from 'react';
 
 /** Mount once under providers to enable FCM token + foreground alerts. */
 export function PushMessagingHost() {
   const { token, isHydrating } = useAuth();
+  const notificationSettings = usePushNotificationPreference();
+  const handleNotificationOpened = useCallback(
+    (payload: {
+      event_id: string | null;
+      deep_link: string | null;
+      data: Record<string, string>;
+    }) => {
+      const route = resolveNotificationRoute(payload);
+      router.push((route ?? '/notifications') as Href);
+    },
+    [],
+  );
+
   usePushMessaging({
     authToken: isHydrating ? null : token,
+    pushNotificationsEnabled:
+      !notificationSettings.isHydrating &&
+      notificationSettings.pushNotificationsEnabled,
+    onNotificationOpened: handleNotificationOpened,
     onFcmToken: __DEV__
       ? (fcmToken) => {
           console.log('[FCM] (prefix for quick scan)', `${fcmToken.slice(0, 40)}…`);

--- a/mobile/src/components/home/HomeHeader.test.tsx
+++ b/mobile/src/components/home/HomeHeader.test.tsx
@@ -52,12 +52,16 @@ import HomeHeader from './HomeHeader';
 jest.mock('@expo/vector-icons', () => {
   const ReactLocal = require('react');
 
-  return {
-    Feather: ({ name }: { name: string }) =>
+  const makeIcon = (library: string) =>
+    ({ name }: { name: string }) =>
       ReactLocal.createElement('span', {
-        'data-icon-library': 'feather',
+        'data-icon-library': library,
         'data-icon': name,
-      }),
+      });
+
+  return {
+    Feather: makeIcon('feather'),
+    Ionicons: makeIcon('ionicons'),
   };
 });
 
@@ -94,5 +98,57 @@ describe('HomeHeader', () => {
     expect((label as HTMLElement).style.fontStyle).toBe('italic');
     expect((label as HTMLElement).style.fontWeight).toBe('800');
     expect((label as HTMLElement).style.fontSize).toBe('12px');
+  });
+
+  it('calls onPressNotifications when the bell button is pressed', () => {
+    const onPressNotifications = jest.fn();
+    render(
+      <HomeHeader
+        locationLabel="Beşiktaş, Istanbul"
+        onPressLocation={jest.fn()}
+        onPressNotifications={onPressNotifications}
+      />,
+    );
+
+    const bellButton = screen.getByRole('button', { name: 'Open notifications' });
+    expect(bellButton).toBeTruthy();
+    fireEvent.click(bellButton);
+    expect(onPressNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a badge when unreadNotificationCount is greater than zero', () => {
+    render(
+      <HomeHeader
+        locationLabel="Beşiktaş, Istanbul"
+        onPressLocation={jest.fn()}
+        unreadNotificationCount={5}
+      />,
+    );
+
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+
+  it('caps the badge at 99+', () => {
+    render(
+      <HomeHeader
+        locationLabel="Beşiktaş, Istanbul"
+        onPressLocation={jest.fn()}
+        unreadNotificationCount={150}
+      />,
+    );
+
+    expect(screen.getByText('99+')).toBeTruthy();
+  });
+
+  it('does not show a badge when unreadNotificationCount is zero', () => {
+    render(
+      <HomeHeader
+        locationLabel="Beşiktaş, Istanbul"
+        onPressLocation={jest.fn()}
+        unreadNotificationCount={0}
+      />,
+    );
+
+    expect(screen.queryByText('0')).toBeNull();
   });
 });

--- a/mobile/src/components/home/HomeHeader.tsx
+++ b/mobile/src/components/home/HomeHeader.tsx
@@ -1,17 +1,22 @@
 import React, { forwardRef } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons';
 import SemLogo from '@/components/common/SemLogo';
 
 interface HomeHeaderProps {
   locationLabel: string;
   onPressLocation?: () => void;
+  onPressNotifications?: () => void;
+  unreadNotificationCount?: number;
 }
 
 const HomeHeader = forwardRef<any, HomeHeaderProps>(function HomeHeader(
   {
     locationLabel,
     onPressLocation,
+    onPressNotifications,
+    unreadNotificationCount = 0,
   },
   locationButtonRef,
 ) {
@@ -21,20 +26,39 @@ const HomeHeader = forwardRef<any, HomeHeaderProps>(function HomeHeader(
         <SemLogo height={56} color="#111827" />
       </View>
 
-      <View ref={locationButtonRef} collapsable={false} style={styles.locationWrap}>
+      <View style={styles.rightWrap}>
         <TouchableOpacity
-          style={styles.locationButton}
-          activeOpacity={0.85}
-          onPress={onPressLocation}
+          style={styles.bellButton}
+          activeOpacity={0.75}
+          onPress={onPressNotifications}
           accessibilityRole="button"
-          accessibilityLabel="Select location"
+          accessibilityLabel="Open notifications"
         >
-          <Feather name="map-pin" size={16} color="#FFFFFF" />
-          <Text style={styles.locationButtonText} numberOfLines={1}>
-            {locationLabel}
-          </Text>
-          <Feather name="chevron-down" size={16} color="#FFFFFF" />
+          <Ionicons name="notifications-outline" size={22} color="#111827" />
+          {unreadNotificationCount > 0 ? (
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>
+                {unreadNotificationCount > 99 ? '99+' : String(unreadNotificationCount)}
+              </Text>
+            </View>
+          ) : null}
         </TouchableOpacity>
+
+        <View ref={locationButtonRef} collapsable={false} style={styles.locationWrap}>
+          <TouchableOpacity
+            style={styles.locationButton}
+            activeOpacity={0.85}
+            onPress={onPressLocation}
+            accessibilityRole="button"
+            accessibilityLabel="Select location"
+          >
+            <Feather name="map-pin" size={16} color="#FFFFFF" />
+            <Text style={styles.locationButtonText} numberOfLines={1}>
+              {locationLabel}
+            </Text>
+            <Feather name="chevron-down" size={16} color="#FFFFFF" />
+          </TouchableOpacity>
+        </View>
       </View>
     </View>
   );
@@ -52,10 +76,43 @@ const styles = StyleSheet.create({
     flexShrink: 0,
     marginRight: 8,
   },
+  rightWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  bellButton: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  badge: {
+    position: 'absolute',
+    top: 2,
+    right: 2,
+    minWidth: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: '#EF4444',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 3,
+  },
+  badgeText: {
+    color: '#FFFFFF',
+    fontSize: 9,
+    fontWeight: '700',
+    lineHeight: 12,
+  },
   locationWrap: {
     flexShrink: 1,
     minWidth: 0,
-    maxWidth: '58%',
+    maxWidth: '80%',
     alignItems: 'flex-end',
   },
   locationButton: {

--- a/mobile/src/firebase/messagingBootstrap.native.js
+++ b/mobile/src/firebase/messagingBootstrap.native.js
@@ -1,4 +1,14 @@
 import { getMessaging, setBackgroundMessageHandler } from '@react-native-firebase/messaging';
+import { normalizePushNotificationPayload } from './pushNotificationPayload';
 
 /** Must stay fast; invoked in a headless context on Android. */
-setBackgroundMessageHandler(getMessaging(), async () => {});
+setBackgroundMessageHandler(getMessaging(), async (remoteMessage) => {
+  const payload = normalizePushNotificationPayload(remoteMessage);
+
+  if (__DEV__) {
+    console.log(
+      '[FCM background payload]',
+      payload.notification_id ?? payload.event_id ?? payload.title,
+    );
+  }
+});

--- a/mobile/src/firebase/pushNotificationPayload.test.ts
+++ b/mobile/src/firebase/pushNotificationPayload.test.ts
@@ -1,0 +1,44 @@
+import { normalizePushNotificationPayload } from './pushNotificationPayload';
+
+describe('normalizePushNotificationPayload', () => {
+  it('normalizes notification and data payload fields', () => {
+    expect(
+      normalizePushNotificationPayload({
+        messageId: 'message-1',
+        notification: {
+          title: 'Event update',
+          body: 'Your request was approved.',
+        },
+        data: {
+          event_id: 'event-1',
+          deep_link: '/events/event-1',
+          notification_id: 'notification-1',
+        },
+      }),
+    ).toEqual({
+      title: 'Event update',
+      body: 'Your request was approved.',
+      notification_id: 'notification-1',
+      event_id: 'event-1',
+      deep_link: '/events/event-1',
+      data: {
+        event_id: 'event-1',
+        deep_link: '/events/event-1',
+        notification_id: 'notification-1',
+      },
+    });
+  });
+
+  it('falls back to data fields and message id', () => {
+    expect(
+      normalizePushNotificationPayload({
+        messageId: 'message-1',
+        data: { title: 'Fallback title', body: 'Fallback body' },
+      }),
+    ).toMatchObject({
+      title: 'Fallback title',
+      body: 'Fallback body',
+      notification_id: 'message-1',
+    });
+  });
+});

--- a/mobile/src/firebase/pushNotificationPayload.ts
+++ b/mobile/src/firebase/pushNotificationPayload.ts
@@ -1,0 +1,51 @@
+export interface PushRemoteMessageLike {
+  messageId?: string;
+  notification?: {
+    title?: string;
+    body?: string;
+  };
+  data?: Record<string, unknown>;
+}
+
+export interface NormalizedPushNotificationPayload {
+  title: string;
+  body: string | null;
+  notification_id: string | null;
+  event_id: string | null;
+  deep_link: string | null;
+  data: Record<string, string>;
+}
+
+function toStringData(data?: Record<string, unknown>): Record<string, string> {
+  if (!data) return {};
+
+  return Object.entries(data).reduce<Record<string, string>>((acc, [key, value]) => {
+    if (value == null) return acc;
+    acc[key] = String(value);
+    return acc;
+  }, {});
+}
+
+function firstString(...values: Array<string | undefined>): string | null {
+  const value = values.find((candidate) => candidate?.trim());
+  return value ? value.trim() : null;
+}
+
+export function normalizePushNotificationPayload(
+  remoteMessage: PushRemoteMessageLike,
+): NormalizedPushNotificationPayload {
+  const data = toStringData(remoteMessage.data);
+
+  return {
+    title: firstString(remoteMessage.notification?.title, data.title) ?? 'Notification',
+    body: firstString(remoteMessage.notification?.body, data.body),
+    notification_id: firstString(
+      data.notification_id,
+      data.notificationId,
+      remoteMessage.messageId,
+    ),
+    event_id: firstString(data.event_id, data.eventId),
+    deep_link: firstString(data.deep_link, data.deepLink),
+    data,
+  };
+}

--- a/mobile/src/firebase/usePushMessaging.test.tsx
+++ b/mobile/src/firebase/usePushMessaging.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { renderHook, waitFor } from '@testing-library/react';
+import { getMessaging } from '@react-native-firebase/messaging';
 import { usePushMessaging } from './usePushMessaging';
 import * as deviceInstallation from '@/services/deviceInstallation';
 import * as pushDeviceService from '@/services/pushDeviceService';
@@ -47,6 +48,26 @@ describe('usePushMessaging', () => {
     });
   });
 
+  it('does not request or register for push while disabled', async () => {
+    const messaging = getMessaging() as unknown as {
+      requestPermission: jest.Mock;
+      getToken: jest.Mock;
+    };
+
+    renderHook(() =>
+      usePushMessaging({
+        authToken: 'access-token',
+        pushNotificationsEnabled: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(messaging.requestPermission).not.toHaveBeenCalled();
+      expect(messaging.getToken).not.toHaveBeenCalled();
+      expect(mockRegisterPushDevice).not.toHaveBeenCalled();
+    });
+  });
+
   it('syncs a previously acquired FCM token after login', async () => {
     const { rerender } = renderHook(
       ({ authToken }: { authToken: string | null }) =>
@@ -86,6 +107,79 @@ describe('usePushMessaging', () => {
       expect(mockUnregisterPushDevice).toHaveBeenCalledWith(
         '550e8400-e29b-41d4-a716-446655440000',
         'access-token',
+      );
+    });
+  });
+
+  it('unregisters the installation when push notifications are disabled', async () => {
+    const { rerender } = renderHook(
+      ({
+        authToken,
+        pushNotificationsEnabled,
+      }: {
+        authToken: string | null;
+        pushNotificationsEnabled: boolean;
+      }) =>
+        usePushMessaging({
+          authToken,
+          pushNotificationsEnabled,
+        }),
+      {
+        initialProps: {
+          authToken: 'access-token' as string | null,
+          pushNotificationsEnabled: true,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockRegisterPushDevice).toHaveBeenCalled();
+    });
+
+    rerender({
+      authToken: 'access-token' as string | null,
+      pushNotificationsEnabled: false,
+    });
+
+    await waitFor(() => {
+      expect(mockUnregisterPushDevice).toHaveBeenCalledWith(
+        '550e8400-e29b-41d4-a716-446655440000',
+        'access-token',
+      );
+    });
+  });
+
+  it('normalizes initial notification payloads for open handling', async () => {
+    const messaging = getMessaging() as unknown as {
+      getInitialNotification: jest.Mock;
+    };
+    messaging.getInitialNotification.mockResolvedValueOnce({
+      messageId: 'message-1',
+      notification: {
+        title: 'Event update',
+        body: 'Tap through',
+      },
+      data: {
+        event_id: 'event-1',
+        deep_link: '/events/event-1',
+      },
+    });
+    const onNotificationOpened = jest.fn();
+
+    renderHook(() =>
+      usePushMessaging({
+        onNotificationOpened,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onNotificationOpened).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Event update',
+          body: 'Tap through',
+          event_id: 'event-1',
+          deep_link: '/events/event-1',
+        }),
       );
     });
   });

--- a/mobile/src/firebase/usePushMessaging.ts
+++ b/mobile/src/firebase/usePushMessaging.ts
@@ -16,6 +16,10 @@ import {
   registerPushDevice,
   unregisterPushDevice,
 } from '@/services/pushDeviceService';
+import {
+  normalizePushNotificationPayload,
+  NormalizedPushNotificationPayload,
+} from '@/firebase/pushNotificationPayload';
 
 async function ensureAndroidPostNotificationsPermission(): Promise<boolean> {
   if (Platform.OS !== 'android' || Platform.Version < 33) {
@@ -29,20 +33,37 @@ async function ensureAndroidPostNotificationsPermission(): Promise<boolean> {
 
 export type PushMessagingOptions = {
   authToken?: string | null;
+  pushNotificationsEnabled?: boolean;
   /** Called whenever an FCM token is acquired or rotated (send this to your server). */
   onFcmToken?: (token: string) => void;
+  onNotificationReceived?: (payload: NormalizedPushNotificationPayload) => void;
+  onNotificationOpened?: (payload: NormalizedPushNotificationPayload) => void;
 };
 
 /** Registers foreground listeners and requests permission + token. Not used on web. */
 export function usePushMessaging(options?: PushMessagingOptions) {
+  const pushNotificationsEnabled = options?.pushNotificationsEnabled ?? true;
   const onFcmTokenRef = useRef(options?.onFcmToken);
+  const onNotificationReceivedRef = useRef(options?.onNotificationReceived);
+  const onNotificationOpenedRef = useRef(options?.onNotificationOpened);
   const authTokenRef = useRef(options?.authToken ?? null);
-  const previousAuthTokenRef = useRef<string | null>(options?.authToken ?? null);
+  const previousEffectiveAuthTokenRef = useRef<string | null>(
+    pushNotificationsEnabled ? options?.authToken ?? null : null,
+  );
   const currentFcmTokenRef = useRef<string | null>(null);
   const lastSyncedKeyRef = useRef<string | null>(null);
+
   useEffect(() => {
     onFcmTokenRef.current = options?.onFcmToken;
   }, [options?.onFcmToken]);
+
+  useEffect(() => {
+    onNotificationReceivedRef.current = options?.onNotificationReceived;
+  }, [options?.onNotificationReceived]);
+
+  useEffect(() => {
+    onNotificationOpenedRef.current = options?.onNotificationOpened;
+  }, [options?.onNotificationOpened]);
 
   useEffect(() => {
     authTokenRef.current = options?.authToken ?? null;
@@ -68,17 +89,21 @@ export function usePushMessaging(options?: PushMessagingOptions) {
   };
 
   useEffect(() => {
-    if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+    if (
+      !pushNotificationsEnabled ||
+      (Platform.OS !== 'ios' && Platform.OS !== 'android')
+    ) {
       return undefined;
     }
 
     const unsubscribers: Array<() => void> = [];
+    let active = true;
 
     (async () => {
       const messaging = getMessaging();
 
       const notificationsOk = await ensureAndroidPostNotificationsPermission();
-      if (!notificationsOk) {
+      if (!active || !notificationsOk) {
         return;
       }
 
@@ -88,7 +113,7 @@ export function usePushMessaging(options?: PushMessagingOptions) {
         status === AuthorizationStatus.PROVISIONAL ||
         status === AuthorizationStatus.EPHEMERAL;
 
-      if (!notificationsAllowed) {
+      if (!active || !notificationsAllowed) {
         return;
       }
 
@@ -98,6 +123,7 @@ export function usePushMessaging(options?: PushMessagingOptions) {
 
       const pushTokenToServer = async () => {
         const token = await getToken(messaging);
+        if (!active) return;
         currentFcmTokenRef.current = token;
         onFcmTokenRef.current?.(token);
         const authToken = authTokenRef.current;
@@ -108,42 +134,72 @@ export function usePushMessaging(options?: PushMessagingOptions) {
 
       await pushTokenToServer();
 
-      unsubscribers.push(onTokenRefresh(messaging, () => pushTokenToServer()));
+      unsubscribers.push(
+        onTokenRefresh(messaging, () => {
+          void pushTokenToServer();
+        }),
+      );
 
       unsubscribers.push(
         onMessage(messaging, (remoteMessage) => {
-          const title = remoteMessage.notification?.title ?? 'Notification';
-          const body = remoteMessage.notification?.body;
-          if (body) {
-            Alert.alert(title, body);
+          const payload = normalizePushNotificationPayload(remoteMessage);
+          onNotificationReceivedRef.current?.(payload);
+
+          if (payload.body) {
+            Alert.alert(payload.title, payload.body, [
+              { text: 'Dismiss', style: 'cancel' },
+              {
+                text: 'View',
+                onPress: () => onNotificationOpenedRef.current?.(payload),
+              },
+            ]);
           }
         }),
       );
 
-      unsubscribers.push(onNotificationOpenedApp(messaging, () => {}));
+      unsubscribers.push(
+        onNotificationOpenedApp(messaging, (remoteMessage) => {
+          onNotificationOpenedRef.current?.(
+            normalizePushNotificationPayload(remoteMessage),
+          );
+        }),
+      );
 
-      await getInitialNotification(messaging);
-    })();
+      const initialNotification = await getInitialNotification(messaging);
+      if (active && initialNotification) {
+        onNotificationOpenedRef.current?.(
+          normalizePushNotificationPayload(initialNotification),
+        );
+      }
+    })().catch(() => {});
 
-    return () => unsubscribers.forEach((u) => u());
-  }, []);
+    return () => {
+      active = false;
+      unsubscribers.forEach((u) => u());
+    };
+  }, [pushNotificationsEnabled]);
 
   useEffect(() => {
-    const authToken = options?.authToken ?? null;
-    const previousAuthToken = previousAuthTokenRef.current;
-    previousAuthTokenRef.current = authToken;
+    const effectiveAuthToken = pushNotificationsEnabled
+      ? options?.authToken ?? null
+      : null;
+    const previousEffectiveAuthToken = previousEffectiveAuthTokenRef.current;
+    previousEffectiveAuthTokenRef.current = effectiveAuthToken;
 
-    if (authToken && currentFcmTokenRef.current) {
-      void syncTokenToBackend(currentFcmTokenRef.current, authToken).catch(() => {});
+    if (effectiveAuthToken && currentFcmTokenRef.current) {
+      void syncTokenToBackend(
+        currentFcmTokenRef.current,
+        effectiveAuthToken,
+      ).catch(() => {});
       return;
     }
 
-    if (!authToken && previousAuthToken) {
+    if (!effectiveAuthToken && previousEffectiveAuthToken) {
       lastSyncedKeyRef.current = null;
       void (async () => {
         const installationID = await getDeviceInstallationID();
-        await unregisterPushDevice(installationID, previousAuthToken);
+        await unregisterPushDevice(installationID, previousEffectiveAuthToken);
       })().catch(() => {});
     }
-  }, [options?.authToken]);
+  }, [options?.authToken, pushNotificationsEnabled]);
 }

--- a/mobile/src/models/notification.ts
+++ b/mobile/src/models/notification.ts
@@ -1,0 +1,31 @@
+export interface NotificationItem {
+  id: string;
+  event_id: string | null;
+  title: string;
+  body: string;
+  type: string | null;
+  deep_link: string | null;
+  image_url: string | null;
+  data: Record<string, string>;
+  is_read: boolean;
+  read_at: string | null;
+  created_at: string;
+}
+
+export interface NotificationPageInfo {
+  next_cursor: string | null;
+  has_next: boolean;
+}
+
+export interface ListNotificationsResponse {
+  items: NotificationItem[];
+  page_info: NotificationPageInfo;
+}
+
+export interface UnreadNotificationCountResponse {
+  unread_count: number;
+}
+
+export interface MarkAllNotificationsReadResponse {
+  updated_count: number;
+}

--- a/mobile/src/services/notificationPreferenceService.test.ts
+++ b/mobile/src/services/notificationPreferenceService.test.ts
@@ -1,0 +1,39 @@
+import * as SecureStore from 'expo-secure-store';
+import {
+  getPushNotificationsEnabled,
+  setPushNotificationsEnabled,
+  subscribePushNotificationsEnabled,
+} from './notificationPreferenceService';
+
+describe('notificationPreferenceService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (SecureStore as unknown as { __reset: () => void }).__reset();
+  });
+
+  it('defaults push notifications to enabled', async () => {
+    await expect(getPushNotificationsEnabled()).resolves.toBe(true);
+  });
+
+  it('persists disabled push notifications', async () => {
+    await setPushNotificationsEnabled(false);
+
+    await expect(getPushNotificationsEnabled()).resolves.toBe(false);
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+      'sem:push-notifications-enabled',
+      'false',
+    );
+  });
+
+  it('notifies subscribers when the preference changes', async () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribePushNotificationsEnabled(listener);
+
+    await setPushNotificationsEnabled(false);
+    unsubscribe();
+    await setPushNotificationsEnabled(true);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(false);
+  });
+});

--- a/mobile/src/services/notificationPreferenceService.test.ts
+++ b/mobile/src/services/notificationPreferenceService.test.ts
@@ -20,7 +20,7 @@ describe('notificationPreferenceService', () => {
 
     await expect(getPushNotificationsEnabled()).resolves.toBe(false);
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
-      'sem:push-notifications-enabled',
+      'sem.push-notifications-enabled',
       'false',
     );
   });

--- a/mobile/src/services/notificationPreferenceService.ts
+++ b/mobile/src/services/notificationPreferenceService.ts
@@ -1,6 +1,6 @@
 import * as SecureStore from 'expo-secure-store';
 
-const PUSH_NOTIFICATIONS_ENABLED_KEY = 'sem:push-notifications-enabled';
+const PUSH_NOTIFICATIONS_ENABLED_KEY = 'sem.push-notifications-enabled';
 
 type PushPreferenceListener = (enabled: boolean) => void;
 

--- a/mobile/src/services/notificationPreferenceService.ts
+++ b/mobile/src/services/notificationPreferenceService.ts
@@ -1,0 +1,31 @@
+import * as SecureStore from 'expo-secure-store';
+
+const PUSH_NOTIFICATIONS_ENABLED_KEY = 'sem:push-notifications-enabled';
+
+type PushPreferenceListener = (enabled: boolean) => void;
+
+const listeners = new Set<PushPreferenceListener>();
+
+function emitPushPreference(enabled: boolean) {
+  listeners.forEach((listener) => listener(enabled));
+}
+
+export async function getPushNotificationsEnabled(): Promise<boolean> {
+  const storedValue = await SecureStore.getItemAsync(PUSH_NOTIFICATIONS_ENABLED_KEY);
+  return storedValue !== 'false';
+}
+
+export async function setPushNotificationsEnabled(enabled: boolean): Promise<void> {
+  await SecureStore.setItemAsync(
+    PUSH_NOTIFICATIONS_ENABLED_KEY,
+    enabled ? 'true' : 'false',
+  );
+  emitPushPreference(enabled);
+}
+
+export function subscribePushNotificationsEnabled(
+  listener: PushPreferenceListener,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/mobile/src/services/notificationService.test.ts
+++ b/mobile/src/services/notificationService.test.ts
@@ -1,0 +1,94 @@
+import * as api from './api';
+import {
+  deleteAllNotifications,
+  deleteNotification,
+  getUnreadNotificationCount,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from './notificationService';
+
+jest.mock('./api');
+
+const mockApiGetAuth = jest.mocked(api.apiGetAuth);
+const mockApiPatchAuth = jest.mocked(api.apiPatchAuth);
+const mockApiDeleteAuth = jest.mocked(api.apiDeleteAuth);
+
+describe('notificationService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiGetAuth.mockResolvedValue({
+      items: [],
+      page_info: { next_cursor: null, has_next: false },
+    });
+    mockApiPatchAuth.mockResolvedValue(undefined);
+    mockApiDeleteAuth.mockResolvedValue(undefined);
+  });
+
+  it('lists notifications through the authenticated feed endpoint', async () => {
+    await listNotifications('access-token', {
+      limit: 10,
+      cursor: 'next-cursor',
+    });
+
+    expect(mockApiGetAuth).toHaveBeenCalledWith(
+      '/me/notifications?limit=10&cursor=next-cursor',
+      'access-token',
+    );
+  });
+
+  it('lists unread notifications when requested', async () => {
+    await listNotifications('access-token', { onlyUnread: true });
+
+    expect(mockApiGetAuth).toHaveBeenCalledWith(
+      '/me/notifications/unread',
+      'access-token',
+    );
+  });
+
+  it('fetches unread count', async () => {
+    mockApiGetAuth.mockResolvedValueOnce({ unread_count: 3 });
+
+    const result = await getUnreadNotificationCount('access-token');
+
+    expect(result).toEqual({ unread_count: 3 });
+    expect(mockApiGetAuth).toHaveBeenCalledWith(
+      '/me/notifications/unread-count',
+      'access-token',
+    );
+  });
+
+  it('marks notifications as read', async () => {
+    await markNotificationRead('notification-1', 'access-token');
+    await markAllNotificationsRead('access-token');
+
+    expect(mockApiPatchAuth).toHaveBeenNthCalledWith(
+      1,
+      '/me/notifications/notification-1/read',
+      {},
+      'access-token',
+    );
+    expect(mockApiPatchAuth).toHaveBeenNthCalledWith(
+      2,
+      '/me/notifications/read',
+      {},
+      'access-token',
+    );
+  });
+
+  it('deletes one notification or the whole visible feed', async () => {
+    await deleteNotification('notification-1', 'access-token');
+    await deleteAllNotifications('access-token');
+
+    expect(mockApiDeleteAuth).toHaveBeenNthCalledWith(
+      1,
+      '/me/notifications/notification-1',
+      'access-token',
+    );
+    expect(mockApiDeleteAuth).toHaveBeenNthCalledWith(
+      2,
+      '/me/notifications',
+      'access-token',
+    );
+  });
+});

--- a/mobile/src/services/notificationService.ts
+++ b/mobile/src/services/notificationService.ts
@@ -1,0 +1,82 @@
+import {
+  ListNotificationsResponse,
+  MarkAllNotificationsReadResponse,
+  UnreadNotificationCountResponse,
+} from '@/models/notification';
+import { apiDeleteAuth, apiGetAuth, apiPatchAuth } from '@/services/api';
+
+export interface ListNotificationsParams {
+  limit?: number;
+  cursor?: string | null;
+  onlyUnread?: boolean;
+}
+
+function notificationListEndpoint(params?: ListNotificationsParams): string {
+  const query = new URLSearchParams();
+
+  if (params?.limit) {
+    query.set('limit', String(params.limit));
+  }
+
+  if (params?.cursor) {
+    query.set('cursor', params.cursor);
+  }
+
+  const path = params?.onlyUnread
+    ? '/me/notifications/unread'
+    : '/me/notifications';
+  const serialized = query.toString();
+
+  return serialized ? `${path}?${serialized}` : path;
+}
+
+export function listNotifications(
+  token: string,
+  params?: ListNotificationsParams,
+): Promise<ListNotificationsResponse> {
+  return apiGetAuth<ListNotificationsResponse>(
+    notificationListEndpoint(params),
+    token,
+  );
+}
+
+export function getUnreadNotificationCount(
+  token: string,
+): Promise<UnreadNotificationCountResponse> {
+  return apiGetAuth<UnreadNotificationCountResponse>(
+    '/me/notifications/unread-count',
+    token,
+  );
+}
+
+export function markNotificationRead(
+  notificationId: string,
+  token: string,
+): Promise<void> {
+  return apiPatchAuth<void>(
+    `/me/notifications/${notificationId}/read`,
+    {},
+    token,
+  );
+}
+
+export function markAllNotificationsRead(
+  token: string,
+): Promise<MarkAllNotificationsReadResponse> {
+  return apiPatchAuth<MarkAllNotificationsReadResponse>(
+    '/me/notifications/read',
+    {},
+    token,
+  );
+}
+
+export function deleteNotification(
+  notificationId: string,
+  token: string,
+): Promise<void> {
+  return apiDeleteAuth<void>(`/me/notifications/${notificationId}`, token);
+}
+
+export function deleteAllNotifications(token: string): Promise<void> {
+  return apiDeleteAuth<void>('/me/notifications', token);
+}

--- a/mobile/src/utils/notificationRouting.test.ts
+++ b/mobile/src/utils/notificationRouting.test.ts
@@ -1,0 +1,30 @@
+import { resolveNotificationRoute } from './notificationRouting';
+
+describe('resolveNotificationRoute', () => {
+  it('maps backend event deep links to the mobile event route', () => {
+    expect(
+      resolveNotificationRoute({
+        deep_link: '/events/550e8400-e29b-41d4-a716-446655440000',
+      }),
+    ).toBe('/event/550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('falls back to event_id metadata', () => {
+    expect(
+      resolveNotificationRoute({
+        event_id: null,
+        data: { event_id: '550e8400-e29b-41d4-a716-446655440000' },
+      }),
+    ).toBe('/event/550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('routes notification links to the inbox', () => {
+    expect(resolveNotificationRoute({ deep_link: '/notifications' })).toBe(
+      '/notifications',
+    );
+  });
+
+  it('returns null when the payload has no routable target', () => {
+    expect(resolveNotificationRoute({ data: { source: 'admin' } })).toBeNull();
+  });
+});

--- a/mobile/src/utils/notificationRouting.ts
+++ b/mobile/src/utils/notificationRouting.ts
@@ -1,0 +1,44 @@
+interface RoutableNotificationPayload {
+  event_id?: string | null;
+  deep_link?: string | null;
+  data?: Record<string, string> | null;
+}
+
+const UUIDISH_SEGMENT = '[0-9a-fA-F-]{20,}';
+
+function normalizeEventRoute(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const eventRouteMatch = trimmed.match(
+    new RegExp(`(?:^|://|/)(?:events|event)/(${UUIDISH_SEGMENT})(?:$|[/?#])`),
+  );
+  if (eventRouteMatch?.[1]) {
+    return `/event/${eventRouteMatch[1]}`;
+  }
+
+  const notificationRouteMatch = trimmed.match(
+    /(?:^|:\/\/|\/)notifications(?:$|[/?#])/,
+  );
+  if (notificationRouteMatch) {
+    return '/notifications';
+  }
+
+  return null;
+}
+
+export function resolveNotificationRoute(
+  notification: RoutableNotificationPayload,
+): string | null {
+  const explicitRoute = notification.deep_link
+    ? normalizeEventRoute(notification.deep_link)
+    : null;
+  if (explicitRoute) return explicitRoute;
+
+  const eventID = notification.event_id ?? notification.data?.event_id;
+  if (eventID) {
+    return `/event/${eventID}`;
+  }
+
+  return null;
+}

--- a/mobile/src/viewmodels/notifications/useNotificationsViewModel.test.tsx
+++ b/mobile/src/viewmodels/notifications/useNotificationsViewModel.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type {
+  ListNotificationsResponse,
+  NotificationItem,
+} from '@/models/notification';
+import * as notificationService from '@/services/notificationService';
+import { useNotificationsViewModel } from './useNotificationsViewModel';
+
+jest.mock('@/services/notificationService');
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    token: 'mock-token',
+    refreshToken: 'mock-refresh-token',
+    setSession: jest.fn(),
+    clearAuth: jest.fn(),
+  }),
+}));
+
+const mockListNotifications = jest.mocked(notificationService.listNotifications);
+const mockMarkNotificationRead = jest.mocked(notificationService.markNotificationRead);
+const mockMarkAllNotificationsRead = jest.mocked(
+  notificationService.markAllNotificationsRead,
+);
+const mockDeleteNotification = jest.mocked(notificationService.deleteNotification);
+
+function makeNotification(
+  id: string,
+  overrides: Partial<NotificationItem> = {},
+): NotificationItem {
+  return {
+    id,
+    event_id: 'event-1',
+    title: `Notification ${id}`,
+    body: 'Notification body',
+    type: 'PROTECTED_EVENT_JOIN_REQUEST_APPROVED',
+    deep_link: '/events/event-1',
+    image_url: null,
+    data: { event_id: 'event-1' },
+    is_read: false,
+    read_at: null,
+    created_at: '2026-04-30T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeResponse(
+  items: NotificationItem[],
+  nextCursor: string | null = null,
+): ListNotificationsResponse {
+  return {
+    items,
+    page_info: {
+      next_cursor: nextCursor,
+      has_next: nextCursor != null,
+    },
+  };
+}
+
+describe('useNotificationsViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListNotifications.mockResolvedValue(makeResponse([makeNotification('n1')]));
+    mockMarkNotificationRead.mockResolvedValue(undefined);
+    mockMarkAllNotificationsRead.mockResolvedValue({ updated_count: 1 });
+    mockDeleteNotification.mockResolvedValue(undefined);
+  });
+
+  it('loads notifications on mount', async () => {
+    const { result } = renderHook(() => useNotificationsViewModel());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockListNotifications).toHaveBeenCalledWith('mock-token', {
+      limit: 25,
+      cursor: null,
+    });
+    expect(result.current.notifications.map((item) => item.id)).toEqual(['n1']);
+    expect(result.current.unreadCount).toBe(1);
+  });
+
+  it('loads more notifications with the next cursor', async () => {
+    mockListNotifications
+      .mockResolvedValueOnce(makeResponse([makeNotification('n1')], 'cursor-2'))
+      .mockResolvedValueOnce(makeResponse([makeNotification('n2')]));
+
+    const { result } = renderHook(() => useNotificationsViewModel());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(mockListNotifications).toHaveBeenLastCalledWith('mock-token', {
+      limit: 25,
+      cursor: 'cursor-2',
+    });
+    expect(result.current.notifications.map((item) => item.id)).toEqual([
+      'n1',
+      'n2',
+    ]);
+  });
+
+  it('marks a notification read optimistically', async () => {
+    const { result } = renderHook(() => useNotificationsViewModel());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.markRead('n1');
+    });
+
+    expect(mockMarkNotificationRead).toHaveBeenCalledWith('n1', 'mock-token');
+    expect(result.current.notifications[0].is_read).toBe(true);
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it('marks all notifications read', async () => {
+    const { result } = renderHook(() => useNotificationsViewModel());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.markAllRead();
+    });
+
+    expect(mockMarkAllNotificationsRead).toHaveBeenCalledWith('mock-token');
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it('removes a notification after delete succeeds', async () => {
+    const { result } = renderHook(() => useNotificationsViewModel());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.removeNotification('n1');
+    });
+
+    expect(mockDeleteNotification).toHaveBeenCalledWith('n1', 'mock-token');
+    expect(result.current.notifications).toEqual([]);
+  });
+});

--- a/mobile/src/viewmodels/notifications/useNotificationsViewModel.ts
+++ b/mobile/src/viewmodels/notifications/useNotificationsViewModel.ts
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { NotificationItem } from '@/models/notification';
+import { ApiError } from '@/services/api';
+import {
+  deleteNotification,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from '@/services/notificationService';
+
+const NOTIFICATION_PAGE_SIZE = 25;
+
+export interface NotificationsViewModel {
+  notifications: NotificationItem[];
+  unreadCount: number;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  apiError: string | null;
+  refresh: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  markRead: (notificationId: string) => Promise<void>;
+  markAllRead: () => Promise<void>;
+  removeNotification: (notificationId: string) => Promise<void>;
+}
+
+function getLoadErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 401) {
+    return 'You must be logged in to view notifications.';
+  }
+
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return 'Failed to load notifications. Please try again.';
+}
+
+function getMutationErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 401) {
+    return 'You must be logged in to manage notifications.';
+  }
+
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return 'Failed to update notifications. Please try again.';
+}
+
+function mergeNotifications(
+  current: NotificationItem[],
+  incoming: NotificationItem[],
+): NotificationItem[] {
+  const seen = new Set(current.map((item) => item.id));
+  const merged = [...current];
+
+  for (const item of incoming) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    merged.push(item);
+  }
+
+  return merged;
+}
+
+function countUnread(notifications: NotificationItem[]): number {
+  return notifications.filter((notification) => !notification.is_read).length;
+}
+
+export function useNotificationsViewModel(): NotificationsViewModel {
+  const { token } = useAuth();
+
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const fetchNotifications = useCallback(
+    async (
+      mode: 'initial' | 'refresh' | 'more',
+      cursor: string | null = null,
+    ) => {
+      if (!token) {
+        setNotifications([]);
+        setNextCursor(null);
+        setHasMore(false);
+        setApiError('You must be logged in to view notifications.');
+        setIsLoading(false);
+        setIsRefreshing(false);
+        setIsLoadingMore(false);
+        return;
+      }
+
+      if (mode === 'initial') setIsLoading(true);
+      if (mode === 'refresh') setIsRefreshing(true);
+      if (mode === 'more') setIsLoadingMore(true);
+
+      setApiError(null);
+
+      try {
+        const response = await listNotifications(token, {
+          limit: NOTIFICATION_PAGE_SIZE,
+          cursor: mode === 'more' ? cursor : null,
+        });
+
+        setNotifications((current) =>
+          mode === 'more'
+            ? mergeNotifications(current, response.items)
+            : response.items,
+        );
+        setNextCursor(response.page_info.next_cursor);
+        setHasMore(response.page_info.has_next);
+      } catch (error) {
+        if (mode === 'initial') {
+          setNotifications([]);
+        }
+
+        setApiError(getLoadErrorMessage(error));
+      } finally {
+        if (mode === 'initial') setIsLoading(false);
+        if (mode === 'refresh') setIsRefreshing(false);
+        if (mode === 'more') setIsLoadingMore(false);
+      }
+    },
+    [token],
+  );
+
+  useEffect(() => {
+    void fetchNotifications('initial');
+  }, [fetchNotifications]);
+
+  const refresh = useCallback(async () => {
+    await fetchNotifications('refresh');
+  }, [fetchNotifications]);
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || isLoadingMore || !nextCursor) return;
+    await fetchNotifications('more', nextCursor);
+  }, [fetchNotifications, hasMore, isLoadingMore, nextCursor]);
+
+  const markRead = useCallback(
+    async (notificationId: string) => {
+      if (!token) return;
+
+      setNotifications((current) =>
+        current.map((notification) =>
+          notification.id === notificationId
+            ? {
+                ...notification,
+                is_read: true,
+                read_at: notification.read_at ?? new Date().toISOString(),
+              }
+            : notification,
+        ),
+      );
+
+      try {
+        await markNotificationRead(notificationId, token);
+      } catch (error) {
+        setApiError(getMutationErrorMessage(error));
+      }
+    },
+    [token],
+  );
+
+  const markAllRead = useCallback(async () => {
+    if (!token) return;
+
+    const readAt = new Date().toISOString();
+    setNotifications((current) =>
+      current.map((notification) => ({
+        ...notification,
+        is_read: true,
+        read_at: notification.read_at ?? readAt,
+      })),
+    );
+
+    try {
+      await markAllNotificationsRead(token);
+    } catch (error) {
+      setApiError(getMutationErrorMessage(error));
+    }
+  }, [token]);
+
+  const removeNotification = useCallback(
+    async (notificationId: string) => {
+      if (!token) return;
+
+      const previous = notifications;
+      setNotifications((current) =>
+        current.filter((notification) => notification.id !== notificationId),
+      );
+
+      try {
+        await deleteNotification(notificationId, token);
+      } catch (error) {
+        setNotifications(previous);
+        setApiError(getMutationErrorMessage(error));
+      }
+    },
+    [notifications, token],
+  );
+
+  return {
+    notifications,
+    unreadCount: countUnread(notifications),
+    isLoading,
+    isRefreshing,
+    isLoadingMore,
+    hasMore,
+    apiError,
+    refresh,
+    loadMore,
+    markRead,
+    markAllRead,
+    removeNotification,
+  };
+}

--- a/mobile/src/viewmodels/notifications/usePushNotificationPreference.ts
+++ b/mobile/src/viewmodels/notifications/usePushNotificationPreference.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getPushNotificationsEnabled,
+  setPushNotificationsEnabled as persistPushNotificationsEnabled,
+  subscribePushNotificationsEnabled,
+} from '@/services/notificationPreferenceService';
+
+export interface PushNotificationPreferenceViewModel {
+  pushNotificationsEnabled: boolean;
+  isHydrating: boolean;
+  isSaving: boolean;
+  errorMessage: string | null;
+  setPushNotificationsEnabled: (enabled: boolean) => Promise<void>;
+}
+
+export function usePushNotificationPreference(): PushNotificationPreferenceViewModel {
+  const [pushNotificationsEnabled, setPushNotificationsEnabledState] = useState(true);
+  const [isHydrating, setIsHydrating] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const unsubscribe = subscribePushNotificationsEnabled((enabled) => {
+      if (mounted) {
+        setPushNotificationsEnabledState(enabled);
+      }
+    });
+
+    void (async () => {
+      try {
+        const enabled = await getPushNotificationsEnabled();
+        if (!mounted) return;
+        setPushNotificationsEnabledState(enabled);
+      } catch {
+        if (!mounted) return;
+        setErrorMessage('Failed to load notification settings.');
+      } finally {
+        if (mounted) setIsHydrating(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  const setPushNotificationsEnabled = useCallback(
+    async (enabled: boolean) => {
+      const previous = pushNotificationsEnabled;
+      setPushNotificationsEnabledState(enabled);
+      setIsSaving(true);
+      setErrorMessage(null);
+
+      try {
+        await persistPushNotificationsEnabled(enabled);
+      } catch {
+        setPushNotificationsEnabledState(previous);
+        setErrorMessage('Failed to update notification settings. Please try again.');
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [pushNotificationsEnabled],
+  );
+
+  return {
+    pushNotificationsEnabled,
+    isHydrating,
+    isSaving,
+    errorMessage,
+    setPushNotificationsEnabled,
+  };
+}

--- a/mobile/src/viewmodels/notifications/useUnreadNotificationCount.ts
+++ b/mobile/src/viewmodels/notifications/useUnreadNotificationCount.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { getUnreadNotificationCount } from '@/services/notificationService';
+
+export interface UnreadNotificationCountViewModel {
+  unreadCount: number;
+  refresh: () => Promise<void>;
+}
+
+export function useUnreadNotificationCount(): UnreadNotificationCountViewModel {
+  const { token } = useAuth();
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  const refresh = useCallback(async () => {
+    if (!token) {
+      setUnreadCount(0);
+      return;
+    }
+
+    try {
+      const response = await getUnreadNotificationCount(token);
+      setUnreadCount(response.unread_count);
+    } catch {
+      // silently ignore — badge is best-effort
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { unreadCount, refresh };
+}

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -16,9 +16,11 @@ import EventCard from '@/components/events/EventCard';
 import FiltersBottomSheet from '@/components/home/FiltersBottomSheet';
 import { useHomeViewModel } from '@/viewmodels/home/useHomeViewModel';
 import LocationPickerPanel from '@/components/home/LocationPickerPanel';
+import { useUnreadNotificationCount } from '@/viewmodels/notifications/useUnreadNotificationCount';
 
 export default function HomeView() {
   const vm = useHomeViewModel();
+  const { unreadCount } = useUnreadNotificationCount();
 
   const locationButtonRef = useRef<any>(null);
   const [locationPopupTop, setLocationPopupTop] = useState(140);
@@ -45,6 +47,8 @@ export default function HomeView() {
             ref={locationButtonRef}
             locationLabel={vm.locationLabel}
             onPressLocation={handleOpenLocationPicker}
+            onPressNotifications={() => router.push('/notifications' as Href)}
+            unreadNotificationCount={unreadCount}
           />
 
           <SearchSection

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -6,7 +6,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import { router, type Href } from 'expo-router';
+import { router, useFocusEffect, type Href } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import HomeHeader from '@/components/home/HomeHeader';
 import SearchSection from '@/components/home/SearchSection';
@@ -20,7 +20,13 @@ import { useUnreadNotificationCount } from '@/viewmodels/notifications/useUnread
 
 export default function HomeView() {
   const vm = useHomeViewModel();
-  const { unreadCount } = useUnreadNotificationCount();
+  const { unreadCount, refresh: refreshUnreadCount } = useUnreadNotificationCount();
+
+  useFocusEffect(
+    useCallback(() => {
+      void refreshUnreadCount();
+    }, [refreshUnreadCount]),
+  );
 
   const locationButtonRef = useRef<any>(null);
   const [locationPopupTop, setLocationPopupTop] = useState(140);

--- a/mobile/src/views/notifications/NotificationsView.tsx
+++ b/mobile/src/views/notifications/NotificationsView.tsx
@@ -1,0 +1,417 @@
+import React, { useCallback } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router, type Href } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { NotificationItem } from '@/models/notification';
+import { resolveNotificationRoute } from '@/utils/notificationRouting';
+import { useNotificationsViewModel } from '@/viewmodels/notifications/useNotificationsViewModel';
+
+function formatNotificationTime(value: string): string {
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) return '';
+
+  const diffMs = Date.now() - timestamp;
+  const minuteMs = 60 * 1000;
+  const hourMs = 60 * minuteMs;
+  const dayMs = 24 * hourMs;
+
+  if (diffMs < minuteMs) return 'Just now';
+  if (diffMs < hourMs) return `${Math.floor(diffMs / minuteMs)}m ago`;
+  if (diffMs < dayMs) return `${Math.floor(diffMs / hourMs)}h ago`;
+  if (diffMs < 7 * dayMs) return `${Math.floor(diffMs / dayMs)}d ago`;
+
+  return new Date(value).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatNotificationType(type: string | null): string | null {
+  if (!type) return null;
+
+  return type
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+interface NotificationRowProps {
+  item: NotificationItem;
+  onOpen: (item: NotificationItem) => void;
+  onDelete: (notificationId: string) => void;
+}
+
+function NotificationRow({ item, onOpen, onDelete }: NotificationRowProps) {
+  const typeLabel = formatNotificationType(item.type);
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.88}
+      style={[styles.notificationRow, !item.is_read && styles.unreadRow]}
+      onPress={() => onOpen(item)}
+      accessibilityRole="button"
+      accessibilityLabel={`Open notification ${item.title}`}
+    >
+      {item.image_url ? (
+        <Image
+          source={{ uri: item.image_url }}
+          style={styles.notificationImage}
+          accessibilityLabel=""
+        />
+      ) : (
+        <View style={styles.notificationIcon}>
+          <Ionicons name="notifications-outline" size={22} color="#0F172A" />
+        </View>
+      )}
+
+      <View style={styles.notificationBody}>
+        <View style={styles.notificationHeader}>
+          <Text style={styles.notificationTitle} numberOfLines={2}>
+            {item.title}
+          </Text>
+          {!item.is_read ? <View style={styles.unreadDot} /> : null}
+        </View>
+
+        <Text style={styles.notificationText} numberOfLines={3}>
+          {item.body}
+        </Text>
+
+        <View style={styles.notificationMetaRow}>
+          {typeLabel ? (
+            <Text style={styles.notificationType} numberOfLines={1}>
+              {typeLabel}
+            </Text>
+          ) : null}
+          <Text style={styles.notificationTime}>
+            {formatNotificationTime(item.created_at)}
+          </Text>
+        </View>
+      </View>
+
+      <TouchableOpacity
+        activeOpacity={0.8}
+        style={styles.deleteButton}
+        onPress={() => onDelete(item.id)}
+        accessibilityRole="button"
+        accessibilityLabel={`Delete notification ${item.title}`}
+      >
+        <Ionicons name="trash-outline" size={18} color="#64748B" />
+      </TouchableOpacity>
+    </TouchableOpacity>
+  );
+}
+
+export default function NotificationsView() {
+  const vm = useNotificationsViewModel();
+
+  const openNotification = useCallback(
+    (item: NotificationItem) => {
+      void vm.markRead(item.id);
+
+      const route = resolveNotificationRoute(item);
+      if (route) {
+        router.push(route as Href);
+      }
+    },
+    [vm],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: NotificationItem }) => (
+      <NotificationRow
+        item={item}
+        onOpen={openNotification}
+        onDelete={(notificationId) => void vm.removeNotification(notificationId)}
+      />
+    ),
+    [openNotification, vm],
+  );
+
+  return (
+    <SafeAreaView edges={['top', 'left', 'right']} style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            activeOpacity={0.82}
+            style={styles.backButton}
+            onPress={() => router.back()}
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
+          >
+            <Ionicons name="chevron-back" size={24} color="#111827" />
+          </TouchableOpacity>
+
+          <View style={styles.titleBlock}>
+            <Text style={styles.screenTitle}>Notifications</Text>
+            <Text style={styles.screenSubtitle}>
+              {vm.unreadCount === 0
+                ? 'All caught up'
+                : `${vm.unreadCount} unread`}
+            </Text>
+          </View>
+
+          <TouchableOpacity
+            activeOpacity={0.82}
+            style={[
+              styles.markAllButton,
+              vm.unreadCount === 0 && styles.markAllButtonDisabled,
+            ]}
+            onPress={() => void vm.markAllRead()}
+            disabled={vm.unreadCount === 0}
+            accessibilityRole="button"
+            accessibilityLabel="Mark all notifications as read"
+          >
+            <Ionicons
+              name="checkmark-done-outline"
+              size={21}
+              color={vm.unreadCount === 0 ? '#CBD5E1' : '#111827'}
+            />
+          </TouchableOpacity>
+        </View>
+
+        {vm.apiError ? (
+          <View style={styles.errorBanner}>
+            <Text style={styles.errorText}>{vm.apiError}</Text>
+          </View>
+        ) : null}
+
+        {vm.isLoading ? (
+          <View style={styles.loadingPanel}>
+            <ActivityIndicator size="large" color="#111827" />
+            <Text style={styles.loadingText}>Loading notifications...</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={vm.notifications}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            contentContainerStyle={styles.listContent}
+            showsVerticalScrollIndicator={false}
+            refreshing={vm.isRefreshing}
+            onRefresh={vm.refresh}
+            onEndReachedThreshold={0.35}
+            onEndReached={vm.loadMore}
+            ListEmptyComponent={
+              vm.apiError ? null : (
+                <View style={styles.emptyState}>
+                  <Ionicons
+                    name="notifications-off-outline"
+                    size={42}
+                    color="#CBD5E1"
+                  />
+                  <Text style={styles.emptyTitle}>No notifications yet</Text>
+                  <Text style={styles.emptySubtitle}>
+                    Event invitations and join request updates will appear here.
+                  </Text>
+                </View>
+              )
+            }
+            ListFooterComponent={
+              vm.isLoadingMore ? (
+                <View style={styles.footerLoader}>
+                  <ActivityIndicator size="small" color="#111827" />
+                </View>
+              ) : null
+            }
+          />
+        )}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#F8FAFC',
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 14,
+    paddingBottom: 18,
+    gap: 12,
+  },
+  backButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: '#E2E8F0',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  titleBlock: {
+    flex: 1,
+  },
+  screenTitle: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#111827',
+  },
+  screenSubtitle: {
+    marginTop: 2,
+    color: '#64748B',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  markAllButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: '#E2E8F0',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  markAllButtonDisabled: {
+    backgroundColor: '#F8FAFC',
+  },
+  errorBanner: {
+    backgroundColor: '#FEF2F2',
+    borderColor: '#FECACA',
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+  },
+  errorText: {
+    color: '#DC2626',
+    fontSize: 14,
+  },
+  loadingPanel: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingBottom: 60,
+  },
+  loadingText: {
+    marginTop: 12,
+    color: '#64748B',
+    fontSize: 15,
+  },
+  listContent: {
+    paddingBottom: 24,
+    gap: 10,
+  },
+  notificationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: '#E2E8F0',
+    borderRadius: 18,
+    padding: 12,
+  },
+  unreadRow: {
+    borderColor: '#BAE6FD',
+    backgroundColor: '#F0F9FF',
+  },
+  notificationImage: {
+    width: 54,
+    height: 54,
+    borderRadius: 12,
+    backgroundColor: '#E2E8F0',
+  },
+  notificationIcon: {
+    width: 54,
+    height: 54,
+    borderRadius: 12,
+    backgroundColor: '#E0F2FE',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  notificationBody: {
+    flex: 1,
+    minWidth: 0,
+  },
+  notificationHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  notificationTitle: {
+    flex: 1,
+    color: '#111827',
+    fontSize: 15,
+    fontWeight: '800',
+    lineHeight: 20,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#0284C7',
+  },
+  notificationText: {
+    marginTop: 4,
+    color: '#475569',
+    fontSize: 14,
+    lineHeight: 19,
+  },
+  notificationMetaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 9,
+  },
+  notificationType: {
+    flex: 1,
+    color: '#0369A1',
+    fontSize: 11,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  notificationTime: {
+    color: '#64748B',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  deleteButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  footerLoader: {
+    paddingVertical: 16,
+  },
+  emptyState: {
+    paddingVertical: 72,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyTitle: {
+    marginTop: 14,
+    fontSize: 18,
+    fontWeight: '800',
+    color: '#111827',
+  },
+  emptySubtitle: {
+    marginTop: 8,
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#64748B',
+    textAlign: 'center',
+    paddingHorizontal: 28,
+  },
+});

--- a/mobile/src/views/profile/ProfileView.tsx
+++ b/mobile/src/views/profile/ProfileView.tsx
@@ -4,6 +4,7 @@ import {
   FlatList,
   Image,
   StyleSheet,
+  Switch,
   Text,
   TouchableOpacity,
   View,
@@ -14,6 +15,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import ProfileEventCard from '@/components/profile/ProfileEventCard';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLogoutViewModel } from '@/viewmodels/auth/useLogoutViewModel';
+import { usePushNotificationPreference } from '@/viewmodels/notifications/usePushNotificationPreference';
 import { useProfileViewModel } from '@/viewmodels/profile/useProfileViewModel';
 import { formatEventLocation } from '@/utils/eventLocation';
 
@@ -22,6 +24,7 @@ type ProfileEventTab = 'hosted' | 'attended';
 export default function ProfileView() {
   const { refreshToken, clearAuth } = useAuth();
   const vm = useProfileViewModel();
+  const notificationSettings = usePushNotificationPreference();
   const [activeTab, setActiveTab] = useState<ProfileEventTab>('hosted');
   const { isLoggingOut, logoutError, handleLogout } = useLogoutViewModel(
     refreshToken,
@@ -218,6 +221,59 @@ export default function ProfileView() {
               </View>
               <Ionicons name="chevron-forward" size={20} color="#9CA3AF" />
             </TouchableOpacity>
+
+            <View style={styles.menuDivider} />
+
+            <TouchableOpacity
+              style={styles.menuRow}
+              onPress={() => router.push('/notifications' as Href)}
+              accessibilityRole="button"
+              accessibilityLabel="Open notifications"
+            >
+              <View style={styles.menuRowLeft}>
+                <Ionicons name="notifications-outline" size={20} color="#111827" />
+                <Text style={styles.menuRowText}>Notifications</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color="#9CA3AF" />
+            </TouchableOpacity>
+
+            <View style={styles.menuDivider} />
+
+            <View style={styles.settingRow}>
+              <View style={styles.menuRowLeft}>
+                <Ionicons name="phone-portrait-outline" size={20} color="#111827" />
+                <View style={styles.settingTextBlock}>
+                  <Text style={styles.menuRowText}>Push Notifications</Text>
+                  <Text style={styles.settingSubtitle}>
+                    Receive alerts on this device
+                  </Text>
+                </View>
+              </View>
+              <Switch
+                value={notificationSettings.pushNotificationsEnabled}
+                onValueChange={(enabled) =>
+                  void notificationSettings.setPushNotificationsEnabled(enabled)
+                }
+                disabled={
+                  notificationSettings.isHydrating ||
+                  notificationSettings.isSaving
+                }
+                trackColor={{ false: '#CBD5E1', true: '#BAE6FD' }}
+                thumbColor={
+                  notificationSettings.pushNotificationsEnabled
+                    ? '#0284C7'
+                    : '#F8FAFC'
+                }
+                ios_backgroundColor="#CBD5E1"
+                accessibilityLabel="Toggle push notifications"
+              />
+            </View>
+
+            {notificationSettings.errorMessage ? (
+              <Text style={styles.settingError}>
+                {notificationSettings.errorMessage}
+              </Text>
+            ) : null}
 
             <View style={styles.menuDivider} />
 
@@ -575,6 +631,29 @@ const styles = StyleSheet.create({
     color: '#DC2626',
     fontSize: 17,
     fontWeight: '600',
+  },
+  settingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingVertical: 18,
+  },
+  settingTextBlock: {
+    flex: 1,
+  },
+  settingSubtitle: {
+    color: '#64748B',
+    fontSize: 13,
+    fontWeight: '600',
+    marginTop: 3,
+  },
+  settingError: {
+    color: '#DC2626',
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: -6,
+    marginBottom: 12,
   },
   menuDivider: {
     height: 1,


### PR DESCRIPTION
## 📋 Summary

Adds a full in-app notification center to the mobile app and surfaces a quick-access notification bell on the home screen. Also wires up push notification device registration so the backend knows which device to target.

## 🔄 Changes

- Added `NotificationsView` screen (`/notifications`) with a paginated inbox, pull-to-refresh, swipe-to-delete, mark-as-read, and mark-all-read actions.
- Added `useNotificationsViewModel` to drive all inbox state through the existing `/me/notifications*` API endpoints.
- Added `usePushNotificationPreference` hook and a Push Notifications toggle row in `ProfileView`; preference is persisted locally via `expo-secure-store`.
- Added `PushMessagingHost` + `usePushMessaging` to register/unregister the FCM device token with the backend (`PUT / DELETE /me/push-devices/{installationID}`) in response to auth state and the user's push preference.
- Added `notificationRouting.ts` to map incoming push payloads to in-app routes for deep-link navigation.
- Added a bell icon button with an unread-count badge to `HomeHeader`; pressing it navigates to `/notifications`.
- Added `useUnreadNotificationCount` hook that calls `GET /me/notifications/unread-count` on mount to populate the badge without loading the full inbox.
- Updated `HomeHeader.test.tsx` to add `Ionicons` to the `@expo/vector-icons` mock and added 4 new test cases for the bell button.
- Updated `notificationPreferenceService.test.ts` to reflect the corrected key name.
- Added new test files: `notificationService.test.ts`, `useNotificationsViewModel.test.tsx`, `usePushMessaging.test.tsx`, `pushNotificationPayload.test.ts`, `notificationRouting.test.ts`.

## 🧪 Testing

- `cd mobile`
- `npm test -- --runInBand`
- Verify on device/simulator:
  - Toggle push notifications off in Profile → no error, preference survives app restart
  - Toggle push notifications on → device registers with the backend
  - Open notifications screen from Profile → inbox loads, pull-to-refresh works
  - Open notifications screen via home bell icon → same screen opens
  - Bell badge reflects the correct unread count; clears after marking all read
  - Tapping a push notification while backgrounded deep-links to the correct screen

## 🔗 Related

Closes #515
Closes #477