### PR TITLE
feat(mobile): added the map view toggle to event discovery screen

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -4,3 +4,8 @@
 # Override API base when defaults are wrong (e.g. physical device on same Wi‑Fi as your Mac).
 # Docker local stack serves the API at http://<host>:80/api — no trailing slash before /api.
 # EXPO_PUBLIC_API_BASE_URL=http://192.168.1.42/api
+
+# Google Maps Android API key — required for the map view on Android.
+# Create at: https://console.cloud.google.com/  →  Maps SDK for Android
+# Restrict by package name: com.bounswe2026group11.socialeventmapper
+# GOOGLE_MAPS_ANDROID_API_KEY=AIza...

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,29 @@
+// app.config.js extends app.json and injects secrets that must not be committed.
+// Expo reads this file automatically when it is present alongside app.json.
+// @ts-check
+
+/** @type {import('@expo/config').ConfigContext} */
+module.exports = ({ config }) => {
+  const androidMapsKey = process.env.GOOGLE_MAPS_ANDROID_API_KEY ?? '';
+
+  // Inject the react-native-maps plugin with the Android API key.
+  // The plugin writes com.google.android.geo.API_KEY into AndroidManifest.xml
+  // at prebuild time. Set GOOGLE_MAPS_ANDROID_API_KEY in .env (never commit it).
+  // Create the key at: https://console.cloud.google.com/
+  //   Enable: "Maps SDK for Android"
+  //   Restrict by package name: com.bounswe2026group11.socialeventmapper
+  const existingPlugins = (config.plugins ?? []).filter(
+    (p) => {
+      const name = Array.isArray(p) ? p[0] : p;
+      return name !== 'react-native-maps';
+    },
+  );
+
+  return {
+    ...config,
+    plugins: [
+      ...existingPlugins,
+      ['react-native-maps', { androidGoogleMapsApiKey: androidMapsKey }],
+    ],
+  };
+};

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -29,6 +29,7 @@
         "lodash": "^4.18.1",
         "react": "19.2.0",
         "react-native": "0.83.6",
+        "react-native-maps": "^1.27.2",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
         "react-native-svg": "15.15.3"
@@ -5426,6 +5427,12 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -13862,6 +13869,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.27.2.tgz",
+      "integrity": "sha512-VKr+xZ2RZGHHJlY6KhlafvGSmK0dq/tUu5uhfJ7K9rwN5pUdubdugzMKGDU/16lXmQSg7xbClKhRctj3Pm5F5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -31,6 +31,7 @@
     "lodash": "^4.18.1",
     "react": "19.2.0",
     "react-native": "0.83.6",
+    "react-native-maps": "^1.27.2",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
     "react-native-svg": "15.15.3"

--- a/mobile/src/components/home/EventMapView.test.tsx
+++ b/mobile/src/components/home/EventMapView.test.tsx
@@ -1,0 +1,406 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import EventMapView from './EventMapView';
+import type { MapRegion } from './EventMapView';
+import type { EventSummary } from '@/models/event';
+
+// ── react-native mock ──────────────────────────────────────────────────────────
+
+jest.mock('react-native', () => {
+  const ReactLocal = require('react');
+
+  const rnProps = new Set([
+    'accessibilityLabel',
+    'accessibilityRole',
+    'accessibilityState',
+    'activeOpacity',
+    'numberOfLines',
+    'showsVerticalScrollIndicator',
+    'testID',
+  ]);
+
+  const strip = (props: Record<string, unknown>) => {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(props)) {
+      if (!rnProps.has(key)) out[key] = props[key];
+    }
+    if (props.testID) out['data-testid'] = props.testID;
+    if (props.accessibilityLabel) out['aria-label'] = props.accessibilityLabel;
+    if (props.accessibilityRole) out['role'] = props.accessibilityRole;
+    return out;
+  };
+
+  const mergeStyle = (style: unknown): React.CSSProperties | undefined => {
+    if (Array.isArray(style)) {
+      return style.reduce(
+        (acc: Record<string, unknown>, item: unknown) => ({
+          ...acc,
+          ...(mergeStyle(item) ?? {}),
+        }),
+        {},
+      ) as React.CSSProperties;
+    }
+    if (style && typeof style === 'object') return style as React.CSSProperties;
+    return undefined;
+  };
+
+  const container =
+    (tag: string) =>
+      ({ children, style, ...props }: { children?: React.ReactNode; style?: unknown }) =>
+        ReactLocal.createElement(
+          tag,
+          { style: mergeStyle(style), ...strip(props as Record<string, unknown>) },
+          children,
+        );
+
+  const button =
+    ({
+      children,
+      onPress,
+      style,
+      disabled,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      style?: unknown;
+      disabled?: boolean;
+    }) =>
+      ReactLocal.createElement(
+        'button',
+        {
+          type: 'button',
+          disabled,
+          style: mergeStyle(style),
+          onClick: disabled ? undefined : onPress,
+          ...strip(props as Record<string, unknown>),
+        },
+        children,
+      );
+
+  return {
+    ActivityIndicator: ({ testID }: { testID?: string }) =>
+      ReactLocal.createElement('div', { 'data-testid': testID ?? 'activity-indicator', role: 'progressbar' }),
+    Platform: { OS: 'ios' },
+    StyleSheet: { create: <T,>(s: T) => s },
+    Text: container('span'),
+    TouchableOpacity: button,
+    View: container('div'),
+  };
+});
+
+// ── react-native-maps mock ─────────────────────────────────────────────────────
+
+jest.mock('react-native-maps', () => {
+  const ReactLocal = require('react');
+
+  const MapView = ({
+    children,
+    testID,
+  }: {
+    children?: React.ReactNode;
+    testID?: string;
+  }) =>
+    ReactLocal.createElement('div', { 'data-testid': testID ?? 'map-surface' }, children);
+
+  const Marker = ({
+    children,
+    testID,
+  }: {
+    children?: React.ReactNode;
+    testID?: string;
+  }) =>
+    ReactLocal.createElement('div', { 'data-testid': testID }, children);
+
+  const Callout = ({
+    children,
+    onPress,
+    testID,
+  }: {
+    children?: React.ReactNode;
+    onPress?: () => void;
+    testID?: string;
+  }) =>
+    ReactLocal.createElement(
+      'div',
+      { 'data-testid': testID, onClick: onPress },
+      children,
+    );
+
+  return {
+    __esModule: true,
+    default: MapView,
+    Marker,
+    Callout,
+    PROVIDER_GOOGLE: 'google',
+  };
+});
+
+// ── @/theme mock ───────────────────────────────────────────────────────────────
+
+jest.mock('@/theme', () => ({
+  useTheme: () => ({
+    theme: {
+      primary: '#111827',
+      text: '#111827',
+      textSecondary: '#6B7280',
+      textOnPrimary: '#FFFFFF',
+      surface: '#FFFFFF',
+      errorText: '#DC2626',
+    },
+  }),
+}));
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+const DEFAULT_REGION: MapRegion = {
+  latitude: 41.0422,
+  longitude: 29.0083,
+  latitudeDelta: 0.18,
+  longitudeDelta: 0.18,
+};
+
+function makeEvent(overrides: Partial<EventSummary> = {}): EventSummary {
+  return {
+    id: 'evt-1',
+    title: 'Test Event',
+    category_name: 'Sports',
+    start_time: '2026-06-01T10:00:00Z',
+    privacy_level: 'PUBLIC',
+    approved_participant_count: 5,
+    is_favorited: false,
+    host_score: { final_score: null, hosted_event_rating_count: 0 },
+    location_lat: 41.0422,
+    location_lon: 29.0083,
+    ...overrides,
+  };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────────
+
+describe('EventMapView', () => {
+  describe('loading state', () => {
+    it('renders a loading indicator and hides the map surface', () => {
+      render(
+        <EventMapView
+          events={[]}
+          isLoading
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('map-loading')).toBeTruthy();
+      expect(screen.queryByTestId('map-surface')).toBeNull();
+    });
+  });
+
+  describe('error state', () => {
+    it('renders the error message and hides the map surface', () => {
+      render(
+        <EventMapView
+          events={[]}
+          isLoading={false}
+          apiError="Could not load events."
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('map-error')).toBeTruthy();
+      expect(screen.getByText('Could not load events.')).toBeTruthy();
+      expect(screen.queryByTestId('map-surface')).toBeNull();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows the map surface and the empty overlay when no events have coordinates', () => {
+      const eventWithoutCoords = makeEvent({
+        location_lat: null,
+        location_lon: null,
+      });
+
+      render(
+        <EventMapView
+          events={[eventWithoutCoords]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('map-surface')).toBeTruthy();
+      expect(screen.getByTestId('map-empty')).toBeTruthy();
+      expect(screen.getByText('No events on the map')).toBeTruthy();
+    });
+
+    it('shows the empty overlay when the events list is empty', () => {
+      render(
+        <EventMapView
+          events={[]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('map-empty')).toBeTruthy();
+    });
+  });
+
+  describe('marker rendering', () => {
+    it('renders a marker for each event that has valid coordinates', () => {
+      const events = [
+        makeEvent({ id: 'evt-1', title: 'Event One', location_lat: 41.0, location_lon: 29.0 }),
+        makeEvent({ id: 'evt-2', title: 'Event Two', location_lat: 41.1, location_lon: 29.1 }),
+        makeEvent({ id: 'evt-3', title: 'Event Three', location_lat: null, location_lon: null }),
+      ];
+
+      render(
+        <EventMapView
+          events={events}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('marker-evt-1')).toBeTruthy();
+      expect(screen.getByTestId('marker-evt-2')).toBeTruthy();
+      expect(screen.queryByTestId('marker-evt-3')).toBeNull();
+    });
+
+    it('does not show the empty overlay when at least one event has coordinates', () => {
+      render(
+        <EventMapView
+          events={[makeEvent()]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('map-empty')).toBeNull();
+    });
+
+    it('displays the event title in the callout', () => {
+      render(
+        <EventMapView
+          events={[makeEvent({ title: 'Trail Run' })]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Trail Run')).toBeTruthy();
+    });
+
+    it('shows participant count and capacity when both are present', () => {
+      render(
+        <EventMapView
+          events={[
+            makeEvent({
+              approved_participant_count: 8,
+              capacity: 20,
+            }),
+          ]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText(/8.*20.*going/s)).toBeTruthy();
+    });
+
+    it('shows participant count without capacity when capacity is not set', () => {
+      render(
+        <EventMapView
+          events={[makeEvent({ approved_participant_count: 5, capacity: undefined })]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText(/5.*going/s)).toBeTruthy();
+      expect(screen.queryByText(/\//)).toBeNull();
+    });
+  });
+
+  describe('navigation', () => {
+    it('calls onMarkerPress with the event id when the callout is pressed', () => {
+      const onMarkerPress = jest.fn();
+      render(
+        <EventMapView
+          events={[makeEvent({ id: 'evt-42' })]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={onMarkerPress}
+        />,
+      );
+
+      const callout = screen.getByTestId('callout-evt-42');
+      fireEvent.click(callout);
+
+      expect(onMarkerPress).toHaveBeenCalledWith('evt-42');
+    });
+  });
+
+  describe('callout content', () => {
+    it('shows category name in the callout', () => {
+      render(
+        <EventMapView
+          events={[makeEvent({ category_name: 'Sports' })]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Sports')).toBeTruthy();
+    });
+
+    it('shows location address when present', () => {
+      render(
+        <EventMapView
+          events={[makeEvent({ location_address: 'Belgrad Forest, Istanbul' })]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText(/Belgrad Forest/)).toBeTruthy();
+    });
+
+    it('omits location line when address is not set', () => {
+      render(
+        <EventMapView
+          events={[makeEvent({ location_address: null })]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.queryByText(/📍/)).toBeNull();
+    });
+  });
+});

--- a/mobile/src/components/home/EventMapView.tsx
+++ b/mobile/src/components/home/EventMapView.tsx
@@ -1,0 +1,229 @@
+import React, { useMemo } from 'react';
+import {
+  ActivityIndicator,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import MapView, { Callout, Marker, PROVIDER_GOOGLE, Region } from 'react-native-maps';
+import { useTheme } from '@/theme';
+import type { Theme } from '@/theme';
+import type { EventSummary } from '@/models/event';
+
+export interface MapRegion {
+  latitude: number;
+  longitude: number;
+  latitudeDelta: number;
+  longitudeDelta: number;
+}
+
+interface EventMapViewProps {
+  events: EventSummary[];
+  isLoading: boolean;
+  apiError: string | null;
+  region: MapRegion;
+  onMarkerPress: (eventId: string) => void;
+}
+
+function formatStartTime(isoString: string): string {
+  try {
+    const date = new Date(isoString);
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return isoString;
+  }
+}
+
+export default function EventMapView({
+  events,
+  isLoading,
+  apiError,
+  region,
+  onMarkerPress,
+}: EventMapViewProps) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme]);
+
+  const mappableEvents = useMemo(
+    () =>
+      events.filter(
+        (e) => e.location_lat != null && e.location_lon != null,
+      ),
+    [events],
+  );
+
+  if (isLoading) {
+    return (
+      <View style={styles.centeredState} testID="map-loading">
+        <ActivityIndicator size="large" color={theme.primary} />
+      </View>
+    );
+  }
+
+  if (apiError) {
+    return (
+      <View style={styles.centeredState} testID="map-error">
+        <Text style={styles.stateText}>{apiError}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container} testID="event-map-view">
+      <MapView
+        style={styles.map}
+        provider={Platform.OS === 'android' ? PROVIDER_GOOGLE : undefined}
+        region={region}
+        testID="map-surface"
+      >
+        {mappableEvents.map((event) => (
+          <Marker
+            key={event.id}
+            identifier={event.id}
+            coordinate={{
+              latitude: event.location_lat as number,
+              longitude: event.location_lon as number,
+            }}
+            pinColor={theme.primary}
+            testID={`marker-${event.id}`}
+          >
+            <Callout
+              tooltip
+              onPress={() => onMarkerPress(event.id)}
+              testID={`callout-${event.id}`}
+            >
+              <View style={styles.callout}>
+                <Text style={styles.calloutCategory}>
+                  {event.category_name}
+                </Text>
+                <Text style={styles.calloutTitle} numberOfLines={2}>
+                  {event.title}
+                </Text>
+                <Text style={styles.calloutMeta}>
+                  🗓 {formatStartTime(event.start_time)}
+                </Text>
+                {event.location_address ? (
+                  <Text style={styles.calloutMeta} numberOfLines={1}>
+                    📍 {event.location_address}
+                  </Text>
+                ) : null}
+                <Text style={styles.calloutMeta}>
+                  👥 {event.approved_participant_count}
+                  {event.capacity != null ? ` / ${event.capacity}` : ''} going
+                </Text>
+                <View style={styles.calloutDivider} />
+                <Text style={styles.calloutHint}>Tap to view details →</Text>
+              </View>
+            </Callout>
+          </Marker>
+        ))}
+      </MapView>
+
+      {!isLoading && mappableEvents.length === 0 && (
+        <View style={styles.emptyOverlay} testID="map-empty">
+          <Text style={styles.emptyTitle}>No events on the map</Text>
+          <Text style={styles.emptySubtitle}>
+            Events will appear here once location data is available.
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function makeStyles(t: Theme) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+    },
+    map: {
+      flex: 1,
+    },
+    centeredState: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    stateText: {
+      color: t.errorText,
+      fontSize: 14,
+      textAlign: 'center',
+      paddingHorizontal: 24,
+    },
+    emptyOverlay: {
+      position: 'absolute',
+      bottom: 32,
+      left: 20,
+      right: 20,
+      backgroundColor: t.surface,
+      borderRadius: 12,
+      padding: 16,
+      alignItems: 'center',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.12,
+      shadowRadius: 8,
+      elevation: 4,
+    },
+    emptyTitle: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: t.text,
+      marginBottom: 4,
+    },
+    emptySubtitle: {
+      fontSize: 13,
+      color: t.textSecondary,
+      textAlign: 'center',
+    },
+    callout: {
+      width: 240,
+      backgroundColor: t.surface,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: t.border,
+      padding: 14,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 4 },
+      shadowOpacity: 0.15,
+      shadowRadius: 8,
+      elevation: 6,
+    },
+    calloutCategory: {
+      fontSize: 11,
+      fontWeight: '600',
+      color: t.primary,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+      marginBottom: 4,
+    },
+    calloutTitle: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: t.text,
+      marginBottom: 6,
+    },
+    calloutMeta: {
+      fontSize: 12,
+      color: t.textSecondary,
+      marginBottom: 3,
+    },
+    calloutDivider: {
+      height: 1,
+      backgroundColor: t.divider,
+      marginVertical: 8,
+    },
+    calloutHint: {
+      fontSize: 12,
+      fontWeight: '600',
+      color: t.primary,
+      textAlign: 'right',
+    },
+  });
+}

--- a/mobile/src/models/event.ts
+++ b/mobile/src/models/event.ts
@@ -62,6 +62,8 @@ export interface EventSummary {
   start_time: string;
   end_time?: string | null;
   location_address?: string | null;
+  location_lat?: number | null;
+  location_lon?: number | null;
   privacy_level: PrivacyLevel;
   approved_participant_count: number;
   is_favorited: boolean;

--- a/mobile/src/viewmodels/home/useHomeViewModel.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.ts
@@ -312,6 +312,8 @@ function validateFilterDatesLive(filters: HomeFiltersDraft): string | null {
   return null;
 }
 
+export type HomeViewMode = 'LIST' | 'MAP';
+
 export interface HomeViewModel {
   locationLabel: string;
   locationQuery: string;
@@ -345,6 +347,9 @@ export interface HomeViewModel {
   isFilterModalOpen: boolean;
   filterDraft: HomeFiltersDraft;
   filterError: string | null;
+  viewMode: HomeViewMode;
+  activeLocation: { lat: number; lon: number };
+  toggleViewMode: () => void;
   updateSearchText: (value: string) => void;
   submitSearch: () => void;
   selectCategory: (categoryId: number | null) => void;
@@ -409,6 +414,12 @@ export function useHomeViewModel(): HomeViewModel {
   const [filterDraft, setFilterDraft] =
     useState<HomeFiltersDraft>(DEFAULT_FILTERS);
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
+
+  const [viewMode, setViewMode] = useState<HomeViewMode>('LIST');
+
+  const toggleViewMode = useCallback(() => {
+    setViewMode((prev) => (prev === 'LIST' ? 'MAP' : 'LIST'));
+  }, []);
 
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
@@ -979,6 +990,8 @@ export function useHomeViewModel(): HomeViewModel {
     suggestion: favoriteLocationToSuggestion(location),
   }));
 
+  const effectiveLocation = selectedLocation ?? defaultLocation ?? FALLBACK_LOCATION;
+
   return {
     locationLabel: selectedLocation
       ? formatEventLocation(selectedLocation.display_name)
@@ -1002,6 +1015,12 @@ export function useHomeViewModel(): HomeViewModel {
     isSearchingLocation,
     isLocationModalOpen,
     pendingLocation,
+    viewMode,
+    activeLocation: {
+      lat: Number(effectiveLocation.lat),
+      lon: Number(effectiveLocation.lon),
+    },
+    toggleViewMode,
     defaultLocationOption: {
       title: 'Use Default Location',
       subtitle: getDefaultLocationSubtitle(

--- a/mobile/src/viewmodels/home/useHomeViewModel.viewMode.test.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.viewMode.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Focused tests for the viewMode toggle introduced in useHomeViewModel.
+ * The broader integration behaviour (events fetching, filters, location) is
+ * covered by other tests; these tests pin only the new list/map toggle.
+ */
+import { act, renderHook } from '@testing-library/react';
+
+// ── module-level mocks required by useHomeViewModel ───────────────────────────
+
+jest.mock('@/services/eventService', () => ({
+  listCategories: jest.fn().mockResolvedValue({ items: [] }),
+  listEvents: jest.fn().mockResolvedValue({
+    items: [],
+    page_info: { has_next: false, next_cursor: null },
+  }),
+  searchLocation: jest.fn().mockResolvedValue({ results: [] }),
+}));
+
+jest.mock('@/services/profileService', () => ({
+  getMyProfile: jest.fn().mockResolvedValue({
+    default_location_address: null,
+    default_location_lat: null,
+    default_location_lon: null,
+  }),
+}));
+
+jest.mock('@/services/favoriteService', () => ({
+  listFavoriteLocations: jest.fn().mockResolvedValue({ items: [] }),
+}));
+
+jest.mock('@/services/deviceLocationService', () => ({
+  getCurrentLocationSuggestion: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/services/homeLocationSelectionStore', () => ({
+  getHomeLocationSelection: jest.fn().mockReturnValue({ mode: 'DEFAULT', location: null }),
+  setHomeLocationSelection: jest.fn(),
+}));
+
+jest.mock('@/utils/eventLocation', () => ({
+  formatEventLocation: (v: string) => v,
+}));
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', user: { id: 'user-1' } }),
+}));
+
+// ── tests ──────────────────────────────────────────────────────────────────────
+
+import { useHomeViewModel } from './useHomeViewModel';
+
+describe('useHomeViewModel – viewMode toggle', () => {
+  it('starts in LIST mode', async () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.viewMode).toBe('LIST');
+  });
+
+  it('switches to MAP mode when toggleViewMode is called once', async () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.toggleViewMode();
+    });
+
+    expect(result.current.viewMode).toBe('MAP');
+  });
+
+  it('switches back to LIST mode when toggleViewMode is called a second time', async () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.toggleViewMode();
+    });
+
+    act(() => {
+      result.current.toggleViewMode();
+    });
+
+    expect(result.current.viewMode).toBe('LIST');
+  });
+
+  it('exposes activeLocation as numeric lat/lon based on the resolved location', async () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(typeof result.current.activeLocation.lat).toBe('number');
+    expect(typeof result.current.activeLocation.lon).toBe('number');
+  });
+});

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -4,6 +4,7 @@ import {
   FlatList,
   StyleSheet,
   Text,
+  TouchableOpacity,
   View,
 } from 'react-native';
 import { router, useFocusEffect, type Href } from 'expo-router';
@@ -14,11 +15,15 @@ import EmptyState from '@/components/home/EmptyState';
 import LoadingState from '@/components/home/LoadingState';
 import EventCard from '@/components/events/EventCard';
 import FiltersBottomSheet from '@/components/home/FiltersBottomSheet';
+import EventMapView from '@/components/home/EventMapView';
 import { useHomeViewModel } from '@/viewmodels/home/useHomeViewModel';
 import LocationPickerPanel from '@/components/home/LocationPickerPanel';
 import { useUnreadNotificationCount } from '@/viewmodels/notifications/useUnreadNotificationCount';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
+
+const REGION_DELTA_PER_KM = 0.009;
+const MIN_DELTA = 0.02;
 
 export default function HomeView() {
   const vm = useHomeViewModel();
@@ -49,6 +54,19 @@ export default function HomeView() {
     vm.openLocationModal();
   };
 
+  const mapRegion = useMemo(() => {
+    const delta = Math.max(
+      vm.filterDraft.radiusKm * REGION_DELTA_PER_KM * 2,
+      MIN_DELTA,
+    );
+    return {
+      latitude: vm.activeLocation.lat,
+      longitude: vm.activeLocation.lon,
+      latitudeDelta: delta,
+      longitudeDelta: delta,
+    };
+  }, [vm.activeLocation, vm.filterDraft.radiusKm]);
+
   return (
     <SafeAreaView edges={['top', 'left', 'right']} style={styles.safeArea}>
       <View style={styles.container}>
@@ -68,7 +86,53 @@ export default function HomeView() {
             onPressFilter={vm.openFilterModal}
           />
 
-          {vm.apiError ? (
+          <View style={styles.viewToggleRow}>
+            <TouchableOpacity
+              style={[
+                styles.viewToggleButton,
+                styles.viewToggleLeft,
+                vm.viewMode === 'LIST' && styles.viewToggleActive,
+              ]}
+              onPress={() => vm.viewMode !== 'LIST' && vm.toggleViewMode()}
+              accessibilityRole="button"
+              accessibilityLabel="List view"
+              accessibilityState={{ selected: vm.viewMode === 'LIST' }}
+              testID="toggle-list"
+            >
+              <Text
+                style={[
+                  styles.viewToggleText,
+                  vm.viewMode === 'LIST' && styles.viewToggleTextActive,
+                ]}
+              >
+                List
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[
+                styles.viewToggleButton,
+                styles.viewToggleRight,
+                vm.viewMode === 'MAP' && styles.viewToggleActive,
+              ]}
+              onPress={() => vm.viewMode !== 'MAP' && vm.toggleViewMode()}
+              accessibilityRole="button"
+              accessibilityLabel="Map view"
+              accessibilityState={{ selected: vm.viewMode === 'MAP' }}
+              testID="toggle-map"
+            >
+              <Text
+                style={[
+                  styles.viewToggleText,
+                  vm.viewMode === 'MAP' && styles.viewToggleTextActive,
+                ]}
+              >
+                Map
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {vm.apiError && vm.viewMode === 'LIST' ? (
             <View style={styles.errorBanner}>
               <Text style={styles.errorBannerText}>{vm.apiError}</Text>
             </View>
@@ -76,7 +140,15 @@ export default function HomeView() {
         </View>
 
         <View style={styles.listWrapper}>
-          {vm.isLoading ? (
+          {vm.viewMode === 'MAP' ? (
+            <EventMapView
+              events={vm.events}
+              isLoading={vm.isLoading}
+              apiError={vm.apiError}
+              region={mapRegion}
+              onMarkerPress={(id) => router.push(`/event/${id}` as Href)}
+            />
+          ) : vm.isLoading ? (
             <LoadingState />
           ) : (
             <FlatList
@@ -181,6 +253,40 @@ function makeStyles(t: Theme) {
     errorBannerText: {
       color: t.errorText,
       fontSize: 14,
+    },
+    viewToggleRow: {
+      flexDirection: 'row',
+      marginTop: 10,
+      marginBottom: 2,
+      alignSelf: 'center',
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: t.border,
+      overflow: 'hidden',
+    },
+    viewToggleButton: {
+      paddingHorizontal: 24,
+      paddingVertical: 8,
+      backgroundColor: t.surface,
+    },
+    viewToggleLeft: {
+      borderTopLeftRadius: 999,
+      borderBottomLeftRadius: 999,
+    },
+    viewToggleRight: {
+      borderTopRightRadius: 999,
+      borderBottomRightRadius: 999,
+    },
+    viewToggleActive: {
+      backgroundColor: t.primary,
+    },
+    viewToggleText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: t.textSecondary,
+    },
+    viewToggleTextActive: {
+      color: t.textOnPrimary,
     },
   });
 }


### PR DESCRIPTION
## 📋 Summary

This PR adds a map view to the Home/Discover screen so users can browse events as map markers in addition to the existing list.

A List / Map toggle sits below the search bar and preserves all active filters, search query, and selected location when switching between views. Events are rendered as markers using `location_lat` / `location_lon` from the discover API response, which is already returned by the backend but was previously unconsumed.

Tapping a marker surfaces a themed callout with the event title, category, date, location address, and participant count. Tapping the callout navigates to event detail. The map centers on the user's selected discover location and scales its initial zoom to the active radius filter. Loading, empty, and error states are handled on the map surface. Dark and light mode are fully supported through the existing theme system.

## 🔄 Changes

- Installed `react-native-maps` and wired the Android Google Maps API key through `app.config.js`
  - Read from `GOOGLE_MAPS_ANDROID_API_KEY` env var
  - API key is never committed
- Added `location_lat` and `location_lon` as optional fields to the `EventSummary` model so the mobile layer can consume coordinates already returned by the backend
- Extended `HomeViewModel` with:
  - `viewMode` (`LIST` | `MAP`)
  - `toggleViewMode`
  - `activeLocation` as numeric `lat` / `lon` of the effective discover location
- Created `EventMapView` component with:
  - Full-screen `MapView`
    - Apple Maps on iOS
    - Google Maps on Android
  - Per-event `Marker` + `Callout` for events with valid coordinates
  - Themed callout card with:
    - Category
    - Title
    - Date
    - Address
    - Participants
    - `Tap to view details →`
  - Loading spinner
  - Error message
  - Empty-state overlay
- Added pill-shaped List / Map toggle to `HomeView` below the search bar
- Updated `.env.example` to document `GOOGLE_MAPS_ANDROID_API_KEY`
- Added test coverage for:
  - Map loading, error, and empty states
  - Marker rendering filtered to events with coordinates
  - Callout content:
    - Title
    - Category
    - Address
    - Capacity
  - Navigation callback on callout press
  - `viewMode` toggle:
    - Starts as `LIST`
    - Toggles to `MAP`
    - Toggles back to `LIST`
  - `activeLocation` exposed as numeric values

## 🧪 Testing

### Automated

```bash
cd mobile
npm test
```

### Manual

- Open the Home screen and confirm the List / Map toggle appears below the search bar
- Switch to Map and verify the map centers on the selected discover location
- Change the radius filter and re-open the map
  - Confirm the zoom level adjusts
- Switch location via the location picker
  - Confirm the map recenters
- Tap a marker
  - Verify the callout shows:
    - Title
    - Category
    - Date
    - Address
    - Participant count
  - Confirm dark/light theme colors are correct
- Tap the callout
  - Confirm navigation to event detail
- Switch back to List
  - Confirm events, filters, and search query are unchanged
- Test with no events in range
  - Confirm the empty-state overlay appears on the map
- On Android:
  - Confirm Google Maps loads without API key errors after:

```bash
npx expo prebuild --clean
npx expo run:android
```

- On iOS:
  - Confirm Apple Maps loads with no additional configuration

## 🔗 Related

Closes #457