### PR TITLE
feat(backend): add badge and achievement system (#435)

### DIFF
--- a/backend/internal/adapter/in/postgres/badge_repo.go
+++ b/backend/internal/adapter/in/postgres/badge_repo.go
@@ -1,0 +1,211 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	badgeapp "github.com/bounswe/bounswe2026group11/backend/internal/application/badge"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// BadgeRepository is the Postgres-backed implementation of badge.Repository.
+type BadgeRepository struct {
+	pool *pgxpool.Pool
+	db   execer
+}
+
+// NewBadgeRepository returns a repository that executes queries against the given connection pool.
+func NewBadgeRepository(pool *pgxpool.Pool) *BadgeRepository {
+	return &BadgeRepository{
+		pool: pool,
+		db:   contextualRunner{fallback: pool},
+	}
+}
+
+// ListAllBadges returns the full badge catalog ordered by sort_order.
+func (r *BadgeRepository) ListAllBadges(ctx context.Context) ([]domain.Badge, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, slug, name, description, icon_url, category, sort_order
+		FROM badge
+		ORDER BY sort_order ASC, id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list badges: %w", err)
+	}
+	defer rows.Close()
+
+	var badges []domain.Badge
+	for rows.Next() {
+		b, err := scanBadge(rows)
+		if err != nil {
+			return nil, err
+		}
+		badges = append(badges, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate badges: %w", err)
+	}
+	if badges == nil {
+		badges = []domain.Badge{}
+	}
+	return badges, nil
+}
+
+// ListUserBadges returns the badges earned by the given user joined against the catalog.
+func (r *BadgeRepository) ListUserBadges(ctx context.Context, userID uuid.UUID) ([]domain.UserBadge, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT
+			ub.user_id,
+			ub.badge_id,
+			ub.earned_at,
+			b.id,
+			b.slug,
+			b.name,
+			b.description,
+			b.icon_url,
+			b.category,
+			b.sort_order
+		FROM user_badge ub
+		JOIN badge b ON b.id = ub.badge_id
+		WHERE ub.user_id = $1
+		ORDER BY ub.earned_at DESC, b.sort_order ASC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list user badges: %w", err)
+	}
+	defer rows.Close()
+
+	var earned []domain.UserBadge
+	for rows.Next() {
+		var (
+			ub       domain.UserBadge
+			def      domain.Badge
+			iconURL  pgtype.Text
+			slug     string
+			category string
+		)
+		if err := rows.Scan(
+			&ub.UserID, &ub.BadgeID, &ub.EarnedAt,
+			&def.ID, &slug, &def.Name, &def.Description, &iconURL, &category, &def.SortOrder,
+		); err != nil {
+			return nil, fmt.Errorf("scan user badge: %w", err)
+		}
+		def.Slug = domain.BadgeSlug(slug)
+		def.Category = domain.BadgeCategory(category)
+		def.IconURL = textPtr(iconURL)
+		ub.Slug = def.Slug
+		ub.Definition = def
+		earned = append(earned, ub)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate user badges: %w", err)
+	}
+	if earned == nil {
+		earned = []domain.UserBadge{}
+	}
+	return earned, nil
+}
+
+// AwardBadge inserts a (user_id, badge_id) row using ON CONFLICT DO NOTHING so
+// repeated evaluation calls never raise duplicate-key errors. Returns true
+// when a new badge row was actually written for the user.
+func (r *BadgeRepository) AwardBadge(ctx context.Context, userID uuid.UUID, slug domain.BadgeSlug) (bool, error) {
+	tag, err := r.db.Exec(ctx, `
+		INSERT INTO user_badge (user_id, badge_id)
+		SELECT $1, b.id
+		FROM badge b
+		WHERE b.slug = $2
+		ON CONFLICT (user_id, badge_id) DO NOTHING
+	`, userID, string(slug))
+	if err != nil {
+		return false, fmt.Errorf("award badge: %w", err)
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// ParticipationStats returns the participant-side metrics required by the
+// participation badge rules.
+func (r *BadgeRepository) ParticipationStats(ctx context.Context, userID uuid.UUID) (badgeapp.ParticipationStatsRecord, error) {
+	var record badgeapp.ParticipationStatsRecord
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			COUNT(*) AS completed_event_count,
+			COUNT(DISTINCT e.category_id) FILTER (WHERE e.category_id IS NOT NULL) AS distinct_categories
+		FROM participation p
+		JOIN event e ON e.id = p.event_id
+		WHERE p.user_id = $1
+		  AND p.status = $2
+		  AND e.status = $3
+	`, userID, domain.ParticipationStatusApproved, domain.EventStatusCompleted).Scan(
+		&record.CompletedEventCount,
+		&record.DistinctCategoriesCount,
+	)
+	if err != nil {
+		return record, fmt.Errorf("participation stats: %w", err)
+	}
+	return record, nil
+}
+
+// HostStats returns the host-side metrics required by the hosting badge rules.
+func (r *BadgeRepository) HostStats(ctx context.Context, hostID uuid.UUID) (badgeapp.HostStatsRecord, error) {
+	var (
+		record    badgeapp.HostStatsRecord
+		hostScore pgtype.Float8
+	)
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			(SELECT COUNT(*) FROM event e WHERE e.host_id = $1 AND e.status = $2) AS completed_hosted_count,
+			us.hosted_event_score,
+			COALESCE(us.hosted_event_rating_count, 0) AS hosted_event_rating_count
+		FROM app_user u
+		LEFT JOIN user_score us ON us.user_id = u.id
+		WHERE u.id = $1
+	`, hostID, domain.EventStatusCompleted).Scan(
+		&record.CompletedHostedEventCount,
+		&hostScore,
+		&record.HostRatingCount,
+	)
+	if err != nil {
+		return record, fmt.Errorf("host stats: %w", err)
+	}
+	if hostScore.Valid {
+		record.HostScore = &hostScore.Float64
+	}
+	return record, nil
+}
+
+// FavoriteLocationCount returns the total number of favorite locations saved
+// by the given user.
+func (r *BadgeRepository) FavoriteLocationCount(ctx context.Context, userID uuid.UUID) (int, error) {
+	var count int
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM favorite_location WHERE user_id = $1
+	`, userID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("favorite location count: %w", err)
+	}
+	return count, nil
+}
+
+func scanBadge(rows interface {
+	Scan(...any) error
+}) (domain.Badge, error) {
+	var (
+		b        domain.Badge
+		iconURL  pgtype.Text
+		slug     string
+		category string
+	)
+	if err := rows.Scan(&b.ID, &slug, &b.Name, &b.Description, &iconURL, &category, &b.SortOrder); err != nil {
+		return domain.Badge{}, fmt.Errorf("scan badge: %w", err)
+	}
+	b.Slug = domain.BadgeSlug(slug)
+	b.Category = domain.BadgeCategory(category)
+	b.IconURL = textPtr(iconURL)
+	return b, nil
+}
+
+var _ badgeapp.Repository = (*BadgeRepository)(nil)

--- a/backend/internal/adapter/out/httpapi/badge_handler/badge_handler.go
+++ b/backend/internal/adapter/out/httpapi/badge_handler/badge_handler.go
@@ -1,0 +1,92 @@
+package badge_handler
+
+import (
+	"log/slog"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/badge"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// Handler exposes HTTP routes for the badge use cases.
+type Handler struct {
+	service badge.UseCase
+}
+
+// NewHandler constructs a badge handler delegating to the given use case.
+func NewHandler(service badge.UseCase) *Handler {
+	return &Handler{service: service}
+}
+
+// RegisterRoutes wires the badge routes onto the given fiber router.
+//
+// Routes registered:
+//   - GET /me/badges            (authenticated viewer's earned badges)
+//   - GET /users/:id/badges     (public profile owner's earned badges)
+//   - GET /badges               (full catalog with viewer earned status)
+func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler) {
+	router.Get("/me/badges", auth, handler.ListMyBadges)
+	router.Get("/users/:id/badges", auth, handler.ListUserBadges)
+	router.Get("/badges", auth, handler.ListBadgeCatalog)
+}
+
+// ListMyBadges handles GET /me/badges.
+func (h *Handler) ListMyBadges(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ListMyBadges(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my badges fetched",
+		httpapi.OperationAttr("badges.list_mine"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(result.Items)),
+	)
+	return c.JSON(result)
+}
+
+// ListUserBadges handles GET /users/:id/badges.
+func (h *Handler) ListUserBadges(c *fiber.Ctx) error {
+	userID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+	result, err := h.service.ListUserBadges(c.UserContext(), userID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	httpapi.LogInfo(
+		c.UserContext(),
+		"user badges fetched",
+		httpapi.OperationAttr("badges.list_user"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("target_user_id", userID.String()),
+		slog.Int("result_count", len(result.Items)),
+	)
+	return c.JSON(result)
+}
+
+// ListBadgeCatalog handles GET /badges.
+func (h *Handler) ListBadgeCatalog(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ListBadges(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"badge catalog fetched",
+		httpapi.OperationAttr("badges.list_catalog"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(result.Items)),
+	)
+	return c.JSON(result)
+}

--- a/backend/internal/application/badge/repository.go
+++ b/backend/internal/application/badge/repository.go
@@ -1,0 +1,32 @@
+package badge
+
+import (
+	"context"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// Repository is the application-layer persistence port for badge flows.
+type Repository interface {
+	// ListAllBadges returns every badge definition in the catalog ordered by
+	// the badge's stable sort order.
+	ListAllBadges(ctx context.Context) ([]domain.Badge, error)
+	// ListUserBadges returns the badges earned by the given user, joined
+	// against their definition and ordered by earned_at descending.
+	ListUserBadges(ctx context.Context, userID uuid.UUID) ([]domain.UserBadge, error)
+	// AwardBadge inserts a (user_id, badge_id) row using a NOT EXISTS clause
+	// so re-evaluation never raises a duplicate-key error. Returns true when
+	// a new badge row was actually written for the user.
+	AwardBadge(ctx context.Context, userID uuid.UUID, slug domain.BadgeSlug) (bool, error)
+
+	// ParticipationStats returns the lightweight metrics required by the
+	// participation badge rules: total completed events, distinct categories
+	// across completed events, and total favorite-location count.
+	ParticipationStats(ctx context.Context, userID uuid.UUID) (ParticipationStatsRecord, error)
+	// HostStats returns the metrics required by the hosting badge rules.
+	HostStats(ctx context.Context, hostID uuid.UUID) (HostStatsRecord, error)
+	// FavoriteLocationCount returns the number of favorite locations saved
+	// by the given user.
+	FavoriteLocationCount(ctx context.Context, userID uuid.UUID) (int, error)
+}

--- a/backend/internal/application/badge/service.go
+++ b/backend/internal/application/badge/service.go
@@ -1,0 +1,163 @@
+package badge
+
+import (
+	"context"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+const (
+	// minTopRatedRatingCount is the minimum number of host ratings required
+	// before the TOP_RATED badge becomes eligible. Mirrors the acceptance
+	// criteria of issue #435.
+	minTopRatedRatingCount = 5
+	// topRatedThreshold is the minimum host score required for TOP_RATED.
+	topRatedThreshold = 4.5
+)
+
+// Service owns badge-specific application behavior.
+type Service struct {
+	repo Repository
+}
+
+var _ UseCase = (*Service)(nil)
+
+// NewService constructs a badge service backed by its repository port.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// ListMyBadges returns the badges earned by the authenticated user.
+func (s *Service) ListMyBadges(ctx context.Context, userID uuid.UUID) (*ListUserBadgesResult, error) {
+	return s.listUserBadges(ctx, userID)
+}
+
+// ListUserBadges returns the badges earned by the given public profile owner.
+func (s *Service) ListUserBadges(ctx context.Context, userID uuid.UUID) (*ListUserBadgesResult, error) {
+	return s.listUserBadges(ctx, userID)
+}
+
+func (s *Service) listUserBadges(ctx context.Context, userID uuid.UUID) (*ListUserBadgesResult, error) {
+	earned, err := s.repo.ListUserBadges(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]EarnedBadgeItem, len(earned))
+	for i, ub := range earned {
+		items[i] = EarnedBadgeItem{
+			BadgeItem: toBadgeItem(ub.Definition),
+			EarnedAt:  ub.EarnedAt.Format(time.RFC3339),
+		}
+	}
+	return &ListUserBadgesResult{Items: items}, nil
+}
+
+// ListBadges returns the full catalog with the viewer's earned status overlay.
+func (s *Service) ListBadges(ctx context.Context, userID uuid.UUID) (*ListBadgesResult, error) {
+	all, err := s.repo.ListAllBadges(ctx)
+	if err != nil {
+		return nil, err
+	}
+	earned, err := s.repo.ListUserBadges(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	earnedAt := make(map[domain.BadgeSlug]time.Time, len(earned))
+	for _, ub := range earned {
+		earnedAt[ub.Slug] = ub.EarnedAt
+	}
+	items := make([]CatalogBadgeItem, len(all))
+	for i, b := range all {
+		entry := CatalogBadgeItem{BadgeItem: toBadgeItem(b)}
+		if t, ok := earnedAt[b.Slug]; ok {
+			entry.Earned = true
+			formatted := t.Format(time.RFC3339)
+			entry.EarnedAt = &formatted
+		}
+		items[i] = entry
+	}
+	return &ListBadgesResult{Items: items}, nil
+}
+
+func toBadgeItem(b domain.Badge) BadgeItem {
+	return BadgeItem{
+		Slug:        b.Slug.String(),
+		Name:        b.Name,
+		Description: b.Description,
+		IconURL:     b.IconURL,
+		Category:    b.Category.String(),
+	}
+}
+
+// EvaluateParticipationBadges awards FIRST_STEPS / REGULAR / VETERAN / EXPLORER
+// based on the participant-side metrics. AwardBadge is idempotent so this
+// method is safe to call from any participation transition.
+func (s *Service) EvaluateParticipationBadges(ctx context.Context, userID uuid.UUID) error {
+	stats, err := s.repo.ParticipationStats(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if stats.CompletedEventCount >= 1 {
+		if _, err := s.repo.AwardBadge(ctx, userID, domain.BadgeSlugFirstSteps); err != nil {
+			return err
+		}
+	}
+	if stats.CompletedEventCount >= 5 {
+		if _, err := s.repo.AwardBadge(ctx, userID, domain.BadgeSlugRegular); err != nil {
+			return err
+		}
+	}
+	if stats.CompletedEventCount >= 20 {
+		if _, err := s.repo.AwardBadge(ctx, userID, domain.BadgeSlugVeteran); err != nil {
+			return err
+		}
+	}
+	if stats.DistinctCategoriesCount >= 3 {
+		if _, err := s.repo.AwardBadge(ctx, userID, domain.BadgeSlugExplorer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EvaluateHostBadges awards HOST_DEBUT / SUPER_HOST / TOP_RATED for the host.
+// Should be called after a host completes a new event or receives a new rating.
+func (s *Service) EvaluateHostBadges(ctx context.Context, hostID uuid.UUID) error {
+	stats, err := s.repo.HostStats(ctx, hostID)
+	if err != nil {
+		return err
+	}
+	if stats.CompletedHostedEventCount >= 1 {
+		if _, err := s.repo.AwardBadge(ctx, hostID, domain.BadgeSlugHostDebut); err != nil {
+			return err
+		}
+	}
+	if stats.CompletedHostedEventCount >= 10 {
+		if _, err := s.repo.AwardBadge(ctx, hostID, domain.BadgeSlugSuperHost); err != nil {
+			return err
+		}
+	}
+	if stats.HostRatingCount >= minTopRatedRatingCount && stats.HostScore != nil && *stats.HostScore >= topRatedThreshold {
+		if _, err := s.repo.AwardBadge(ctx, hostID, domain.BadgeSlugTopRated); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EvaluateFavoriteLocationBadges awards FAVORITE_FINDER once the user has saved
+// at least 3 favorite locations.
+func (s *Service) EvaluateFavoriteLocationBadges(ctx context.Context, userID uuid.UUID) error {
+	count, err := s.repo.FavoriteLocationCount(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if count >= 3 {
+		if _, err := s.repo.AwardBadge(ctx, userID, domain.BadgeSlugFavoriteFinder); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/backend/internal/application/badge/service_dto.go
+++ b/backend/internal/application/badge/service_dto.go
@@ -1,0 +1,48 @@
+package badge
+
+// ParticipationStatsRecord aggregates the participant-side metrics consumed
+// by participation badge rules.
+type ParticipationStatsRecord struct {
+	CompletedEventCount     int
+	DistinctCategoriesCount int
+}
+
+// HostStatsRecord aggregates the host-side metrics consumed by hosting badge
+// rules.
+type HostStatsRecord struct {
+	CompletedHostedEventCount int
+	HostScore                 *float64
+	HostRatingCount           int
+}
+
+// BadgeItem is the wire representation of a badge definition.
+type BadgeItem struct {
+	Slug        string  `json:"slug"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	IconURL     *string `json:"icon_url"`
+	Category    string  `json:"category"`
+}
+
+// EarnedBadgeItem extends BadgeItem with the time when the viewer earned it.
+type EarnedBadgeItem struct {
+	BadgeItem
+	EarnedAt string `json:"earned_at"`
+}
+
+// ListUserBadgesResult is the output shape of ListMyBadges and ListUserBadges.
+type ListUserBadgesResult struct {
+	Items []EarnedBadgeItem `json:"items"`
+}
+
+// CatalogBadgeItem is BadgeItem with viewer-specific earned status fields.
+type CatalogBadgeItem struct {
+	BadgeItem
+	Earned   bool    `json:"earned"`
+	EarnedAt *string `json:"earned_at"`
+}
+
+// ListBadgesResult is the output of the catalog endpoint.
+type ListBadgesResult struct {
+	Items []CatalogBadgeItem `json:"items"`
+}

--- a/backend/internal/application/badge/service_test.go
+++ b/backend/internal/application/badge/service_test.go
@@ -1,0 +1,370 @@
+package badge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+type fakeRepo struct {
+	all              []domain.Badge
+	earnedByUser     map[uuid.UUID][]domain.UserBadge
+	participation    map[uuid.UUID]ParticipationStatsRecord
+	host             map[uuid.UUID]HostStatsRecord
+	favoriteCounts   map[uuid.UUID]int
+	awarded          map[uuid.UUID][]domain.BadgeSlug
+	awardErr         error
+	listAllErr       error
+	listUserErr      error
+	participationErr error
+	hostErr          error
+	favoriteCountErr error
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{
+		earnedByUser:   map[uuid.UUID][]domain.UserBadge{},
+		participation:  map[uuid.UUID]ParticipationStatsRecord{},
+		host:           map[uuid.UUID]HostStatsRecord{},
+		favoriteCounts: map[uuid.UUID]int{},
+		awarded:        map[uuid.UUID][]domain.BadgeSlug{},
+	}
+}
+
+func (r *fakeRepo) ListAllBadges(ctx context.Context) ([]domain.Badge, error) {
+	if r.listAllErr != nil {
+		return nil, r.listAllErr
+	}
+	return r.all, nil
+}
+
+func (r *fakeRepo) ListUserBadges(ctx context.Context, userID uuid.UUID) ([]domain.UserBadge, error) {
+	if r.listUserErr != nil {
+		return nil, r.listUserErr
+	}
+	return r.earnedByUser[userID], nil
+}
+
+func (r *fakeRepo) AwardBadge(ctx context.Context, userID uuid.UUID, slug domain.BadgeSlug) (bool, error) {
+	if r.awardErr != nil {
+		return false, r.awardErr
+	}
+	for _, existing := range r.awarded[userID] {
+		if existing == slug {
+			return false, nil
+		}
+	}
+	r.awarded[userID] = append(r.awarded[userID], slug)
+	return true, nil
+}
+
+func (r *fakeRepo) ParticipationStats(ctx context.Context, userID uuid.UUID) (ParticipationStatsRecord, error) {
+	if r.participationErr != nil {
+		return ParticipationStatsRecord{}, r.participationErr
+	}
+	return r.participation[userID], nil
+}
+
+func (r *fakeRepo) HostStats(ctx context.Context, hostID uuid.UUID) (HostStatsRecord, error) {
+	if r.hostErr != nil {
+		return HostStatsRecord{}, r.hostErr
+	}
+	return r.host[hostID], nil
+}
+
+func (r *fakeRepo) FavoriteLocationCount(ctx context.Context, userID uuid.UUID) (int, error) {
+	if r.favoriteCountErr != nil {
+		return 0, r.favoriteCountErr
+	}
+	return r.favoriteCounts[userID], nil
+}
+
+func sampleCatalog() []domain.Badge {
+	return []domain.Badge{
+		{ID: 1, Slug: domain.BadgeSlugFirstSteps, Name: "First Steps", Description: "First completed event.", Category: domain.BadgeCategoryParticipation, SortOrder: 1},
+		{ID: 2, Slug: domain.BadgeSlugRegular, Name: "Regular Attendee", Description: "Five completed events.", Category: domain.BadgeCategoryParticipation, SortOrder: 2},
+		{ID: 3, Slug: domain.BadgeSlugFavoriteFinder, Name: "Favorite Finder", Description: "Saved three favorite locations.", Category: domain.BadgeCategorySocial, SortOrder: 3},
+	}
+}
+
+func TestServiceListMyBadgesEmpty(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo)
+
+	result, err := svc.ListMyBadges(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Items) != 0 {
+		t.Fatalf("expected zero items, got %d", len(result.Items))
+	}
+}
+
+func TestServiceListMyBadgesProjectsRowsToWire(t *testing.T) {
+	repo := newFakeRepo()
+	userID := uuid.New()
+	earnedAt := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	repo.earnedByUser[userID] = []domain.UserBadge{{
+		UserID:   userID,
+		BadgeID:  1,
+		Slug:     domain.BadgeSlugFirstSteps,
+		EarnedAt: earnedAt,
+		Definition: domain.Badge{
+			ID: 1, Slug: domain.BadgeSlugFirstSteps,
+			Name: "First Steps", Description: "First completed event.",
+			Category: domain.BadgeCategoryParticipation, SortOrder: 1,
+		},
+	}}
+	svc := NewService(repo)
+
+	result, err := svc.ListMyBadges(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result.Items))
+	}
+	got := result.Items[0]
+	if got.Slug != string(domain.BadgeSlugFirstSteps) {
+		t.Errorf("slug = %q, want %q", got.Slug, domain.BadgeSlugFirstSteps)
+	}
+	if got.Category != string(domain.BadgeCategoryParticipation) {
+		t.Errorf("category = %q, want %q", got.Category, domain.BadgeCategoryParticipation)
+	}
+	if got.EarnedAt != earnedAt.Format(time.RFC3339) {
+		t.Errorf("earned_at = %q, want %q", got.EarnedAt, earnedAt.Format(time.RFC3339))
+	}
+}
+
+func TestServiceListBadgesMergesEarnedStatus(t *testing.T) {
+	repo := newFakeRepo()
+	repo.all = sampleCatalog()
+	userID := uuid.New()
+	earnedAt := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	repo.earnedByUser[userID] = []domain.UserBadge{{
+		Slug: domain.BadgeSlugFirstSteps, EarnedAt: earnedAt,
+		Definition: repo.all[0],
+	}}
+	svc := NewService(repo)
+
+	result, err := svc.ListBadges(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Items) != 3 {
+		t.Fatalf("expected 3 catalog entries, got %d", len(result.Items))
+	}
+
+	first := result.Items[0]
+	if first.Slug != string(domain.BadgeSlugFirstSteps) || !first.Earned {
+		t.Errorf("first badge = %+v; want earned FIRST_STEPS", first)
+	}
+	if first.EarnedAt == nil || *first.EarnedAt != earnedAt.Format(time.RFC3339) {
+		t.Errorf("first.earned_at = %v, want %q", first.EarnedAt, earnedAt.Format(time.RFC3339))
+	}
+	for _, item := range result.Items[1:] {
+		if item.Earned {
+			t.Errorf("badge %s should be unearned", item.Slug)
+		}
+		if item.EarnedAt != nil {
+			t.Errorf("badge %s should have nil earned_at, got %v", item.Slug, item.EarnedAt)
+		}
+	}
+}
+
+func TestEvaluateParticipationBadgesAwardsTieredBadges(t *testing.T) {
+	repo := newFakeRepo()
+	userID := uuid.New()
+	repo.participation[userID] = ParticipationStatsRecord{
+		CompletedEventCount:     5,
+		DistinctCategoriesCount: 3,
+	}
+	svc := NewService(repo)
+
+	if err := svc.EvaluateParticipationBadges(context.Background(), userID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := repo.awarded[userID]
+	want := []domain.BadgeSlug{
+		domain.BadgeSlugFirstSteps,
+		domain.BadgeSlugRegular,
+		domain.BadgeSlugExplorer,
+	}
+	if !sameSet(got, want) {
+		t.Errorf("awarded slugs = %v, want %v", got, want)
+	}
+}
+
+func TestEvaluateParticipationBadgesBelowThreshold(t *testing.T) {
+	repo := newFakeRepo()
+	userID := uuid.New()
+	repo.participation[userID] = ParticipationStatsRecord{
+		CompletedEventCount:     0,
+		DistinctCategoriesCount: 1,
+	}
+	svc := NewService(repo)
+
+	if err := svc.EvaluateParticipationBadges(context.Background(), userID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.awarded[userID]) != 0 {
+		t.Errorf("expected no awards, got %v", repo.awarded[userID])
+	}
+}
+
+func TestEvaluateParticipationBadgesIdempotent(t *testing.T) {
+	repo := newFakeRepo()
+	userID := uuid.New()
+	repo.participation[userID] = ParticipationStatsRecord{
+		CompletedEventCount:     20,
+		DistinctCategoriesCount: 4,
+	}
+	svc := NewService(repo)
+
+	for i := 0; i < 3; i++ {
+		if err := svc.EvaluateParticipationBadges(context.Background(), userID); err != nil {
+			t.Fatalf("unexpected error on iteration %d: %v", i, err)
+		}
+	}
+	got := repo.awarded[userID]
+	want := []domain.BadgeSlug{
+		domain.BadgeSlugFirstSteps,
+		domain.BadgeSlugRegular,
+		domain.BadgeSlugVeteran,
+		domain.BadgeSlugExplorer,
+	}
+	if !sameSet(got, want) {
+		t.Errorf("awarded slugs = %v, want %v", got, want)
+	}
+}
+
+func TestEvaluateHostBadgesRequiresMinRatingsForTopRated(t *testing.T) {
+	repo := newFakeRepo()
+	hostID := uuid.New()
+	score := 4.9
+	repo.host[hostID] = HostStatsRecord{
+		CompletedHostedEventCount: 10,
+		HostScore:                 &score,
+		HostRatingCount:           4, // below minTopRatedRatingCount (5)
+	}
+	svc := NewService(repo)
+
+	if err := svc.EvaluateHostBadges(context.Background(), hostID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := repo.awarded[hostID]
+	want := []domain.BadgeSlug{
+		domain.BadgeSlugHostDebut,
+		domain.BadgeSlugSuperHost,
+	}
+	if !sameSet(got, want) {
+		t.Errorf("awarded slugs = %v, want %v", got, want)
+	}
+}
+
+func TestEvaluateHostBadgesAwardsTopRated(t *testing.T) {
+	repo := newFakeRepo()
+	hostID := uuid.New()
+	score := 4.6
+	repo.host[hostID] = HostStatsRecord{
+		CompletedHostedEventCount: 10,
+		HostScore:                 &score,
+		HostRatingCount:           5,
+	}
+	svc := NewService(repo)
+
+	if err := svc.EvaluateHostBadges(context.Background(), hostID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := repo.awarded[hostID]
+	want := []domain.BadgeSlug{
+		domain.BadgeSlugHostDebut,
+		domain.BadgeSlugSuperHost,
+		domain.BadgeSlugTopRated,
+	}
+	if !sameSet(got, want) {
+		t.Errorf("awarded slugs = %v, want %v", got, want)
+	}
+}
+
+func TestEvaluateHostBadgesScoreBelowThreshold(t *testing.T) {
+	repo := newFakeRepo()
+	hostID := uuid.New()
+	score := 4.4
+	repo.host[hostID] = HostStatsRecord{
+		CompletedHostedEventCount: 1,
+		HostScore:                 &score,
+		HostRatingCount:           10,
+	}
+	svc := NewService(repo)
+
+	if err := svc.EvaluateHostBadges(context.Background(), hostID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := repo.awarded[hostID]
+	want := []domain.BadgeSlug{domain.BadgeSlugHostDebut}
+	if !sameSet(got, want) {
+		t.Errorf("awarded slugs = %v, want %v", got, want)
+	}
+}
+
+func TestEvaluateFavoriteLocationBadgesAwardsAtThree(t *testing.T) {
+	repo := newFakeRepo()
+	userID := uuid.New()
+	repo.favoriteCounts[userID] = 3
+	svc := NewService(repo)
+
+	if err := svc.EvaluateFavoriteLocationBadges(context.Background(), userID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := repo.awarded[userID]
+	want := []domain.BadgeSlug{domain.BadgeSlugFavoriteFinder}
+	if !sameSet(got, want) {
+		t.Errorf("awarded slugs = %v, want %v", got, want)
+	}
+}
+
+func TestEvaluateFavoriteLocationBadgesBelowThreshold(t *testing.T) {
+	repo := newFakeRepo()
+	userID := uuid.New()
+	repo.favoriteCounts[userID] = 2
+	svc := NewService(repo)
+
+	if err := svc.EvaluateFavoriteLocationBadges(context.Background(), userID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.awarded[userID]) != 0 {
+		t.Errorf("expected no awards, got %v", repo.awarded[userID])
+	}
+}
+
+func TestEvaluateParticipationBadgesPropagatesRepoError(t *testing.T) {
+	repo := newFakeRepo()
+	repo.participationErr = errors.New("boom")
+	svc := NewService(repo)
+
+	err := svc.EvaluateParticipationBadges(context.Background(), uuid.New())
+	if err == nil || err.Error() != "boom" {
+		t.Errorf("err = %v, want boom", err)
+	}
+}
+
+func sameSet(got, want []domain.BadgeSlug) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotMap := make(map[domain.BadgeSlug]struct{}, len(got))
+	for _, slug := range got {
+		gotMap[slug] = struct{}{}
+	}
+	for _, slug := range want {
+		if _, ok := gotMap[slug]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/application/badge/usecase.go
+++ b/backend/internal/application/badge/usecase.go
@@ -1,0 +1,29 @@
+package badge
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// UseCase is the inbound application port for badge flows.
+type UseCase interface {
+	// ListMyBadges returns the badges earned by the authenticated user.
+	ListMyBadges(ctx context.Context, userID uuid.UUID) (*ListUserBadgesResult, error)
+	// ListUserBadges returns badges earned by the given public profile owner.
+	ListUserBadges(ctx context.Context, userID uuid.UUID) (*ListUserBadgesResult, error)
+	// ListBadges returns the full badge catalog with earned status for the
+	// authenticated user. earnedAt is omitted for badges the viewer has not
+	// earned yet.
+	ListBadges(ctx context.Context, userID uuid.UUID) (*ListBadgesResult, error)
+
+	// EvaluateParticipationBadges runs idempotent badge evaluation after a
+	// participation status change for the given user.
+	EvaluateParticipationBadges(ctx context.Context, userID uuid.UUID) error
+	// EvaluateHostBadges runs idempotent badge evaluation after a rating is
+	// submitted against the given host or after a host completes a new event.
+	EvaluateHostBadges(ctx context.Context, hostID uuid.UUID) error
+	// EvaluateFavoriteLocationBadges runs idempotent badge evaluation after a
+	// favorite-location is saved by the given user.
+	EvaluateFavoriteLocationBadges(ctx context.Context, userID uuid.UUID) error
+}

--- a/backend/internal/application/event/helpers_test.go
+++ b/backend/internal/application/event/helpers_test.go
@@ -44,10 +44,10 @@ func TestToEventDetailLocationPublicEventNeverFuzzes(t *testing.T) {
 
 func TestToEventDetailLocationProtectedEventFuzzesNonParticipants(t *testing.T) {
 	cases := []struct {
-		name         string
-		isHost       bool
-		status       domain.EventDetailParticipationStatus
-		wantExact    bool
+		name      string
+		isHost    bool
+		status    domain.EventDetailParticipationStatus
+		wantExact bool
 	}{
 		{"host gets exact", true, domain.EventDetailParticipationStatusNone, true},
 		{"joined gets exact", false, domain.EventDetailParticipationStatusJoined, true},

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"time"
 
-	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
+	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/participation"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"

--- a/backend/internal/application/favorite_location/service.go
+++ b/backend/internal/application/favorite_location/service.go
@@ -3,16 +3,25 @@ package favorite_location
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
 )
 
+// BadgeEvaluator is the local port for triggering favorite-location badge
+// evaluation after a save. It is intentionally minimal so this service does
+// not depend on the full badge use case.
+type BadgeEvaluator interface {
+	EvaluateFavoriteLocationBadges(ctx context.Context, userID uuid.UUID) error
+}
+
 // Service owns favorite-location application behavior.
 type Service struct {
-	repo       Repository
-	unitOfWork uow.UnitOfWork
+	repo           Repository
+	unitOfWork     uow.UnitOfWork
+	badgeEvaluator BadgeEvaluator
 }
 
 var _ UseCase = (*Service)(nil)
@@ -23,6 +32,12 @@ func NewService(repo Repository, unitOfWork uow.UnitOfWork) *Service {
 		repo:       repo,
 		unitOfWork: unitOfWork,
 	}
+}
+
+// SetBadgeEvaluator wires in the badge use case so the service can re-evaluate
+// favorite-location badges after a new location is saved.
+func (s *Service) SetBadgeEvaluator(evaluator BadgeEvaluator) {
+	s.badgeEvaluator = evaluator
 }
 
 // ListMyFavoriteLocations returns the authenticated user's favorite locations.
@@ -74,6 +89,7 @@ func (s *Service) CreateMyFavoriteLocation(ctx context.Context, input CreateFavo
 		return nil, err
 	}
 
+	s.evaluateFavoriteLocationBadges(ctx, input.UserID)
 	result := toFavoriteLocationResult(*location)
 	return &result, nil
 }
@@ -159,4 +175,19 @@ func favoriteLocationNotFoundError() *domain.AppError {
 		domain.ErrorCodeFavoriteLocationNotFound,
 		"The requested favorite location does not exist.",
 	)
+}
+
+// evaluateFavoriteLocationBadges runs badge evaluation as a best-effort hook
+// so transient failures never fail the parent operation.
+func (s *Service) evaluateFavoriteLocationBadges(ctx context.Context, userID uuid.UUID) {
+	if s.badgeEvaluator == nil {
+		return
+	}
+	if err := s.badgeEvaluator.EvaluateFavoriteLocationBadges(ctx, userID); err != nil {
+		slog.WarnContext(ctx, "favorite location badge evaluation failed",
+			slog.String("operation", "favorite_location.evaluate_badges"),
+			slog.String("user_id", userID.String()),
+			slog.String("error", err.Error()),
+		)
+	}
 }

--- a/backend/internal/application/participation/service.go
+++ b/backend/internal/application/participation/service.go
@@ -2,14 +2,23 @@ package participation
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
 )
 
+// BadgeEvaluator is the local port for triggering participation-related badge
+// evaluation after a participation status change. It is intentionally minimal
+// so the participation service does not depend on the full badge use case.
+type BadgeEvaluator interface {
+	EvaluateParticipationBadges(ctx context.Context, userID uuid.UUID) error
+}
+
 // Service owns participation-specific application behavior.
 type Service struct {
-	repo Repository
+	repo           Repository
+	badgeEvaluator BadgeEvaluator
 }
 
 var _ UseCase = (*Service)(nil)
@@ -19,10 +28,21 @@ func NewService(repo Repository) *Service {
 	return &Service{repo: repo}
 }
 
+// SetBadgeEvaluator wires in the badge use case so the participation service
+// can re-evaluate participation badges after status changes.
+func (s *Service) SetBadgeEvaluator(evaluator BadgeEvaluator) {
+	s.badgeEvaluator = evaluator
+}
+
 // CreateApprovedParticipation persists an APPROVED participation for the given
 // event and user.
 func (s *Service) CreateApprovedParticipation(ctx context.Context, eventID, userID uuid.UUID) (*domain.Participation, error) {
-	return s.repo.CreateParticipation(ctx, eventID, userID)
+	participation, err := s.repo.CreateParticipation(ctx, eventID, userID)
+	if err != nil {
+		return nil, err
+	}
+	s.evaluateParticipationBadges(ctx, userID)
+	return participation, nil
 }
 
 // LeaveParticipation marks an APPROVED participation as LEAVED for the given
@@ -35,4 +55,19 @@ func (s *Service) LeaveParticipation(ctx context.Context, eventID, userID uuid.U
 // and returns the user IDs of every participation that was transitioned.
 func (s *Service) CancelEventParticipations(ctx context.Context, eventID uuid.UUID) ([]uuid.UUID, error) {
 	return s.repo.CancelEventParticipations(ctx, eventID)
+}
+
+// evaluateParticipationBadges runs badge evaluation as a best-effort hook so
+// transient badge-evaluation failures never fail the parent operation.
+func (s *Service) evaluateParticipationBadges(ctx context.Context, userID uuid.UUID) {
+	if s.badgeEvaluator == nil {
+		return
+	}
+	if err := s.badgeEvaluator.EvaluateParticipationBadges(ctx, userID); err != nil {
+		slog.WarnContext(ctx, "participation badge evaluation failed",
+			slog.String("operation", "participation.evaluate_badges"),
+			slog.String("user_id", userID.String()),
+			slog.String("error", err.Error()),
+		)
+	}
 }

--- a/backend/internal/application/rating/service.go
+++ b/backend/internal/application/rating/service.go
@@ -3,6 +3,7 @@ package rating
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
@@ -10,12 +11,21 @@ import (
 	"github.com/google/uuid"
 )
 
+// BadgeEvaluator is the local port for triggering rating-driven badge
+// evaluation after rating writes. It is intentionally minimal so the rating
+// service does not depend on the full badge use case.
+type BadgeEvaluator interface {
+	EvaluateHostBadges(ctx context.Context, hostID uuid.UUID) error
+	EvaluateParticipationBadges(ctx context.Context, userID uuid.UUID) error
+}
+
 // Service owns rating-specific application behavior.
 type Service struct {
-	repo       Repository
-	unitOfWork uow.UnitOfWork
-	settings   Settings
-	now        func() time.Time
+	repo           Repository
+	unitOfWork     uow.UnitOfWork
+	settings       Settings
+	now            func() time.Time
+	badgeEvaluator BadgeEvaluator
 }
 
 var _ UseCase = (*Service)(nil)
@@ -30,6 +40,12 @@ func NewService(repo Repository, unitOfWork uow.UnitOfWork, settings Settings) *
 	}
 }
 
+// SetBadgeEvaluator wires in the badge use case so the rating service can
+// re-evaluate host and participant badges after rating changes.
+func (s *Service) SetBadgeEvaluator(evaluator BadgeEvaluator) {
+	s.badgeEvaluator = evaluator
+}
+
 // UpsertEventRating creates or updates the caller's rating for an event.
 func (s *Service) UpsertEventRating(
 	ctx context.Context,
@@ -41,7 +57,10 @@ func (s *Service) UpsertEventRating(
 		return nil, domain.ValidationError(errs)
 	}
 
-	var result *domain.EventRating
+	var (
+		result *domain.EventRating
+		hostID uuid.UUID
+	)
 	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
 		ratingContext, err := s.repo.GetEventRatingContext(ctx, eventID, participantUserID)
 		if err != nil {
@@ -61,12 +80,14 @@ func (s *Service) UpsertEventRating(
 			return err
 		}
 
+		hostID = ratingContext.HostUserID
 		return s.refreshUserScore(ctx, s.repo, ratingContext.HostUserID)
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	s.evaluateHostBadges(ctx, hostID)
 	return toEventRatingResult(result), nil
 }
 
@@ -131,6 +152,7 @@ func (s *Service) UpsertParticipantRating(
 		return nil, err
 	}
 
+	s.evaluateParticipationBadges(ctx, participantUserID)
 	return toParticipantRatingResult(result), nil
 }
 
@@ -229,4 +251,35 @@ func (s *Service) refreshUserScore(ctx context.Context, repo Repository, userID 
 		HostedEventRatingCount: hostedAggregate.Count,
 		FinalScore:             calculateFinalScore(participantAggregate, hostedAggregate, s.settings),
 	})
+}
+
+// evaluateHostBadges runs host-side badge evaluation as a best-effort hook so
+// transient failures never fail the parent rating operation.
+func (s *Service) evaluateHostBadges(ctx context.Context, hostID uuid.UUID) {
+	if s.badgeEvaluator == nil {
+		return
+	}
+	if err := s.badgeEvaluator.EvaluateHostBadges(ctx, hostID); err != nil {
+		slog.WarnContext(ctx, "host badge evaluation failed",
+			slog.String("operation", "rating.evaluate_host_badges"),
+			slog.String("host_id", hostID.String()),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// evaluateParticipationBadges runs participant-side badge evaluation as a
+// best-effort hook so transient failures never fail the parent rating
+// operation.
+func (s *Service) evaluateParticipationBadges(ctx context.Context, userID uuid.UUID) {
+	if s.badgeEvaluator == nil {
+		return
+	}
+	if err := s.badgeEvaluator.EvaluateParticipationBadges(ctx, userID); err != nil {
+		slog.WarnContext(ctx, "participation badge evaluation failed",
+			slog.String("operation", "rating.evaluate_participation_badges"),
+			slog.String("user_id", userID.String()),
+			slog.String("error", err.Error()),
+		)
+	}
 }

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -17,6 +17,7 @@ import (
 	spacesadapter "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/spaces"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/admin"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/auth"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/badge"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/category"
 	emailapp "github.com/bounswe/bounswe2026group11/backend/internal/application/email"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/event"
@@ -57,6 +58,7 @@ type Container struct {
 	categoryRepo            *postgres.CategoryRepository
 	profileRepo             *postgres.ProfileRepository
 	favoriteLocationRepo    *postgres.FavoriteLocationRepository
+	badgeRepo               *postgres.BadgeRepository
 	AuthService             auth.UseCase
 	AdminService            admin.UseCase
 	EventService            event.UseCase
@@ -71,6 +73,7 @@ type Container struct {
 	ProfileService          profile.UseCase
 	FavoriteLocationService favoritelocation.UseCase
 	ImageUploadService      imageupload.UseCase
+	BadgeService            badge.UseCase
 	// Extend with additional services as features are added
 }
 
@@ -115,12 +118,14 @@ func New(ctx context.Context) (*Container, error) {
 	container.categoryRepo = postgres.NewCategoryRepository(container.DB)
 	container.profileRepo = postgres.NewProfileRepository(container.DB)
 	container.favoriteLocationRepo = postgres.NewFavoriteLocationRepository(container.DB)
+	container.badgeRepo = postgres.NewBadgeRepository(container.DB)
 	notificationService, err := newNotificationService(ctx, container)
 	if err != nil {
 		db.Close()
 		return nil, err
 	}
 	container.NotificationService = notificationService
+	container.BadgeService = newBadgeService(container)
 	container.ParticipationService = newParticipationService(container)
 	container.TicketService = newTicketService(container)
 	container.InvitationService = newInvitationService(container)
@@ -261,7 +266,9 @@ func newEventService(c *Container) event.UseCase {
 // newParticipationService wires the participation use-case service with its
 // driven adapter.
 func newParticipationService(c *Container) participation.UseCase {
-	return participation.NewService(c.participationRepo)
+	service := participation.NewService(c.participationRepo)
+	service.SetBadgeEvaluator(c.BadgeService)
+	return service
 }
 
 func newInvitationService(c *Container) invitation.UseCase {
@@ -303,7 +310,14 @@ func newProfileService(c *Container) profile.UseCase {
 
 // newFavoriteLocationService wires the favorite-location use-case service with its driven adapter.
 func newFavoriteLocationService(c *Container) favoritelocation.UseCase {
-	return favoritelocation.NewService(c.favoriteLocationRepo, c.UnitOfWork)
+	service := favoritelocation.NewService(c.favoriteLocationRepo, c.UnitOfWork)
+	service.SetBadgeEvaluator(c.BadgeService)
+	return service
+}
+
+// newBadgeService wires the badge use-case service with its driven adapter.
+func newBadgeService(c *Container) badge.UseCase {
+	return badge.NewService(c.badgeRepo)
 }
 
 func newNotificationService(ctx context.Context, c *Container) (notification.UseCase, error) {
@@ -330,10 +344,12 @@ func newImageUploadService(c *Container, storage *spacesadapter.Storage) imageup
 
 // newRatingService wires the rating use-case service with its driven adapter.
 func newRatingService(c *Container) rating.UseCase {
-	return rating.NewService(c.ratingRepo, c.UnitOfWork, rating.Settings{
+	service := rating.NewService(c.ratingRepo, c.UnitOfWork, rating.Settings{
 		GlobalPrior: c.Config.RatingGlobalPrior,
 		BayesianM:   c.Config.RatingBayesianM,
 	})
+	service.SetBadgeEvaluator(c.BadgeService)
+	return service
 }
 
 // newAuthService wires the auth use-case service with its driven adapters.

--- a/backend/internal/domain/badge.go
+++ b/backend/internal/domain/badge.go
@@ -1,0 +1,55 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BadgeCategory groups badges by the kind of activity they reward.
+type BadgeCategory string
+
+const (
+	BadgeCategoryHosting       BadgeCategory = "HOSTING"
+	BadgeCategoryParticipation BadgeCategory = "PARTICIPATION"
+	BadgeCategorySocial        BadgeCategory = "SOCIAL"
+)
+
+func (c BadgeCategory) String() string { return string(c) }
+
+// BadgeSlug is the stable, machine-friendly identifier of a badge definition.
+// Slugs are seeded in migration 000026 and must stay UPPERCASE.
+type BadgeSlug string
+
+const (
+	BadgeSlugFirstSteps     BadgeSlug = "FIRST_STEPS"
+	BadgeSlugRegular        BadgeSlug = "REGULAR"
+	BadgeSlugVeteran        BadgeSlug = "VETERAN"
+	BadgeSlugExplorer       BadgeSlug = "EXPLORER"
+	BadgeSlugHostDebut      BadgeSlug = "HOST_DEBUT"
+	BadgeSlugSuperHost      BadgeSlug = "SUPER_HOST"
+	BadgeSlugTopRated       BadgeSlug = "TOP_RATED"
+	BadgeSlugFavoriteFinder BadgeSlug = "FAVORITE_FINDER"
+)
+
+func (s BadgeSlug) String() string { return string(s) }
+
+// Badge is the catalog definition of a badge that users can earn.
+type Badge struct {
+	ID          int16
+	Slug        BadgeSlug
+	Name        string
+	Description string
+	IconURL     *string
+	Category    BadgeCategory
+	SortOrder   int16
+}
+
+// UserBadge represents one badge earned by a user.
+type UserBadge struct {
+	UserID     uuid.UUID
+	BadgeID    int16
+	Slug       BadgeSlug
+	EarnedAt   time.Time
+	Definition Badge
+}

--- a/backend/internal/domain/event_test.go
+++ b/backend/internal/domain/event_test.go
@@ -21,10 +21,10 @@ func haversineMeters(a, b domain.GeoPoint) float64 {
 
 func TestApproximateGeoPointStaysWithin250m(t *testing.T) {
 	origins := []domain.GeoPoint{
-		{Lat: 41.01234, Lon: 29.98765},  // Istanbul
-		{Lat: 51.50736, Lon: -0.12776},  // London
-		{Lat: -33.8688, Lon: 151.2093},  // Sydney
-		{Lat: 0.0, Lon: 0.0},            // equator/prime meridian
+		{Lat: 41.01234, Lon: 29.98765}, // Istanbul
+		{Lat: 51.50736, Lon: -0.12776}, // London
+		{Lat: -33.8688, Lon: 151.2093}, // Sydney
+		{Lat: 0.0, Lon: 0.0},           // equator/prime meridian
 	}
 
 	const iterations = 500

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/admin_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/auth_handler"
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/badge_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/category_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/event_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/favorite_location_handler"
@@ -84,6 +85,10 @@ func NewHTTP(container *bootstrap.Container) *fiber.App {
 	// Direct image upload routes (authenticated)
 	imageUploadHandler := image_upload_handler.NewHandler(container.ImageUploadService)
 	image_upload_handler.RegisterRoutes(app, imageUploadHandler, auth)
+
+	// Badge routes (authenticated)
+	badgeHandler := badge_handler.NewHandler(container.BadgeService)
+	badge_handler.RegisterRoutes(app, badgeHandler, auth)
 
 	return app
 }

--- a/backend/migrations/000026_badges.down.sql
+++ b/backend/migrations/000026_badges.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS user_badge;
+DROP TABLE IF EXISTS badge;

--- a/backend/migrations/000026_badges.up.sql
+++ b/backend/migrations/000026_badges.up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE badge
+(
+    id          SMALLINT PRIMARY KEY,
+    slug        TEXT     NOT NULL UNIQUE,
+    name        TEXT     NOT NULL,
+    description TEXT     NOT NULL,
+    icon_url    TEXT,
+    category    TEXT     NOT NULL,
+    sort_order  SMALLINT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_badge_category
+        CHECK (category IN ('HOSTING', 'PARTICIPATION', 'SOCIAL'))
+);
+
+CREATE TABLE user_badge
+(
+    user_id   UUID                     NOT NULL REFERENCES app_user (id) ON DELETE CASCADE,
+    badge_id  SMALLINT                 NOT NULL REFERENCES badge (id) ON DELETE CASCADE,
+    earned_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, badge_id)
+);
+
+CREATE INDEX idx_user_badge_user_earned ON user_badge (user_id, earned_at DESC);
+CREATE INDEX idx_user_badge_badge ON user_badge (badge_id);
+
+INSERT INTO badge (id, slug, name, description, category, sort_order)
+VALUES (1, 'FIRST_STEPS', 'First Steps', 'Attend your first event.', 'PARTICIPATION', 10),
+       (2, 'REGULAR', 'Regular', 'Attend 5 events.', 'PARTICIPATION', 20),
+       (3, 'VETERAN', 'Veteran', 'Attend 20 events.', 'PARTICIPATION', 30),
+       (4, 'EXPLORER', 'Explorer', 'Attend events in 3 different categories.', 'PARTICIPATION', 40),
+       (5, 'HOST_DEBUT', 'Host Debut', 'Host your first event.', 'HOSTING', 50),
+       (6, 'SUPER_HOST', 'Super Host', 'Host 10 events.', 'HOSTING', 60),
+       (7, 'TOP_RATED', 'Top Rated', 'Receive an average rating of 4.5+ as a host with at least 5 ratings.', 'HOSTING', 70),
+       (8, 'FAVORITE_FINDER', 'Favorite Finder', 'Save 3 favorite locations.', 'SOCIAL', 80);

--- a/docs/openapi/badge.yaml
+++ b/docs/openapi/badge.yaml
@@ -1,0 +1,287 @@
+openapi: 3.1.0
+info:
+  title: Social Event Mapper - Badge API
+  version: 0.1.0
+  description: >
+    Authenticated endpoints for browsing the badge catalog and listing badges
+    earned by the authenticated user or another public profile owner. Badge
+    state is recomputed synchronously after participation, rating, and
+    favorite-location writes; clients should refetch these endpoints when they
+    expect the user's badge list to have changed.
+
+servers:
+  - url: /api
+
+paths:
+  /me/badges:
+    get:
+      summary: List the authenticated user's earned badges
+      description: >
+        Returns the badges earned by the authenticated user, ordered by
+        `earned_at` descending. The response shape is identical to
+        `GET /users/{id}/badges`.
+      tags:
+        - Badges
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Earned badges listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserBadgesResponse"
+              examples:
+                default:
+                  value:
+                    items:
+                      - slug: REGULAR
+                        name: Regular Attendee
+                        description: Completed at least 5 events as an approved participant.
+                        icon_url: null
+                        category: PARTICIPATION
+                        earned_at: "2026-04-30T12:34:56Z"
+                      - slug: FIRST_STEPS
+                        name: First Steps
+                        description: Completed your first event.
+                        icon_url: null
+                        category: PARTICIPATION
+                        earned_at: "2026-03-12T09:08:07Z"
+        "401":
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+              examples:
+                missing_token:
+                  value:
+                    error:
+                      code: missing_token
+                      message: Authorization header with Bearer token is required.
+
+  /users/{id}/badges:
+    get:
+      summary: List a public profile's earned badges
+      description: >
+        Returns the badges earned by the public profile owner identified by
+        `id`. Unlike `/me/badges`, this endpoint never returns viewer-specific
+        progress data and is safe to call with any user id.
+      tags:
+        - Badges
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Profile owner's user id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Earned badges listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserBadgesResponse"
+        "400":
+          description: The supplied `id` is not a valid UUID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+              examples:
+                invalid_id:
+                  value:
+                    error:
+                      code: validation_error
+                      message: The request body contains invalid fields. See error.details for field-specific messages.
+                      details:
+                        id: must be a valid UUID
+        "401":
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /badges:
+    get:
+      summary: List the full badge catalog
+      description: >
+        Returns every badge defined in the catalog (ordered by `sort_order`
+        ascending) annotated with whether the authenticated viewer has earned
+        each one. Unearned badges have `earned=false` and `earned_at=null`.
+      tags:
+        - Badges
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Badge catalog listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadgeCatalogResponse"
+              examples:
+                default:
+                  value:
+                    items:
+                      - slug: FIRST_STEPS
+                        name: First Steps
+                        description: Completed your first event.
+                        icon_url: null
+                        category: PARTICIPATION
+                        earned: true
+                        earned_at: "2026-03-12T09:08:07Z"
+                      - slug: VETERAN
+                        name: Veteran
+                        description: Completed 20 events as an approved participant.
+                        icon_url: null
+                        category: PARTICIPATION
+                        earned: false
+                        earned_at: null
+        "401":
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    BadgeCategory:
+      type: string
+      description: High-level grouping used for client-side tabs and filters.
+      enum:
+        - HOSTING
+        - PARTICIPATION
+        - SOCIAL
+
+    BadgeSlug:
+      type: string
+      description: Stable machine-readable identifier for a badge.
+      enum:
+        - FIRST_STEPS
+        - REGULAR
+        - VETERAN
+        - EXPLORER
+        - HOST_DEBUT
+        - SUPER_HOST
+        - TOP_RATED
+        - FAVORITE_FINDER
+
+    BadgeBase:
+      type: object
+      additionalProperties: false
+      required:
+        - slug
+        - name
+        - description
+        - icon_url
+        - category
+      properties:
+        slug:
+          $ref: "#/components/schemas/BadgeSlug"
+        name:
+          type: string
+          description: Human-readable badge title.
+        description:
+          type: string
+          description: Short explanation of how the badge is awarded.
+        icon_url:
+          type:
+            - string
+            - "null"
+          description: Optional CDN URL for the badge icon. `null` while iconography is pending.
+        category:
+          $ref: "#/components/schemas/BadgeCategory"
+
+    EarnedBadge:
+      allOf:
+        - $ref: "#/components/schemas/BadgeBase"
+        - type: object
+          additionalProperties: false
+          required:
+            - earned_at
+          properties:
+            earned_at:
+              type: string
+              format: date-time
+              description: UTC timestamp of when the user earned the badge.
+
+    CatalogBadge:
+      allOf:
+        - $ref: "#/components/schemas/BadgeBase"
+        - type: object
+          additionalProperties: false
+          required:
+            - earned
+            - earned_at
+          properties:
+            earned:
+              type: boolean
+              description: Whether the authenticated viewer has earned this badge.
+            earned_at:
+              type:
+                - string
+                - "null"
+              format: date-time
+              description: When the viewer earned the badge, or `null` if unearned.
+
+    UserBadgesResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          description: Earned badges ordered by `earned_at` descending.
+          items:
+            $ref: "#/components/schemas/EarnedBadge"
+
+    BadgeCatalogResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          description: Catalog badges ordered by `sort_order` ascending.
+          items:
+            $ref: "#/components/schemas/CatalogBadge"
+
+    ErrorEnvelope:
+      type: object
+      additionalProperties: false
+      required:
+        - error
+      properties:
+        error:
+          $ref: "#/components/schemas/ErrorBody"
+
+    ErrorBody:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties:
+            type: string


### PR DESCRIPTION
## 📋 Summary                                                                                                         
  Implements the badge and achievement system from issue #435. Adds an 8-badge catalog with three categories (HOSTING / 
  PARTICIPATION / SOCIAL), three authenticated read endpoints, and synchronous best-effort evaluation hooks that award  
  badges right after the triggering action without ever failing the parent operation.
                                                                                                                        
  ## 🔄 Changes                                             
  - **DB migration `000026_badges`** — new `badge` catalog table + `user_badge` join table (PK on `(user_id, badge_id)`,
   ON DELETE CASCADE), seeded with 8 badges: FIRST_STEPS, REGULAR, VETERAN, EXPLORER, HOST_DEBUT, SUPER_HOST, TOP_RATED,
   FAVORITE_FINDER.
  - **Domain** — `domain/badge.go` adds `Badge`, `UserBadge`, `BadgeSlug`, `BadgeCategory` types with UPPERCASE wire    
  values.                                                                                                               
  - **Application layer** — new `internal/application/badge` package with `UseCase`, `Repository`, DTOs, and `Service` 
  implementing `ListMyBadges`, `ListUserBadges`, `ListBadges`, plus three idempotent evaluators                         
  (`EvaluateParticipationBadges`, `EvaluateHostBadges`, `EvaluateFavoriteLocationBadges`).
  - **Postgres adapter** — `internal/adapter/in/postgres/badge_repo.go` implements the repository, using `INSERT ... ON 
  CONFLICT DO NOTHING` for award idempotency.                                                                           
  - **HTTP handler** — `internal/adapter/out/httpapi/badge_handler` exposes `GET /me/badges`, `GET /users/:id/badges`, 
  `GET /badges` (all behind `RequireAuth`).                                                                             
  - **Hooks** — participation, rating, and favorite-location services each declare a local `BadgeEvaluator` port and a 
  `SetBadgeEvaluator` setter; hooks run after `CreateApprovedParticipation`, `UpsertEventRating`,                       
  `UpsertParticipantRating`, and `CreateMyFavoriteLocation`. Failures log via `slog.WarnContext` but never fail the 
  parent op.                                                                                                            
  - **Composition root** — `bootstrap/container.go` builds the badge service first, then injects it into the three 
  consumer services.                                                                                                    
  - **Docs** — `docs/openapi/badge.yaml` describes all three endpoints with full request/response schemas and examples.
  - **Tests** — `internal/application/badge/service_test.go` covers list/catalog projection, all three evaluators,      
  threshold edges, idempotency over repeated calls, and repo-error propagation (11 tests).                              
                                                                                                                        
  ## 🧪 Testing                                                                                                         
  - `cd backend && SKIP_INTEGRATION=1 ./shipcheck.sh` — gofmt, go vet, staticcheck, golangci-lint, build, and `go test 
  -race ./...` all pass. govulncheck stdlib hits and gosec G404 in `domain/event.go` are pre-existing, unrelated to this PR.
  - Apply migration 000026 against a dev DB and confirm 8 rows seeded into \`badge\`.                                   
  - \`GET /badges\` with a fresh user -> all entries returned with \`earned=false\`, \`earned_at=null\`.                
  - Save 3 favorite locations -> \`GET /me/badges\` includes \`FAVORITE_FINDER\`.                                       
  - Complete an event as approved participant -> \`FIRST_STEPS\` appears in \`GET /me/badges\`.                         
  - Re-trigger any evaluator path multiple times -> no duplicate \`user_badge\` rows.                                   
                                                                                                                        
  ## 🔗 Related                                                                                                         
  Closes #435 