### PR TITLE
feat(backend): support image attachment for join requests

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -1287,6 +1287,7 @@ func (r *EventRepository) loadPendingJoinRequests(
 			jr.id,
 			jr.status,
 			jr.message,
+			jr.image_url,
 			jr.created_at,
 			jr.updated_at,
 			u.id,
@@ -1316,6 +1317,7 @@ func (r *EventRepository) loadPendingJoinRequests(
 			joinRequestID uuid.UUID
 			status        string
 			message       pgtype.Text
+			imageURL      pgtype.Text
 			createdAt     time.Time
 			updatedAt     time.Time
 			userID        uuid.UUID
@@ -1329,6 +1331,7 @@ func (r *EventRepository) loadPendingJoinRequests(
 			&joinRequestID,
 			&status,
 			&message,
+			&imageURL,
 			&createdAt,
 			&updatedAt,
 			&userID,
@@ -1354,6 +1357,9 @@ func (r *EventRepository) loadPendingJoinRequests(
 		}
 		if message.Valid {
 			request.Message = &message.String
+		}
+		if imageURL.Valid {
+			request.ImageURL = &imageURL.String
 		}
 		if displayName.Valid {
 			request.User.DisplayName = &displayName.String
@@ -1635,6 +1641,39 @@ func (r *EventRepository) SetEventImageIfVersion(
 }
 
 var _ imageuploadapp.EventRepository = (*EventRepository)(nil)
+
+// GetEventJoinRequestImageState loads the event state needed to authorize
+// join-request image uploads.
+func (r *EventRepository) GetEventJoinRequestImageState(ctx context.Context, eventID uuid.UUID) (*imageuploadapp.EventJoinRequestImageState, error) {
+	var state imageuploadapp.EventJoinRequestImageState
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			e.id,
+			e.host_id,
+			CASE
+				WHEN e.status = 'ACTIVE' AND e.end_time < NOW() THEN 'COMPLETED'
+				WHEN e.status = 'ACTIVE' AND e.start_time < NOW() THEN 'IN_PROGRESS'
+				WHEN e.status = 'IN_PROGRESS' AND e.end_time < NOW() THEN 'COMPLETED'
+				ELSE e.status
+			END AS status,
+			e.privacy_level
+		FROM event e
+		WHERE e.id = $1
+	`, eventID).Scan(
+		&state.EventID,
+		&state.HostID,
+		&state.Status,
+		&state.PrivacyLevel,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get event join request image state: %w", err)
+	}
+
+	return &state, nil
+}
 
 // GetEventReviewImageState loads the event and caller relation needed to
 // authorize review image uploads.

--- a/backend/internal/adapter/in/postgres/join_request_repo.go
+++ b/backend/internal/adapter/in/postgres/join_request_repo.go
@@ -237,14 +237,14 @@ func (r *JoinRequestRepository) handleExistingJoinRequestForCreate(
 		return nil, domain.ConflictError(domain.ErrorCodeAlreadyRequested, "You already have a pending join request for this event.")
 	case domain.JoinRequestStatusApproved:
 		if canReactivateLeavedParticipation(participation, eventStart) {
-			return r.reactivateJoinRequest(ctx, existing.ID, params.HostUserID, params.Message)
+			return r.reactivateJoinRequest(ctx, existing.ID, params.HostUserID, params.Message, params.ImageURL)
 		}
 		return nil, domain.ConflictError(domain.ErrorCodeAlreadyParticipating, "You are already participating in this event.")
 	case domain.JoinRequestStatusRejected:
 		if time.Now().UTC().Before(existing.UpdatedAt.Add(domain.JoinRequestCooldown)) {
 			return nil, domain.ConflictError(domain.ErrorCodeJoinRequestCooldownActive, "You must wait 3 days after rejection before requesting to join this event again.")
 		}
-		return r.reactivateJoinRequest(ctx, existing.ID, params.HostUserID, params.Message)
+		return r.reactivateJoinRequest(ctx, existing.ID, params.HostUserID, params.Message, params.ImageURL)
 	default:
 		return nil, fmt.Errorf("unsupported join request status %q", existing.Status)
 	}
@@ -297,7 +297,7 @@ func (r *JoinRequestRepository) loadJoinRequestByEventAndUser(
 	forUpdate bool,
 ) (*domain.JoinRequest, error) {
 	query := `
-		SELECT id, event_id, user_id, participation_id, host_user_id, status, message, created_at, updated_at
+		SELECT id, event_id, user_id, participation_id, host_user_id, status, message, image_url, created_at, updated_at
 		FROM join_request
 		WHERE event_id = $1
 		  AND user_id = $2
@@ -315,7 +315,7 @@ func (r *JoinRequestRepository) loadJoinRequestByID(
 	forUpdate bool,
 ) (*domain.JoinRequest, error) {
 	query := `
-		SELECT id, event_id, user_id, participation_id, host_user_id, status, message, created_at, updated_at
+		SELECT id, event_id, user_id, participation_id, host_user_id, status, message, image_url, created_at, updated_at
 		FROM join_request
 		WHERE event_id = $1
 		  AND id = $2
@@ -332,10 +332,10 @@ func (r *JoinRequestRepository) insertJoinRequest(
 	params joinrequestapp.CreateJoinRequestParams,
 ) (*domain.JoinRequest, error) {
 	row := r.db.QueryRow(ctx, `
-		INSERT INTO join_request (event_id, user_id, host_user_id, status, message)
-		VALUES ($1, $2, $3, $4, $5)
-		RETURNING id, event_id, user_id, participation_id, host_user_id, status, message, created_at, updated_at
-	`, params.EventID, params.UserID, params.HostUserID, domain.JoinRequestStatusPending, params.Message)
+		INSERT INTO join_request (event_id, user_id, host_user_id, status, message, image_url)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, event_id, user_id, participation_id, host_user_id, status, message, image_url, created_at, updated_at
+	`, params.EventID, params.UserID, params.HostUserID, domain.JoinRequestStatusPending, params.Message, params.ImageURL)
 
 	request, err := scanJoinRequest(row)
 	if err != nil {
@@ -349,6 +349,7 @@ func (r *JoinRequestRepository) reactivateJoinRequest(
 	ctx context.Context,
 	joinRequestID, hostUserID uuid.UUID,
 	message *string,
+	imageURL *string,
 ) (*domain.JoinRequest, error) {
 	row := r.db.QueryRow(ctx, `
 		UPDATE join_request
@@ -356,11 +357,12 @@ func (r *JoinRequestRepository) reactivateJoinRequest(
 			status = $3,
 			participation_id = NULL,
 			message = $4,
+			image_url = $5,
 			created_at = now(),
 			updated_at = now()
 		WHERE id = $1
-		RETURNING id, event_id, user_id, participation_id, host_user_id, status, message, created_at, updated_at
-	`, joinRequestID, hostUserID, domain.JoinRequestStatusPending, message)
+		RETURNING id, event_id, user_id, participation_id, host_user_id, status, message, image_url, created_at, updated_at
+	`, joinRequestID, hostUserID, domain.JoinRequestStatusPending, message, imageURL)
 
 	request, err := scanJoinRequest(row)
 	if err != nil {
@@ -437,7 +439,7 @@ func (r *JoinRequestRepository) updateJoinRequestStatus(
 			participation_id = $3,
 			updated_at = now()
 		WHERE id = $1
-		RETURNING id, event_id, user_id, participation_id, host_user_id, status, message, created_at, updated_at
+		RETURNING id, event_id, user_id, participation_id, host_user_id, status, message, image_url, created_at, updated_at
 	`, joinRequestID, status, participationID)
 
 	request, err := scanJoinRequest(row)
@@ -457,6 +459,7 @@ func scanJoinRequest(row pgx.Row) (*domain.JoinRequest, error) {
 		hostUserID      uuid.UUID
 		status          string
 		message         pgtype.Text
+		imageURL        pgtype.Text
 		createdAt       time.Time
 		updatedAt       time.Time
 	)
@@ -469,6 +472,7 @@ func scanJoinRequest(row pgx.Row) (*domain.JoinRequest, error) {
 		&hostUserID,
 		&status,
 		&message,
+		&imageURL,
 		&createdAt,
 		&updatedAt,
 	)
@@ -499,6 +503,9 @@ func scanJoinRequest(row pgx.Row) (*domain.JoinRequest, error) {
 	}
 	if message.Valid {
 		request.Message = &message.String
+	}
+	if imageURL.Valid {
+		request.ImageURL = &imageURL.String
 	}
 
 	return request, nil

--- a/backend/internal/adapter/out/httpapi/event_handler/dto.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/dto.go
@@ -23,7 +23,8 @@ type createEventBody struct {
 
 // requestJoinBody is the JSON request body for POST /events/:id/join-request.
 type requestJoinBody struct {
-	Message *string `json:"message"`
+	Message           *string `json:"message"`
+	ImageConfirmToken *string `json:"image_confirm_token"`
 }
 
 // constraintBody represents a single participation constraint in the request.

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
@@ -466,7 +466,8 @@ func (h *EventHandler) RequestJoin(c *fiber.Ctx) error {
 
 	claims := httpapi.UserClaims(c)
 	result, err := h.service.RequestJoin(c.UserContext(), claims.UserID, eventID, event.RequestJoinInput{
-		Message: body.Message,
+		Message:           body.Message,
+		ImageConfirmToken: body.ImageConfirmToken,
 	})
 	if err != nil {
 		return httpapi.WriteError(c, err)
@@ -478,7 +479,10 @@ func (h *EventHandler) RequestJoin(c *fiber.Ctx) error {
 		httpapi.OperationAttr("event.join_request.create"),
 		httpapi.UserIDAttr(claims.UserID),
 		httpapi.EventIDAttr(eventID),
-		httpapi.QuerySummaryAttr(httpapi.JoinSummary(httpapi.BoolSummary("has_message", body.Message != nil && strings.TrimSpace(*body.Message) != ""))),
+		httpapi.QuerySummaryAttr(httpapi.JoinSummary(
+			httpapi.BoolSummary("has_message", body.Message != nil && strings.TrimSpace(*body.Message) != ""),
+			httpapi.BoolSummary("has_image_token", body.ImageConfirmToken != nil && strings.TrimSpace(*body.ImageConfirmToken) != ""),
+		)),
 	)
 
 	return c.Status(fiber.StatusCreated).JSON(result)

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -1083,6 +1083,33 @@ func TestRequestJoinParsesMessageBeforeCallingService(t *testing.T) {
 	}
 }
 
+func TestRequestJoinParsesImageConfirmTokenBeforeCallingService(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+	token := "confirm-token"
+
+	req := httptest.NewRequest(fiber.MethodPost, "/events/"+eventID.String()+"/join-request", bytes.NewBufferString(`{"image_confirm_token":"`+token+`"}`))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("expected status %d, got %d", fiber.StatusCreated, resp.StatusCode)
+	}
+	if svc.lastRequestJoinInput.ImageConfirmToken == nil || *svc.lastRequestJoinInput.ImageConfirmToken != token {
+		t.Fatalf("expected parsed image confirm token %q, got %v", token, svc.lastRequestJoinInput.ImageConfirmToken)
+	}
+}
+
 func TestApproveJoinRequestInvalidEventIDReturns400(t *testing.T) {
 	// given
 	app := newEventTestApp(&stubEventService{}, authedVerifier())

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
@@ -31,6 +31,7 @@ func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler) {
 	events.Post("/:id/image/upload-url", handler.CreateEventImageUpload)
 	events.Post("/:id/image/confirm", handler.ConfirmEventImageUpload)
 	events.Post("/:id/review-comments/image/upload-url", handler.CreateEventReviewImageUpload)
+	events.Post("/:id/join-request/image/upload-url", handler.CreateEventJoinRequestImageUpload)
 }
 
 // CreateProfileAvatarUpload handles POST /me/avatar/upload-url.
@@ -150,6 +151,32 @@ func (h *Handler) CreateEventReviewImageUpload(c *fiber.Ctx) error {
 		c.UserContext(),
 		"event review image upload URL created",
 		httpapi.OperationAttr("image_upload.event_review.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.String("base_url", result.BaseURL),
+		slog.Int("upload_count", len(result.Uploads)),
+	)
+
+	return c.JSON(result)
+}
+
+// CreateEventJoinRequestImageUpload handles POST /events/:id/join-request/image/upload-url.
+func (h *Handler) CreateEventJoinRequestImageUpload(c *fiber.Ctx) error {
+	eventID, err := parseEventID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.CreateEventJoinRequestImageUpload(c.UserContext(), claims.UserID, eventID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event join request image upload URL created",
+		httpapi.OperationAttr("image_upload.event_join_request.create"),
 		httpapi.UserIDAttr(claims.UserID),
 		httpapi.EventIDAttr(eventID),
 		slog.String("base_url", result.BaseURL),

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler_test.go
@@ -18,14 +18,17 @@ type stubImageUploadService struct {
 	createProfileResult *imageupload.CreateUploadResult
 	createEventResult   *imageupload.CreateUploadResult
 	createReviewResult  *imageupload.CreateUploadResult
+	createJoinResult    *imageupload.CreateUploadResult
 	createProfileErr    error
 	createEventErr      error
 	createReviewErr     error
+	createJoinErr       error
 	confirmProfileErr   error
 	confirmEventErr     error
 	confirmReviewErr    error
 	lastEventID         uuid.UUID
 	lastReviewEventID   uuid.UUID
+	lastJoinEventID     uuid.UUID
 	lastConfirmInput    imageupload.ConfirmUploadInput
 	lastConfirmEventID  uuid.UUID
 }
@@ -80,6 +83,23 @@ func (s *stubImageUploadService) ConfirmEventReviewImageUpload(_ context.Context
 		return nil, s.confirmReviewErr
 	}
 	return &imageupload.ConfirmReviewImageResult{BaseURL: "https://cdn.example/review.jpg"}, nil
+}
+
+func (s *stubImageUploadService) CreateEventJoinRequestImageUpload(_ context.Context, _ uuid.UUID, eventID uuid.UUID) (*imageupload.CreateUploadResult, error) {
+	s.lastJoinEventID = eventID
+	if s.createJoinErr != nil {
+		return nil, s.createJoinErr
+	}
+	if s.createJoinResult != nil {
+		return s.createJoinResult, nil
+	}
+	return defaultUploadResult(), nil
+}
+
+func (s *stubImageUploadService) ConfirmEventJoinRequestImageUpload(_ context.Context, _ uuid.UUID, eventID uuid.UUID, input imageupload.ConfirmUploadInput) (*imageupload.ConfirmJoinRequestImageResult, error) {
+	s.lastConfirmEventID = eventID
+	s.lastConfirmInput = input
+	return &imageupload.ConfirmJoinRequestImageResult{BaseURL: "https://cdn.example/join-request.jpg"}, nil
 }
 
 type fakeVerifier struct {
@@ -257,6 +277,52 @@ func TestCreateEventImageUploadNotFoundReturns404(t *testing.T) {
 
 	if resp.StatusCode != fiber.StatusNotFound {
 		t.Fatalf("expected status %d, got %d", fiber.StatusNotFound, resp.StatusCode)
+	}
+}
+
+func TestCreateEventJoinRequestImageUploadReturnsSignedInstructions(t *testing.T) {
+	svc := &stubImageUploadService{}
+	app := newTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodPost, "/events/"+eventID.String()+"/join-request/image/upload-url", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.lastJoinEventID != eventID {
+		t.Fatalf("expected join request image event id %s, got %s", eventID, svc.lastJoinEventID)
+	}
+	var body imageupload.CreateUploadResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.BaseURL == "" || body.ConfirmToken == "" || len(body.Uploads) != 2 {
+		t.Fatalf("unexpected response body: %+v", body)
+	}
+}
+
+func TestCreateEventJoinRequestImageUploadWithoutAuthReturns401(t *testing.T) {
+	app := newTestApp(&stubImageUploadService{}, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodPost, "/events/"+eventID.String()+"/join-request/image/upload-url", nil)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", fiber.StatusUnauthorized, resp.StatusCode)
 	}
 }
 

--- a/backend/internal/application/event/helpers.go
+++ b/backend/internal/application/event/helpers.go
@@ -143,6 +143,13 @@ func toEventDetailResult(record *EventDetailRecord, now time.Time) *GetEventDeta
 		preferredGender := string(*record.PreferredGender)
 		result.PreferredGender = &preferredGender
 	}
+	if record.HostContext != nil {
+		result.HostContext = &EventDetailHostContext{
+			ApprovedParticipants: toEventDetailApprovedParticipants(record.HostContext.ApprovedParticipants),
+			PendingJoinRequests:  toEventDetailPendingJoinRequests(record.HostContext.PendingJoinRequests),
+			Invitations:          toEventDetailInvitations(record.HostContext.Invitations),
+		}
+	}
 
 	return result
 }
@@ -213,6 +220,7 @@ func toEventDetailPendingJoinRequests(records []EventDetailPendingJoinRequestRec
 			JoinRequestID: record.JoinRequestID.String(),
 			Status:        record.Status,
 			Message:       record.Message,
+			ImageURL:      record.ImageURL,
 			CreatedAt:     record.CreatedAt,
 			UpdatedAt:     record.UpdatedAt,
 			User:          toEventDetailHostContextUser(record.User),

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -232,6 +232,7 @@ type EventDetailPendingJoinRequestRecord struct {
 	JoinRequestID uuid.UUID
 	Status        string
 	Message       *string
+	ImageURL      *string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 	User          EventDetailHostContextUserRecord

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
 	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/participation"
@@ -21,6 +23,7 @@ type Service struct {
 	eventRepo            Repository
 	participationService participation.UseCase
 	joinRequestService   join_request.UseCase
+	joinRequestImages    JoinRequestImageConfirmer
 	ticketService        ticket.LifecycleUseCase
 	notifications        notificationapp.UseCase
 	unitOfWork           uow.UnitOfWork
@@ -31,6 +34,12 @@ type Service struct {
 // service can fan out notifications for cancellations and other lifecycle events.
 func (s *Service) SetNotificationService(notifications notificationapp.UseCase) {
 	s.notifications = notifications
+}
+
+// SetJoinRequestImageConfirmer wires in the image upload service for optional
+// join-request image confirmation.
+func (s *Service) SetJoinRequestImageConfirmer(confirmer JoinRequestImageConfirmer) {
+	s.joinRequestImages = confirmer
 }
 
 var _ UseCase = (*Service)(nil)
@@ -392,8 +401,14 @@ func (s *Service) RequestJoin(ctx context.Context, userID, eventID uuid.UUID, in
 		return nil, err
 	}
 
+	imageURL, err := s.confirmJoinRequestImage(ctx, userID, eventID, input.ImageConfirmToken)
+	if err != nil {
+		return nil, err
+	}
+
 	jr, err := s.joinRequestService.CreatePendingJoinRequest(ctx, eventID, userID, event.HostID, join_request.CreatePendingJoinRequestInput{
-		Message: input.Message,
+		Message:  input.Message,
+		ImageURL: imageURL,
 	})
 	if err != nil {
 		return nil, err
@@ -403,8 +418,25 @@ func (s *Service) RequestJoin(ctx context.Context, userID, eventID uuid.UUID, in
 		JoinRequestID: jr.ID.String(),
 		EventID:       jr.EventID.String(),
 		Status:        string(domain.JoinRequestStatusPending),
+		ImageURL:      jr.ImageURL,
 		CreatedAt:     jr.CreatedAt,
 	}, nil
+}
+
+func (s *Service) confirmJoinRequestImage(ctx context.Context, userID, eventID uuid.UUID, confirmToken *string) (*string, error) {
+	if confirmToken == nil || strings.TrimSpace(*confirmToken) == "" {
+		return nil, nil
+	}
+	if s.joinRequestImages == nil {
+		return nil, domain.ForbiddenError(domain.ErrorCodeImageUploadNotAllowed, "Join request image uploads are not available.")
+	}
+	confirmed, err := s.joinRequestImages.ConfirmEventJoinRequestImageUpload(ctx, userID, eventID, imageupload.ConfirmUploadInput{
+		ConfirmToken: *confirmToken,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &confirmed.BaseURL, nil
 }
 
 // ApproveJoinRequest allows the authenticated host to approve a pending join

--- a/backend/internal/application/event/service_dto.go
+++ b/backend/internal/application/event/service_dto.go
@@ -1,10 +1,18 @@
 package event
 
 import (
+	"context"
 	"time"
 
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
 )
+
+// JoinRequestImageConfirmer verifies a previously uploaded join-request image.
+type JoinRequestImageConfirmer interface {
+	ConfirmEventJoinRequestImageUpload(ctx context.Context, userID, eventID uuid.UUID, input imageupload.ConfirmUploadInput) (*imageupload.ConfirmJoinRequestImageResult, error)
+}
 
 // CreateEventInput is the validated input for creating an event.
 type CreateEventInput struct {
@@ -245,6 +253,7 @@ type EventDetailPendingJoinRequest struct {
 	JoinRequestID string                     `json:"join_request_id"`
 	Status        string                     `json:"status"`
 	Message       *string                    `json:"message"`
+	ImageURL      *string                    `json:"image_url"`
 	CreatedAt     time.Time                  `json:"created_at"`
 	UpdatedAt     time.Time                  `json:"updated_at"`
 	User          EventDetailHostContextUser `json:"user"`
@@ -316,7 +325,8 @@ type LeaveEventResult struct {
 
 // RequestJoinInput is the validated input for creating a protected-event join request.
 type RequestJoinInput struct {
-	Message *string
+	Message           *string
+	ImageConfirmToken *string
 }
 
 // RequestJoinResult is returned after a user successfully creates a join request
@@ -325,6 +335,7 @@ type RequestJoinResult struct {
 	JoinRequestID string    `json:"join_request_id"`
 	EventID       string    `json:"event_id"`
 	Status        string    `json:"status"`
+	ImageURL      *string   `json:"image_url"`
 	CreatedAt     time.Time `json:"created_at"`
 }
 

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
@@ -280,6 +281,26 @@ type fakeJoinRequestService struct {
 	lastInput         join_request.CreatePendingJoinRequestInput
 }
 
+type fakeJoinRequestImageConfirmer struct {
+	baseURL          string
+	err              error
+	callCount        int
+	lastUserID       uuid.UUID
+	lastEventID      uuid.UUID
+	lastConfirmToken string
+}
+
+func (f *fakeJoinRequestImageConfirmer) ConfirmEventJoinRequestImageUpload(_ context.Context, userID, eventID uuid.UUID, input imageupload.ConfirmUploadInput) (*imageupload.ConfirmJoinRequestImageResult, error) {
+	f.callCount++
+	f.lastUserID = userID
+	f.lastEventID = eventID
+	f.lastConfirmToken = input.ConfirmToken
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &imageupload.ConfirmJoinRequestImageResult{BaseURL: f.baseURL}, nil
+}
+
 type fakeTicketLifecycle struct {
 	cancelParticipationCallCount int
 	cancelEventCallCount         int
@@ -336,6 +357,7 @@ func (s *fakeJoinRequestService) CreatePendingJoinRequest(
 		UserID:     userID,
 		HostUserID: hostUserID,
 		Status:     domain.JoinRequestStatusPending,
+		ImageURL:   input.ImageURL,
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}, nil
@@ -498,6 +520,7 @@ func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
 	viewerRatingMessage := "Great event host."
 	viewerRatingCreatedAt := createdAt.Add(5 * time.Minute)
 	viewerRatingUpdatedAt := viewerRatingCreatedAt.Add(2 * time.Minute)
+	joinRequestImageURL := "https://cdn.example/join-request.jpg"
 	svc.now = func() time.Time { return fixedNow }
 
 	eventRepo.detailRecord = &EventDetailRecord{
@@ -554,6 +577,21 @@ func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
 			CreatedAt: viewerRatingCreatedAt,
 			UpdatedAt: viewerRatingUpdatedAt,
 		},
+		HostContext: &EventDetailHostContextRecord{
+			PendingJoinRequests: []EventDetailPendingJoinRequestRecord{
+				{
+					JoinRequestID: uuid.New(),
+					Status:        string(domain.JoinRequestStatusPending),
+					ImageURL:      &joinRequestImageURL,
+					CreatedAt:     createdAt,
+					UpdatedAt:     updatedAt,
+					User: EventDetailHostContextUserRecord{
+						ID:       uuid.New(),
+						Username: "requester_user",
+					},
+				},
+			},
+		},
 	}
 
 	// when
@@ -589,6 +627,9 @@ func TestGetEventDetailMapsRepositoryRecord(t *testing.T) {
 	}
 	if len(result.Location.RoutePoints) != 2 {
 		t.Fatalf("expected 2 route points, got %d", len(result.Location.RoutePoints))
+	}
+	if result.HostContext == nil || len(result.HostContext.PendingJoinRequests) != 1 || result.HostContext.PendingJoinRequests[0].ImageURL == nil || *result.HostContext.PendingJoinRequests[0].ImageURL != joinRequestImageURL {
+		t.Fatalf("expected host context join request image URL %q, got %+v", joinRequestImageURL, result.HostContext)
 	}
 }
 
@@ -1822,6 +1863,63 @@ func TestRequestJoinSuccessReturnsPending(t *testing.T) {
 	}
 	if joinRequestService.lastInput.Message == nil || *joinRequestService.lastInput.Message != message {
 		t.Fatalf("expected join request service to receive message %q, got %v", message, joinRequestService.lastInput.Message)
+	}
+}
+
+func TestRequestJoinWithImageTokenConfirmsAndStoresImageURL(t *testing.T) {
+	// given
+	hostID := uuid.New()
+	requesterID := uuid.New()
+	ev := protectedEvent(hostID)
+	svc, _, _, joinRequestService := newTestEventServiceWithEvent(ev)
+	confirmer := &fakeJoinRequestImageConfirmer{baseURL: "https://cdn.example/join-request.jpg"}
+	svc.SetJoinRequestImageConfirmer(confirmer)
+	token := "confirm-token"
+
+	// when
+	result, err := svc.RequestJoin(context.Background(), requesterID, ev.ID, RequestJoinInput{
+		ImageConfirmToken: &token,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("RequestJoin() error = %v", err)
+	}
+	if confirmer.callCount != 1 {
+		t.Fatalf("expected image confirmer to be called once, got %d", confirmer.callCount)
+	}
+	if confirmer.lastUserID != requesterID || confirmer.lastEventID != ev.ID || confirmer.lastConfirmToken != token {
+		t.Fatalf("unexpected image confirmer input: user=%s event=%s token=%q", confirmer.lastUserID, confirmer.lastEventID, confirmer.lastConfirmToken)
+	}
+	if joinRequestService.lastInput.ImageURL == nil || *joinRequestService.lastInput.ImageURL != confirmer.baseURL {
+		t.Fatalf("expected join request image URL %q, got %v", confirmer.baseURL, joinRequestService.lastInput.ImageURL)
+	}
+	if result.ImageURL == nil || *result.ImageURL != confirmer.baseURL {
+		t.Fatalf("expected response image URL %q, got %v", confirmer.baseURL, result.ImageURL)
+	}
+}
+
+func TestRequestJoinWithoutImageTokenDoesNotConfirmImage(t *testing.T) {
+	// given
+	hostID := uuid.New()
+	requesterID := uuid.New()
+	ev := protectedEvent(hostID)
+	svc, _, _, joinRequestService := newTestEventServiceWithEvent(ev)
+	confirmer := &fakeJoinRequestImageConfirmer{baseURL: "https://cdn.example/join-request.jpg"}
+	svc.SetJoinRequestImageConfirmer(confirmer)
+
+	// when
+	_, err := svc.RequestJoin(context.Background(), requesterID, ev.ID, RequestJoinInput{})
+
+	// then
+	if err != nil {
+		t.Fatalf("RequestJoin() error = %v", err)
+	}
+	if confirmer.callCount != 0 {
+		t.Fatalf("expected image confirmer not to be called, got %d", confirmer.callCount)
+	}
+	if joinRequestService.lastInput.ImageURL != nil {
+		t.Fatalf("expected no join request image URL, got %v", joinRequestService.lastInput.ImageURL)
 	}
 }
 

--- a/backend/internal/application/imageupload/repository.go
+++ b/backend/internal/application/imageupload/repository.go
@@ -18,6 +18,7 @@ type EventRepository interface {
 	GetEventImageState(ctx context.Context, eventID uuid.UUID) (*EventImageState, error)
 	SetEventImageIfVersion(ctx context.Context, eventID uuid.UUID, expectedVersion, nextVersion int, baseURL string, updatedAt time.Time) (bool, error)
 	GetEventReviewImageState(ctx context.Context, eventID, userID uuid.UUID) (*EventReviewImageState, error)
+	GetEventJoinRequestImageState(ctx context.Context, eventID uuid.UUID) (*EventJoinRequestImageState, error)
 }
 
 // Storage presigns uploads and verifies uploaded objects exist.

--- a/backend/internal/application/imageupload/service.go
+++ b/backend/internal/application/imageupload/service.go
@@ -231,6 +231,46 @@ func (s *Service) ConfirmEventReviewImageUpload(ctx context.Context, userID, eve
 	return &ConfirmReviewImageResult{BaseURL: payload.BaseURL}, nil
 }
 
+// CreateEventJoinRequestImageUpload prepares a direct-upload flow for one join-request image.
+func (s *Service) CreateEventJoinRequestImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error) {
+	state, err := s.eventRepo.GetEventJoinRequestImageState(ctx, eventID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+		return nil, err
+	}
+	if err := validateJoinRequestImageState(state, userID); err != nil {
+		return nil, err
+	}
+
+	uploadID := uuid.NewString()
+	return s.createUpload(ctx, uploadDescriptor{
+		Resource:     ResourceJoinRequestImage,
+		OwnerUserID:  userID,
+		NextVersion:  1,
+		OriginalKey:  fmt.Sprintf("events/%s/join-requests/%s/%s", eventID, userID, uploadID),
+		UploadID:     uploadID,
+		CurrentEvent: &eventID,
+	})
+}
+
+// ConfirmEventJoinRequestImageUpload verifies a join-request image upload and
+// returns the public image URL. Persistence happens when the join request is created.
+func (s *Service) ConfirmEventJoinRequestImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) (*ConfirmJoinRequestImageResult, error) {
+	payload, err := s.verifyConfirmToken(input, ResourceJoinRequestImage)
+	if err != nil {
+		return nil, err
+	}
+	if payload.OwnerUserID != userID || payload.EventID == nil || *payload.EventID != eventID {
+		return nil, invalidConfirmTokenError()
+	}
+	if err := s.ensureUploadedObjectsExist(ctx, payload); err != nil {
+		return nil, err
+	}
+	return &ConfirmJoinRequestImageResult{BaseURL: payload.BaseURL}, nil
+}
+
 type uploadDescriptor struct {
 	Resource     string
 	OwnerUserID  uuid.UUID
@@ -255,6 +295,19 @@ func validateReviewImageState(state *EventReviewImageState, userID uuid.UUID) er
 	}
 	if !state.IsQualifyingParticipant {
 		return domain.ForbiddenError(domain.ErrorCodeReviewImageNotAllowed, "Only participants can upload review images.")
+	}
+	return nil
+}
+
+func validateJoinRequestImageState(state *EventJoinRequestImageState, userID uuid.UUID) error {
+	if state.HostID == userID {
+		return domain.ForbiddenError(domain.ErrorCodeHostCannotJoin, "The event host cannot request to join their own event.")
+	}
+	if state.Status == string(domain.EventStatusCanceled) || state.Status == string(domain.EventStatusCompleted) {
+		return domain.ConflictError(domain.ErrorCodeEventNotJoinable, "This event is no longer accepting participants.")
+	}
+	if state.PrivacyLevel != string(domain.PrivacyProtected) {
+		return domain.ConflictError(domain.ErrorCodeEventJoinNotAllowed, "Only PROTECTED events accept join requests.")
 	}
 	return nil
 }

--- a/backend/internal/application/imageupload/service_dto.go
+++ b/backend/internal/application/imageupload/service_dto.go
@@ -11,6 +11,7 @@ const (
 	ResourceProfileAvatar    = "PROFILE_AVATAR"
 	ResourceEventImage       = "EVENT_IMAGE"
 	ResourceEventReviewImage = "EVENT_REVIEW_IMAGE"
+	ResourceJoinRequestImage = "EVENT_JOIN_REQUEST_IMAGE"
 
 	VariantOriginal = "ORIGINAL"
 	VariantSmall    = "SMALL"
@@ -45,6 +46,12 @@ type ConfirmReviewImageResult struct {
 	BaseURL string `json:"base_url"`
 }
 
+// ConfirmJoinRequestImageResult exposes the uploaded join-request image URL
+// after token and object validation.
+type ConfirmJoinRequestImageResult struct {
+	BaseURL string `json:"base_url"`
+}
+
 // EventImageState is the event image persistence state used by the service.
 type EventImageState struct {
 	EventID        uuid.UUID
@@ -59,6 +66,14 @@ type EventReviewImageState struct {
 	Status                  string
 	PrivacyLevel            string
 	IsQualifyingParticipant bool
+}
+
+// EventJoinRequestImageState is the event state used to authorize join-request image uploads.
+type EventJoinRequestImageState struct {
+	EventID      uuid.UUID
+	HostID       uuid.UUID
+	Status       string
+	PrivacyLevel string
 }
 
 // ConfirmTokenPayload is signed into the confirm token and later verified.

--- a/backend/internal/application/imageupload/service_test.go
+++ b/backend/internal/application/imageupload/service_test.go
@@ -62,6 +62,8 @@ type fakeEventRepo struct {
 	getStateCallCount int
 	reviewState       *EventReviewImageState
 	reviewStateErr    error
+	joinState         *EventJoinRequestImageState
+	joinStateErr      error
 }
 
 func (r *fakeEventRepo) GetEventImageState(_ context.Context, _ uuid.UUID) (*EventImageState, error) {
@@ -103,6 +105,21 @@ func (r *fakeEventRepo) GetEventReviewImageState(_ context.Context, eventID, use
 		Status:                  string(domain.EventStatusCompleted),
 		PrivacyLevel:            string(domain.PrivacyPublic),
 		IsQualifyingParticipant: true,
+	}, nil
+}
+
+func (r *fakeEventRepo) GetEventJoinRequestImageState(_ context.Context, eventID uuid.UUID) (*EventJoinRequestImageState, error) {
+	if r.joinStateErr != nil {
+		return nil, r.joinStateErr
+	}
+	if r.joinState != nil {
+		return r.joinState, nil
+	}
+	return &EventJoinRequestImageState{
+		EventID:      eventID,
+		HostID:       uuid.New(),
+		Status:       string(domain.EventStatusActive),
+		PrivacyLevel: string(domain.PrivacyProtected),
 	}, nil
 }
 
@@ -326,5 +343,112 @@ func TestConfirmEventImageUploadRejectsInvalidToken(t *testing.T) {
 	}
 	if appErr.Code != domain.ErrorCodeImageUploadTokenInvalid {
 		t.Fatalf("expected error code %q, got %q", domain.ErrorCodeImageUploadTokenInvalid, appErr.Code)
+	}
+}
+
+func TestCreateEventJoinRequestImageUploadBuildsKeysAndToken(t *testing.T) {
+	// given
+	svc, _, _, storage, tokens := newServiceForTests()
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	eventID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	// when
+	result, err := svc.CreateEventJoinRequestImageUpload(context.Background(), userID, eventID)
+
+	// then
+	if err != nil {
+		t.Fatalf("CreateEventJoinRequestImageUpload() error = %v", err)
+	}
+	expectedPrefix := "events/" + eventID.String() + "/join-requests/" + userID.String() + "/"
+	if len(storage.presignedKeys) != 2 {
+		t.Fatalf("expected 2 presigned keys, got %d", len(storage.presignedKeys))
+	}
+	if tokens.payload.Resource != ResourceJoinRequestImage {
+		t.Fatalf("expected token resource %q, got %q", ResourceJoinRequestImage, tokens.payload.Resource)
+	}
+	if tokens.payload.EventID == nil || *tokens.payload.EventID != eventID {
+		t.Fatalf("expected token event %s, got %v", eventID, tokens.payload.EventID)
+	}
+	if tokens.payload.OwnerUserID != userID {
+		t.Fatalf("expected token owner %s, got %s", userID, tokens.payload.OwnerUserID)
+	}
+	if tokens.payload.OriginalKey[:len(expectedPrefix)] != expectedPrefix {
+		t.Fatalf("expected original key prefix %q, got %q", expectedPrefix, tokens.payload.OriginalKey)
+	}
+	if got, want := result.BaseURL, "https://sem-bucket.fra1.cdn.digitaloceanspaces.com/"+tokens.payload.OriginalKey; got != want {
+		t.Fatalf("expected base URL %q, got %q", want, got)
+	}
+}
+
+func TestConfirmEventJoinRequestImageUploadReturnsBaseURLWhenObjectsExist(t *testing.T) {
+	// given
+	svc, _, _, storage, tokens := newServiceForTests()
+	userID := uuid.New()
+	eventID := uuid.New()
+	_, err := svc.CreateEventJoinRequestImageUpload(context.Background(), userID, eventID)
+	if err != nil {
+		t.Fatalf("CreateEventJoinRequestImageUpload() error = %v", err)
+	}
+	storage.existingKeys[tokens.payload.OriginalKey] = true
+	storage.existingKeys[tokens.payload.SmallKey] = true
+
+	// when
+	result, err := svc.ConfirmEventJoinRequestImageUpload(context.Background(), userID, eventID, ConfirmUploadInput{ConfirmToken: "confirm-token"})
+
+	// then
+	if err != nil {
+		t.Fatalf("ConfirmEventJoinRequestImageUpload() error = %v", err)
+	}
+	if result.BaseURL != tokens.payload.BaseURL {
+		t.Fatalf("expected base URL %q, got %q", tokens.payload.BaseURL, result.BaseURL)
+	}
+}
+
+func TestConfirmEventJoinRequestImageUploadRejectsWrongOwner(t *testing.T) {
+	// given
+	svc, _, _, storage, tokens := newServiceForTests()
+	userID := uuid.New()
+	eventID := uuid.New()
+	_, err := svc.CreateEventJoinRequestImageUpload(context.Background(), userID, eventID)
+	if err != nil {
+		t.Fatalf("CreateEventJoinRequestImageUpload() error = %v", err)
+	}
+	storage.existingKeys[tokens.payload.OriginalKey] = true
+	storage.existingKeys[tokens.payload.SmallKey] = true
+
+	// when
+	_, err = svc.ConfirmEventJoinRequestImageUpload(context.Background(), uuid.New(), eventID, ConfirmUploadInput{ConfirmToken: "confirm-token"})
+
+	// then
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T", err)
+	}
+	if appErr.Code != domain.ErrorCodeImageUploadTokenInvalid {
+		t.Fatalf("expected error code %q, got %q", domain.ErrorCodeImageUploadTokenInvalid, appErr.Code)
+	}
+}
+
+func TestConfirmEventJoinRequestImageUploadRejectsIncompleteUpload(t *testing.T) {
+	// given
+	svc, _, _, storage, tokens := newServiceForTests()
+	userID := uuid.New()
+	eventID := uuid.New()
+	_, err := svc.CreateEventJoinRequestImageUpload(context.Background(), userID, eventID)
+	if err != nil {
+		t.Fatalf("CreateEventJoinRequestImageUpload() error = %v", err)
+	}
+	storage.existingKeys[tokens.payload.OriginalKey] = true
+
+	// when
+	_, err = svc.ConfirmEventJoinRequestImageUpload(context.Background(), userID, eventID, ConfirmUploadInput{ConfirmToken: "confirm-token"})
+
+	// then
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T", err)
+	}
+	if appErr.Code != domain.ErrorCodeImageUploadIncomplete {
+		t.Fatalf("expected error code %q, got %q", domain.ErrorCodeImageUploadIncomplete, appErr.Code)
 	}
 }

--- a/backend/internal/application/imageupload/usecase.go
+++ b/backend/internal/application/imageupload/usecase.go
@@ -14,4 +14,6 @@ type UseCase interface {
 	ConfirmEventImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) error
 	CreateEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error)
 	ConfirmEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) (*ConfirmReviewImageResult, error)
+	CreateEventJoinRequestImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error)
+	ConfirmEventJoinRequestImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) (*ConfirmJoinRequestImageResult, error)
 }

--- a/backend/internal/application/join_request/repository_dto.go
+++ b/backend/internal/application/join_request/repository_dto.go
@@ -12,11 +12,13 @@ type CreateJoinRequestParams struct {
 	UserID     uuid.UUID
 	HostUserID uuid.UUID
 	Message    *string
+	ImageURL   *string
 }
 
 // CreatePendingJoinRequestInput carries optional join-request details supplied by the caller.
 type CreatePendingJoinRequestInput struct {
-	Message *string
+	Message  *string
+	ImageURL *string
 }
 
 // ApproveJoinRequestParams carries the identifiers needed to approve a join request.

--- a/backend/internal/application/join_request/service.go
+++ b/backend/internal/application/join_request/service.go
@@ -61,6 +61,7 @@ func (s *Service) CreatePendingJoinRequest(
 			UserID:     userID,
 			HostUserID: hostUserID,
 			Message:    input.Message,
+			ImageURL:   input.ImageURL,
 		})
 		return err
 	})

--- a/backend/internal/application/join_request/service_test.go
+++ b/backend/internal/application/join_request/service_test.go
@@ -159,10 +159,12 @@ func TestCreatePendingJoinRequestDelegatesToRepo(t *testing.T) {
 	userID := uuid.New()
 	hostUserID := uuid.New()
 	message := "Please let me join."
+	imageURL := "https://cdn.example/join-request.jpg"
 
 	// when
 	result, err := service.CreatePendingJoinRequest(context.Background(), eventID, userID, hostUserID, CreatePendingJoinRequestInput{
-		Message: &message,
+		Message:  &message,
+		ImageURL: &imageURL,
 	})
 
 	// then
@@ -180,6 +182,9 @@ func TestCreatePendingJoinRequestDelegatesToRepo(t *testing.T) {
 	}
 	if repo.lastParams.Message == nil || *repo.lastParams.Message != message {
 		t.Fatalf("expected repo message %q, got %v", message, repo.lastParams.Message)
+	}
+	if repo.lastParams.ImageURL == nil || *repo.lastParams.ImageURL != imageURL {
+		t.Fatalf("expected repo image URL %q, got %v", imageURL, repo.lastParams.ImageURL)
 	}
 }
 

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -143,6 +143,9 @@ func New(ctx context.Context) (*Container, error) {
 	container.ProfileService = newProfileService(container)
 	container.FavoriteLocationService = newFavoriteLocationService(container)
 	container.ImageUploadService = newImageUploadService(container, spacesStorage)
+	if eventService, ok := container.EventService.(*event.Service); ok {
+		eventService.SetJoinRequestImageConfirmer(container.ImageUploadService)
+	}
 	if commentService, ok := container.CommentService.(*comment.Service); ok {
 		commentService.SetReviewImageConfirmer(container.ImageUploadService)
 	}

--- a/backend/internal/domain/join_request.go
+++ b/backend/internal/domain/join_request.go
@@ -38,6 +38,7 @@ type JoinRequest struct {
 	HostUserID      uuid.UUID
 	Status          JoinRequestStatus
 	Message         *string
+	ImageURL        *string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }

--- a/backend/migrations/000028_join_request_image_url.down.sql
+++ b/backend/migrations/000028_join_request_image_url.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE join_request
+    DROP COLUMN IF EXISTS image_url;

--- a/backend/migrations/000028_join_request_image_url.up.sql
+++ b/backend/migrations/000028_join_request_image_url.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE join_request
+    ADD COLUMN image_url TEXT;

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	postgresrepo "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/postgres"
 	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
 	invitationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/invitation"
+	joinrequestapp "github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
 	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
@@ -2009,6 +2011,51 @@ func TestRequestJoinSuccessPath(t *testing.T) {
 	}
 	if storedMessage == nil || *storedMessage != message {
 		t.Fatalf("expected stored message %q, got %v", message, storedMessage)
+	}
+}
+
+func TestRequestJoinImageURLIsVisibleToHostManagementFlows(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	requester := common.GivenUser(t, harness.AuthRepo)
+	event := common.GivenProtectedEvent(t, harness.Service, host.ID)
+	imageURL := "https://cdn.example/join-request.jpg"
+	repo := postgresrepo.NewJoinRequestRepository(common.RequirePool(t))
+
+	created, err := repo.CreateJoinRequest(context.Background(), joinrequestapp.CreateJoinRequestParams{
+		EventID:    event.ID,
+		UserID:     requester.ID,
+		HostUserID: host.ID,
+		ImageURL:   &imageURL,
+	})
+	if err != nil {
+		t.Fatalf("CreateJoinRequest() error = %v", err)
+	}
+
+	// when
+	hostRequests, err := harness.Service.ListEventPendingJoinRequests(context.Background(), host.ID, event.ID, eventapp.ListEventCollectionInput{})
+	if err != nil {
+		t.Fatalf("ListEventPendingJoinRequests() error = %v", err)
+	}
+
+	// then
+	var storedImageURL *string
+	err = common.RequirePool(t).QueryRow(
+		context.Background(),
+		`SELECT image_url FROM join_request WHERE id = $1`,
+		created.ID,
+	).Scan(&storedImageURL)
+	if err != nil {
+		t.Fatalf("select join_request image_url error = %v", err)
+	}
+	if storedImageURL == nil || *storedImageURL != imageURL {
+		t.Fatalf("expected stored image URL %q, got %v", imageURL, storedImageURL)
+	}
+	if len(hostRequests.Items) != 1 || hostRequests.Items[0].ImageURL == nil || *hostRequests.Items[0].ImageURL != imageURL {
+		t.Fatalf("expected pending list image URL %q, got %+v", imageURL, hostRequests.Items)
 	}
 }
 

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -932,6 +932,67 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
 
+  /events/{id}/join-request/image/upload-url:
+    post:
+      tags: [Events]
+      summary: Create upload URLs for a join-request image
+      description: |
+        Creates presigned upload instructions for the authenticated user's optional one image on a protected-event join request.
+        The caller must upload both `ORIGINAL` and `SMALL` JPEG variants, then pass the returned
+        `confirm_token` as `image_confirm_token` when calling `POST /events/{id}/join-request`.
+
+        Naming convention:
+        - original object key: `events/{event_id}/join-requests/{user_id}/{upload_id}`
+        - small object key: `events/{event_id}/join-requests/{user_id}/{upload_id}-small`
+      operationId: createEventJoinRequestImageUpload
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: UUID of the protected event the caller wants to join.
+      responses:
+        '200':
+          description: Upload instructions returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageUploadInitResponse'
+        '400':
+          description: Invalid event id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '403':
+          description: Caller is the event host.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Event is not PROTECTED or is no longer accepting participants.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
   /events/{id}/rating:
     put:
       tags: [Events]
@@ -1556,6 +1617,7 @@ paths:
         - A user can only submit one pending request per event; a second attempt returns `409`.
         - After the host rejects a request, the same user must wait **3 days** before requesting again.
         - When the cooldown expires, the backend reactivates the same `join_request` row as `PENDING`.
+        - When a reactivated request omits `image_confirm_token`, any previous join-request image is cleared.
         - If the user previously had an approved participation but left before `start_time`, the backend reactivates the same `join_request` row as `PENDING` so the host can approve them again.
         - If the user left at or after `start_time`, later request attempts return `409 already_participating`.
         - Calling this endpoint on a `PUBLIC` event returns `409 event_join_not_allowed`.
@@ -1581,6 +1643,10 @@ paths:
               with_message:
                 value:
                   message: I have attended similar events and can help with setup.
+              with_image:
+                value:
+                  message: I have attended similar events and can help with setup.
+                  image_confirm_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
       responses:
         '201':
           description: Join request created successfully.
@@ -1594,9 +1660,10 @@ paths:
                     join_request_id: b2c3d4e5-f6a7-8901-bcde-f01234567890
                     event_id: 7a2c8b1e-3d4f-5e6a-bcde-f90123456789
                     status: PENDING
+                    image_url: https://sem-bucket.fra1.cdn.digitaloceanspaces.com/events/7a2c8b1e-3d4f-5e6a-bcde-f90123456789/join-requests/11111111-1111-1111-1111-111111111111/upload-id
                     created_at: "2026-03-26T12:00:00+03:00"
         '400':
-          description: "Invalid event ID format, malformed JSON body, or the requester's profile is missing a field required by the event (`profile_incomplete`)."
+          description: "Invalid event ID format, malformed JSON body, invalid image confirm token (`image_upload_token_invalid`), or the requester's profile is missing a field required by the event (`profile_incomplete`)."
           content:
             application/json:
               schema:
@@ -1621,6 +1688,11 @@ paths:
                     error:
                       code: profile_incomplete
                       message: Your gender must be set on your profile to join this event.
+                invalid_image_token:
+                  value:
+                    error:
+                      code: image_upload_token_invalid
+                      message: The confirm token is invalid or expired.
         '401':
           description: Missing or invalid access token.
           content:
@@ -1658,7 +1730,8 @@ paths:
             requests (`event_join_not_allowed`), a rejection cooldown is still active
             (`join_request_cooldown_active`), the requester is below the event's minimum age
             (`age_requirement_not_met`), or the requester's gender does not match the event's
-            preferred gender (`gender_requirement_not_met`).
+            preferred gender (`gender_requirement_not_met`), or the image upload is incomplete
+            (`image_upload_incomplete`).
           content:
             application/json:
               schema:
@@ -1696,6 +1769,11 @@ paths:
                     error:
                       code: gender_requirement_not_met
                       message: This event is restricted to participants of a specific gender.
+                image_upload_incomplete:
+                  value:
+                    error:
+                      code: image_upload_incomplete
+                      message: The uploaded image files could not be found. Upload both variants before confirming.
         '500':
           description: Unexpected server error.
           content:
@@ -2822,6 +2900,11 @@ components:
             - type: "null"
         viewer_context:
           $ref: '#/components/schemas/EventDetailViewerContext'
+        host_context:
+          oneOf:
+            - $ref: '#/components/schemas/EventDetailHostContext'
+            - type: "null"
+          description: Host-only embedded management context when included by the backend. Pending join request items include optional `image_url`.
 
     EventHostContextSummaryResponse:
       type: object
@@ -3197,6 +3280,13 @@ components:
             - string
             - "null"
           example: I have attended similar events before.
+        image_url:
+          type:
+            - string
+            - "null"
+          format: uri
+          description: Optional image attached by the requester. Append `-small` to fetch the small variant.
+          example: https://sem-bucket.fra1.cdn.digitaloceanspaces.com/events/7a2c8b1e-3d4f-5e6a-bcde-f90123456789/join-requests/11111111-1111-1111-1111-111111111111/upload-id
         created_at:
           type: string
           format: date-time
@@ -3485,7 +3575,7 @@ components:
         base_url:
           type: string
           description: >
-            Versioned CDN base URL persisted in the database after confirm.
+            CDN base URL persisted after the corresponding confirm or create mutation.
             Append `-small` to fetch the small variant.
           example: "https://sem-bucket.fra1.cdn.digitaloceanspaces.com/events/5f81d6de-8cb4-4639-8f60-7c9f55456121/cover/v2-2c1a8d5a-77c5-4e6a-b5da-84af656ba6fa"
         version:
@@ -3626,6 +3716,11 @@ components:
             - "null"
           description: Optional note from the requester to the event host. Omit or send `null` when no message is needed.
           example: I have attended similar events and can help with setup.
+        image_confirm_token:
+          type:
+            - string
+            - "null"
+          description: Optional opaque token from `POST /events/{id}/join-request/image/upload-url`. Empty, omitted, or `null` means no image.
 
     RequestJoinResponse:
       type: object
@@ -3647,6 +3742,12 @@ components:
           enum: [PENDING]
           description: Join request status. Always `PENDING` until approved or rejected by the host.
           example: PENDING
+        image_url:
+          type:
+            - string
+            - "null"
+          format: uri
+          description: Confirmed join-request image URL, or `null` when no image was attached. Append `-small` to fetch the small variant.
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## 📋 Summary
Adds backend support for one optional image attachment on protected-event join request messages, using the existing direct-upload and confirm-token image flow while keeping current join-request endpoints backward compatible.

## 🔄 Changes
- Added nullable `image_url` persistence for `join_request`.
- Added join-request image upload initialization endpoint: `POST /events/{id}/join-request/image/upload-url`.
- Added optional `image_confirm_token` to `POST /events/{id}/join-request`.
- Validates uploaded image tokens and object existence before storing the confirmed CDN URL.
- Returns `image_url` in join-request create responses and host-visible pending join request payloads.
- Updated OpenAPI documentation for the new upload flow, request/response fields, and image upload errors.
- Added unit and integration coverage for upload creation, confirmation, persistence, parsing, and host-list exposure.

## 🧪 Testing
- `go test ./...`
- `./shipcheck.sh`

## 🔗 Related
Closes #429
