### PR TITLE
feat(backend): allow pending-invited users to view private event detail (#540)

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -854,7 +854,7 @@ func (r *EventRepository) loadEventDetailCore(
 				FROM invitation inv
 				WHERE inv.event_id = e.id
 				  AND inv.invited_user_id = $2
-				  AND inv.status = $13
+				  AND inv.status IN ($13, $16)
 			)
 		  )
 	`,
@@ -873,6 +873,7 @@ func (r *EventRepository) loadEventDetailCore(
 		string(domain.InvitationStatusAccepted),
 		domain.ParticipationStatusCanceled,
 		string(domain.EventDetailParticipationStatusCanceled),
+		string(domain.InvitationStatusPending),
 	).Scan(
 		&id,
 		&title,

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -33,8 +33,9 @@ paths:
         Visibility rules:
         - `PUBLIC` and `PROTECTED` events are readable by any caller, authenticated or not.
         - `PRIVATE` events are readable only by the host, users with an `APPROVED`
-          participation, or users with an `ACCEPTED` invitation. Anonymous callers cannot
-          read `PRIVATE` events.
+          participation, users with an `ACCEPTED` invitation, or users with a `PENDING`
+          invitation (so invited users can review the event before responding). Anonymous
+          callers cannot read `PRIVATE` events.
         - When a `PRIVATE` event is not readable by the caller, the API responds with
           `404 event_not_found` to avoid leaking the event's existence.
 


### PR DESCRIPTION
📋 Summary                                                                                                            
                                                                                                                        
  Extends GET /events/{id} so users with a PENDING invitation to a PRIVATE event can fetch its details. This lets       
  invited users review the event before accepting or declining. No response shape changes; existing
  host/participant/accepted-invitee behavior preserved.                                                                 
                                                            
  🔄 Changes

  - adapter/in/postgres/event_repo.go — loadEventDetailCore visibility clause now allows inv.status IN (ACCEPTED,       
  PENDING) instead of just ACCEPTED. Added domain.InvitationStatusPending as $16.
  - docs/openapi/event.yaml — GET /events/{id} description updated to list PENDING invitation as a valid visibility     
  path.                                                                                                                 
   
  🧪 Testing                                                                                                            
                                                            
  Manually via Swagger UI at http://localhost/docs/swagger-ui/:                                                         
                                                            
  1. Login as User A → create a PRIVATE event → invite User B (creates PENDING invitation)                              
  2. Login as User B → GET /events/{id} → 200 with viewer_context.participation_status = "INVITED" ✅
  3. Login as User C (no invitation) → GET /events/{id} → 404 event_not_found (still hidden) ✅                         
  4. Sanity: host still sees their event; PUBLIC/PROTECTED events still readable by anyone.                             
                                                                                                                        
  🔗 Related                                                                                                            
                                                                                                                        
  Closes #540