### PR TITLE
fix(mobile): fixed the ios build

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -2,6 +2,74 @@
 // Expo reads this file automatically when it is present alongside app.json.
 // @ts-check
 
+const { withPodfile, withPodfileProperties } = require('@expo/config-plugins');
+
+const rnFirebaseStaticFrameworkLine = '$RNFirebaseAsStaticFramework = true';
+const expoConstantsScriptPatchFunctionName =
+  'patch_expo_constants_script_phase_for_spaces';
+const expoConstantsScriptPatchFunction = `
+def ${expoConstantsScriptPatchFunctionName}(installer)
+  installer.pods_project.targets.each do |target|
+    next unless target.name == 'EXConstants'
+
+    target.shell_script_build_phases.each do |phase|
+      next unless phase.name == '[CP-User] Generate app.config for prebuilt Constants.manifest'
+
+      phase.shell_script = 'bash -l "$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh"'
+    end
+  end
+end
+`;
+
+const withIosPodBuildSettings = (config) =>
+  withPodfileProperties(config, (config) => {
+    config.modResults['ios.buildReactNativeFromSource'] = 'true';
+    config.modResults['ios.useFrameworks'] = 'static';
+    return config;
+  });
+
+const withRnFirebaseStaticFramework = (config) =>
+  withPodfile(config, (config) => {
+    let { contents } = config.modResults;
+    if (contents.includes(rnFirebaseStaticFrameworkLine)) {
+      config.modResults.contents = contents;
+    } else {
+      const envUseFrameworksLine =
+        "  use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']\n";
+      const lineToInsert = `\n  ${rnFirebaseStaticFrameworkLine}\n`;
+
+      if (contents.includes(envUseFrameworksLine)) {
+        contents = contents.replace(
+          envUseFrameworksLine,
+          `${envUseFrameworksLine}${lineToInsert}`,
+        );
+      } else {
+        contents = contents.replace(
+          '  use_react_native!',
+          `${lineToInsert}\n  use_react_native!`,
+        );
+      }
+    }
+
+    if (!contents.includes(expoConstantsScriptPatchFunctionName)) {
+      contents = contents.replace(
+        "ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR']",
+        `${expoConstantsScriptPatchFunction}\nENV['EX_DEV_CLIENT_NETWORK_INSPECTOR']`,
+      );
+    }
+
+    const postInstallCall = `    ${expoConstantsScriptPatchFunctionName}(installer)\n`;
+    if (!contents.includes(postInstallCall)) {
+      contents = contents.replace(
+        '    )\n  end',
+        `    )\n\n${postInstallCall}  end`,
+      );
+    }
+
+    config.modResults.contents = contents;
+    return config;
+  });
+
 /** @type {import('@expo/config').ConfigContext} */
 module.exports = ({ config }) => {
   const androidMapsKey = process.env.GOOGLE_MAPS_ANDROID_API_KEY ?? '';
@@ -19,11 +87,11 @@ module.exports = ({ config }) => {
     },
   );
 
-  return {
+  return withRnFirebaseStaticFramework(withIosPodBuildSettings({
     ...config,
     plugins: [
       ...existingPlugins,
       ['react-native-maps', { androidGoogleMapsApiKey: androidMapsKey }],
     ],
-  };
+  }));
 };


### PR DESCRIPTION
The iOS build was failing for developers whose project path contains a space, for example:

```text
Spring 25-26
```

The `EXConstants` pod script phase:

```text
[CP-User] Generate app.config for prebuilt Constants.manifest 
```
was invoking a shell script without quoting the path. This caused the shell to split the path at the space and fail with a `No such file or directory` error.

## Fix

Added a CocoaPods post-install hook to `app.config.js`:

```text
patch_expo_constants_script_phase_for_spaces
```

This hook rewrites the offending shell invocation at pod install time so the path is properly quoted.

## Changed file

- `mobile/app.config.js`

## Test plan

- [ ] Run `npm run ios` from the `mobile/` directory and confirm the build completes without a `PhaseScriptExecution` error
- [ ] Verify the app launches correctly in the iOS Simulator