### PR TITLE
fix(backend): stop stale QR streams on disconnect

### DIFF
--- a/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler.go
+++ b/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler.go
@@ -99,7 +99,9 @@ func (h *Handler) StreamQRToken(c *fiber.Ctx) error {
 	c.Set(fiber.HeaderCacheControl, "no-cache, no-store")
 	c.Set(fiber.HeaderConnection, "keep-alive")
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-		writeSSE(w, "qr_token", firstToken)
+		if !writeSSE(w, "qr_token", firstToken) {
+			return
+		}
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
 
@@ -117,10 +119,12 @@ func (h *Handler) StreamQRToken(c *fiber.Ctx) error {
 				default:
 				}
 				if err != nil {
-					writeSSE(w, "error", fiber.Map{"message": err.Error()})
+					_ = writeSSE(w, "error", fiber.Map{"message": err.Error()})
 					return
 				}
-				writeSSE(w, "qr_token", nextToken)
+				if !writeSSE(w, "qr_token", nextToken) {
+					return
+				}
 			}
 		}
 	})
@@ -217,12 +221,16 @@ func parseRequiredFloatQuery(c *fiber.Ctx, key string) (float64, error) {
 	return value, nil
 }
 
-func writeSSE(w *bufio.Writer, event string, data any) {
+func writeSSE(w *bufio.Writer, event string, data any) bool {
 	payload, err := json.Marshal(data)
 	if err != nil {
 		payload = []byte(`{"message":"failed to encode event"}`)
 	}
-	_, _ = fmt.Fprintf(w, "event: %s\n", event)
-	_, _ = fmt.Fprintf(w, "data: %s\n\n", payload)
-	_ = w.Flush()
+	if _, err := fmt.Fprintf(w, "event: %s\n", event); err != nil {
+		return false
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+		return false
+	}
+	return w.Flush() == nil
 }

--- a/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler_test.go
@@ -1,10 +1,13 @@
 package ticket_handler
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,6 +71,12 @@ func (v fakeVerifier) VerifyAccessToken(string) (*domain.AuthClaims, error) {
 	return v.claims, nil
 }
 
+type failingWriter struct{}
+
+func (f failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("broken pipe")
+}
+
 func TestScanTicketRequiresMobileHeader(t *testing.T) {
 	app := newTicketTestApp(&fakeTicketService{}, uuid.New())
 	req := httptest.NewRequest(fiber.MethodPost, "/host/events/"+uuid.NewString()+"/ticket-scans", bytes.NewBufferString(`{"qr_token":"token"}`))
@@ -126,6 +135,31 @@ func TestListMyTicketsDoesNotRequireMobileHeader(t *testing.T) {
 
 	if resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+}
+
+func TestWriteSSEFlushesEventPayload(t *testing.T) {
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+
+	ok := writeSSE(writer, "qr_token", fiber.Map{"token": "signed-token"})
+
+	if !ok {
+		t.Fatal("expected writeSSE to report success")
+	}
+	body := buf.String()
+	if !strings.Contains(body, "event: qr_token\n") || !strings.Contains(body, `"token":"signed-token"`) {
+		t.Fatalf("unexpected SSE payload: %q", body)
+	}
+}
+
+func TestWriteSSEReturnsFalseWhenFlushFails(t *testing.T) {
+	writer := bufio.NewWriter(failingWriter{})
+
+	ok := writeSSE(writer, "qr_token", fiber.Map{"token": "signed-token"})
+
+	if ok {
+		t.Fatal("expected writeSSE to report flush failure")
 	}
 }
 


### PR DESCRIPTION
## 📋 Summary
Fixes stale ticket QR SSE streams continuing to issue new QR tokens after the mobile client disconnects. The backend now stops the stream when writing/flushing to the client fails.

## 🔄 Changes
- Updated `ticket_handler.writeSSE` to return whether the SSE write and flush succeeded.
- Updated QR stream handling to exit when the initial or refresh token write fails.
- Added tests covering successful SSE writes and flush/write failure handling.
- No API contract changes.

## 🧪 Testing
- `go test ./internal/adapter/out/httpapi/ticket_handler`
- `./shipcheck.sh`

## 🔗 Related
Closes #546
