### PR TITLE
feat(backend): add change-password endpoint (#431)

### DIFF
--- a/backend/internal/adapter/in/postgres/profile_repo.go
+++ b/backend/internal/adapter/in/postgres/profile_repo.go
@@ -438,4 +438,29 @@ func (r *ProfileRepository) SetAvatarIfVersion(
 	return tag.RowsAffected() == 1, nil
 }
 
+// GetPasswordHash returns the bcrypt hash stored for the given user.
+func (r *ProfileRepository) GetPasswordHash(ctx context.Context, userID uuid.UUID) (string, error) {
+	var hash string
+	err := r.pool.QueryRow(ctx, `SELECT password_hash FROM app_user WHERE id = $1`, userID).Scan(&hash)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", domain.ErrNotFound
+		}
+		return "", fmt.Errorf("get password hash: %w", err)
+	}
+	return hash, nil
+}
+
+// UpdatePasswordHash replaces the stored password hash for the given user.
+func (r *ProfileRepository) UpdatePasswordHash(ctx context.Context, userID uuid.UUID, newHash string) error {
+	_, err := r.db.Exec(ctx,
+		`UPDATE app_user SET password_hash = $2, updated_at = now() WHERE id = $1`,
+		userID, newHash,
+	)
+	if err != nil {
+		return fmt.Errorf("update password hash: %w", err)
+	}
+	return nil
+}
+
 var _ imageuploadapp.ProfileRepository = (*ProfileRepository)(nil)

--- a/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
+++ b/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
@@ -34,6 +34,7 @@ func RegisterProfileRoutes(router fiber.Router, handler *ProfileHandler, auth fi
 	me := router.Group("/me", auth)
 	me.Get("", handler.GetMyProfile)
 	me.Patch("", handler.UpdateMyProfile)
+	me.Post("/change-password", handler.ChangePassword)
 	me.Get("/events/hosted", handler.GetMyHostedEvents)
 	me.Get("/events/upcoming", handler.GetMyUpcomingEvents)
 	me.Get("/events/completed", handler.GetMyCompletedEvents)
@@ -272,6 +273,39 @@ func (h *ProfileHandler) DeclineInvitation(c *fiber.Ctx) error {
 		slog.String("invitation_id", invitationID.String()),
 	)
 	return c.JSON(result)
+}
+
+// changePasswordBody is the request body for POST /me/change-password.
+type changePasswordBody struct {
+	OldPassword string `json:"old_password"`
+	NewPassword string `json:"new_password"`
+}
+
+// ChangePassword handles POST /me/change-password.
+func (h *ProfileHandler) ChangePassword(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+
+	var body changePasswordBody
+	if err := c.BodyParser(&body); err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"body": "must be valid JSON"}))
+	}
+
+	if err := h.service.ChangePassword(c.UserContext(), profile.ChangePasswordInput{
+		UserID:      claims.UserID,
+		OldPassword: body.OldPassword,
+		NewPassword: body.NewPassword,
+	}); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"password changed",
+		httpapi.OperationAttr("profile.change_password"),
+		httpapi.UserIDAttr(claims.UserID),
+	)
+
+	return c.SendStatus(fiber.StatusNoContent)
 }
 
 func parseInvitationIDParam(c *fiber.Ctx) (uuid.UUID, error) {

--- a/backend/internal/application/profile/repository.go
+++ b/backend/internal/application/profile/repository.go
@@ -16,4 +16,6 @@ type Repository interface {
 	GetCompletedEvents(ctx context.Context, userID uuid.UUID) ([]domain.EventSummary, error)
 	GetCanceledEvents(ctx context.Context, userID uuid.UUID) ([]domain.EventSummary, error)
 	SearchUsers(ctx context.Context, query string, limit int) ([]UserSearchRecord, error)
+	GetPasswordHash(ctx context.Context, userID uuid.UUID) (string, error)
+	UpdatePasswordHash(ctx context.Context, userID uuid.UUID, newHash string) error
 }

--- a/backend/internal/application/profile/service.go
+++ b/backend/internal/application/profile/service.go
@@ -11,18 +11,23 @@ import (
 
 // Service owns profile-specific application behavior.
 type Service struct {
-	repo       Repository
-	unitOfWork uow.UnitOfWork
+	repo           Repository
+	unitOfWork     uow.UnitOfWork
+	passwordHasher PasswordHasher
 }
 
 var _ UseCase = (*Service)(nil)
 
 // NewService constructs a profile service backed by its own repository.
-func NewService(repo Repository, unitOfWork uow.UnitOfWork) *Service {
-	return &Service{
+func NewService(repo Repository, unitOfWork uow.UnitOfWork, passwordHasher ...PasswordHasher) *Service {
+	s := &Service{
 		repo:       repo,
 		unitOfWork: unitOfWork,
 	}
+	if len(passwordHasher) > 0 {
+		s.passwordHasher = passwordHasher[0]
+	}
+	return s
 }
 
 // GetMyProfile returns the combined app_user + profile data for the given user.
@@ -143,6 +148,27 @@ func toEventSummaries(events []domain.EventSummary) []EventSummary {
 		}
 	}
 	return result
+}
+
+// ChangePassword verifies the current password and replaces it with the new one.
+func (s *Service) ChangePassword(ctx context.Context, input ChangePasswordInput) error {
+	if err := validateChangePasswordInput(input); err != nil {
+		return err
+	}
+	return s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		currentHash, err := s.repo.GetPasswordHash(ctx, input.UserID)
+		if err != nil {
+			return err
+		}
+		if err := s.passwordHasher.Compare(currentHash, input.OldPassword); err != nil {
+			return domain.AuthError(domain.ErrorCodePasswordMismatch, "Current password is incorrect.")
+		}
+		newHash, err := s.passwordHasher.Hash(input.NewPassword)
+		if err != nil {
+			return err
+		}
+		return s.repo.UpdatePasswordHash(ctx, input.UserID, newHash)
+	})
 }
 
 // UpdateMyProfile validates and persists the editable profile fields.

--- a/backend/internal/application/profile/service_dto.go
+++ b/backend/internal/application/profile/service_dto.go
@@ -2,6 +2,19 @@ package profile
 
 import "github.com/google/uuid"
 
+// PasswordHasher is the profile package's local port for password hashing operations.
+type PasswordHasher interface {
+	Hash(value string) (string, error)
+	Compare(hash, value string) error
+}
+
+// ChangePasswordInput carries the authenticated user's current and new password.
+type ChangePasswordInput struct {
+	UserID      uuid.UUID
+	OldPassword string
+	NewPassword string
+}
+
 // EventSummary is a lightweight event representation used in profile responses.
 type EventSummary struct {
 	ID                string  `json:"id"`

--- a/backend/internal/application/profile/service_test.go
+++ b/backend/internal/application/profile/service_test.go
@@ -21,6 +21,7 @@ func (u *fakeUnitOfWork) RunInTx(ctx context.Context, fn func(ctx context.Contex
 type fakeProfileRepo struct {
 	profile         *domain.UserProfile
 	profileErr      error
+	passwordHash    string
 	hostedEvents    []domain.EventSummary
 	upcomingEvents  []domain.EventSummary
 	completedEvents []domain.EventSummary
@@ -55,6 +56,14 @@ func (r *fakeProfileRepo) GetCanceledEvents(_ context.Context, _ uuid.UUID) ([]d
 
 func (r *fakeProfileRepo) SearchUsers(_ context.Context, _ string, _ int) ([]UserSearchRecord, error) {
 	return r.searchUsers, r.eventsErr
+}
+
+func (r *fakeProfileRepo) GetPasswordHash(_ context.Context, _ uuid.UUID) (string, error) {
+	return r.passwordHash, r.profileErr
+}
+
+func (r *fakeProfileRepo) UpdatePasswordHash(_ context.Context, _ uuid.UUID, _ string) error {
+	return r.profileErr
 }
 
 func newService(repo *fakeProfileRepo) *Service {
@@ -232,5 +241,85 @@ func TestGetMyCanceledEventsIncludesPrivacyLevel(t *testing.T) {
 
 	if events[0].PrivacyLevel != "PRIVATE" {
 		t.Fatalf("expected PRIVATE, got %q", events[0].PrivacyLevel)
+	}
+}
+
+// --- ChangePassword tests ---
+
+type fakeHasher struct {
+	compareErr error
+	hashErr    error
+}
+
+func (h fakeHasher) Hash(_ string) (string, error) {
+	if h.hashErr != nil {
+		return "", h.hashErr
+	}
+	return "hashed", nil
+}
+
+func (h fakeHasher) Compare(_, _ string) error { return h.compareErr }
+
+func newServiceWithHasher(repo *fakeProfileRepo, ph PasswordHasher) *Service {
+	return NewService(repo, &fakeUnitOfWork{}, ph)
+}
+
+func TestChangePassword_Success(t *testing.T) {
+	repo := &fakeProfileRepo{passwordHash: "$2a$10$stored"}
+	svc := newServiceWithHasher(repo, fakeHasher{})
+
+	err := svc.ChangePassword(context.Background(), ChangePasswordInput{
+		UserID:      uuid.New(),
+		OldPassword: "oldpass123",
+		NewPassword: "newpass456",
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestChangePassword_WrongOldPassword(t *testing.T) {
+	repo := &fakeProfileRepo{passwordHash: "$2a$10$stored"}
+	svc := newServiceWithHasher(repo, fakeHasher{compareErr: errors.New("mismatch")})
+
+	err := svc.ChangePassword(context.Background(), ChangePasswordInput{
+		UserID:      uuid.New(),
+		OldPassword: "wrongpass",
+		NewPassword: "newpass456",
+	})
+	if err == nil {
+		t.Fatal("expected error for wrong old password")
+	}
+	appErr, ok := err.(*domain.AppError)
+	if !ok || appErr.Code != domain.ErrorCodePasswordMismatch {
+		t.Fatalf("expected password_mismatch AppError, got %v", err)
+	}
+}
+
+func TestChangePassword_ValidationFailsShortNew(t *testing.T) {
+	repo := &fakeProfileRepo{}
+	svc := newServiceWithHasher(repo, fakeHasher{})
+
+	err := svc.ChangePassword(context.Background(), ChangePasswordInput{
+		UserID:      uuid.New(),
+		OldPassword: "oldpass123",
+		NewPassword: "short",
+	})
+	if err == nil {
+		t.Fatal("expected validation error for short new password")
+	}
+}
+
+func TestChangePassword_SamePassword(t *testing.T) {
+	repo := &fakeProfileRepo{}
+	svc := newServiceWithHasher(repo, fakeHasher{})
+
+	err := svc.ChangePassword(context.Background(), ChangePasswordInput{
+		UserID:      uuid.New(),
+		OldPassword: "samepass123",
+		NewPassword: "samepass123",
+	})
+	if err == nil {
+		t.Fatal("expected validation error when new == old password")
 	}
 }

--- a/backend/internal/application/profile/usecase.go
+++ b/backend/internal/application/profile/usecase.go
@@ -15,4 +15,5 @@ type UseCase interface {
 	GetMyCompletedEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error)
 	GetMyCanceledEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error)
 	SearchUsers(ctx context.Context, input UserSearchInput) (*UserSearchResult, error)
+	ChangePassword(ctx context.Context, input ChangePasswordInput) error
 }

--- a/backend/internal/application/profile/validator.go
+++ b/backend/internal/application/profile/validator.go
@@ -7,6 +7,25 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 )
 
+func validateChangePasswordInput(input ChangePasswordInput) *domain.AppError {
+	details := make(map[string]string)
+
+	if len(input.OldPassword) == 0 {
+		details["old_password"] = "must not be empty"
+	}
+	if len(input.NewPassword) < 8 || len(input.NewPassword) > 128 {
+		details["new_password"] = "must be between 8 and 128 characters"
+	}
+	if input.OldPassword == input.NewPassword && len(details) == 0 {
+		details["new_password"] = "must differ from current password"
+	}
+
+	if len(details) > 0 {
+		return domain.ValidationError(details)
+	}
+	return nil
+}
+
 func validateUpdateProfileInput(input UpdateProfileInput) (*UpdateProfileInput, *domain.AppError) {
 	details := make(map[string]string)
 

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -298,7 +298,7 @@ func newCategoryService(c *Container) category.UseCase {
 
 // newProfileService wires the profile use-case service with its driven adapter.
 func newProfileService(c *Container) profile.UseCase {
-	return profile.NewService(c.profileRepo, c.UnitOfWork)
+	return profile.NewService(c.profileRepo, c.UnitOfWork, hasher.BcryptHasher{})
 }
 
 // newFavoriteLocationService wires the favorite-location use-case service with its driven adapter.

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -80,6 +80,8 @@ const (
 
 	ErrorCodeAdminAccessRequired        = "admin_access_required"
 	ErrorCodeAdminDependencyUnavailable = "admin_dependency_unavailable"
+
+	ErrorCodePasswordMismatch = "password_mismatch"
 )
 
 // ErrNotFound is a sentinel error returned when a queried entity does not exist.


### PR DESCRIPTION
📋 Summary                                                                                                            
                                                                                                                        
  Adds POST /api/v1/me/change-password endpoint that lets authenticated users update their password by providing their  
  current and new password.                                                                                             
                                                                                                                        
  🔄 Changes                                                                                                            
   
  - domain/errors.go — added ErrorCodePasswordMismatch error code                                                       
  - application/profile/service_dto.go — added PasswordHasher interface and ChangePasswordInput DTO
  - application/profile/repository.go — added GetPasswordHash and UpdatePasswordHash port methods                       
  - application/profile/usecase.go — added ChangePassword to UseCase interface                                          
  - application/profile/validator.go — added validateChangePasswordInput (old non-empty, new 8–128 chars, new ≠ old)    
  - application/profile/service.go — implemented ChangePassword with bcrypt verify + rehash in transaction              
  - application/profile/service_test.go — unit tests for success, wrong password, short new password, same password     
  - adapter/in/postgres/profile_repo.go — implemented GetPasswordHash and UpdatePasswordHash queries                    
  - adapter/out/httpapi/profile_handler/profile_handler.go — added ChangePassword handler and route                     
  - bootstrap/container.go — injected BcryptHasher{} into newProfileService                                             
                                                                                                                        
  🧪 Testing                                                                                                            
```                                                                                                                        
  # Wrong old password -> 401                                         
  curl -X POST http://localhost:8080/api/v1/me/change-password \
    -H "Authorization: Bearer YOUR_JWT" \                                                                               
    -H "Content-Type: application/json" \
    -d '{"old_password":"wrong","new_password":"newpass456"}'                                                           
                                                                      
  # Success -> 204                                                                                                      
  curl -X POST http://localhost:8080/api/v1/me/change-password \      
    -H "Authorization: Bearer YOUR_JWT" \                                                                               
    -H "Content-Type: application/json" \
    -d '{"old_password":"correctpass","new_password":"newpass456"}'                                                     
```                                                                                                                        
  🔗 Related
                                                                                                                        
  Closes #431 