### PR TITLE
feat(backend): add event reporting system

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -1687,6 +1687,36 @@ func (r *EventRepository) GetEventReviewImageState(ctx context.Context, eventID,
 	return &state, nil
 }
 
+// GetEventReportImageState loads event state needed to authorize report image uploads.
+func (r *EventRepository) GetEventReportImageState(ctx context.Context, eventID uuid.UUID) (*imageuploadapp.EventReportImageState, error) {
+	var (
+		state  imageuploadapp.EventReportImageState
+		status string
+	)
+
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			e.id,
+			CASE
+				WHEN e.status = 'ACTIVE' AND e.end_time < NOW() THEN 'COMPLETED'
+				WHEN e.status = 'ACTIVE' AND e.start_time < NOW() THEN 'IN_PROGRESS'
+				WHEN e.status = 'IN_PROGRESS' AND e.end_time < NOW() THEN 'COMPLETED'
+				ELSE e.status
+			END AS status
+		FROM event e
+		WHERE e.id = $1
+	`, eventID).Scan(&state.EventID, &status)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get event report image state: %w", err)
+	}
+
+	state.Status = status
+	return &state, nil
+}
+
 // CancelEvent sets the event status to CANCELED and transitions active
 // participations to CANCELED atomically while preserving historical LEAVED rows.
 // Returns ErrEventNotCancelable if the event is not in ACTIVE status.

--- a/backend/internal/adapter/in/postgres/event_report_repo.go
+++ b/backend/internal/adapter/in/postgres/event_report_repo.go
@@ -1,0 +1,107 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	eventreportapp "github.com/bounswe/bounswe2026group11/backend/internal/application/eventreport"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// EventReportRepository is the Postgres-backed implementation of eventreport.Repository.
+type EventReportRepository struct {
+	pool *pgxpool.Pool
+	db   execer
+}
+
+// NewEventReportRepository returns a repository that executes queries against the given pool.
+func NewEventReportRepository(pool *pgxpool.Pool) *EventReportRepository {
+	return &EventReportRepository{
+		pool: pool,
+		db:   contextualRunner{fallback: pool},
+	}
+}
+
+var _ eventreportapp.Repository = (*EventReportRepository)(nil)
+
+// GetEventReportContext loads event state needed before creating a report.
+func (r *EventReportRepository) GetEventReportContext(ctx context.Context, eventID uuid.UUID) (*eventreportapp.EventReportContext, error) {
+	var (
+		record eventreportapp.EventReportContext
+		status string
+	)
+
+	err := r.db.QueryRow(ctx, `
+		SELECT
+			e.id,
+			e.host_id,
+			CASE
+				WHEN e.status = 'ACTIVE' AND e.end_time < NOW() THEN 'COMPLETED'
+				WHEN e.status = 'ACTIVE' AND e.start_time < NOW() THEN 'IN_PROGRESS'
+				WHEN e.status = 'IN_PROGRESS' AND e.end_time < NOW() THEN 'COMPLETED'
+				ELSE e.status
+			END AS status
+		FROM event e
+		WHERE e.id = $1
+	`, eventID).Scan(&record.EventID, &record.HostID, &status)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get event report context: %w", err)
+	}
+
+	record.Status = domain.EventStatus(status)
+	return &record, nil
+}
+
+// CreateEventReport inserts a user-submitted event report.
+func (r *EventReportRepository) CreateEventReport(ctx context.Context, params eventreportapp.CreateEventReportParams) (*eventreportapp.EventReportRecord, error) {
+	var (
+		record   eventreportapp.EventReportRecord
+		category string
+		status   string
+	)
+
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO event_report (
+			event_id,
+			reporter_user_id,
+			report_category,
+			message,
+			image_url,
+			status
+		) VALUES (
+			$1, $2, $3, $4, $5, $6
+		)
+		RETURNING id, event_id, reporter_user_id, report_category, message, image_url, status, created_at, updated_at
+	`,
+		params.EventID,
+		params.ReporterUserID,
+		string(params.Category),
+		params.Message,
+		params.ImageURL,
+		string(domain.EventReportStatusPending),
+	).Scan(
+		&record.ID,
+		&record.EventID,
+		&record.ReporterUserID,
+		&category,
+		&record.Message,
+		&record.ImageURL,
+		&status,
+		&record.CreatedAt,
+		&record.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create event report: %w", err)
+	}
+
+	record.Category = domain.EventReportCategory(category)
+	record.Status = domain.EventReportStatus(status)
+	return &record, nil
+}

--- a/backend/internal/adapter/out/httpapi/event_report_handler/dto.go
+++ b/backend/internal/adapter/out/httpapi/event_report_handler/dto.go
@@ -1,0 +1,7 @@
+package event_report_handler
+
+type createEventReportBody struct {
+	ReportCategory    string  `json:"report_category"`
+	Message           string  `json:"message"`
+	ImageConfirmToken *string `json:"image_confirm_token"`
+}

--- a/backend/internal/adapter/out/httpapi/event_report_handler/event_report_handler.go
+++ b/backend/internal/adapter/out/httpapi/event_report_handler/event_report_handler.go
@@ -1,0 +1,87 @@
+package event_report_handler
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
+	eventreportapp "github.com/bounswe/bounswe2026group11/backend/internal/application/eventreport"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// Handler groups HTTP handlers for event reports.
+type Handler struct {
+	service eventreportapp.UseCase
+}
+
+// NewHandler constructs an event-report handler.
+func NewHandler(service eventreportapp.UseCase) *Handler {
+	return &Handler{service: service}
+}
+
+// RegisterRoutes mounts event-report routes under /events.
+func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler) {
+	events := router.Group("/events", auth)
+	events.Post("/:id/reports", handler.CreateEventReport)
+}
+
+// CreateEventReport handles POST /events/:id/reports.
+func (h *Handler) CreateEventReport(c *fiber.Ctx) error {
+	eventID, err := parseEventID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	input, err := parseCreateEventReportBody(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, svcErr := h.service.CreateEventReport(c.UserContext(), claims.UserID, eventID, input)
+	if svcErr != nil {
+		return httpapi.WriteError(c, svcErr)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event report created",
+		httpapi.OperationAttr("event_report.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.String("report_category", result.Category),
+		slog.Bool("has_image_token", input.ImageConfirmToken != nil && strings.TrimSpace(*input.ImageConfirmToken) != ""),
+	)
+
+	return c.Status(fiber.StatusCreated).JSON(result)
+}
+
+func parseCreateEventReportBody(c *fiber.Ctx) (eventreportapp.CreateEventReportInput, error) {
+	var body createEventReportBody
+	if err := c.BodyParser(&body); err != nil {
+		return eventreportapp.CreateEventReportInput{}, domain.ValidationError(map[string]string{"body": "must be valid JSON"})
+	}
+
+	category, ok := domain.ParseEventReportCategory(body.ReportCategory)
+	if !ok {
+		return eventreportapp.CreateEventReportInput{}, domain.ValidationError(map[string]string{
+			"report_category": "must be one of: SAFETY, HARASSMENT, SPAM_OR_SCAM, INAPPROPRIATE_CONTENT, EVENT_NOT_AS_DESCRIBED, ILLEGAL_OR_DANGEROUS, OTHER",
+		})
+	}
+
+	return eventreportapp.CreateEventReportInput{
+		Category:          category,
+		Message:           body.Message,
+		ImageConfirmToken: body.ImageConfirmToken,
+	}, nil
+}
+
+func parseEventID(c *fiber.Ctx) (uuid.UUID, error) {
+	eventID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return uuid.Nil, domain.ValidationError(map[string]string{"id": "must be a valid UUID"})
+	}
+	return eventID, nil
+}

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
@@ -31,6 +31,7 @@ func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler) {
 	events.Post("/:id/image/upload-url", handler.CreateEventImageUpload)
 	events.Post("/:id/image/confirm", handler.ConfirmEventImageUpload)
 	events.Post("/:id/review-comments/image/upload-url", handler.CreateEventReviewImageUpload)
+	events.Post("/:id/reports/image/upload-url", handler.CreateEventReportImageUpload)
 }
 
 // CreateProfileAvatarUpload handles POST /me/avatar/upload-url.
@@ -150,6 +151,32 @@ func (h *Handler) CreateEventReviewImageUpload(c *fiber.Ctx) error {
 		c.UserContext(),
 		"event review image upload URL created",
 		httpapi.OperationAttr("image_upload.event_review.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		httpapi.EventIDAttr(eventID),
+		slog.String("base_url", result.BaseURL),
+		slog.Int("upload_count", len(result.Uploads)),
+	)
+
+	return c.JSON(result)
+}
+
+// CreateEventReportImageUpload handles POST /events/:id/reports/image/upload-url.
+func (h *Handler) CreateEventReportImageUpload(c *fiber.Ctx) error {
+	eventID, err := parseEventID(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.CreateEventReportImageUpload(c.UserContext(), claims.UserID, eventID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"event report image upload URL created",
+		httpapi.OperationAttr("image_upload.event_report.create"),
 		httpapi.UserIDAttr(claims.UserID),
 		httpapi.EventIDAttr(eventID),
 		slog.String("base_url", result.BaseURL),

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler_test.go
@@ -18,14 +18,18 @@ type stubImageUploadService struct {
 	createProfileResult *imageupload.CreateUploadResult
 	createEventResult   *imageupload.CreateUploadResult
 	createReviewResult  *imageupload.CreateUploadResult
+	createReportResult  *imageupload.CreateUploadResult
 	createProfileErr    error
 	createEventErr      error
 	createReviewErr     error
+	createReportErr     error
 	confirmProfileErr   error
 	confirmEventErr     error
 	confirmReviewErr    error
+	confirmReportErr    error
 	lastEventID         uuid.UUID
 	lastReviewEventID   uuid.UUID
+	lastReportEventID   uuid.UUID
 	lastConfirmInput    imageupload.ConfirmUploadInput
 	lastConfirmEventID  uuid.UUID
 }
@@ -80,6 +84,26 @@ func (s *stubImageUploadService) ConfirmEventReviewImageUpload(_ context.Context
 		return nil, s.confirmReviewErr
 	}
 	return &imageupload.ConfirmReviewImageResult{BaseURL: "https://cdn.example/review.jpg"}, nil
+}
+
+func (s *stubImageUploadService) CreateEventReportImageUpload(_ context.Context, _ uuid.UUID, eventID uuid.UUID) (*imageupload.CreateUploadResult, error) {
+	s.lastReportEventID = eventID
+	if s.createReportErr != nil {
+		return nil, s.createReportErr
+	}
+	if s.createReportResult != nil {
+		return s.createReportResult, nil
+	}
+	return defaultUploadResult(), nil
+}
+
+func (s *stubImageUploadService) ConfirmEventReportImageUpload(_ context.Context, _ uuid.UUID, eventID uuid.UUID, input imageupload.ConfirmUploadInput) (*imageupload.ConfirmReportImageResult, error) {
+	s.lastConfirmEventID = eventID
+	s.lastConfirmInput = input
+	if s.confirmReportErr != nil {
+		return nil, s.confirmReportErr
+	}
+	return &imageupload.ConfirmReportImageResult{BaseURL: "https://cdn.example/report.jpg"}, nil
 }
 
 type fakeVerifier struct {
@@ -287,5 +311,51 @@ func TestConfirmEventImageUploadParsesRequest(t *testing.T) {
 	}
 	if svc.lastConfirmInput.ConfirmToken != "confirm-token" {
 		t.Fatalf("expected confirm token to be parsed, got %+v", svc.lastConfirmInput)
+	}
+}
+
+func TestCreateEventReportImageUploadReturnsSignedInstructions(t *testing.T) {
+	svc := &stubImageUploadService{}
+	app := newTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodPost, "/events/"+eventID.String()+"/reports/image/upload-url", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.lastReportEventID != eventID {
+		t.Fatalf("expected report event id %s, got %s", eventID, svc.lastReportEventID)
+	}
+}
+
+func TestCreateEventReportImageUploadConflictReturns409(t *testing.T) {
+	svc := &stubImageUploadService{
+		createReportErr: domain.ConflictError(
+			domain.ErrorCodeEventReportImageNotAllowed,
+			"Report images are allowed only while an event is in progress or completed.",
+		),
+	}
+	app := newTestApp(svc, authedVerifier())
+	eventID := uuid.New()
+
+	req := httptest.NewRequest(fiber.MethodPost, "/events/"+eventID.String()+"/reports/image/upload-url", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("expected status %d, got %d", fiber.StatusConflict, resp.StatusCode)
 	}
 }

--- a/backend/internal/application/eventreport/helpers.go
+++ b/backend/internal/application/eventreport/helpers.go
@@ -1,0 +1,34 @@
+package eventreport
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+)
+
+func normalizeMessage(message string) string {
+	return strings.TrimSpace(message)
+}
+
+func validateMessage(message string) map[string]string {
+	errs := make(map[string]string)
+	length := utf8.RuneCountInString(message)
+	if length < domain.EventReportMessageMinLength || length > domain.EventReportMessageMaxLength {
+		errs["message"] = "message must be between 1 and 1000 characters"
+	}
+	return errs
+}
+
+func toEventReportResult(record *EventReportRecord) *EventReportResult {
+	return &EventReportResult{
+		ID:             record.ID.String(),
+		EventID:        record.EventID.String(),
+		ReporterUserID: record.ReporterUserID.String(),
+		Category:       string(record.Category),
+		Message:        record.Message,
+		ImageURL:       record.ImageURL,
+		Status:         string(record.Status),
+		CreatedAt:      record.CreatedAt,
+	}
+}

--- a/backend/internal/application/eventreport/repository.go
+++ b/backend/internal/application/eventreport/repository.go
@@ -1,0 +1,13 @@
+package eventreport
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Repository is the application-layer persistence port for event reports.
+type Repository interface {
+	GetEventReportContext(ctx context.Context, eventID uuid.UUID) (*EventReportContext, error)
+	CreateEventReport(ctx context.Context, params CreateEventReportParams) (*EventReportRecord, error)
+}

--- a/backend/internal/application/eventreport/service.go
+++ b/backend/internal/application/eventreport/service.go
@@ -1,0 +1,78 @@
+package eventreport
+
+import (
+	"context"
+	"errors"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// Service owns event-report application behavior.
+type Service struct {
+	repo           Repository
+	imageConfirmer ReportImageConfirmer
+}
+
+var _ UseCase = (*Service)(nil)
+
+// NewService constructs an event-report service backed by its repository.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// SetReportImageConfirmer wires in the image-upload service.
+func (s *Service) SetReportImageConfirmer(confirmer ReportImageConfirmer) {
+	s.imageConfirmer = confirmer
+}
+
+// CreateEventReport creates a moderation report for an existing event.
+func (s *Service) CreateEventReport(ctx context.Context, userID, eventID uuid.UUID, input CreateEventReportInput) (*EventReportResult, error) {
+	input.Message = normalizeMessage(input.Message)
+	if errs := validateMessage(input.Message); len(errs) > 0 {
+		return nil, domain.ValidationError(errs)
+	}
+
+	reportContext, err := s.repo.GetEventReportContext(ctx, eventID)
+	if err != nil {
+		return nil, s.mapEventLookupError(err)
+	}
+
+	var imageURL *string
+	if input.ImageConfirmToken != nil && *input.ImageConfirmToken != "" {
+		if reportContext.Status != domain.EventStatusInProgress && reportContext.Status != domain.EventStatusCompleted {
+			return nil, domain.ConflictError(domain.ErrorCodeEventReportImageNotAllowed, "Report images are allowed only while an event is in progress or completed.")
+		}
+		if s.imageConfirmer == nil {
+			return nil, domain.ForbiddenError(domain.ErrorCodeEventReportImageNotAllowed, "Report image uploads are not available.")
+		}
+		confirmed, err := s.imageConfirmer.ConfirmEventReportImageUpload(ctx, userID, eventID, imageupload.ConfirmUploadInput{
+			ConfirmToken: *input.ImageConfirmToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		imageURL = &confirmed.BaseURL
+	}
+
+	created, err := s.repo.CreateEventReport(ctx, CreateEventReportParams{
+		EventID:        eventID,
+		ReporterUserID: userID,
+		Category:       input.Category,
+		Message:        input.Message,
+		ImageURL:       imageURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toEventReportResult(created), nil
+}
+
+func (s *Service) mapEventLookupError(err error) error {
+	if errors.Is(err, domain.ErrNotFound) {
+		return domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+	}
+	return err
+}

--- a/backend/internal/application/eventreport/service_dto.go
+++ b/backend/internal/application/eventreport/service_dto.go
@@ -1,0 +1,63 @@
+package eventreport
+
+import (
+	"context"
+	"time"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+// ReportImageConfirmer verifies an uploaded report image and returns its public base URL.
+type ReportImageConfirmer interface {
+	ConfirmEventReportImageUpload(ctx context.Context, userID, eventID uuid.UUID, input imageupload.ConfirmUploadInput) (*imageupload.ConfirmReportImageResult, error)
+}
+
+// CreateEventReportInput is the write payload for reporting an event.
+type CreateEventReportInput struct {
+	Category          domain.EventReportCategory
+	Message           string
+	ImageConfirmToken *string
+}
+
+// EventReportContext contains event state needed to authorize report creation.
+type EventReportContext struct {
+	EventID uuid.UUID
+	HostID  uuid.UUID
+	Status  domain.EventStatus
+}
+
+// CreateEventReportParams carries data for inserting an event report.
+type CreateEventReportParams struct {
+	EventID        uuid.UUID
+	ReporterUserID uuid.UUID
+	Category       domain.EventReportCategory
+	Message        string
+	ImageURL       *string
+}
+
+// EventReportRecord is the persistence-layer report projection.
+type EventReportRecord struct {
+	ID             uuid.UUID
+	EventID        uuid.UUID
+	ReporterUserID uuid.UUID
+	Category       domain.EventReportCategory
+	Message        string
+	ImageURL       *string
+	Status         domain.EventReportStatus
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// EventReportResult is returned after a report is created.
+type EventReportResult struct {
+	ID             string    `json:"id"`
+	EventID        string    `json:"event_id"`
+	ReporterUserID string    `json:"reporter_user_id"`
+	Category       string    `json:"report_category"`
+	Message        string    `json:"message"`
+	ImageURL       *string   `json:"image_url"`
+	Status         string    `json:"status"`
+	CreatedAt      time.Time `json:"created_at"`
+}

--- a/backend/internal/application/eventreport/service_test.go
+++ b/backend/internal/application/eventreport/service_test.go
@@ -1,0 +1,135 @@
+package eventreport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+type fakeEventReportRepo struct {
+	reportContext *EventReportContext
+	reportRecord  *EventReportRecord
+	lastCreate    CreateEventReportParams
+}
+
+func (r *fakeEventReportRepo) GetEventReportContext(_ context.Context, eventID uuid.UUID) (*EventReportContext, error) {
+	if r.reportContext == nil {
+		return nil, domain.ErrNotFound
+	}
+	ctx := *r.reportContext
+	ctx.EventID = eventID
+	return &ctx, nil
+}
+
+func (r *fakeEventReportRepo) CreateEventReport(_ context.Context, params CreateEventReportParams) (*EventReportRecord, error) {
+	r.lastCreate = params
+	if r.reportRecord != nil {
+		return r.reportRecord, nil
+	}
+	return &EventReportRecord{
+		ID:             uuid.New(),
+		EventID:        params.EventID,
+		ReporterUserID: params.ReporterUserID,
+		Category:       params.Category,
+		Message:        params.Message,
+		ImageURL:       params.ImageURL,
+		Status:         domain.EventReportStatusPending,
+	}, nil
+}
+
+type fakeReportImageConfirmer struct {
+	baseURL string
+}
+
+func (f fakeReportImageConfirmer) ConfirmEventReportImageUpload(context.Context, uuid.UUID, uuid.UUID, imageupload.ConfirmUploadInput) (*imageupload.ConfirmReportImageResult, error) {
+	return &imageupload.ConfirmReportImageResult{BaseURL: f.baseURL}, nil
+}
+
+func TestCreateEventReportStoresNormalizedReport(t *testing.T) {
+	eventID := uuid.New()
+	userID := uuid.New()
+	repo := &fakeEventReportRepo{reportContext: baseReportContext(domain.EventStatusActive)}
+	service := NewService(repo)
+
+	result, err := service.CreateEventReport(context.Background(), userID, eventID, CreateEventReportInput{
+		Category: domain.EventReportCategorySpamOrScam,
+		Message:  "  suspicious invite link  ",
+	})
+
+	if err != nil {
+		t.Fatalf("CreateEventReport() error = %v", err)
+	}
+	if result.Message != "suspicious invite link" {
+		t.Fatalf("expected trimmed message, got %q", result.Message)
+	}
+	if repo.lastCreate.Category != domain.EventReportCategorySpamOrScam {
+		t.Fatalf("expected category %q, got %q", domain.EventReportCategorySpamOrScam, repo.lastCreate.Category)
+	}
+}
+
+func TestCreateEventReportRequiresMessage(t *testing.T) {
+	service := NewService(&fakeEventReportRepo{reportContext: baseReportContext(domain.EventStatusActive)})
+
+	_, err := service.CreateEventReport(context.Background(), uuid.New(), uuid.New(), CreateEventReportInput{
+		Category: domain.EventReportCategorySafety,
+		Message:  "  ",
+	})
+
+	requireReportAppError(t, err, domain.ErrorCodeValidation)
+}
+
+func TestCreateEventReportRejectsImageBeforeEventStarts(t *testing.T) {
+	token := "token"
+	service := NewService(&fakeEventReportRepo{reportContext: baseReportContext(domain.EventStatusActive)})
+	service.SetReportImageConfirmer(fakeReportImageConfirmer{baseURL: "https://cdn.example/report.jpg"})
+
+	_, err := service.CreateEventReport(context.Background(), uuid.New(), uuid.New(), CreateEventReportInput{
+		Category:          domain.EventReportCategorySafety,
+		Message:           "needs an image",
+		ImageConfirmToken: &token,
+	})
+
+	requireReportAppError(t, err, domain.ErrorCodeEventReportImageNotAllowed)
+}
+
+func TestCreateEventReportStoresConfirmedImageForInProgressEvent(t *testing.T) {
+	token := "token"
+	repo := &fakeEventReportRepo{reportContext: baseReportContext(domain.EventStatusInProgress)}
+	service := NewService(repo)
+	service.SetReportImageConfirmer(fakeReportImageConfirmer{baseURL: "https://cdn.example/report.jpg"})
+
+	_, err := service.CreateEventReport(context.Background(), uuid.New(), uuid.New(), CreateEventReportInput{
+		Category:          domain.EventReportCategoryInappropriateContent,
+		Message:           "inappropriate incident happened",
+		ImageConfirmToken: &token,
+	})
+
+	if err != nil {
+		t.Fatalf("CreateEventReport() error = %v", err)
+	}
+	if repo.lastCreate.ImageURL == nil || *repo.lastCreate.ImageURL != "https://cdn.example/report.jpg" {
+		t.Fatalf("expected confirmed image URL to be stored, got %#v", repo.lastCreate.ImageURL)
+	}
+}
+
+func baseReportContext(status domain.EventStatus) *EventReportContext {
+	return &EventReportContext{
+		EventID: uuid.New(),
+		HostID:  uuid.New(),
+		Status:  status,
+	}
+}
+
+func requireReportAppError(t *testing.T, err error, code string) {
+	t.Helper()
+	appErr, ok := err.(*domain.AppError)
+	if !ok {
+		t.Fatalf("expected AppError %q, got %T: %v", code, err, err)
+	}
+	if appErr.Code != code {
+		t.Fatalf("expected error code %q, got %q", code, appErr.Code)
+	}
+}

--- a/backend/internal/application/eventreport/usecase.go
+++ b/backend/internal/application/eventreport/usecase.go
@@ -1,0 +1,12 @@
+package eventreport
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// UseCase is the inbound application port for event reports.
+type UseCase interface {
+	CreateEventReport(ctx context.Context, userID, eventID uuid.UUID, input CreateEventReportInput) (*EventReportResult, error)
+}

--- a/backend/internal/application/imageupload/repository.go
+++ b/backend/internal/application/imageupload/repository.go
@@ -18,6 +18,7 @@ type EventRepository interface {
 	GetEventImageState(ctx context.Context, eventID uuid.UUID) (*EventImageState, error)
 	SetEventImageIfVersion(ctx context.Context, eventID uuid.UUID, expectedVersion, nextVersion int, baseURL string, updatedAt time.Time) (bool, error)
 	GetEventReviewImageState(ctx context.Context, eventID, userID uuid.UUID) (*EventReviewImageState, error)
+	GetEventReportImageState(ctx context.Context, eventID uuid.UUID) (*EventReportImageState, error)
 }
 
 // Storage presigns uploads and verifies uploaded objects exist.

--- a/backend/internal/application/imageupload/service.go
+++ b/backend/internal/application/imageupload/service.go
@@ -231,6 +231,46 @@ func (s *Service) ConfirmEventReviewImageUpload(ctx context.Context, userID, eve
 	return &ConfirmReviewImageResult{BaseURL: payload.BaseURL}, nil
 }
 
+// CreateEventReportImageUpload prepares a direct-upload flow for one event report image.
+func (s *Service) CreateEventReportImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error) {
+	state, err := s.eventRepo.GetEventReportImageState(ctx, eventID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+		return nil, err
+	}
+	if err := validateReportImageState(state); err != nil {
+		return nil, err
+	}
+
+	uploadID := uuid.NewString()
+	return s.createUpload(ctx, uploadDescriptor{
+		Resource:     ResourceEventReportImage,
+		OwnerUserID:  userID,
+		NextVersion:  1,
+		OriginalKey:  fmt.Sprintf("events/%s/reports/%s/%s", eventID, userID, uploadID),
+		UploadID:     uploadID,
+		CurrentEvent: &eventID,
+	})
+}
+
+// ConfirmEventReportImageUpload verifies a report image upload and returns the
+// public image URL. Persistence happens when the event report is created.
+func (s *Service) ConfirmEventReportImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) (*ConfirmReportImageResult, error) {
+	payload, err := s.verifyConfirmToken(input, ResourceEventReportImage)
+	if err != nil {
+		return nil, err
+	}
+	if payload.OwnerUserID != userID || payload.EventID == nil || *payload.EventID != eventID {
+		return nil, invalidConfirmTokenError()
+	}
+	if err := s.ensureUploadedObjectsExist(ctx, payload); err != nil {
+		return nil, err
+	}
+	return &ConfirmReportImageResult{BaseURL: payload.BaseURL}, nil
+}
+
 type uploadDescriptor struct {
 	Resource     string
 	OwnerUserID  uuid.UUID
@@ -255,6 +295,13 @@ func validateReviewImageState(state *EventReviewImageState, userID uuid.UUID) er
 	}
 	if !state.IsQualifyingParticipant {
 		return domain.ForbiddenError(domain.ErrorCodeReviewImageNotAllowed, "Only participants can upload review images.")
+	}
+	return nil
+}
+
+func validateReportImageState(state *EventReportImageState) error {
+	if state.Status != string(domain.EventStatusInProgress) && state.Status != string(domain.EventStatusCompleted) {
+		return domain.ConflictError(domain.ErrorCodeEventReportImageNotAllowed, "Report images are allowed only while an event is in progress or completed.")
 	}
 	return nil
 }

--- a/backend/internal/application/imageupload/service_dto.go
+++ b/backend/internal/application/imageupload/service_dto.go
@@ -11,6 +11,7 @@ const (
 	ResourceProfileAvatar    = "PROFILE_AVATAR"
 	ResourceEventImage       = "EVENT_IMAGE"
 	ResourceEventReviewImage = "EVENT_REVIEW_IMAGE"
+	ResourceEventReportImage = "EVENT_REPORT_IMAGE"
 
 	VariantOriginal = "ORIGINAL"
 	VariantSmall    = "SMALL"
@@ -45,6 +46,12 @@ type ConfirmReviewImageResult struct {
 	BaseURL string `json:"base_url"`
 }
 
+// ConfirmReportImageResult exposes the uploaded report image URL after token
+// and object validation.
+type ConfirmReportImageResult struct {
+	BaseURL string `json:"base_url"`
+}
+
 // EventImageState is the event image persistence state used by the service.
 type EventImageState struct {
 	EventID        uuid.UUID
@@ -59,6 +66,12 @@ type EventReviewImageState struct {
 	Status                  string
 	PrivacyLevel            string
 	IsQualifyingParticipant bool
+}
+
+// EventReportImageState is the event state used to authorize report image uploads.
+type EventReportImageState struct {
+	EventID uuid.UUID
+	Status  string
 }
 
 // ConfirmTokenPayload is signed into the confirm token and later verified.

--- a/backend/internal/application/imageupload/service_test.go
+++ b/backend/internal/application/imageupload/service_test.go
@@ -62,6 +62,8 @@ type fakeEventRepo struct {
 	getStateCallCount int
 	reviewState       *EventReviewImageState
 	reviewStateErr    error
+	reportState       *EventReportImageState
+	reportStateErr    error
 }
 
 func (r *fakeEventRepo) GetEventImageState(_ context.Context, _ uuid.UUID) (*EventImageState, error) {
@@ -103,6 +105,19 @@ func (r *fakeEventRepo) GetEventReviewImageState(_ context.Context, eventID, use
 		Status:                  string(domain.EventStatusCompleted),
 		PrivacyLevel:            string(domain.PrivacyPublic),
 		IsQualifyingParticipant: true,
+	}, nil
+}
+
+func (r *fakeEventRepo) GetEventReportImageState(_ context.Context, eventID uuid.UUID) (*EventReportImageState, error) {
+	if r.reportStateErr != nil {
+		return nil, r.reportStateErr
+	}
+	if r.reportState != nil {
+		return r.reportState, nil
+	}
+	return &EventReportImageState{
+		EventID: eventID,
+		Status:  string(domain.EventStatusInProgress),
 	}, nil
 }
 

--- a/backend/internal/application/imageupload/usecase.go
+++ b/backend/internal/application/imageupload/usecase.go
@@ -14,4 +14,6 @@ type UseCase interface {
 	ConfirmEventImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) error
 	CreateEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error)
 	ConfirmEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) (*ConfirmReviewImageResult, error)
+	CreateEventReportImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error)
+	ConfirmEventReportImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) (*ConfirmReportImageResult, error)
 }

--- a/backend/internal/bootstrap/container.go
+++ b/backend/internal/bootstrap/container.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/comment"
 	emailapp "github.com/bounswe/bounswe2026group11/backend/internal/application/email"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/event"
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/eventreport"
 	favoritelocation "github.com/bounswe/bounswe2026group11/backend/internal/application/favorite_location"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/invitation"
@@ -56,6 +57,7 @@ type Container struct {
 	ticketRepo              *postgres.TicketRepository
 	ratingRepo              *postgres.RatingRepository
 	commentRepo             *postgres.CommentRepository
+	eventReportRepo         *postgres.EventReportRepository
 	notificationRepo        *postgres.NotificationRepository
 	categoryRepo            *postgres.CategoryRepository
 	profileRepo             *postgres.ProfileRepository
@@ -70,6 +72,7 @@ type Container struct {
 	TicketService           ticket.UseCase
 	RatingService           rating.UseCase
 	CommentService          comment.UseCase
+	EventReportService      eventreport.UseCase
 	NotificationService     notification.UseCase
 	NotificationBroker      *notification.Broker
 	CategoryService         category.UseCase
@@ -117,6 +120,7 @@ func New(ctx context.Context) (*Container, error) {
 	container.ticketRepo = postgres.NewTicketRepository(container.DB)
 	container.ratingRepo = postgres.NewRatingRepository(container.DB)
 	container.commentRepo = postgres.NewCommentRepository(container.DB)
+	container.eventReportRepo = postgres.NewEventReportRepository(container.DB)
 	container.notificationRepo = postgres.NewNotificationRepository(container.DB)
 	container.NotificationBroker = notification.NewBroker()
 	container.categoryRepo = postgres.NewCategoryRepository(container.DB)
@@ -136,6 +140,7 @@ func New(ctx context.Context) (*Container, error) {
 	container.JoinRequestService = newJoinRequestService(container)
 	container.RatingService = newRatingService(container)
 	container.CommentService = newCommentService(container)
+	container.EventReportService = newEventReportService(container)
 	container.AuthService = newAuthService(container)
 	container.AdminService = newAdminService(container)
 	container.EventService = newEventService(container)
@@ -145,6 +150,9 @@ func New(ctx context.Context) (*Container, error) {
 	container.ImageUploadService = newImageUploadService(container, spacesStorage)
 	if commentService, ok := container.CommentService.(*comment.Service); ok {
 		commentService.SetReviewImageConfirmer(container.ImageUploadService)
+	}
+	if eventReportService, ok := container.EventReportService.(*eventreport.Service); ok {
+		eventReportService.SetReportImageConfirmer(container.ImageUploadService)
 	}
 	return container, nil
 }
@@ -365,6 +373,11 @@ func newCommentService(c *Container) comment.UseCase {
 	service := comment.NewService(c.commentRepo, c.UnitOfWork)
 	service.SetReviewScoreUpdater(c.RatingService)
 	return service
+}
+
+// newEventReportService wires the event-report use-case service with its driven adapter.
+func newEventReportService(c *Container) eventreport.UseCase {
+	return eventreport.NewService(c.eventReportRepo)
 }
 
 // newAuthService wires the auth use-case service with its driven adapters.

--- a/backend/internal/domain/event_report.go
+++ b/backend/internal/domain/event_report.go
@@ -1,0 +1,68 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	EventReportMessageMinLength = 1
+	EventReportMessageMaxLength = 1000
+)
+
+const (
+	ErrorCodeEventReportNotAllowed      = "event_report_not_allowed"
+	ErrorCodeEventReportImageNotAllowed = "event_report_image_not_allowed"
+)
+
+// EventReportCategory defines the reason selected by a user when reporting an event.
+type EventReportCategory string
+
+const (
+	EventReportCategorySafety               EventReportCategory = "SAFETY"
+	EventReportCategoryHarassment           EventReportCategory = "HARASSMENT"
+	EventReportCategorySpamOrScam           EventReportCategory = "SPAM_OR_SCAM"
+	EventReportCategoryInappropriateContent EventReportCategory = "INAPPROPRIATE_CONTENT"
+	EventReportCategoryEventNotAsDescribed  EventReportCategory = "EVENT_NOT_AS_DESCRIBED"
+	EventReportCategoryIllegalOrDangerous   EventReportCategory = "ILLEGAL_OR_DANGEROUS"
+	EventReportCategoryOther                EventReportCategory = "OTHER"
+)
+
+// EventReportStatus defines the moderation state for a submitted report.
+type EventReportStatus string
+
+const (
+	EventReportStatusPending   EventReportStatus = "PENDING"
+	EventReportStatusReviewed  EventReportStatus = "REVIEWED"
+	EventReportStatusDismissed EventReportStatus = "DISMISSED"
+)
+
+var eventReportCategories = map[string]EventReportCategory{
+	string(EventReportCategorySafety):               EventReportCategorySafety,
+	string(EventReportCategoryHarassment):           EventReportCategoryHarassment,
+	string(EventReportCategorySpamOrScam):           EventReportCategorySpamOrScam,
+	string(EventReportCategoryInappropriateContent): EventReportCategoryInappropriateContent,
+	string(EventReportCategoryEventNotAsDescribed):  EventReportCategoryEventNotAsDescribed,
+	string(EventReportCategoryIllegalOrDangerous):   EventReportCategoryIllegalOrDangerous,
+	string(EventReportCategoryOther):                EventReportCategoryOther,
+}
+
+// ParseEventReportCategory converts a wire string to an EventReportCategory.
+func ParseEventReportCategory(value string) (EventReportCategory, bool) {
+	category, ok := eventReportCategories[value]
+	return category, ok
+}
+
+// EventReport stores a user-submitted report for an event.
+type EventReport struct {
+	ID             uuid.UUID
+	EventID        uuid.UUID
+	ReporterUserID uuid.UUID
+	Category       EventReportCategory
+	Message        string
+	ImageURL       *string
+	Status         EventReportStatus
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/category_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/comment_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/event_handler"
+	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/event_report_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/favorite_location_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/image_upload_handler"
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi/notification_handler"
@@ -59,6 +60,10 @@ func NewHTTP(container *bootstrap.Container) *fiber.App {
 	// Comment routes
 	commentHandler := comment_handler.NewHandler(container.CommentService)
 	comment_handler.RegisterRoutes(app, commentHandler, auth, optionalAuth)
+
+	// Event report routes
+	eventReportHandler := event_report_handler.NewHandler(container.EventReportService)
+	event_report_handler.RegisterRoutes(app, eventReportHandler, auth)
 
 	// Rating routes
 	ratingHandler := rating_handler.NewRatingHandler(container.RatingService)

--- a/backend/migrations/000028_event_reports.down.sql
+++ b/backend/migrations/000028_event_reports.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS event_report;

--- a/backend/migrations/000028_event_reports.up.sql
+++ b/backend/migrations/000028_event_reports.up.sql
@@ -1,0 +1,40 @@
+CREATE TABLE event_report
+(
+    id               UUID PRIMARY KEY                  DEFAULT gen_random_uuid(),
+    event_id         UUID                     NOT NULL,
+    reporter_user_id UUID                     NOT NULL,
+    report_category  TEXT                     NOT NULL,
+    message          TEXT                     NOT NULL,
+    image_url        TEXT,
+    status           TEXT                     NOT NULL DEFAULT 'PENDING',
+
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_event_report_event FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE,
+    CONSTRAINT fk_event_report_reporter FOREIGN KEY (reporter_user_id) REFERENCES app_user (id) ON DELETE CASCADE,
+    CONSTRAINT chk_event_report_category CHECK (
+        report_category IN (
+            'SAFETY',
+            'HARASSMENT',
+            'SPAM_OR_SCAM',
+            'INAPPROPRIATE_CONTENT',
+            'EVENT_NOT_AS_DESCRIBED',
+            'ILLEGAL_OR_DANGEROUS',
+            'OTHER'
+        )
+    ),
+    CONSTRAINT chk_event_report_status CHECK (status IN ('PENDING', 'REVIEWED', 'DISMISSED')),
+    CONSTRAINT chk_event_report_message_length CHECK (
+        length(btrim(message)) BETWEEN 1 AND 1000
+    )
+);
+
+CREATE INDEX idx_event_report_event_created
+    ON event_report (event_id, created_at DESC);
+
+CREATE INDEX idx_event_report_reporter_created
+    ON event_report (reporter_user_id, created_at DESC);
+
+CREATE INDEX idx_event_report_status_created
+    ON event_report (status, created_at DESC);

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -932,6 +932,130 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
 
+  /events/{id}/reports:
+    post:
+      tags: [Events]
+      summary: Report an event
+      description: |
+        Creates a moderation report for the event from the authenticated user.
+
+        Client flow:
+        - Always require the user to choose `report_category` and enter a non-blank `message`.
+        - To attach an image, first call `POST /events/{id}/reports/image/upload-url`, upload both JPEG variants,
+          then send the returned `confirm_token` as `image_confirm_token`.
+        - Report images are accepted only when the event's computed status is `IN_PROGRESS` or `COMPLETED`.
+        - Reports are stored with status `PENDING` for future moderation workflows.
+      operationId: createEventReport
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEventReportRequest'
+            examples:
+              safety:
+                value:
+                  report_category: SAFETY
+                  message: The event location felt unsafe and needs moderation review.
+              with_image:
+                value:
+                  report_category: INAPPROPRIATE_CONTENT
+                  message: There was inappropriate content shown during the event.
+                  image_confirm_token: eyJhbGciOi...
+      responses:
+        '201':
+          description: Report created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventReportResponse'
+        '400':
+          description: Invalid event id, invalid category, blank message, or invalid image token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: An image token was supplied for an event that is not in progress or completed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /events/{id}/reports/image/upload-url:
+    post:
+      tags: [Events]
+      summary: Create upload URLs for a report image
+      description: |
+        Creates presigned upload instructions for an optional event-report image.
+        The authenticated caller must upload both `ORIGINAL` and `SMALL` JPEG variants,
+        then pass the returned `confirm_token` as `image_confirm_token` when creating the report.
+
+        This endpoint returns `409 event_report_image_not_allowed` unless the event's computed status
+        is `IN_PROGRESS` or `COMPLETED`.
+      operationId: createEventReportImageUpload
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Upload instructions returned successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageUploadInitResponse'
+        '400':
+          description: Invalid event id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '401':
+          description: Missing or invalid access token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '404':
+          description: Event does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Report images are not available for this event state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
   /events/{id}/rating:
     put:
       tags: [Events]
@@ -3391,6 +3515,83 @@ components:
             - string
             - "null"
           description: Optional confirm token returned by the review image upload flow.
+
+    CreateEventReportRequest:
+      type: object
+      additionalProperties: false
+      required: [report_category, message]
+      properties:
+        report_category:
+          type: string
+          enum:
+            - SAFETY
+            - HARASSMENT
+            - SPAM_OR_SCAM
+            - INAPPROPRIATE_CONTENT
+            - EVENT_NOT_AS_DESCRIBED
+            - ILLEGAL_OR_DANGEROUS
+            - OTHER
+          description: User-selected reason for reporting the event.
+        message:
+          type: string
+          minLength: 1
+          maxLength: 1000
+          description: Required free-form report details. Blank-after-trim strings are rejected.
+        image_confirm_token:
+          type:
+            - string
+            - "null"
+          description: Optional confirm token returned by the report image upload flow.
+
+    EventReportResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - event_id
+        - reporter_user_id
+        - report_category
+        - message
+        - image_url
+        - status
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        event_id:
+          type: string
+          format: uuid
+        reporter_user_id:
+          type: string
+          format: uuid
+        report_category:
+          type: string
+          enum:
+            - SAFETY
+            - HARASSMENT
+            - SPAM_OR_SCAM
+            - INAPPROPRIATE_CONTENT
+            - EVENT_NOT_AS_DESCRIBED
+            - ILLEGAL_OR_DANGEROUS
+            - OTHER
+        message:
+          type: string
+          minLength: 1
+          maxLength: 1000
+        image_url:
+          type:
+            - string
+            - "null"
+          format: uri
+          description: Public CDN base URL for the optional report image. Append `-small` for the small variant.
+        status:
+          type: string
+          enum: [PENDING, REVIEWED, DISMISSED]
+          description: Newly created reports are returned as `PENDING`.
+        created_at:
+          type: string
+          format: date-time
 
     RatingWriteRequest:
       type: object


### PR DESCRIPTION
## 📋 Summary
Adds a backend event reporting mechanism so authenticated users can report events with a required category and message, plus an optional image for in-progress or completed events.

## 🔄 Changes
- Added `POST /events/{id}/reports` for creating event reports.
- Added `POST /events/{id}/reports/image/upload-url` for optional report image uploads.
- Added report categories: `SAFETY`, `HARASSMENT`, `SPAM_OR_SCAM`, `INAPPROPRIATE_CONTENT`, `EVENT_NOT_AS_DESCRIBED`, `ILLEGAL_OR_DANGEROUS`, `OTHER`.
- Added `event_report` database table and migration.
- Added event report domain, application service, Postgres repository, HTTP handler, and bootstrap/server wiring.
- Extended image upload support with `EVENT_REPORT_IMAGE`.
- Updated OpenAPI documentation for the new report and report-image endpoints.

## 🧪 Testing
- Ran `go test ./...`
- Ran `./shipcheck.sh`
- Verified shipcheck passed, including formatting, vet/static checks, linting, build, race-enabled unit tests, and integration tests.

## 🔗 Related
Closes #478
