### PR TITLE
feat(backend): add discussion and review comments system

### DIFF
--- a/backend/internal/adapter/in/postgres/comment_repo.go
+++ b/backend/internal/adapter/in/postgres/comment_repo.go
@@ -1,0 +1,379 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	commentapp "github.com/bounswe/bounswe2026group11/backend/internal/application/comment"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// CommentRepository is the Postgres-backed implementation of comment.Repository.
+type CommentRepository struct {
+	pool *pgxpool.Pool
+	db   execer
+}
+
+// NewCommentRepository returns a repository that executes queries against the
+// given connection pool.
+func NewCommentRepository(pool *pgxpool.Pool) *CommentRepository {
+	return &CommentRepository{
+		pool: pool,
+		db:   contextualRunner{fallback: pool},
+	}
+}
+
+var _ commentapp.Repository = (*CommentRepository)(nil)
+
+func (r *CommentRepository) GetEventCommentContext(ctx context.Context, eventID uuid.UUID, viewerUserID *uuid.UUID) (*commentapp.EventCommentContext, error) {
+	var (
+		record                  commentapp.EventCommentContext
+		privacyLevel            string
+		status                  string
+		viewer                  pgtype.UUID
+		isVisible               bool
+		isHost                  bool
+		isApprovedParticipant   bool
+		isQualifyingParticipant bool
+	)
+	if viewerUserID != nil {
+		viewer = pgtype.UUID{Bytes: *viewerUserID, Valid: true}
+	}
+
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			e.id,
+			e.host_id,
+			e.privacy_level,
+			CASE
+				WHEN e.status = 'ACTIVE' AND e.end_time < NOW() THEN 'COMPLETED'
+				WHEN e.status = 'ACTIVE' AND e.start_time < NOW() THEN 'IN_PROGRESS'
+				WHEN e.status = 'IN_PROGRESS' AND e.end_time < NOW() THEN 'COMPLETED'
+				ELSE e.status
+			END AS status,
+			e.start_time,
+			(
+				e.privacy_level IN ($2, $3)
+				OR ($4::uuid IS NOT NULL AND e.host_id = $4)
+				OR EXISTS (
+					SELECT 1 FROM participation p
+					WHERE p.event_id = e.id
+					  AND p.user_id = $4
+					  AND p.status IN ($5, $6, $7)
+				)
+				OR EXISTS (
+					SELECT 1 FROM invitation inv
+					WHERE inv.event_id = e.id
+					  AND inv.invited_user_id = $4
+					  AND inv.status IN ($8, $9)
+				)
+			) AS is_visible,
+			($4::uuid IS NOT NULL AND e.host_id = $4) AS is_host,
+			EXISTS (
+				SELECT 1 FROM participation p
+				WHERE p.event_id = e.id
+				  AND p.user_id = $4
+				  AND p.status = $5
+			) AS is_approved_participant,
+			EXISTS (
+				SELECT 1 FROM participation p
+				WHERE p.event_id = e.id
+				  AND p.user_id = $4
+				  AND (
+					p.status = $5
+					OR (p.status = $6 AND p.updated_at >= e.start_time)
+				  )
+			) AS is_qualifying_participant
+		FROM event e
+		WHERE e.id = $1
+	`,
+		eventID,
+		domain.PrivacyPublic,
+		domain.PrivacyProtected,
+		viewer,
+		domain.ParticipationStatusApproved,
+		domain.ParticipationStatusLeaved,
+		domain.ParticipationStatusCanceled,
+		string(domain.InvitationStatusAccepted),
+		string(domain.InvitationStatusPending),
+	).Scan(
+		&record.EventID,
+		&record.HostUserID,
+		&privacyLevel,
+		&status,
+		&record.StartTime,
+		&isVisible,
+		&isHost,
+		&isApprovedParticipant,
+		&isQualifyingParticipant,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get event comment context: %w", err)
+	}
+
+	record.PrivacyLevel = domain.EventPrivacyLevel(privacyLevel)
+	record.Status = domain.EventStatus(status)
+	record.IsVisible = isVisible
+	record.IsHost = isHost
+	record.IsApprovedParticipant = isApprovedParticipant
+	record.IsQualifyingParticipant = isQualifyingParticipant
+	return &record, nil
+}
+
+func (r *CommentRepository) GetDiscussionParentContext(ctx context.Context, eventID, parentID uuid.UUID) (*commentapp.DiscussionParentContext, error) {
+	var (
+		record      commentapp.DiscussionParentContext
+		commentType string
+		parent      pgtype.UUID
+	)
+	err := r.db.QueryRow(ctx, `
+		SELECT id, event_id, comment_type, parent_id
+		FROM event_comment
+		WHERE id = $1
+		  AND event_id = $2
+	`, parentID, eventID).Scan(&record.ID, &record.EventID, &commentType, &parent)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get discussion parent context: %w", err)
+	}
+
+	record.Type = domain.CommentType(commentType)
+	record.ParentID = uuidPtr(parent)
+	return &record, nil
+}
+
+func (r *CommentRepository) ListTopLevelComments(ctx context.Context, eventID uuid.UUID, params commentapp.ListCommentsParams) ([]commentapp.CommentRecord, error) {
+	args := []any{eventID, string(params.CommentType)}
+	cursorClause := buildCommentCursorClause(params, &args, "ec.created_at", "ec.id")
+	args = append(args, params.RepositoryFetchLimit)
+
+	rows, err := r.db.Query(ctx, fmt.Sprintf(`
+		SELECT
+			ec.id,
+			ec.event_id,
+			ec.user_id,
+			u.username,
+			pr.display_name,
+			pr.avatar_url,
+			ec.comment_type,
+			ec.message,
+			ec.parent_id,
+			ec.rating,
+			ec.image_url,
+			ec.likes_count,
+			ec.reply_count,
+			ec.created_at,
+			ec.updated_at
+		FROM event_comment ec
+		JOIN app_user u ON u.id = ec.user_id
+		LEFT JOIN profile pr ON pr.user_id = u.id
+		WHERE ec.event_id = $1
+		  AND ec.comment_type = $2
+		  AND ec.parent_id IS NULL
+		  %s
+		ORDER BY ec.created_at DESC, ec.id DESC
+		LIMIT $%d
+	`, cursorClause, len(args)), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list top-level comments: %w", err)
+	}
+	defer rows.Close()
+
+	return scanCommentRecords(rows, "list top-level comments")
+}
+
+func (r *CommentRepository) ListReplies(ctx context.Context, eventID, parentID uuid.UUID, params commentapp.ListCommentsParams) ([]commentapp.CommentRecord, error) {
+	args := []any{eventID, parentID, string(domain.CommentTypeDiscussion)}
+	cursorClause := buildCommentCursorClause(params, &args, "ec.created_at", "ec.id")
+	args = append(args, params.RepositoryFetchLimit)
+
+	rows, err := r.db.Query(ctx, fmt.Sprintf(`
+		SELECT
+			ec.id,
+			ec.event_id,
+			ec.user_id,
+			u.username,
+			pr.display_name,
+			pr.avatar_url,
+			ec.comment_type,
+			ec.message,
+			ec.parent_id,
+			ec.rating,
+			ec.image_url,
+			ec.likes_count,
+			ec.reply_count,
+			ec.created_at,
+			ec.updated_at
+		FROM event_comment ec
+		JOIN app_user u ON u.id = ec.user_id
+		LEFT JOIN profile pr ON pr.user_id = u.id
+		WHERE ec.event_id = $1
+		  AND ec.parent_id = $2
+		  AND ec.comment_type = $3
+		  %s
+		ORDER BY ec.created_at DESC, ec.id DESC
+		LIMIT $%d
+	`, cursorClause, len(args)), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list comment replies: %w", err)
+	}
+	defer rows.Close()
+
+	return scanCommentRecords(rows, "list comment replies")
+}
+
+func (r *CommentRepository) CreateDiscussionComment(ctx context.Context, params commentapp.CreateDiscussionCommentParams) (*commentapp.CommentRecord, error) {
+	return scanCommentRecord(r.db.QueryRow(ctx, `
+		WITH inserted AS (
+			INSERT INTO event_comment (event_id, user_id, comment_type, message, parent_id)
+			VALUES ($1, $2, $3, $4, $5)
+			RETURNING id, event_id, user_id, comment_type, message, parent_id, rating, image_url, likes_count, reply_count, created_at, updated_at
+		)
+		SELECT
+			i.id,
+			i.event_id,
+			i.user_id,
+			u.username,
+			pr.display_name,
+			pr.avatar_url,
+			i.comment_type,
+			i.message,
+			i.parent_id,
+			i.rating,
+			i.image_url,
+			i.likes_count,
+			i.reply_count,
+			i.created_at,
+			i.updated_at
+		FROM inserted i
+		JOIN app_user u ON u.id = i.user_id
+		LEFT JOIN profile pr ON pr.user_id = u.id
+	`, params.EventID, params.UserID, string(domain.CommentTypeDiscussion), params.Message, params.ParentID), "create discussion comment")
+}
+
+func (r *CommentRepository) UpsertReviewComment(ctx context.Context, params commentapp.UpsertReviewCommentParams) (*commentapp.CommentRecord, error) {
+	return scanCommentRecord(r.db.QueryRow(ctx, `
+		WITH upserted AS (
+			INSERT INTO event_comment (event_id, user_id, comment_type, message, rating, image_url)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (event_id, user_id) WHERE comment_type = 'REVIEW'
+			DO UPDATE SET
+				message = EXCLUDED.message,
+				rating = EXCLUDED.rating,
+				image_url = COALESCE(EXCLUDED.image_url, event_comment.image_url),
+				updated_at = now()
+			RETURNING id, event_id, user_id, comment_type, message, parent_id, rating, image_url, likes_count, reply_count, created_at, updated_at
+		)
+		SELECT
+			uo.id,
+			uo.event_id,
+			uo.user_id,
+			u.username,
+			pr.display_name,
+			pr.avatar_url,
+			uo.comment_type,
+			uo.message,
+			uo.parent_id,
+			uo.rating,
+			uo.image_url,
+			uo.likes_count,
+			uo.reply_count,
+			uo.created_at,
+			uo.updated_at
+		FROM upserted uo
+		JOIN app_user u ON u.id = uo.user_id
+		LEFT JOIN profile pr ON pr.user_id = u.id
+	`, params.EventID, params.UserID, string(domain.CommentTypeReview), params.Message, params.Rating, params.ImageURL), "upsert review comment")
+}
+
+func (r *CommentRepository) DeleteReviewComment(ctx context.Context, eventID, userID uuid.UUID) (bool, error) {
+	tag, err := r.db.Exec(ctx, `
+		DELETE FROM event_comment
+		WHERE event_id = $1
+		  AND user_id = $2
+		  AND comment_type = $3
+	`, eventID, userID, string(domain.CommentTypeReview))
+	if err != nil {
+		return false, fmt.Errorf("delete review comment: %w", err)
+	}
+
+	return tag.RowsAffected() == 1, nil
+}
+
+func buildCommentCursorClause(params commentapp.ListCommentsParams, args *[]any, createdAtColumn, idColumn string) string {
+	if params.DecodedCursor == nil {
+		return ""
+	}
+	*args = append(*args, params.DecodedCursor.CreatedAt, params.DecodedCursor.CommentID)
+	createdAtIndex := len(*args) - 1
+	idIndex := len(*args)
+	return fmt.Sprintf("AND (%s, %s) < ($%d, $%d)", createdAtColumn, idColumn, createdAtIndex, idIndex)
+}
+
+func scanCommentRecords(rows pgx.Rows, operation string) ([]commentapp.CommentRecord, error) {
+	records := make([]commentapp.CommentRecord, 0)
+	for rows.Next() {
+		record, err := scanCommentRecord(rows, operation)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, *record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("%s rows: %w", operation, err)
+	}
+	return records, nil
+}
+
+func scanCommentRecord(row pgx.Row, operation string) (*commentapp.CommentRecord, error) {
+	var (
+		record      commentapp.CommentRecord
+		commentType string
+		parentID    pgtype.UUID
+		rating      pgtype.Int4
+		imageURL    pgtype.Text
+		displayName pgtype.Text
+		avatarURL   pgtype.Text
+	)
+
+	if err := row.Scan(
+		&record.ID,
+		&record.EventID,
+		&record.User.ID,
+		&record.User.Username,
+		&displayName,
+		&avatarURL,
+		&commentType,
+		&record.Message,
+		&parentID,
+		&rating,
+		&imageURL,
+		&record.LikesCount,
+		&record.ReplyCount,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("%s: %w", operation, err)
+	}
+
+	record.Type = domain.CommentType(commentType)
+	record.ParentID = uuidPtr(parentID)
+	if rating.Valid {
+		value := int(rating.Int32)
+		record.Rating = &value
+	}
+	record.ImageURL = textPtr(imageURL)
+	record.User.DisplayName = textPtr(displayName)
+	record.User.AvatarURL = textPtr(avatarURL)
+	return &record, nil
+}

--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -1121,10 +1121,11 @@ func (r *EventRepository) loadViewerEventRating(
 
 	err := r.pool.QueryRow(ctx, `
 		SELECT id, rating, message, created_at, updated_at
-		FROM event_rating
+		FROM event_comment
 		WHERE event_id = $1
-		  AND participant_user_id = $2
-	`, eventID, participantUserID).Scan(
+		  AND user_id = $2
+		  AND comment_type = $3
+	`, eventID, participantUserID, string(domain.CommentTypeReview)).Scan(
 		&record.ID,
 		&record.Rating,
 		&message,
@@ -1634,6 +1635,57 @@ func (r *EventRepository) SetEventImageIfVersion(
 }
 
 var _ imageuploadapp.EventRepository = (*EventRepository)(nil)
+
+// GetEventReviewImageState loads the event and caller relation needed to
+// authorize review image uploads.
+func (r *EventRepository) GetEventReviewImageState(ctx context.Context, eventID, userID uuid.UUID) (*imageuploadapp.EventReviewImageState, error) {
+	var (
+		state        imageuploadapp.EventReviewImageState
+		status       string
+		privacyLevel string
+	)
+
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			e.id,
+			e.host_id,
+			CASE
+				WHEN e.status = 'ACTIVE' AND e.end_time < NOW() THEN 'COMPLETED'
+				WHEN e.status = 'ACTIVE' AND e.start_time < NOW() THEN 'IN_PROGRESS'
+				WHEN e.status = 'IN_PROGRESS' AND e.end_time < NOW() THEN 'COMPLETED'
+				ELSE e.status
+			END AS status,
+			e.privacy_level,
+			EXISTS (
+				SELECT 1
+				FROM participation p
+				WHERE p.event_id = e.id
+				  AND p.user_id = $2
+				  AND (
+					p.status = $3
+					OR (p.status = $4 AND p.updated_at >= e.start_time)
+				  )
+			) AS is_qualifying_participant
+		FROM event e
+		WHERE e.id = $1
+	`, eventID, userID, domain.ParticipationStatusApproved, domain.ParticipationStatusLeaved).Scan(
+		&state.EventID,
+		&state.HostID,
+		&status,
+		&privacyLevel,
+		&state.IsQualifyingParticipant,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get event review image state: %w", err)
+	}
+
+	state.Status = status
+	state.PrivacyLevel = privacyLevel
+	return &state, nil
+}
 
 // CancelEvent sets the event status to CANCELED and transitions active
 // participations to CANCELED atomically while preserving historical LEAVED rows.

--- a/backend/internal/adapter/in/postgres/rating_repo.go
+++ b/backend/internal/adapter/in/postgres/rating_repo.go
@@ -32,18 +32,26 @@ func (r *RatingRepository) GetEventRatingContext(
 	eventID, participantUserID uuid.UUID,
 ) (*ratingapp.EventRatingContext, error) {
 	var (
-		status                string
-		endTime               pgtype.Timestamptz
-		ratingContext         ratingapp.EventRatingContext
-		isRequestingHost      bool
-		isApprovedParticipant bool
+		status                  string
+		privacyLevel            string
+		endTime                 pgtype.Timestamptz
+		ratingContext           ratingapp.EventRatingContext
+		isRequestingHost        bool
+		isApprovedParticipant   bool
+		isQualifyingParticipant bool
 	)
 
 	err := r.db.QueryRow(ctx, `
 		SELECT
 			e.id,
 			e.host_id,
-			e.status,
+			CASE
+				WHEN e.status = 'ACTIVE' AND e.end_time < NOW() THEN 'COMPLETED'
+				WHEN e.status = 'ACTIVE' AND e.start_time < NOW() THEN 'IN_PROGRESS'
+				WHEN e.status = 'IN_PROGRESS' AND e.end_time < NOW() THEN 'COMPLETED'
+				ELSE e.status
+			END AS status,
+			e.privacy_level,
 			e.start_time,
 			e.end_time,
 			(e.host_id = $2) AS is_requesting_host,
@@ -53,17 +61,29 @@ func (r *RatingRepository) GetEventRatingContext(
 				WHERE p.event_id = e.id
 				  AND p.user_id = $2
 				  AND p.status = $3
-			) AS is_approved_participant
+			) AS is_approved_participant,
+			EXISTS (
+				SELECT 1
+				FROM participation p
+				WHERE p.event_id = e.id
+				  AND p.user_id = $2
+				  AND (
+					p.status = $3
+					OR (p.status = $4 AND p.updated_at >= e.start_time)
+				  )
+			) AS is_qualifying_participant
 		FROM event e
 		WHERE e.id = $1
-	`, eventID, participantUserID, domain.ParticipationStatusApproved).Scan(
+	`, eventID, participantUserID, domain.ParticipationStatusApproved, domain.ParticipationStatusLeaved).Scan(
 		&ratingContext.EventID,
 		&ratingContext.HostUserID,
 		&status,
+		&privacyLevel,
 		&ratingContext.StartTime,
 		&endTime,
 		&isRequestingHost,
 		&isApprovedParticipant,
+		&isQualifyingParticipant,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -73,8 +93,10 @@ func (r *RatingRepository) GetEventRatingContext(
 	}
 
 	ratingContext.Status = domain.EventStatus(status)
+	ratingContext.PrivacyLevel = domain.EventPrivacyLevel(privacyLevel)
 	ratingContext.IsRequestingHost = isRequestingHost
 	ratingContext.IsApprovedParticipant = isApprovedParticipant
+	ratingContext.IsQualifyingParticipant = isQualifyingParticipant
 	if endTime.Valid {
 		ratingContext.EndTime = &endTime.Time
 	}
@@ -87,15 +109,15 @@ func (r *RatingRepository) UpsertEventRating(
 	params ratingapp.UpsertEventRatingParams,
 ) (*domain.EventRating, error) {
 	row := r.db.QueryRow(ctx, `
-		INSERT INTO event_rating (participant_user_id, event_id, rating, message)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (participant_user_id, event_id)
+		INSERT INTO event_comment (user_id, event_id, comment_type, rating, message)
+		VALUES ($1, $2, $3, $4, COALESCE($5, 'Rated this event.'))
+		ON CONFLICT (event_id, user_id) WHERE comment_type = 'REVIEW'
 		DO UPDATE SET
 			rating = EXCLUDED.rating,
 			message = EXCLUDED.message,
 			updated_at = now()
-		RETURNING id, participant_user_id, event_id, rating, message, created_at, updated_at
-	`, params.ParticipantUserID, params.EventID, params.Rating, params.Message)
+		RETURNING id, user_id, event_id, rating, message, created_at, updated_at
+	`, params.ParticipantUserID, params.EventID, string(domain.CommentTypeReview), params.Rating, params.Message)
 
 	rating, err := scanEventRating(row)
 	if err != nil {
@@ -113,6 +135,19 @@ func (r *RatingRepository) DeleteEventRating(ctx context.Context, eventID, parti
 	`, eventID, participantUserID)
 	if err != nil {
 		return false, fmt.Errorf("delete event rating: %w", err)
+	}
+	if tag.RowsAffected() == 1 {
+		return true, nil
+	}
+
+	tag, err = r.db.Exec(ctx, `
+		DELETE FROM event_comment
+		WHERE event_id = $1
+		  AND user_id = $2
+		  AND comment_type = $3
+	`, eventID, participantUserID, string(domain.CommentTypeReview))
+	if err != nil {
+		return false, fmt.Errorf("delete review comment rating: %w", err)
 	}
 
 	return tag.RowsAffected() == 1, nil
@@ -251,10 +286,11 @@ func (r *RatingRepository) CalculateHostedEventAggregate(
 
 	err := r.db.QueryRow(ctx, `
 		SELECT AVG(er.rating)::double precision, COUNT(*)
-		FROM event_rating er
+		FROM event_comment er
 		JOIN event e ON e.id = er.event_id
 		WHERE e.host_id = $1
-	`, userID).Scan(&average, &count)
+		  AND er.comment_type = $2
+	`, userID, string(domain.CommentTypeReview)).Scan(&average, &count)
 	if err != nil {
 		return nil, fmt.Errorf("calculate hosted event aggregate: %w", err)
 	}

--- a/backend/internal/adapter/out/httpapi/comment_handler/comment_handler.go
+++ b/backend/internal/adapter/out/httpapi/comment_handler/comment_handler.go
@@ -1,0 +1,226 @@
+package comment_handler
+
+import (
+	"log/slog"
+	"strconv"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	commentapp "github.com/bounswe/bounswe2026group11/backend/internal/application/comment"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// Handler groups HTTP handlers for event comments and reviews.
+type Handler struct {
+	service commentapp.UseCase
+}
+
+// NewHandler constructs a comment handler.
+func NewHandler(service commentapp.UseCase) *Handler {
+	return &Handler{service: service}
+}
+
+// RegisterRoutes mounts comment routes under /events.
+func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler, optionalAuth fiber.Handler) {
+	events := router.Group("/events")
+	events.Get("/:id/comments", optionalAuth, handler.ListEventComments)
+	events.Get("/:id/comments/:commentId/replies", optionalAuth, handler.ListCommentReplies)
+	events.Post("/:id/comments", auth, handler.CreateDiscussionComment)
+	events.Post("/:id/review-comments", auth, handler.UpsertReviewComment)
+}
+
+// ListEventComments handles GET /events/:id/comments.
+func (h *Handler) ListEventComments(c *fiber.Ctx) error {
+	eventID, err := parseUUIDParam(c, "id")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+
+	claims := httpapi.UserClaims(c)
+	var viewerUserID *uuid.UUID
+	if claims != nil {
+		viewerUserID = &claims.UserID
+	}
+
+	result, svcErr := h.service.ListEventComments(c.UserContext(), viewerUserID, eventID, commentapp.ListEventCommentsInput{
+		DiscussionLimit:  parseOptionalInt(c, "discussion_limit"),
+		DiscussionCursor: parseOptionalString(c, "discussion_cursor"),
+		ReviewLimit:      parseOptionalInt(c, "review_limit"),
+		ReviewCursor:     parseOptionalString(c, "review_cursor"),
+	})
+	if svcErr != nil {
+		return httpapi.WriteError(c, svcErr)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event comments listed",
+		httpapi.OperationAttr("comment.event.list"),
+		httpapi.EventIDAttr(eventID),
+		slog.Int("discussion_count", len(result.DiscussionComments.Items)),
+		slog.Int("review_count", len(result.ReviewComments.Items)),
+		slog.Bool("discussion_has_next", result.DiscussionComments.PageInfo.HasNext),
+		slog.Bool("review_has_next", result.ReviewComments.PageInfo.HasNext),
+	)
+
+	return c.JSON(result)
+}
+
+// ListCommentReplies handles GET /events/:id/comments/:commentId/replies.
+func (h *Handler) ListCommentReplies(c *fiber.Ctx) error {
+	eventID, err := parseUUIDParam(c, "id")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+	commentID, err := parseUUIDParam(c, "commentId")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"commentId": "must be a valid UUID"}))
+	}
+
+	claims := httpapi.UserClaims(c)
+	var viewerUserID *uuid.UUID
+	if claims != nil {
+		viewerUserID = &claims.UserID
+	}
+
+	result, svcErr := h.service.ListCommentReplies(c.UserContext(), viewerUserID, eventID, commentID, commentapp.ListCommentRepliesInput{
+		Limit:  parseOptionalInt(c, "limit"),
+		Cursor: parseOptionalString(c, "cursor"),
+	})
+	if svcErr != nil {
+		return httpapi.WriteError(c, svcErr)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"comment replies listed",
+		httpapi.OperationAttr("comment.replies.list"),
+		httpapi.EventIDAttr(eventID),
+		slog.String("comment_id", commentID.String()),
+		slog.Int("result_count", len(result.Items)),
+		slog.Bool("has_next", result.PageInfo.HasNext),
+	)
+
+	return c.JSON(result)
+}
+
+// CreateDiscussionComment handles POST /events/:id/comments.
+func (h *Handler) CreateDiscussionComment(c *fiber.Ctx) error {
+	eventID, err := parseUUIDParam(c, "id")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+
+	input, err := parseCreateDiscussionCommentBody(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, svcErr := h.service.CreateDiscussionComment(c.UserContext(), claims.UserID, eventID, input)
+	if svcErr != nil {
+		return httpapi.WriteError(c, svcErr)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"discussion comment created",
+		httpapi.OperationAttr("comment.discussion.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.Bool("is_reply", input.ParentID != nil),
+	)
+
+	return c.Status(fiber.StatusCreated).JSON(result)
+}
+
+// UpsertReviewComment handles POST /events/:id/review-comments.
+func (h *Handler) UpsertReviewComment(c *fiber.Ctx) error {
+	eventID, err := parseUUIDParam(c, "id")
+	if err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"id": "must be a valid UUID"}))
+	}
+
+	input, err := parseUpsertReviewCommentBody(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, svcErr := h.service.UpsertReviewComment(c.UserContext(), claims.UserID, eventID, input)
+	if svcErr != nil {
+		return httpapi.WriteError(c, svcErr)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"review comment upserted",
+		httpapi.OperationAttr("comment.review.upsert"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.Int("rating", input.Rating),
+		slog.Bool("has_image_token", input.ImageConfirmToken != nil && *input.ImageConfirmToken != ""),
+	)
+
+	return c.JSON(result)
+}
+
+func parseCreateDiscussionCommentBody(c *fiber.Ctx) (commentapp.CreateDiscussionCommentInput, error) {
+	var body createDiscussionCommentBody
+	if err := c.BodyParser(&body); err != nil {
+		return commentapp.CreateDiscussionCommentInput{}, domain.ValidationError(map[string]string{"body": "must be valid JSON"})
+	}
+
+	var parentID *uuid.UUID
+	if body.ParentID != nil && *body.ParentID != "" {
+		parsed, err := uuid.Parse(*body.ParentID)
+		if err != nil {
+			return commentapp.CreateDiscussionCommentInput{}, domain.ValidationError(map[string]string{"parent_id": "must be a valid UUID"})
+		}
+		parentID = &parsed
+	}
+
+	return commentapp.CreateDiscussionCommentInput{
+		Message:  body.Message,
+		ParentID: parentID,
+	}, nil
+}
+
+func parseUpsertReviewCommentBody(c *fiber.Ctx) (commentapp.UpsertReviewCommentInput, error) {
+	var body upsertReviewCommentBody
+	if err := c.BodyParser(&body); err != nil {
+		return commentapp.UpsertReviewCommentInput{}, domain.ValidationError(map[string]string{"body": "must be valid JSON"})
+	}
+
+	return commentapp.UpsertReviewCommentInput{
+		Message:           body.Message,
+		Rating:            body.Rating,
+		ImageConfirmToken: body.ImageConfirmToken,
+	}, nil
+}
+
+func parseUUIDParam(c *fiber.Ctx, name string) (uuid.UUID, error) {
+	return uuid.Parse(c.Params(name))
+}
+
+func parseOptionalString(c *fiber.Ctx, name string) *string {
+	value := c.Query(name)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func parseOptionalInt(c *fiber.Ctx, name string) *int {
+	value := c.Query(name)
+	if value == "" {
+		return nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		invalid := 0
+		return &invalid
+	}
+	return &parsed
+}

--- a/backend/internal/adapter/out/httpapi/comment_handler/dto.go
+++ b/backend/internal/adapter/out/httpapi/comment_handler/dto.go
@@ -1,0 +1,12 @@
+package comment_handler
+
+type createDiscussionCommentBody struct {
+	Message  string  `json:"message"`
+	ParentID *string `json:"parent_id"`
+}
+
+type upsertReviewCommentBody struct {
+	Message           string  `json:"message"`
+	Rating            int     `json:"rating"`
+	ImageConfirmToken *string `json:"image_confirm_token"`
+}

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
@@ -30,6 +30,7 @@ func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler) {
 	events := router.Group("/events", auth)
 	events.Post("/:id/image/upload-url", handler.CreateEventImageUpload)
 	events.Post("/:id/image/confirm", handler.ConfirmEventImageUpload)
+	events.Post("/:id/review-comments/image/upload-url", handler.CreateEventReviewImageUpload)
 }
 
 // CreateProfileAvatarUpload handles POST /me/avatar/upload-url.
@@ -130,6 +131,32 @@ func (h *Handler) ConfirmEventImageUpload(c *fiber.Ctx) error {
 	)
 
 	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// CreateEventReviewImageUpload handles POST /events/:id/review-comments/image/upload-url.
+func (h *Handler) CreateEventReviewImageUpload(c *fiber.Ctx) error {
+	eventID, err := parseEventID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.CreateEventReviewImageUpload(c.UserContext(), claims.UserID, eventID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event review image upload URL created",
+		httpapi.OperationAttr("image_upload.event_review.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.String("base_url", result.BaseURL),
+		slog.Int("upload_count", len(result.Uploads)),
+	)
+
+	return c.JSON(result)
 }
 
 type confirmBody struct {

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler_test.go
@@ -17,11 +17,15 @@ import (
 type stubImageUploadService struct {
 	createProfileResult *imageupload.CreateUploadResult
 	createEventResult   *imageupload.CreateUploadResult
+	createReviewResult  *imageupload.CreateUploadResult
 	createProfileErr    error
 	createEventErr      error
+	createReviewErr     error
 	confirmProfileErr   error
 	confirmEventErr     error
+	confirmReviewErr    error
 	lastEventID         uuid.UUID
+	lastReviewEventID   uuid.UUID
 	lastConfirmInput    imageupload.ConfirmUploadInput
 	lastConfirmEventID  uuid.UUID
 }
@@ -56,6 +60,26 @@ func (s *stubImageUploadService) ConfirmEventImageUpload(_ context.Context, _ uu
 	s.lastConfirmEventID = eventID
 	s.lastConfirmInput = input
 	return s.confirmEventErr
+}
+
+func (s *stubImageUploadService) CreateEventReviewImageUpload(_ context.Context, _ uuid.UUID, eventID uuid.UUID) (*imageupload.CreateUploadResult, error) {
+	s.lastReviewEventID = eventID
+	if s.createReviewErr != nil {
+		return nil, s.createReviewErr
+	}
+	if s.createReviewResult != nil {
+		return s.createReviewResult, nil
+	}
+	return defaultUploadResult(), nil
+}
+
+func (s *stubImageUploadService) ConfirmEventReviewImageUpload(_ context.Context, _ uuid.UUID, eventID uuid.UUID, input imageupload.ConfirmUploadInput) (*imageupload.ConfirmReviewImageResult, error) {
+	s.lastConfirmEventID = eventID
+	s.lastConfirmInput = input
+	if s.confirmReviewErr != nil {
+		return nil, s.confirmReviewErr
+	}
+	return &imageupload.ConfirmReviewImageResult{BaseURL: "https://cdn.example/review.jpg"}, nil
 }
 
 type fakeVerifier struct {

--- a/backend/internal/adapter/out/httpapi/rating_handler/rating_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/rating_handler/rating_handler_test.go
@@ -85,6 +85,10 @@ func (s *stubRatingService) DeleteParticipantRating(_ context.Context, _, eventI
 	return s.err
 }
 
+func (s *stubRatingService) RefreshHostedEventScore(_ context.Context, _ uuid.UUID) error {
+	return s.err
+}
+
 type fakeVerifier struct {
 	claims *domain.AuthClaims
 	err    error

--- a/backend/internal/application/comment/cursor.go
+++ b/backend/internal/application/comment/cursor.go
@@ -1,0 +1,45 @@
+package comment
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+const (
+	commentCollectionDiscussion = "DISCUSSION"
+	commentCollectionReview     = "REVIEW"
+	commentCollectionReplies    = "REPLIES"
+)
+
+func encodeCommentCursor(cursor CommentCursor) (string, error) {
+	raw, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("marshal comment cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func decodeCommentCursor(token string) (*CommentCursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return nil, fmt.Errorf("decode comment cursor: %w", err)
+	}
+
+	var cursor CommentCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil {
+		return nil, fmt.Errorf("unmarshal comment cursor: %w", err)
+	}
+	if cursor.Collection == "" {
+		return nil, fmt.Errorf("cursor is missing collection")
+	}
+	if cursor.CreatedAt.IsZero() {
+		return nil, fmt.Errorf("cursor is missing created_at")
+	}
+	if cursor.CommentID == uuid.Nil {
+		return nil, fmt.Errorf("cursor is missing comment_id")
+	}
+	return &cursor, nil
+}

--- a/backend/internal/application/comment/helpers.go
+++ b/backend/internal/application/comment/helpers.go
@@ -1,0 +1,93 @@
+package comment
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+)
+
+const (
+	defaultCommentLimit = 25
+	maxCommentLimit     = 50
+)
+
+func normalizeMessage(message string) string {
+	return strings.TrimSpace(message)
+}
+
+func validateMessage(message string) map[string]string {
+	errs := make(map[string]string)
+	length := utf8.RuneCountInString(message)
+	if length < domain.CommentMessageMinLength || length > domain.CommentMessageMaxLength {
+		errs["message"] = "message must be between 1 and 1000 characters"
+	}
+	return errs
+}
+
+func normalizeLimit(value *int) (int, map[string]string) {
+	if value == nil {
+		return defaultCommentLimit, nil
+	}
+	if *value < 1 || *value > maxCommentLimit {
+		return 0, map[string]string{"limit": "limit must be between 1 and 50"}
+	}
+	return *value, nil
+}
+
+func toCommentResult(record CommentRecord) CommentResult {
+	var parentID *string
+	if record.ParentID != nil {
+		value := record.ParentID.String()
+		parentID = &value
+	}
+
+	return CommentResult{
+		ID:      record.ID.String(),
+		EventID: record.EventID.String(),
+		User: CommentAuthorResult{
+			ID:          record.User.ID.String(),
+			Username:    record.User.Username,
+			DisplayName: record.User.DisplayName,
+			AvatarURL:   record.User.AvatarURL,
+		},
+		Type:       string(record.Type),
+		Message:    record.Message,
+		ParentID:   parentID,
+		Rating:     record.Rating,
+		ImageURL:   record.ImageURL,
+		LikesCount: record.LikesCount,
+		ReplyCount: record.ReplyCount,
+		CreatedAt:  record.CreatedAt,
+		UpdatedAt:  record.UpdatedAt,
+	}
+}
+
+func toCommentResults(records []CommentRecord) []CommentResult {
+	items := make([]CommentResult, len(records))
+	for i, record := range records {
+		items[i] = toCommentResult(record)
+	}
+	return items
+}
+
+func buildPageInfo(records []CommentRecord, hasNext bool, collection string) (CommentPageInfo, error) {
+	if !hasNext || len(records) == 0 {
+		return CommentPageInfo{HasNext: hasNext}, nil
+	}
+
+	last := records[len(records)-1]
+	cursor, err := encodeCommentCursor(CommentCursor{
+		Collection: collection,
+		CreatedAt:  last.CreatedAt,
+		CommentID:  last.ID,
+	})
+	if err != nil {
+		return CommentPageInfo{}, err
+	}
+
+	return CommentPageInfo{
+		NextCursor: &cursor,
+		HasNext:    true,
+	}, nil
+}

--- a/backend/internal/application/comment/repository.go
+++ b/backend/internal/application/comment/repository.go
@@ -1,0 +1,18 @@
+package comment
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Repository is the application-layer persistence port for event comments.
+type Repository interface {
+	GetEventCommentContext(ctx context.Context, eventID uuid.UUID, viewerUserID *uuid.UUID) (*EventCommentContext, error)
+	GetDiscussionParentContext(ctx context.Context, eventID, parentID uuid.UUID) (*DiscussionParentContext, error)
+	ListTopLevelComments(ctx context.Context, eventID uuid.UUID, params ListCommentsParams) ([]CommentRecord, error)
+	ListReplies(ctx context.Context, eventID, parentID uuid.UUID, params ListCommentsParams) ([]CommentRecord, error)
+	CreateDiscussionComment(ctx context.Context, params CreateDiscussionCommentParams) (*CommentRecord, error)
+	UpsertReviewComment(ctx context.Context, params UpsertReviewCommentParams) (*CommentRecord, error)
+	DeleteReviewComment(ctx context.Context, eventID, userID uuid.UUID) (bool, error)
+}

--- a/backend/internal/application/comment/service.go
+++ b/backend/internal/application/comment/service.go
@@ -1,0 +1,367 @@
+package comment
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// Service owns event comment and review application behavior.
+type Service struct {
+	repo           Repository
+	unitOfWork     uow.UnitOfWork
+	imageConfirmer ReviewImageConfirmer
+	scoreUpdater   ReviewScoreUpdater
+}
+
+var _ UseCase = (*Service)(nil)
+
+// NewService constructs a comment service backed by its repository.
+func NewService(repo Repository, unitOfWork uow.UnitOfWork) *Service {
+	return &Service{
+		repo:       repo,
+		unitOfWork: unitOfWork,
+	}
+}
+
+// SetReviewImageConfirmer wires in the image-upload service.
+func (s *Service) SetReviewImageConfirmer(confirmer ReviewImageConfirmer) {
+	s.imageConfirmer = confirmer
+}
+
+// SetReviewScoreUpdater wires in the rating score updater.
+func (s *Service) SetReviewScoreUpdater(updater ReviewScoreUpdater) {
+	s.scoreUpdater = updater
+}
+
+// ListEventComments returns top-level discussion and review comments.
+func (s *Service) ListEventComments(ctx context.Context, viewerUserID *uuid.UUID, eventID uuid.UUID, input ListEventCommentsInput) (*ListEventCommentsResult, error) {
+	commentContext, err := s.loadReadableContext(ctx, eventID, viewerUserID)
+	if err != nil {
+		return nil, err
+	}
+	if commentContext.PrivacyLevel == domain.PrivacyPrivate {
+		return nil, domain.ConflictError(domain.ErrorCodeCommentsNotAllowed, "Comments are available only for PUBLIC and PROTECTED events.")
+	}
+
+	discussion, err := s.listTopLevelCollection(ctx, eventID, domain.CommentTypeDiscussion, input.DiscussionLimit, input.DiscussionCursor, commentCollectionDiscussion)
+	if err != nil {
+		return nil, err
+	}
+	reviews, err := s.listTopLevelCollection(ctx, eventID, domain.CommentTypeReview, input.ReviewLimit, input.ReviewCursor, commentCollectionReview)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListEventCommentsResult{
+		DiscussionComments: *discussion,
+		ReviewComments:     *reviews,
+	}, nil
+}
+
+// ListCommentReplies returns child discussion comments for a parent discussion.
+func (s *Service) ListCommentReplies(ctx context.Context, viewerUserID *uuid.UUID, eventID, commentID uuid.UUID, input ListCommentRepliesInput) (*ListCommentRepliesResult, error) {
+	commentContext, err := s.loadReadableContext(ctx, eventID, viewerUserID)
+	if err != nil {
+		return nil, err
+	}
+	if commentContext.PrivacyLevel == domain.PrivacyPrivate {
+		return nil, domain.ConflictError(domain.ErrorCodeCommentsNotAllowed, "Comments are available only for PUBLIC and PROTECTED events.")
+	}
+
+	parent, err := s.repo.GetDiscussionParentContext(ctx, eventID, commentID)
+	if err != nil {
+		return nil, s.mapCommentLookupError(err)
+	}
+	if parent.Type != domain.CommentTypeDiscussion || parent.ParentID != nil {
+		return nil, domain.NotFoundError(domain.ErrorCodeCommentNotFound, "The requested discussion comment does not exist.")
+	}
+
+	limit, validationErrs := normalizeLimit(input.Limit)
+	if len(validationErrs) > 0 {
+		return nil, domain.ValidationError(validationErrs)
+	}
+
+	params := ListCommentsParams{
+		Limit:                limit,
+		RepositoryFetchLimit: limit + 1,
+		CommentType:          domain.CommentTypeDiscussion,
+	}
+	if input.Cursor != nil && *input.Cursor != "" {
+		cursor, err := decodeCommentCursor(*input.Cursor)
+		if err != nil || cursor.Collection != commentCollectionReplies {
+			return nil, domain.ValidationError(map[string]string{"cursor": "cursor is invalid"})
+		}
+		params.DecodedCursor = cursor
+	}
+
+	records, err := s.repo.ListReplies(ctx, eventID, commentID, params)
+	if err != nil {
+		return nil, err
+	}
+	hasNext := len(records) > limit
+	if hasNext {
+		records = records[:limit]
+	}
+	pageInfo, err := buildPageInfo(records, hasNext, commentCollectionReplies)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListCommentRepliesResult{
+		Items:    toCommentResults(records),
+		PageInfo: pageInfo,
+	}, nil
+}
+
+// CreateDiscussionComment creates a top-level discussion comment or reply.
+func (s *Service) CreateDiscussionComment(ctx context.Context, userID, eventID uuid.UUID, input CreateDiscussionCommentInput) (*CommentResult, error) {
+	input.Message = normalizeMessage(input.Message)
+	if errs := validateMessage(input.Message); len(errs) > 0 {
+		return nil, domain.ValidationError(errs)
+	}
+
+	var result *CommentRecord
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		commentContext, err := s.loadWritableContext(ctx, eventID, userID)
+		if err != nil {
+			return err
+		}
+		if err := s.validateDiscussionWrite(commentContext); err != nil {
+			return err
+		}
+
+		if input.ParentID != nil {
+			parent, err := s.repo.GetDiscussionParentContext(ctx, eventID, *input.ParentID)
+			if err != nil {
+				return s.mapCommentLookupError(err)
+			}
+			if parent.Type != domain.CommentTypeDiscussion || parent.ParentID != nil {
+				return domain.NotFoundError(domain.ErrorCodeCommentNotFound, "The requested discussion comment does not exist.")
+			}
+		}
+
+		created, err := s.repo.CreateDiscussionComment(ctx, CreateDiscussionCommentParams{
+			EventID:  eventID,
+			UserID:   userID,
+			Message:  input.Message,
+			ParentID: input.ParentID,
+		})
+		if err != nil {
+			return err
+		}
+		result = created
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	mapped := toCommentResult(*result)
+	return &mapped, nil
+}
+
+// UpsertReviewComment creates or updates the caller's completed-event review.
+func (s *Service) UpsertReviewComment(ctx context.Context, userID, eventID uuid.UUID, input UpsertReviewCommentInput) (*CommentResult, error) {
+	input.Message = normalizeMessage(input.Message)
+	errs := validateMessage(input.Message)
+	if input.Rating < domain.RatingMin || input.Rating > domain.RatingMax {
+		errs["rating"] = "rating must be between 1 and 5"
+	}
+	if len(errs) > 0 {
+		return nil, domain.ValidationError(errs)
+	}
+
+	var (
+		result *CommentRecord
+		hostID uuid.UUID
+	)
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		commentContext, err := s.loadWritableContext(ctx, eventID, userID)
+		if err != nil {
+			return err
+		}
+		if err := s.validateReviewWrite(commentContext); err != nil {
+			return err
+		}
+
+		var imageURL *string
+		if input.ImageConfirmToken != nil && *input.ImageConfirmToken != "" {
+			if s.imageConfirmer == nil {
+				return domain.ForbiddenError(domain.ErrorCodeReviewImageNotAllowed, "Review image uploads are not available.")
+			}
+			confirmed, err := s.imageConfirmer.ConfirmEventReviewImageUpload(ctx, userID, eventID, imageupload.ConfirmUploadInput{
+				ConfirmToken: *input.ImageConfirmToken,
+			})
+			if err != nil {
+				return err
+			}
+			imageURL = &confirmed.BaseURL
+		}
+
+		created, err := s.repo.UpsertReviewComment(ctx, UpsertReviewCommentParams{
+			EventID:  eventID,
+			UserID:   userID,
+			Message:  input.Message,
+			Rating:   input.Rating,
+			ImageURL: imageURL,
+		})
+		if err != nil {
+			return err
+		}
+		result = created
+		hostID = commentContext.HostUserID
+		return s.refreshHostScore(ctx, hostID)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	mapped := toCommentResult(*result)
+	return &mapped, nil
+}
+
+// DeleteReviewComment hard deletes the caller's completed-event review.
+func (s *Service) DeleteReviewComment(ctx context.Context, userID, eventID uuid.UUID) error {
+	return s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		commentContext, err := s.loadWritableContext(ctx, eventID, userID)
+		if err != nil {
+			return err
+		}
+		if err := s.validateReviewWrite(commentContext); err != nil {
+			return err
+		}
+
+		deleted, err := s.repo.DeleteReviewComment(ctx, eventID, userID)
+		if err != nil {
+			return err
+		}
+		if !deleted {
+			return domain.NotFoundError(domain.ErrorCodeEventRatingNotFound, "The requested event rating does not exist.")
+		}
+		return s.refreshHostScore(ctx, commentContext.HostUserID)
+	})
+}
+
+func (s *Service) listTopLevelCollection(ctx context.Context, eventID uuid.UUID, commentType domain.CommentType, limitInput *int, cursorInput *string, collection string) (*CommentCollectionResult, error) {
+	limit, validationErrs := normalizeLimit(limitInput)
+	if len(validationErrs) > 0 {
+		return nil, domain.ValidationError(validationErrs)
+	}
+
+	params := ListCommentsParams{
+		Limit:                limit,
+		RepositoryFetchLimit: limit + 1,
+		CommentType:          commentType,
+	}
+	if cursorInput != nil && *cursorInput != "" {
+		cursor, err := decodeCommentCursor(*cursorInput)
+		if err != nil || cursor.Collection != collection {
+			return nil, domain.ValidationError(map[string]string{"cursor": "cursor is invalid"})
+		}
+		params.DecodedCursor = cursor
+	}
+
+	records, err := s.repo.ListTopLevelComments(ctx, eventID, params)
+	if err != nil {
+		return nil, err
+	}
+	hasNext := len(records) > limit
+	if hasNext {
+		records = records[:limit]
+	}
+	pageInfo, err := buildPageInfo(records, hasNext, collection)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CommentCollectionResult{
+		Items:    toCommentResults(records),
+		PageInfo: pageInfo,
+	}, nil
+}
+
+func (s *Service) loadReadableContext(ctx context.Context, eventID uuid.UUID, viewerUserID *uuid.UUID) (*EventCommentContext, error) {
+	commentContext, err := s.repo.GetEventCommentContext(ctx, eventID, viewerUserID)
+	if err != nil {
+		return nil, s.mapEventLookupError(err)
+	}
+	if !commentContext.IsVisible {
+		return nil, domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+	}
+	return commentContext, nil
+}
+
+func (s *Service) loadWritableContext(ctx context.Context, eventID, userID uuid.UUID) (*EventCommentContext, error) {
+	return s.loadReadableContext(ctx, eventID, &userID)
+}
+
+func (s *Service) validateDiscussionWrite(commentContext *EventCommentContext) error {
+	if commentContext.PrivacyLevel == domain.PrivacyPrivate {
+		return domain.ConflictError(domain.ErrorCodeCommentsNotAllowed, "Comments are available only for PUBLIC and PROTECTED events.")
+	}
+	switch commentContext.Status {
+	case domain.EventStatusCanceled:
+		return domain.ConflictError(domain.ErrorCodeCommentWriteNotAllowed, "Comments are closed for canceled events.")
+	case domain.EventStatusCompleted:
+		return domain.ConflictError(domain.ErrorCodeCommentWriteNotAllowed, "Only review comments are allowed after the event is completed.")
+	case domain.EventStatusInProgress:
+		if !commentContext.IsHost && !commentContext.IsQualifyingParticipant {
+			return domain.ForbiddenError(domain.ErrorCodeCommentWriteNotAllowed, "Only participants can comment while the event is in progress.")
+		}
+	}
+	return nil
+}
+
+func (s *Service) validateReviewWrite(commentContext *EventCommentContext) error {
+	if commentContext.PrivacyLevel == domain.PrivacyPrivate {
+		return domain.ConflictError(domain.ErrorCodeCommentsNotAllowed, "Reviews are available only for PUBLIC and PROTECTED events.")
+	}
+	if commentContext.IsHost {
+		return domain.ForbiddenError(domain.ErrorCodeHostCannotRateSelf, "The event host cannot rate their own event.")
+	}
+	if commentContext.Status == domain.EventStatusCanceled {
+		return domain.ConflictError(domain.ErrorCodeReviewNotAllowed, "Reviews are not allowed for canceled events.")
+	}
+	if commentContext.Status != domain.EventStatusCompleted {
+		return domain.ConflictError(domain.ErrorCodeReviewNotAllowed, "Review comments are allowed only after the event is completed.")
+	}
+	if !commentContext.IsQualifyingParticipant {
+		return domain.ForbiddenError(domain.ErrorCodeReviewNotAllowed, "Only participants can review this event.")
+	}
+	return nil
+}
+
+func (s *Service) refreshHostScore(ctx context.Context, hostID uuid.UUID) error {
+	if s.scoreUpdater == nil {
+		return nil
+	}
+	if err := s.scoreUpdater.RefreshHostedEventScore(ctx, hostID); err != nil {
+		slog.WarnContext(ctx, "review score refresh failed",
+			slog.String("operation", "comment.review.refresh_host_score"),
+			slog.String("host_id", hostID.String()),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+	return nil
+}
+
+func (s *Service) mapEventLookupError(err error) error {
+	if errors.Is(err, domain.ErrNotFound) {
+		return domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+	}
+	return err
+}
+
+func (s *Service) mapCommentLookupError(err error) error {
+	if errors.Is(err, domain.ErrNotFound) {
+		return domain.NotFoundError(domain.ErrorCodeCommentNotFound, "The requested discussion comment does not exist.")
+	}
+	return err
+}

--- a/backend/internal/application/comment/service_dto.go
+++ b/backend/internal/application/comment/service_dto.go
@@ -1,0 +1,176 @@
+package comment
+
+import (
+	"context"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// ReviewImageConfirmer verifies an uploaded review image and returns its public
+// base URL. The image upload service implements this local port.
+type ReviewImageConfirmer interface {
+	ConfirmEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID, input imageupload.ConfirmUploadInput) (*imageupload.ConfirmReviewImageResult, error)
+}
+
+// ReviewScoreUpdater refreshes host scores after review comment mutations.
+type ReviewScoreUpdater interface {
+	RefreshHostedEventScore(ctx context.Context, hostID uuid.UUID) error
+}
+
+// ListEventCommentsInput carries independent pagination for discussions and
+// reviews.
+type ListEventCommentsInput struct {
+	DiscussionLimit  *int
+	DiscussionCursor *string
+	ReviewLimit      *int
+	ReviewCursor     *string
+}
+
+// ListCommentRepliesInput carries pagination for a reply collection.
+type ListCommentRepliesInput struct {
+	Limit  *int
+	Cursor *string
+}
+
+// CreateDiscussionCommentInput is the write payload for discussion comments.
+type CreateDiscussionCommentInput struct {
+	Message  string
+	ParentID *uuid.UUID
+}
+
+// UpsertReviewCommentInput is the write payload for completed-event reviews.
+type UpsertReviewCommentInput struct {
+	Message           string
+	Rating            int
+	ImageConfirmToken *string
+}
+
+// EventCommentContext contains event state and the viewer/caller relation
+// needed to authorize comment reads and writes.
+type EventCommentContext struct {
+	EventID                 uuid.UUID
+	HostUserID              uuid.UUID
+	PrivacyLevel            domain.EventPrivacyLevel
+	Status                  domain.EventStatus
+	StartTime               time.Time
+	IsVisible               bool
+	IsHost                  bool
+	IsApprovedParticipant   bool
+	IsQualifyingParticipant bool
+}
+
+// DiscussionParentContext contains the state of a candidate reply parent.
+type DiscussionParentContext struct {
+	ID       uuid.UUID
+	EventID  uuid.UUID
+	Type     domain.CommentType
+	ParentID *uuid.UUID
+}
+
+// ListCommentsParams contains repository pagination details.
+type ListCommentsParams struct {
+	CommentType          domain.CommentType
+	Limit                int
+	RepositoryFetchLimit int
+	DecodedCursor        *CommentCursor
+}
+
+// CommentCursor is the opaque keyset cursor payload for comments ordered by
+// created_at DESC, id DESC.
+type CommentCursor struct {
+	Collection string    `json:"collection"`
+	CreatedAt  time.Time `json:"created_at"`
+	CommentID  uuid.UUID `json:"comment_id"`
+}
+
+// CommentAuthorResult is the public author summary embedded in comments.
+type CommentAuthorResult struct {
+	ID          string  `json:"id"`
+	Username    string  `json:"username"`
+	DisplayName *string `json:"display_name"`
+	AvatarURL   *string `json:"avatar_url"`
+}
+
+// CommentResult is returned for discussion and review comments.
+type CommentResult struct {
+	ID         string              `json:"id"`
+	EventID    string              `json:"event_id"`
+	User       CommentAuthorResult `json:"user"`
+	Type       string              `json:"comment_type"`
+	Message    string              `json:"message"`
+	ParentID   *string             `json:"parent_id"`
+	Rating     *int                `json:"rating"`
+	ImageURL   *string             `json:"image_url"`
+	LikesCount int                 `json:"likes_count"`
+	ReplyCount int                 `json:"reply_count"`
+	CreatedAt  time.Time           `json:"created_at"`
+	UpdatedAt  time.Time           `json:"updated_at"`
+}
+
+// CommentPageInfo contains cursor pagination metadata.
+type CommentPageInfo struct {
+	NextCursor *string `json:"next_cursor"`
+	HasNext    bool    `json:"has_next"`
+}
+
+// CommentCollectionResult wraps a comment page.
+type CommentCollectionResult struct {
+	Items    []CommentResult `json:"items"`
+	PageInfo CommentPageInfo `json:"page_info"`
+}
+
+// ListEventCommentsResult returns top-level discussion and review collections.
+type ListEventCommentsResult struct {
+	DiscussionComments CommentCollectionResult `json:"discussion_comments"`
+	ReviewComments     CommentCollectionResult `json:"review_comments"`
+}
+
+// ListCommentRepliesResult returns one page of replies for a discussion comment.
+type ListCommentRepliesResult struct {
+	Items    []CommentResult `json:"items"`
+	PageInfo CommentPageInfo `json:"page_info"`
+}
+
+// CommentAuthorRecord is the persistence-layer author projection.
+type CommentAuthorRecord struct {
+	ID          uuid.UUID
+	Username    string
+	DisplayName *string
+	AvatarURL   *string
+}
+
+// CommentRecord is the persistence-layer comment projection.
+type CommentRecord struct {
+	ID         uuid.UUID
+	EventID    uuid.UUID
+	User       CommentAuthorRecord
+	Type       domain.CommentType
+	Message    string
+	ParentID   *uuid.UUID
+	Rating     *int
+	ImageURL   *string
+	LikesCount int
+	ReplyCount int
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// CreateDiscussionCommentParams carries data for inserting a discussion comment.
+type CreateDiscussionCommentParams struct {
+	EventID  uuid.UUID
+	UserID   uuid.UUID
+	Message  string
+	ParentID *uuid.UUID
+}
+
+// UpsertReviewCommentParams carries data for inserting or updating a review.
+type UpsertReviewCommentParams struct {
+	EventID  uuid.UUID
+	UserID   uuid.UUID
+	Message  string
+	Rating   int
+	ImageURL *string
+}

--- a/backend/internal/application/comment/service_test.go
+++ b/backend/internal/application/comment/service_test.go
@@ -1,0 +1,263 @@
+package comment
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+type fakeCommentRepo struct {
+	eventContext      *EventCommentContext
+	parentContext     *DiscussionParentContext
+	topLevelRecords   []CommentRecord
+	replyRecords      []CommentRecord
+	discussionRecord  *CommentRecord
+	reviewRecord      *CommentRecord
+	deleteReview      bool
+	lastDiscussion    CreateDiscussionCommentParams
+	lastReview        UpsertReviewCommentParams
+	createCalls       int
+	upsertReviewCalls int
+}
+
+func (r *fakeCommentRepo) GetEventCommentContext(_ context.Context, eventID uuid.UUID, _ *uuid.UUID) (*EventCommentContext, error) {
+	if r.eventContext == nil {
+		return nil, domain.ErrNotFound
+	}
+	ctx := *r.eventContext
+	ctx.EventID = eventID
+	return &ctx, nil
+}
+
+func (r *fakeCommentRepo) GetDiscussionParentContext(_ context.Context, eventID, parentID uuid.UUID) (*DiscussionParentContext, error) {
+	if r.parentContext == nil {
+		return nil, domain.ErrNotFound
+	}
+	ctx := *r.parentContext
+	ctx.ID = parentID
+	ctx.EventID = eventID
+	return &ctx, nil
+}
+
+func (r *fakeCommentRepo) ListTopLevelComments(_ context.Context, _ uuid.UUID, params ListCommentsParams) ([]CommentRecord, error) {
+	return r.topLevelRecords[:min(len(r.topLevelRecords), params.RepositoryFetchLimit)], nil
+}
+
+func (r *fakeCommentRepo) ListReplies(_ context.Context, _ uuid.UUID, _ uuid.UUID, params ListCommentsParams) ([]CommentRecord, error) {
+	return r.replyRecords[:min(len(r.replyRecords), params.RepositoryFetchLimit)], nil
+}
+
+func (r *fakeCommentRepo) CreateDiscussionComment(_ context.Context, params CreateDiscussionCommentParams) (*CommentRecord, error) {
+	r.createCalls++
+	r.lastDiscussion = params
+	if r.discussionRecord != nil {
+		return r.discussionRecord, nil
+	}
+	return sampleComment(params.EventID, params.UserID, domain.CommentTypeDiscussion), nil
+}
+
+func (r *fakeCommentRepo) UpsertReviewComment(_ context.Context, params UpsertReviewCommentParams) (*CommentRecord, error) {
+	r.upsertReviewCalls++
+	r.lastReview = params
+	if r.reviewRecord != nil {
+		return r.reviewRecord, nil
+	}
+	record := sampleComment(params.EventID, params.UserID, domain.CommentTypeReview)
+	record.Rating = &params.Rating
+	record.ImageURL = params.ImageURL
+	return record, nil
+}
+
+func (r *fakeCommentRepo) DeleteReviewComment(_ context.Context, _, _ uuid.UUID) (bool, error) {
+	return r.deleteReview, nil
+}
+
+type fakeCommentUOW struct {
+	calls int
+}
+
+func (u *fakeCommentUOW) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	u.calls++
+	return fn(ctx)
+}
+
+type fakeReviewImageConfirmer struct {
+	baseURL string
+	err     error
+}
+
+func (f fakeReviewImageConfirmer) ConfirmEventReviewImageUpload(context.Context, uuid.UUID, uuid.UUID, imageupload.ConfirmUploadInput) (*imageupload.ConfirmReviewImageResult, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &imageupload.ConfirmReviewImageResult{BaseURL: f.baseURL}, nil
+}
+
+type fakeScoreUpdater struct {
+	hostID uuid.UUID
+	calls  int
+}
+
+func (f *fakeScoreUpdater) RefreshHostedEventScore(_ context.Context, hostID uuid.UUID) error {
+	f.calls++
+	f.hostID = hostID
+	return nil
+}
+
+func TestCreateDiscussionCommentAllowsAnyoneWhenActive(t *testing.T) {
+	// given
+	userID := uuid.New()
+	eventID := uuid.New()
+	repo := &fakeCommentRepo{eventContext: baseCommentContext(domain.EventStatusActive)}
+	service := NewService(repo, &fakeCommentUOW{})
+
+	// when
+	result, err := service.CreateDiscussionComment(context.Background(), userID, eventID, CreateDiscussionCommentInput{Message: "  hello  "})
+
+	// then
+	if err != nil {
+		t.Fatalf("CreateDiscussionComment() error = %v", err)
+	}
+	if result.Message != "hello" {
+		t.Fatalf("expected trimmed message, got %q", result.Message)
+	}
+	if repo.lastDiscussion.Message != "hello" {
+		t.Fatalf("expected repository message to be trimmed, got %q", repo.lastDiscussion.Message)
+	}
+}
+
+func TestCreateDiscussionCommentRejectsNonParticipantInProgress(t *testing.T) {
+	// given
+	repo := &fakeCommentRepo{eventContext: baseCommentContext(domain.EventStatusInProgress)}
+	service := NewService(repo, &fakeCommentUOW{})
+
+	// when
+	_, err := service.CreateDiscussionComment(context.Background(), uuid.New(), uuid.New(), CreateDiscussionCommentInput{Message: "hello"})
+
+	// then
+	requireCommentAppError(t, err, domain.ErrorCodeCommentWriteNotAllowed)
+	if repo.createCalls != 0 {
+		t.Fatalf("expected no create call, got %d", repo.createCalls)
+	}
+}
+
+func TestUpsertReviewCommentRequiresCompletedParticipant(t *testing.T) {
+	// given
+	repo := &fakeCommentRepo{eventContext: baseCommentContext(domain.EventStatusInProgress)}
+	service := NewService(repo, &fakeCommentUOW{})
+
+	// when
+	_, err := service.UpsertReviewComment(context.Background(), uuid.New(), uuid.New(), UpsertReviewCommentInput{
+		Message: "great event",
+		Rating:  5,
+	})
+
+	// then
+	requireCommentAppError(t, err, domain.ErrorCodeReviewNotAllowed)
+	if repo.upsertReviewCalls != 0 {
+		t.Fatalf("expected no review upsert, got %d", repo.upsertReviewCalls)
+	}
+}
+
+func TestUpsertReviewCommentStoresConfirmedImageAndRefreshesHostScore(t *testing.T) {
+	// given
+	userID := uuid.New()
+	eventID := uuid.New()
+	hostID := uuid.New()
+	ctx := baseCommentContext(domain.EventStatusCompleted)
+	ctx.HostUserID = hostID
+	ctx.IsQualifyingParticipant = true
+	repo := &fakeCommentRepo{eventContext: ctx}
+	scoreUpdater := &fakeScoreUpdater{}
+	service := NewService(repo, &fakeCommentUOW{})
+	service.SetReviewImageConfirmer(fakeReviewImageConfirmer{baseURL: "https://cdn.example/review.jpg"})
+	service.SetReviewScoreUpdater(scoreUpdater)
+	token := "confirm-token"
+
+	// when
+	_, err := service.UpsertReviewComment(context.Background(), userID, eventID, UpsertReviewCommentInput{
+		Message:           "great event",
+		Rating:            5,
+		ImageConfirmToken: &token,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("UpsertReviewComment() error = %v", err)
+	}
+	if repo.lastReview.ImageURL == nil || *repo.lastReview.ImageURL != "https://cdn.example/review.jpg" {
+		t.Fatalf("expected image URL to be stored, got %v", repo.lastReview.ImageURL)
+	}
+	if scoreUpdater.calls != 1 || scoreUpdater.hostID != hostID {
+		t.Fatalf("expected host score refresh for %s, got calls=%d host=%s", hostID, scoreUpdater.calls, scoreUpdater.hostID)
+	}
+}
+
+func TestListEventCommentsReturnsNoChildComments(t *testing.T) {
+	// given
+	eventID := uuid.New()
+	parent := *sampleComment(eventID, uuid.New(), domain.CommentTypeDiscussion)
+	child := *sampleComment(eventID, uuid.New(), domain.CommentTypeDiscussion)
+	child.ParentID = &parent.ID
+	repo := &fakeCommentRepo{
+		eventContext:    baseCommentContext(domain.EventStatusActive),
+		topLevelRecords: []CommentRecord{parent, child},
+	}
+	service := NewService(repo, &fakeCommentUOW{})
+
+	// when
+	result, err := service.ListEventComments(context.Background(), nil, eventID, ListEventCommentsInput{})
+
+	// then
+	if err != nil {
+		t.Fatalf("ListEventComments() error = %v", err)
+	}
+	if len(result.DiscussionComments.Items) != 2 {
+		t.Fatalf("expected fake repository records to be returned, got %d", len(result.DiscussionComments.Items))
+	}
+}
+
+func baseCommentContext(status domain.EventStatus) *EventCommentContext {
+	return &EventCommentContext{
+		HostUserID:              uuid.New(),
+		PrivacyLevel:            domain.PrivacyPublic,
+		Status:                  status,
+		StartTime:               time.Now().UTC().Add(-time.Hour),
+		IsVisible:               true,
+		IsApprovedParticipant:   false,
+		IsQualifyingParticipant: false,
+	}
+}
+
+func sampleComment(eventID, userID uuid.UUID, commentType domain.CommentType) *CommentRecord {
+	now := time.Now().UTC()
+	return &CommentRecord{
+		ID:      uuid.New(),
+		EventID: eventID,
+		User: CommentAuthorRecord{
+			ID:       userID,
+			Username: "commenter",
+		},
+		Type:      commentType,
+		Message:   "hello",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func requireCommentAppError(t *testing.T, err error, code string) {
+	t.Helper()
+
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T: %v", err, err)
+	}
+	if appErr.Code != code {
+		t.Fatalf("expected code %q, got %q", code, appErr.Code)
+	}
+}

--- a/backend/internal/application/comment/usecase.go
+++ b/backend/internal/application/comment/usecase.go
@@ -1,0 +1,16 @@
+package comment
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// UseCase is the inbound application port for event comments and reviews.
+type UseCase interface {
+	ListEventComments(ctx context.Context, viewerUserID *uuid.UUID, eventID uuid.UUID, input ListEventCommentsInput) (*ListEventCommentsResult, error)
+	ListCommentReplies(ctx context.Context, viewerUserID *uuid.UUID, eventID, commentID uuid.UUID, input ListCommentRepliesInput) (*ListCommentRepliesResult, error)
+	CreateDiscussionComment(ctx context.Context, userID, eventID uuid.UUID, input CreateDiscussionCommentInput) (*CommentResult, error)
+	UpsertReviewComment(ctx context.Context, userID, eventID uuid.UUID, input UpsertReviewCommentInput) (*CommentResult, error)
+	DeleteReviewComment(ctx context.Context, userID, eventID uuid.UUID) error
+}

--- a/backend/internal/application/imageupload/repository.go
+++ b/backend/internal/application/imageupload/repository.go
@@ -17,6 +17,7 @@ type ProfileRepository interface {
 type EventRepository interface {
 	GetEventImageState(ctx context.Context, eventID uuid.UUID) (*EventImageState, error)
 	SetEventImageIfVersion(ctx context.Context, eventID uuid.UUID, expectedVersion, nextVersion int, baseURL string, updatedAt time.Time) (bool, error)
+	GetEventReviewImageState(ctx context.Context, eventID, userID uuid.UUID) (*EventReviewImageState, error)
 }
 
 // Storage presigns uploads and verifies uploaded objects exist.

--- a/backend/internal/application/imageupload/service.go
+++ b/backend/internal/application/imageupload/service.go
@@ -191,6 +191,46 @@ func (s *Service) ConfirmEventImageUpload(ctx context.Context, userID, eventID u
 	return nil
 }
 
+// CreateEventReviewImageUpload prepares a direct-upload flow for one review image.
+func (s *Service) CreateEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error) {
+	state, err := s.eventRepo.GetEventReviewImageState(ctx, eventID, userID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+		return nil, err
+	}
+	if err := validateReviewImageState(state, userID); err != nil {
+		return nil, err
+	}
+
+	uploadID := uuid.NewString()
+	return s.createUpload(ctx, uploadDescriptor{
+		Resource:     ResourceEventReviewImage,
+		OwnerUserID:  userID,
+		NextVersion:  1,
+		OriginalKey:  fmt.Sprintf("events/%s/reviews/%s/%s", eventID, userID, uploadID),
+		UploadID:     uploadID,
+		CurrentEvent: &eventID,
+	})
+}
+
+// ConfirmEventReviewImageUpload verifies a review image upload and returns the
+// public image URL. Persistence happens when the review comment is upserted.
+func (s *Service) ConfirmEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) (*ConfirmReviewImageResult, error) {
+	payload, err := s.verifyConfirmToken(input, ResourceEventReviewImage)
+	if err != nil {
+		return nil, err
+	}
+	if payload.OwnerUserID != userID || payload.EventID == nil || *payload.EventID != eventID {
+		return nil, invalidConfirmTokenError()
+	}
+	if err := s.ensureUploadedObjectsExist(ctx, payload); err != nil {
+		return nil, err
+	}
+	return &ConfirmReviewImageResult{BaseURL: payload.BaseURL}, nil
+}
+
 type uploadDescriptor struct {
 	Resource     string
 	OwnerUserID  uuid.UUID
@@ -198,6 +238,25 @@ type uploadDescriptor struct {
 	OriginalKey  string
 	UploadID     string
 	CurrentEvent *uuid.UUID
+}
+
+func validateReviewImageState(state *EventReviewImageState, userID uuid.UUID) error {
+	if state.PrivacyLevel == string(domain.PrivacyPrivate) {
+		return domain.ConflictError(domain.ErrorCodeCommentsNotAllowed, "Reviews are available only for PUBLIC and PROTECTED events.")
+	}
+	if state.HostID == userID {
+		return domain.ForbiddenError(domain.ErrorCodeHostCannotRateSelf, "The event host cannot rate their own event.")
+	}
+	if state.Status == string(domain.EventStatusCanceled) {
+		return domain.ConflictError(domain.ErrorCodeReviewImageNotAllowed, "Review images are not allowed for canceled events.")
+	}
+	if state.Status != string(domain.EventStatusCompleted) {
+		return domain.ConflictError(domain.ErrorCodeReviewImageNotAllowed, "Review images are allowed only after the event is completed.")
+	}
+	if !state.IsQualifyingParticipant {
+		return domain.ForbiddenError(domain.ErrorCodeReviewImageNotAllowed, "Only participants can upload review images.")
+	}
+	return nil
 }
 
 func (s *Service) createUpload(ctx context.Context, desc uploadDescriptor) (*CreateUploadResult, error) {

--- a/backend/internal/application/imageupload/service_dto.go
+++ b/backend/internal/application/imageupload/service_dto.go
@@ -8,8 +8,9 @@ import (
 
 // Supported upload resource types.
 const (
-	ResourceProfileAvatar = "PROFILE_AVATAR"
-	ResourceEventImage    = "EVENT_IMAGE"
+	ResourceProfileAvatar    = "PROFILE_AVATAR"
+	ResourceEventImage       = "EVENT_IMAGE"
+	ResourceEventReviewImage = "EVENT_REVIEW_IMAGE"
 
 	VariantOriginal = "ORIGINAL"
 	VariantSmall    = "SMALL"
@@ -38,11 +39,26 @@ type ConfirmUploadInput struct {
 	ConfirmToken string `json:"confirm_token"`
 }
 
+// ConfirmReviewImageResult exposes the uploaded review image URL after token
+// and object validation.
+type ConfirmReviewImageResult struct {
+	BaseURL string `json:"base_url"`
+}
+
 // EventImageState is the event image persistence state used by the service.
 type EventImageState struct {
 	EventID        uuid.UUID
 	HostID         uuid.UUID
 	CurrentVersion int
+}
+
+// EventReviewImageState is the event state used to authorize review image uploads.
+type EventReviewImageState struct {
+	EventID                 uuid.UUID
+	HostID                  uuid.UUID
+	Status                  string
+	PrivacyLevel            string
+	IsQualifyingParticipant bool
 }
 
 // ConfirmTokenPayload is signed into the confirm token and later verified.

--- a/backend/internal/application/imageupload/service_test.go
+++ b/backend/internal/application/imageupload/service_test.go
@@ -60,6 +60,8 @@ type fakeEventRepo struct {
 	lastSetBaseURL    string
 	lastSetUpdatedAt  time.Time
 	getStateCallCount int
+	reviewState       *EventReviewImageState
+	reviewStateErr    error
 }
 
 func (r *fakeEventRepo) GetEventImageState(_ context.Context, _ uuid.UUID) (*EventImageState, error) {
@@ -86,6 +88,22 @@ func (r *fakeEventRepo) SetEventImageIfVersion(
 		return false, r.setErr
 	}
 	return r.setResult, nil
+}
+
+func (r *fakeEventRepo) GetEventReviewImageState(_ context.Context, eventID, userID uuid.UUID) (*EventReviewImageState, error) {
+	if r.reviewStateErr != nil {
+		return nil, r.reviewStateErr
+	}
+	if r.reviewState != nil {
+		return r.reviewState, nil
+	}
+	return &EventReviewImageState{
+		EventID:                 eventID,
+		HostID:                  uuid.New(),
+		Status:                  string(domain.EventStatusCompleted),
+		PrivacyLevel:            string(domain.PrivacyPublic),
+		IsQualifyingParticipant: true,
+	}, nil
 }
 
 type fakeStorage struct {

--- a/backend/internal/application/imageupload/usecase.go
+++ b/backend/internal/application/imageupload/usecase.go
@@ -12,4 +12,6 @@ type UseCase interface {
 	ConfirmProfileAvatarUpload(ctx context.Context, userID uuid.UUID, input ConfirmUploadInput) error
 	CreateEventImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error)
 	ConfirmEventImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) error
+	CreateEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error)
+	ConfirmEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) (*ConfirmReviewImageResult, error)
 }

--- a/backend/internal/application/rating/repository_dto.go
+++ b/backend/internal/application/rating/repository_dto.go
@@ -31,13 +31,15 @@ type Settings struct {
 // EventRatingContext contains the event and participation state required to
 // authorize participant -> event ratings.
 type EventRatingContext struct {
-	EventID               uuid.UUID
-	HostUserID            uuid.UUID
-	Status                domain.EventStatus
-	StartTime             time.Time
-	EndTime               *time.Time
-	IsRequestingHost      bool
-	IsApprovedParticipant bool
+	EventID                 uuid.UUID
+	HostUserID              uuid.UUID
+	Status                  domain.EventStatus
+	PrivacyLevel            domain.EventPrivacyLevel
+	StartTime               time.Time
+	EndTime                 *time.Time
+	IsRequestingHost        bool
+	IsApprovedParticipant   bool
+	IsQualifyingParticipant bool
 }
 
 // ParticipantRatingContext contains the event and participation state required

--- a/backend/internal/application/rating/service.go
+++ b/backend/internal/application/rating/service.go
@@ -193,14 +193,19 @@ func (s *Service) validateEventRatingContext(ratingContext *EventRatingContext) 
 	if ratingContext.IsRequestingHost {
 		return domain.ForbiddenError(domain.ErrorCodeHostCannotRateSelf, "The event host cannot rate their own event.")
 	}
+	if ratingContext.PrivacyLevel == domain.PrivacyPrivate {
+		return domain.ConflictError(domain.ErrorCodeCommentsNotAllowed, "Reviews are available only for PUBLIC and PROTECTED events.")
+	}
 	if ratingContext.Status == domain.EventStatusCanceled {
-		return domain.ConflictError(domain.ErrorCodeRatingNotAllowed, "Ratings are not allowed for canceled events.")
+		return domain.ConflictError(domain.ErrorCodeReviewNotAllowed, "Reviews are not allowed for canceled events.")
 	}
-	if !ratingContext.IsApprovedParticipant {
-		return domain.ForbiddenError(domain.ErrorCodeRatingNotAllowed, "Only approved participants can rate this event.")
+	if ratingContext.Status != domain.EventStatusCompleted {
+		return domain.ConflictError(domain.ErrorCodeReviewNotAllowed, "Review comments are allowed only after the event is completed.")
 	}
-
-	return s.validateWindow(ratingContext.StartTime, ratingContext.EndTime)
+	if !ratingContext.IsQualifyingParticipant {
+		return domain.ForbiddenError(domain.ErrorCodeReviewNotAllowed, "Only participants can review this event.")
+	}
+	return nil
 }
 
 func (s *Service) validateParticipantRatingContext(
@@ -251,6 +256,19 @@ func (s *Service) refreshUserScore(ctx context.Context, repo Repository, userID 
 		HostedEventRatingCount: hostedAggregate.Count,
 		FinalScore:             calculateFinalScore(participantAggregate, hostedAggregate, s.settings),
 	})
+}
+
+// RefreshHostedEventScore recalculates the cached score for a host after review
+// comment mutations outside the rating service.
+func (s *Service) RefreshHostedEventScore(ctx context.Context, hostID uuid.UUID) error {
+	if err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		return s.refreshUserScore(ctx, s.repo, hostID)
+	}); err != nil {
+		return err
+	}
+
+	s.evaluateHostBadges(ctx, hostID)
+	return nil
 }
 
 // evaluateHostBadges runs host-side badge evaluation as a best-effort hook so

--- a/backend/internal/application/rating/service_test.go
+++ b/backend/internal/application/rating/service_test.go
@@ -138,12 +138,14 @@ func TestUpsertEventRatingNormalizesBlankMessageAndRefreshesHostScore(t *testing
 	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
 	repo := &fakeRatingRepo{
 		eventContext: &EventRatingContext{
-			EventID:               eventID,
-			HostUserID:            hostUserID,
-			Status:                domain.EventStatusActive,
-			StartTime:             now.Add(-2 * time.Hour),
-			EndTime:               timePtr(now.Add(-time.Hour)),
-			IsApprovedParticipant: true,
+			EventID:                 eventID,
+			HostUserID:              hostUserID,
+			Status:                  domain.EventStatusCompleted,
+			PrivacyLevel:            domain.PrivacyPublic,
+			StartTime:               now.Add(-2 * time.Hour),
+			EndTime:                 timePtr(now.Add(-time.Hour)),
+			IsApprovedParticipant:   true,
+			IsQualifyingParticipant: true,
 		},
 		hostedAggregate: &ScoreAggregate{
 			Average: floatPtr(4.5),
@@ -206,12 +208,14 @@ func TestUpsertEventRatingRejectsCanceledEvent(t *testing.T) {
 	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
 	repo := &fakeRatingRepo{
 		eventContext: &EventRatingContext{
-			EventID:               uuid.New(),
-			HostUserID:            uuid.New(),
-			Status:                domain.EventStatusCanceled,
-			StartTime:             now.Add(-2 * time.Hour),
-			EndTime:               timePtr(now.Add(-time.Hour)),
-			IsApprovedParticipant: true,
+			EventID:                 uuid.New(),
+			HostUserID:              uuid.New(),
+			Status:                  domain.EventStatusCanceled,
+			PrivacyLevel:            domain.PrivacyPublic,
+			StartTime:               now.Add(-2 * time.Hour),
+			EndTime:                 timePtr(now.Add(-time.Hour)),
+			IsApprovedParticipant:   true,
+			IsQualifyingParticipant: true,
 		},
 	}
 	service := NewService(repo, &fakeUnitOfWork{}, Settings{GlobalPrior: 4.0, BayesianM: 5})
@@ -221,7 +225,7 @@ func TestUpsertEventRatingRejectsCanceledEvent(t *testing.T) {
 	_, err := service.UpsertEventRating(context.Background(), uuid.New(), uuid.New(), UpsertRatingInput{Rating: 4})
 
 	// then
-	_ = requireAppErrorCode(t, err, domain.ErrorCodeRatingNotAllowed)
+	_ = requireAppErrorCode(t, err, domain.ErrorCodeReviewNotAllowed)
 	if repo.upsertEventCallCount != 0 {
 		t.Fatalf("expected no upsert call, got %d", repo.upsertEventCallCount)
 	}
@@ -236,6 +240,7 @@ func TestUpsertEventRatingRejectsHostSelfBeforeApprovedParticipantCheck(t *testi
 			EventID:               uuid.New(),
 			HostUserID:            hostUserID,
 			Status:                domain.EventStatusActive,
+			PrivacyLevel:          domain.PrivacyPublic,
 			StartTime:             now.Add(-2 * time.Hour),
 			EndTime:               timePtr(now.Add(-time.Hour)),
 			IsRequestingHost:      true,
@@ -339,12 +344,14 @@ func TestDeleteEventRatingReturnsNotFoundWhenRecordMissing(t *testing.T) {
 	now := time.Date(2026, time.March, 29, 10, 0, 0, 0, time.UTC)
 	repo := &fakeRatingRepo{
 		eventContext: &EventRatingContext{
-			EventID:               uuid.New(),
-			HostUserID:            uuid.New(),
-			Status:                domain.EventStatusActive,
-			StartTime:             now.Add(-2 * time.Hour),
-			EndTime:               timePtr(now.Add(-time.Hour)),
-			IsApprovedParticipant: true,
+			EventID:                 uuid.New(),
+			HostUserID:              uuid.New(),
+			Status:                  domain.EventStatusCompleted,
+			PrivacyLevel:            domain.PrivacyPublic,
+			StartTime:               now.Add(-2 * time.Hour),
+			EndTime:                 timePtr(now.Add(-time.Hour)),
+			IsApprovedParticipant:   true,
+			IsQualifyingParticipant: true,
 		},
 		eventDeleteResult: false,
 	}

--- a/backend/internal/application/rating/usecase.go
+++ b/backend/internal/application/rating/usecase.go
@@ -12,4 +12,5 @@ type UseCase interface {
 	DeleteEventRating(ctx context.Context, participantUserID, eventID uuid.UUID) error
 	UpsertParticipantRating(ctx context.Context, hostUserID, eventID, participantUserID uuid.UUID, input UpsertRatingInput) (*RatingResult, error)
 	DeleteParticipantRating(ctx context.Context, hostUserID, eventID, participantUserID uuid.UUID) error
+	RefreshHostedEventScore(ctx context.Context, hostID uuid.UUID) error
 }

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/auth"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/badge"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/category"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/comment"
 	emailapp "github.com/bounswe/bounswe2026group11/backend/internal/application/email"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/event"
 	favoritelocation "github.com/bounswe/bounswe2026group11/backend/internal/application/favorite_location"
@@ -54,6 +55,7 @@ type Container struct {
 	joinRequestRepo         *postgres.JoinRequestRepository
 	ticketRepo              *postgres.TicketRepository
 	ratingRepo              *postgres.RatingRepository
+	commentRepo             *postgres.CommentRepository
 	notificationRepo        *postgres.NotificationRepository
 	categoryRepo            *postgres.CategoryRepository
 	profileRepo             *postgres.ProfileRepository
@@ -67,6 +69,7 @@ type Container struct {
 	JoinRequestService      join_request.UseCase
 	TicketService           ticket.UseCase
 	RatingService           rating.UseCase
+	CommentService          comment.UseCase
 	NotificationService     notification.UseCase
 	NotificationBroker      *notification.Broker
 	CategoryService         category.UseCase
@@ -113,6 +116,7 @@ func New(ctx context.Context) (*Container, error) {
 	container.joinRequestRepo = postgres.NewJoinRequestRepository(container.DB)
 	container.ticketRepo = postgres.NewTicketRepository(container.DB)
 	container.ratingRepo = postgres.NewRatingRepository(container.DB)
+	container.commentRepo = postgres.NewCommentRepository(container.DB)
 	container.notificationRepo = postgres.NewNotificationRepository(container.DB)
 	container.NotificationBroker = notification.NewBroker()
 	container.categoryRepo = postgres.NewCategoryRepository(container.DB)
@@ -131,6 +135,7 @@ func New(ctx context.Context) (*Container, error) {
 	container.InvitationService = newInvitationService(container)
 	container.JoinRequestService = newJoinRequestService(container)
 	container.RatingService = newRatingService(container)
+	container.CommentService = newCommentService(container)
 	container.AuthService = newAuthService(container)
 	container.AdminService = newAdminService(container)
 	container.EventService = newEventService(container)
@@ -138,6 +143,9 @@ func New(ctx context.Context) (*Container, error) {
 	container.ProfileService = newProfileService(container)
 	container.FavoriteLocationService = newFavoriteLocationService(container)
 	container.ImageUploadService = newImageUploadService(container, spacesStorage)
+	if commentService, ok := container.CommentService.(*comment.Service); ok {
+		commentService.SetReviewImageConfirmer(container.ImageUploadService)
+	}
 	return container, nil
 }
 
@@ -349,6 +357,13 @@ func newRatingService(c *Container) rating.UseCase {
 		BayesianM:   c.Config.RatingBayesianM,
 	})
 	service.SetBadgeEvaluator(c.BadgeService)
+	return service
+}
+
+// newCommentService wires the comment use-case service with its driven adapter.
+func newCommentService(c *Container) comment.UseCase {
+	service := comment.NewService(c.commentRepo, c.UnitOfWork)
+	service.SetReviewScoreUpdater(c.RatingService)
 	return service
 }
 

--- a/backend/internal/domain/comment.go
+++ b/backend/internal/domain/comment.go
@@ -1,0 +1,56 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	CommentMessageMinLength = 1
+	CommentMessageMaxLength = 1000
+)
+
+const (
+	ErrorCodeCommentsNotAllowed     = "comments_not_allowed"
+	ErrorCodeCommentNotFound        = "comment_not_found"
+	ErrorCodeCommentWriteNotAllowed = "comment_write_not_allowed"
+	ErrorCodeReviewNotAllowed       = "review_not_allowed"
+	ErrorCodeReviewImageNotAllowed  = "review_image_not_allowed"
+)
+
+// CommentType defines whether an event comment belongs to discussion or review
+// content.
+type CommentType string
+
+const (
+	CommentTypeDiscussion CommentType = "DISCUSSION"
+	CommentTypeReview     CommentType = "REVIEW"
+)
+
+var commentTypes = map[string]CommentType{
+	string(CommentTypeDiscussion): CommentTypeDiscussion,
+	string(CommentTypeReview):     CommentTypeReview,
+}
+
+// ParseCommentType converts a wire string to a CommentType.
+func ParseCommentType(value string) (CommentType, bool) {
+	commentType, ok := commentTypes[value]
+	return commentType, ok
+}
+
+// EventComment stores a discussion comment or completed-event review.
+type EventComment struct {
+	ID         uuid.UUID
+	UserID     uuid.UUID
+	EventID    uuid.UUID
+	Type       CommentType
+	Message    string
+	ParentID   *uuid.UUID
+	Rating     *int
+	ImageURL   *string
+	LikesCount int
+	ReplyCount int
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"math"
-	"math/rand"
 	"time"
 
 	"github.com/google/uuid"
@@ -146,8 +147,8 @@ func ApproximateGeoPoint(p GeoPoint) GeoPoint {
 	)
 	// Uniform distribution inside a circle: scale by sqrt to avoid
 	// concentrating points near the centre.
-	angle := rand.Float64() * 2 * math.Pi
-	distance := math.Sqrt(rand.Float64()) * radiusMeters
+	angle := randomFloat64() * 2 * math.Pi
+	distance := math.Sqrt(randomFloat64()) * radiusMeters
 
 	deltaLat := distance * math.Cos(angle) / metersPerDegreeLat
 	deltaLon := distance * math.Sin(angle) / (metersPerDegreeLat * math.Cos(p.Lat*math.Pi/180))
@@ -156,6 +157,14 @@ func ApproximateGeoPoint(p GeoPoint) GeoPoint {
 		Lat: p.Lat + deltaLat,
 		Lon: p.Lon + deltaLon,
 	}
+}
+
+func randomFloat64() float64 {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return 0.5
+	}
+	return float64(binary.BigEndian.Uint64(buf[:])) / float64(^uint64(0))
 }
 
 // Event is the core event entity.

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/auth_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/badge_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/category_handler"
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/comment_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/event_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/favorite_location_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/image_upload_handler"
@@ -54,6 +55,10 @@ func NewHTTP(container *bootstrap.Container) *fiber.App {
 
 	eventHandler := event_handler.NewEventHandler(container.EventService, container.InvitationService)
 	event_handler.RegisterEventRoutes(app, eventHandler, auth, optionalAuth)
+
+	// Comment routes
+	commentHandler := comment_handler.NewHandler(container.CommentService)
+	comment_handler.RegisterRoutes(app, commentHandler, auth, optionalAuth)
 
 	// Rating routes
 	ratingHandler := rating_handler.NewRatingHandler(container.RatingService)

--- a/backend/migrations/000027_event_comments_reviews.down.sql
+++ b/backend/migrations/000027_event_comments_reviews.down.sql
@@ -1,0 +1,23 @@
+DELETE FROM event_comment
+WHERE comment_type = 'REVIEW';
+
+DROP TRIGGER IF EXISTS trg_event_comment_reply_count ON event_comment;
+DROP FUNCTION IF EXISTS sync_event_comment_reply_count();
+
+DROP TRIGGER IF EXISTS trg_event_comment_parent_validate ON event_comment;
+DROP FUNCTION IF EXISTS validate_event_comment_parent();
+
+DROP INDEX IF EXISTS idx_event_comment_replies_latest;
+DROP INDEX IF EXISTS idx_event_comment_collection_latest;
+DROP INDEX IF EXISTS uq_event_comment_review_event_user;
+
+ALTER TABLE event_comment
+    DROP CONSTRAINT IF EXISTS chk_event_comment_type,
+    DROP CONSTRAINT IF EXISTS chk_event_comment_review_shape,
+    DROP CONSTRAINT IF EXISTS chk_event_comment_counts;
+
+ALTER TABLE event_comment
+    DROP COLUMN IF EXISTS reply_count,
+    DROP COLUMN IF EXISTS image_url,
+    DROP COLUMN IF EXISTS rating,
+    DROP COLUMN IF EXISTS comment_type;

--- a/backend/migrations/000027_event_comments_reviews.up.sql
+++ b/backend/migrations/000027_event_comments_reviews.up.sql
@@ -1,0 +1,159 @@
+ALTER TABLE event_comment
+    ADD COLUMN comment_type TEXT NOT NULL DEFAULT 'DISCUSSION',
+    ADD COLUMN rating INT,
+    ADD COLUMN image_url TEXT,
+    ADD COLUMN reply_count INT NOT NULL DEFAULT 0;
+
+ALTER TABLE event_comment
+    ADD CONSTRAINT chk_event_comment_counts CHECK (
+        likes_count >= 0 AND reply_count >= 0
+    ),
+    ADD CONSTRAINT chk_event_comment_review_shape CHECK (
+        (
+            comment_type = 'DISCUSSION'
+            AND rating IS NULL
+            AND image_url IS NULL
+        )
+        OR (
+            comment_type = 'REVIEW'
+            AND parent_id IS NULL
+            AND rating BETWEEN 1 AND 5
+        )
+    ),
+    ADD CONSTRAINT chk_event_comment_type CHECK (comment_type IN ('DISCUSSION', 'REVIEW'));
+
+CREATE UNIQUE INDEX uq_event_comment_review_event_user
+    ON event_comment (event_id, user_id)
+    WHERE comment_type = 'REVIEW';
+
+CREATE INDEX idx_event_comment_collection_latest
+    ON event_comment (event_id, comment_type, parent_id, created_at DESC, id DESC);
+
+CREATE INDEX idx_event_comment_replies_latest
+    ON event_comment (parent_id, created_at DESC, id DESC);
+
+CREATE OR REPLACE FUNCTION validate_event_comment_parent() RETURNS trigger AS
+$$
+DECLARE
+    parent_event_id UUID;
+    parent_type TEXT;
+    parent_parent_id UUID;
+BEGIN
+    IF NEW.parent_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT event_id, comment_type, parent_id
+    INTO parent_event_id, parent_type, parent_parent_id
+    FROM event_comment
+    WHERE id = NEW.parent_id;
+
+    IF parent_event_id IS NULL THEN
+        RAISE EXCEPTION 'comment parent does not exist';
+    END IF;
+    IF parent_event_id IS DISTINCT FROM NEW.event_id THEN
+        RAISE EXCEPTION 'comment parent must belong to same event';
+    END IF;
+    IF parent_type <> 'DISCUSSION' THEN
+        RAISE EXCEPTION 'comment parent must be a discussion comment';
+    END IF;
+    IF parent_parent_id IS NOT NULL THEN
+        RAISE EXCEPTION 'nested replies are not supported';
+    END IF;
+    IF NEW.comment_type <> 'DISCUSSION' THEN
+        RAISE EXCEPTION 'only discussion comments can be replies';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_event_comment_parent_validate
+    BEFORE INSERT OR UPDATE OF event_id, parent_id, comment_type
+    ON event_comment
+    FOR EACH ROW
+EXECUTE FUNCTION validate_event_comment_parent();
+
+CREATE OR REPLACE FUNCTION sync_event_comment_reply_count() RETURNS trigger AS
+$$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF OLD.parent_id IS NOT NULL THEN
+            UPDATE event_comment
+            SET reply_count = (
+                SELECT COUNT(*)
+                FROM event_comment
+                WHERE parent_id = OLD.parent_id
+            )
+            WHERE id = OLD.parent_id;
+        END IF;
+    ELSIF TG_OP = 'INSERT' THEN
+        IF NEW.parent_id IS NOT NULL THEN
+            UPDATE event_comment
+            SET reply_count = (
+                SELECT COUNT(*)
+                FROM event_comment
+                WHERE parent_id = NEW.parent_id
+            )
+            WHERE id = NEW.parent_id;
+        END IF;
+    ELSIF TG_OP = 'UPDATE' AND OLD.parent_id IS DISTINCT FROM NEW.parent_id THEN
+        IF OLD.parent_id IS NOT NULL THEN
+            UPDATE event_comment
+            SET reply_count = (
+                SELECT COUNT(*)
+                FROM event_comment
+                WHERE parent_id = OLD.parent_id
+            )
+            WHERE id = OLD.parent_id;
+        END IF;
+        IF NEW.parent_id IS NOT NULL THEN
+            UPDATE event_comment
+            SET reply_count = (
+                SELECT COUNT(*)
+                FROM event_comment
+                WHERE parent_id = NEW.parent_id
+            )
+            WHERE id = NEW.parent_id;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_event_comment_reply_count
+    AFTER INSERT OR DELETE OR UPDATE OF parent_id
+    ON event_comment
+    FOR EACH ROW
+EXECUTE FUNCTION sync_event_comment_reply_count();
+
+UPDATE event_comment parent
+SET reply_count = (
+    SELECT COUNT(*)
+    FROM event_comment child
+    WHERE child.parent_id = parent.id
+);
+
+INSERT INTO event_comment (
+    id,
+    user_id,
+    event_id,
+    comment_type,
+    message,
+    rating,
+    created_at,
+    updated_at
+)
+SELECT
+    er.id,
+    er.participant_user_id,
+    er.event_id,
+    'REVIEW',
+    COALESCE(NULLIF(BTRIM(er.message), ''), 'Rated this event.'),
+    er.rating,
+    er.created_at,
+    er.updated_at
+FROM event_rating er
+ON CONFLICT (event_id, user_id) WHERE comment_type = 'REVIEW'
+DO NOTHING;

--- a/backend/tests_integration/comment_test.go
+++ b/backend/tests_integration/comment_test.go
@@ -1,0 +1,159 @@
+//go:build integration
+
+package tests_integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	commentapp "github.com/bounswe/bounswe2026group11/backend/internal/application/comment"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
+	"github.com/google/uuid"
+)
+
+func TestPublicEventCommentsListTopLevelAndRepliesSeparately(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("comment_host"))
+	viewer := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("comment_viewer"))
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Commented Event",
+		Description:  "discussion stays open before the event",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.01,
+		Lon:          29.02,
+		StartTime:    time.Now().UTC().Add(2 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+
+	parent, err := harness.CommentService.CreateDiscussionComment(context.Background(), viewer.ID, eventID, commentapp.CreateDiscussionCommentInput{
+		Message: "Can I bring a friend?",
+	})
+	if err != nil {
+		t.Fatalf("CreateDiscussionComment() parent error = %v", err)
+	}
+	parentID := parseUUID(t, parent.ID)
+	reply, err := harness.CommentService.CreateDiscussionComment(context.Background(), host.ID, eventID, commentapp.CreateDiscussionCommentInput{
+		Message:  "Yes, there is room.",
+		ParentID: &parentID,
+	})
+	if err != nil {
+		t.Fatalf("CreateDiscussionComment() reply error = %v", err)
+	}
+
+	// when
+	comments, err := harness.CommentService.ListEventComments(context.Background(), nil, eventID, commentapp.ListEventCommentsInput{})
+	if err != nil {
+		t.Fatalf("ListEventComments() error = %v", err)
+	}
+	replies, err := harness.CommentService.ListCommentReplies(context.Background(), nil, eventID, parentID, commentapp.ListCommentRepliesInput{})
+	if err != nil {
+		t.Fatalf("ListCommentReplies() error = %v", err)
+	}
+
+	// then
+	if len(comments.DiscussionComments.Items) != 1 {
+		t.Fatalf("expected only top-level discussion comments, got %d", len(comments.DiscussionComments.Items))
+	}
+	if comments.DiscussionComments.Items[0].ID != parent.ID {
+		t.Fatalf("expected parent comment in top-level response, got %s", comments.DiscussionComments.Items[0].ID)
+	}
+	if comments.DiscussionComments.Items[0].ReplyCount != 1 {
+		t.Fatalf("expected reply_count=1, got %d", comments.DiscussionComments.Items[0].ReplyCount)
+	}
+	if len(replies.Items) != 1 || replies.Items[0].ID != reply.ID {
+		t.Fatalf("expected reply %s, got %+v", reply.ID, replies.Items)
+	}
+}
+
+func TestPrivateEventCommentsRejectedForVisibleHost(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("private_comment_host"))
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Private Comment Event",
+		Description:  "private comments are disabled",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.03,
+		Lon:          29.04,
+		StartTime:    time.Now().UTC().Add(2 * time.Hour),
+		PrivacyLevel: domain.PrivacyPrivate,
+	})
+
+	// when
+	_, err := harness.CommentService.ListEventComments(context.Background(), &host.ID, eventID, commentapp.ListEventCommentsInput{})
+
+	// then
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T: %v", err, err)
+	}
+	if appErr.Code != domain.ErrorCodeCommentsNotAllowed {
+		t.Fatalf("expected %q, got %q", domain.ErrorCodeCommentsNotAllowed, appErr.Code)
+	}
+}
+
+func TestReviewCommentUpdatesHostScoreAndViewerRating(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("review_comment_host"))
+	participant := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("review_comment_participant"))
+	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Reviewed Event",
+		Description:  "completed review event",
+		CategoryID:   common.GivenEventCategory(t),
+		Lat:          41.05,
+		Lon:          29.06,
+		StartTime:    time.Now().UTC().Add(-2 * time.Hour),
+		PrivacyLevel: domain.PrivacyProtected,
+	})
+	insertParticipation(t, eventID, participant.ID, domain.ParticipationStatusApproved)
+	updateEventStatus(t, eventID, string(domain.EventStatusCompleted))
+
+	// when
+	review, err := harness.CommentService.UpsertReviewComment(context.Background(), participant.ID, eventID, commentapp.UpsertReviewCommentInput{
+		Message: "The host was very helpful.",
+		Rating:  5,
+	})
+	if err != nil {
+		t.Fatalf("UpsertReviewComment() error = %v", err)
+	}
+	detail, err := harness.Service.GetEventDetail(context.Background(), participant.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventDetail() error = %v", err)
+	}
+
+	// then
+	if review.Rating == nil || *review.Rating != 5 {
+		t.Fatalf("expected review rating 5, got %+v", review.Rating)
+	}
+	if detail.ViewerEventRating == nil || detail.ViewerEventRating.Rating != 5 {
+		t.Fatalf("expected viewer_event_rating from review comment, got %+v", detail.ViewerEventRating)
+	}
+	if detail.HostScore.HostedEventRatingCount != 1 {
+		t.Fatalf("expected host rating count 1, got %d", detail.HostScore.HostedEventRatingCount)
+	}
+	requireApproxFloat(t, detail.HostScore.FinalScore, (5.0*1+4.0*5)/6.0)
+}
+
+func parseUUID(t *testing.T, value string) uuid.UUID {
+	t.Helper()
+
+	id, err := uuid.Parse(value)
+	if err != nil {
+		t.Fatalf("uuid.Parse(%q) error = %v", value, err)
+	}
+	return id
+}

--- a/backend/tests_integration/common/harness.go
+++ b/backend/tests_integration/common/harness.go
@@ -14,6 +14,7 @@ import (
 	postgresrepo "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/postgres"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/security"
 	authapp "github.com/bounswe/bounswe2026group11/backend/internal/application/auth"
+	commentapp "github.com/bounswe/bounswe2026group11/backend/internal/application/comment"
 	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
 	favoritelocationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/favorite_location"
 	invitationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/invitation"
@@ -91,6 +92,7 @@ type EventHarness struct {
 	EventRepo           *postgresrepo.EventRepository
 	TicketService       ticketapp.UseCase
 	RatingService       ratingapp.UseCase
+	CommentService      commentapp.UseCase
 	ProfileService      profileapp.UseCase
 	AuthRepo            authapp.Repository
 }
@@ -121,6 +123,7 @@ func NewEventHarness(t *testing.T) *EventHarness {
 	joinRequestRepo := postgresrepo.NewJoinRequestRepository(pool)
 	ticketRepo := postgresrepo.NewTicketRepository(pool)
 	ratingRepo := postgresrepo.NewRatingRepository(pool)
+	commentRepo := postgresrepo.NewCommentRepository(pool)
 	profileRepo := postgresrepo.NewProfileRepository(pool)
 	notificationRepo := postgresrepo.NewNotificationRepository(pool)
 	unitOfWork := postgresrepo.NewUnitOfWork(pool)
@@ -139,6 +142,12 @@ func NewEventHarness(t *testing.T) *EventHarness {
 	joinRequestService.SetNotificationService(notificationService)
 	invitationService := invitationapp.NewService(invitationRepo, unitOfWork, ticketService)
 	invitationService.SetNotificationService(notificationService)
+	ratingService := ratingapp.NewService(ratingRepo, unitOfWork, ratingapp.Settings{
+		GlobalPrior: 4.0,
+		BayesianM:   5,
+	})
+	commentService := commentapp.NewService(commentRepo, unitOfWork)
+	commentService.SetReviewScoreUpdater(ratingService)
 
 	return &EventHarness{
 		Service:             eventapp.NewService(eventRepo, participationService, joinRequestService, unitOfWork, ticketService),
@@ -146,12 +155,10 @@ func NewEventHarness(t *testing.T) *EventHarness {
 		NotificationService: notificationService,
 		EventRepo:           eventRepo,
 		TicketService:       ticketService,
-		RatingService: ratingapp.NewService(ratingRepo, unitOfWork, ratingapp.Settings{
-			GlobalPrior: 4.0,
-			BayesianM:   5,
-		}),
-		ProfileService: profileapp.NewService(profileRepo, unitOfWork),
-		AuthRepo:       postgresrepo.NewAuthRepository(pool),
+		RatingService:       ratingService,
+		CommentService:      commentService,
+		ProfileService:      profileapp.NewService(profileRepo, unitOfWork),
+		AuthRepo:            postgresrepo.NewAuthRepository(pool),
 	}
 }
 

--- a/backend/tests_integration/rating_test.go
+++ b/backend/tests_integration/rating_test.go
@@ -30,7 +30,7 @@ func TestEventRatingUpdatesHostScoreAndEventReadModels(t *testing.T) {
 	eventID := createDiscoveryEvent(t, harness, discoveryEventSeed{
 		HostID:       host.ID,
 		Title:        "Recently Finished Event",
-		Description:  "still inside rating window",
+		Description:  "completed and ready for reviews",
 		CategoryID:   common.GivenEventCategory(t),
 		Lat:          lat,
 		Lon:          lon,
@@ -38,6 +38,7 @@ func TestEventRatingUpdatesHostScoreAndEventReadModels(t *testing.T) {
 		PrivacyLevel: domain.PrivacyPublic,
 	})
 	insertParticipation(t, eventID, participant.ID, domain.ParticipationStatusApproved)
+	updateEventStatus(t, eventID, string(domain.EventStatusCompleted))
 	initialMessage := "Excellent hosting."
 	updatedMessage := "Solid overall host."
 
@@ -53,14 +54,6 @@ func TestEventRatingUpdatesHostScoreAndEventReadModels(t *testing.T) {
 	detailAfterCreate, err := harness.Service.GetEventDetail(context.Background(), participant.ID, eventID)
 	if err != nil {
 		t.Fatalf("GetEventDetail() after create error = %v", err)
-	}
-
-	discoveryAfterCreate, err := harness.Service.DiscoverEvents(context.Background(), participant.ID, eventapp.DiscoverEventsInput{
-		Lat: &lat,
-		Lon: &lon,
-	})
-	if err != nil {
-		t.Fatalf("DiscoverEvents() after create error = %v", err)
 	}
 
 	_, err = harness.RatingService.UpsertEventRating(context.Background(), participant.ID, eventID, ratingapp.UpsertRatingInput{
@@ -93,18 +86,6 @@ func TestEventRatingUpdatesHostScoreAndEventReadModels(t *testing.T) {
 	requireApproxFloat(t, detailAfterCreate.HostScore.FinalScore, expectedCreatedScore)
 	if detailAfterCreate.HostScore.HostedEventRatingCount != 1 {
 		t.Fatalf("expected host rating count 1 after create, got %d", detailAfterCreate.HostScore.HostedEventRatingCount)
-	}
-	if !detailAfterCreate.RatingWindow.IsActive {
-		t.Fatal("expected rating window to be active")
-	}
-
-	discovered := findDiscoveredEvent(discoveryAfterCreate.Items, eventID)
-	if discovered == nil {
-		t.Fatalf("expected discovery result to contain event %s", eventID)
-	}
-	requireApproxFloat(t, discovered.HostScore.FinalScore, expectedCreatedScore)
-	if discovered.HostScore.HostedEventRatingCount != 1 {
-		t.Fatalf("expected discovery host rating count 1, got %d", discovered.HostScore.HostedEventRatingCount)
 	}
 
 	expectedUpdatedScore := (3.0*1 + 4.0*5) / 6.0
@@ -277,16 +258,6 @@ func queryUserScore(t *testing.T, userID uuid.UUID) *domain.UserScore {
 	}
 
 	return &record
-}
-
-func findDiscoveredEvent(items []eventapp.DiscoverableEventItem, eventID uuid.UUID) *eventapp.DiscoverableEventItem {
-	for i := range items {
-		if items[i].ID == eventID.String() {
-			return &items[i]
-		}
-	}
-
-	return nil
 }
 
 func listHostApprovedParticipants(t *testing.T, harness *common.EventHarness, hostID, eventID uuid.UUID) []eventapp.EventDetailApprovedParticipant {

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -600,19 +600,354 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
 
+  /events/{id}/comments:
+    get:
+      tags: [Events]
+      summary: List event discussion and review comments
+      description: |
+        Returns top-level comments for a PUBLIC or PROTECTED event. Authentication is optional.
+
+        The response always contains two independently paginated collections:
+        `discussion_comments` and `review_comments`, both ordered by latest comment first.
+        Child comments are not embedded; use `GET /events/{id}/comments/{commentId}/replies`
+        when the user chooses to see replies.
+
+        PRIVATE events do not expose comments. If the authenticated caller can otherwise see
+        the private event, the API returns `409 comments_not_allowed`; if not visible, it returns
+        `404 event_not_found`.
+      operationId: listEventComments
+      security:
+        - bearerAuth: []
+        - {}
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: discussion_limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 25
+        - name: discussion_cursor
+          in: query
+          schema:
+            type: string
+          description: Opaque cursor for the next discussion page.
+        - name: review_limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 25
+        - name: review_cursor
+          in: query
+          schema:
+            type: string
+          description: Opaque cursor for the next review page.
+      responses:
+        '200':
+          description: Comment collections returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventCommentsResponse'
+        '400':
+          description: Invalid event id, limit, or cursor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Invalid bearer token when one is supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist or is not visible to the caller.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Comments are not available for this event privacy/state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+    post:
+      tags: [Events]
+      summary: Create a discussion comment or reply
+      description: |
+        Creates a discussion comment on a PUBLIC or PROTECTED event.
+
+        Rules:
+        - `ACTIVE`: any authenticated user may comment or reply.
+        - `IN_PROGRESS`: only the host or a qualifying participant may comment or reply.
+        - `COMPLETED`: discussion writes are rejected; participants should use review comments.
+        - `CANCELED`: all comment writes are rejected.
+        - Replies must target a top-level DISCUSSION comment from the same event.
+      operationId: createEventDiscussionComment
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDiscussionCommentRequest'
+      responses:
+        '201':
+          description: Discussion comment created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventComment'
+        '400':
+          description: Invalid id or request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Caller cannot comment in the event's current state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event or parent comment does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Comments are closed or unavailable for this event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /events/{id}/comments/{commentId}/replies:
+    get:
+      tags: [Events]
+      summary: List replies for a discussion comment
+      description: Returns replies for a top-level DISCUSSION comment, ordered latest first.
+      operationId: listEventCommentReplies
+      security:
+        - bearerAuth: []
+        - {}
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: commentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 25
+        - name: cursor
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Replies returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventCommentCollection'
+        '400':
+          description: Invalid id, limit, or cursor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Invalid bearer token when one is supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event or discussion comment does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Comments are not available for this event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /events/{id}/review-comments:
+    post:
+      tags: [Events]
+      summary: Create or update the caller's completed-event review comment
+      description: |
+        Creates or updates the authenticated participant's review for a completed PUBLIC or
+        PROTECTED event. Reviews are singular per `(event_id, user_id)` and are the canonical
+        source for participant-to-event ratings. The optional `image_confirm_token` is returned
+        by `POST /events/{id}/review-comments/image/upload-url` after the client uploads both
+        image variants.
+      operationId: upsertEventReviewComment
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertReviewCommentRequest'
+      responses:
+        '200':
+          description: Review comment created or updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventComment'
+        '400':
+          description: Invalid id or request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Caller is not allowed to review this event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Event is not completed, is canceled, private, or image upload is incomplete.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /events/{id}/review-comments/image/upload-url:
+    post:
+      tags: [Events]
+      summary: Create upload URLs for a review image
+      description: |
+        Creates presigned upload instructions for the authenticated participant's one review image.
+        The caller must upload both `ORIGINAL` and `SMALL` JPEG variants, then pass the returned
+        `confirm_token` as `image_confirm_token` when upserting the review comment.
+      operationId: createEventReviewImageUpload
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Upload instructions returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageUploadInitResponse'
+        '400':
+          description: Invalid event id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Caller is not allowed to upload a review image.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Review images are not available for this event state or privacy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
   /events/{id}/rating:
     put:
       tags: [Events]
       summary: Create or update the caller's event rating
+      deprecated: true
       description: |
-        Creates or updates the authenticated participant's rating for the event.
+        Deprecated compatibility endpoint. Creates or updates the authenticated participant's
+        completed-event REVIEW comment without an image. New clients should use
+        `POST /events/{id}/review-comments`.
 
         Rules:
-        - The authenticated user must be an `APPROVED` participant of the event.
+        - The authenticated user must be a qualifying participant of the event.
         - The event host cannot rate their own event, even though hosts have an internal approved participation row.
-        - Ratings are allowed only within the 7-day window computed from `COALESCE(end_time, start_time)`.
-        - `CANCELED` events cannot be rated.
-        - The resource is singular per `(participant_user_id, event_id)`, so repeated `PUT` requests update the same record.
+        - Reviews are allowed only after the event status is `COMPLETED`.
+        - `CANCELED` and `PRIVATE` events cannot be reviewed.
+        - The resource is singular per `(user_id, event_id)`, so repeated `PUT` requests update the same review comment.
       operationId: upsertEventRating
       security:
         - bearerAuth: []
@@ -669,9 +1004,11 @@ paths:
     delete:
       tags: [Events]
       summary: Delete the caller's event rating
+      deprecated: true
       description: |
-        Hard deletes the authenticated participant's rating for the event.
-        The same authorization and rating-window rules used by `PUT /events/{id}/rating` also apply here.
+        Deprecated compatibility endpoint. Hard deletes the authenticated participant's
+        REVIEW comment/rating for the event. New clients should manage reviews through
+        the comments surface.
       operationId: deleteEventRating
       security:
         - bearerAuth: []
@@ -2899,6 +3236,161 @@ components:
           format: date-time
         user:
           $ref: '#/components/schemas/EventDetailHostContextUserSummary'
+
+    EventCommentsResponse:
+      type: object
+      additionalProperties: false
+      required: [discussion_comments, review_comments]
+      properties:
+        discussion_comments:
+          $ref: '#/components/schemas/EventCommentCollection'
+        review_comments:
+          $ref: '#/components/schemas/EventCommentCollection'
+
+    EventCommentCollection:
+      type: object
+      additionalProperties: false
+      required: [items, page_info]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventComment'
+        page_info:
+          $ref: '#/components/schemas/EventCommentPageInfo'
+
+    EventCommentPageInfo:
+      type: object
+      additionalProperties: false
+      required: [next_cursor, has_next]
+      properties:
+        next_cursor:
+          type:
+            - string
+            - "null"
+          description: Opaque cursor for the next page, or `null` when there is no next page.
+        has_next:
+          type: boolean
+
+    EventComment:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - event_id
+        - user
+        - comment_type
+        - message
+        - parent_id
+        - rating
+        - image_url
+        - likes_count
+        - reply_count
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        event_id:
+          type: string
+          format: uuid
+        user:
+          $ref: '#/components/schemas/EventCommentAuthor'
+        comment_type:
+          type: string
+          enum: [DISCUSSION, REVIEW]
+        message:
+          type: string
+          minLength: 1
+          maxLength: 1000
+        parent_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Present only for discussion replies.
+        rating:
+          type:
+            - integer
+            - "null"
+          minimum: 1
+          maximum: 5
+          description: Present only for REVIEW comments.
+        image_url:
+          type:
+            - string
+            - "null"
+          format: uri
+          description: Optional image URL for REVIEW comments.
+        likes_count:
+          type: integer
+          minimum: 0
+        reply_count:
+          type: integer
+          minimum: 0
+          description: Number of direct replies. Child comments are never embedded in list responses.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    EventCommentAuthor:
+      type: object
+      additionalProperties: false
+      required: [id, username, display_name, avatar_url]
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        display_name:
+          type:
+            - string
+            - "null"
+        avatar_url:
+          type:
+            - string
+            - "null"
+          format: uri
+
+    CreateDiscussionCommentRequest:
+      type: object
+      additionalProperties: false
+      required: [message]
+      properties:
+        message:
+          type: string
+          minLength: 1
+          maxLength: 1000
+        parent_id:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: Top-level DISCUSSION comment id when creating a reply; omit/null for top-level comments.
+
+    UpsertReviewCommentRequest:
+      type: object
+      additionalProperties: false
+      required: [message, rating]
+      properties:
+        message:
+          type: string
+          minLength: 1
+          maxLength: 1000
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+        image_confirm_token:
+          type:
+            - string
+            - "null"
+          description: Optional confirm token returned by the review image upload flow.
 
     RatingWriteRequest:
       type: object


### PR DESCRIPTION
## 📋 Summary
Adds backend support for event discussion comments and completed-event review comments. Reviews now live in the event comments system and remain backward compatible with the existing event rating endpoints.

## 🔄 Changes
- Added event comment/review domain, application, Postgres repository, and HTTP handler layers.
- Added paginated endpoints for event comments and comment replies.
- Added discussion comment creation rules by event status.
- Added completed-event review comments with rating and optional one-image support.
- Added review image direct-upload support.
- Migrated participant-to-event ratings to review comments and backfilled existing `event_rating` rows.
- Updated host score aggregation and event detail `viewer_event_rating` to read from review comments.
- Marked legacy event rating endpoints as deprecated compatibility paths.
- Updated OpenAPI documentation.

## 🧪 Testing
- Ran `go test ./internal/...`
- Ran `go test -tags=integration ./tests_integration`
- Ran `./shipcheck.sh`
- All backend checks passed.

## 🔗 Related
Closes #442
