### PR TITLE
feat(frontend): add profile change password section

### DIFF
--- a/frontend/src/models/profile.ts
+++ b/frontend/src/models/profile.ts
@@ -42,6 +42,11 @@ export interface UpdateProfileRequest {
   default_location_lon?: number | null;
 }
 
+export interface ChangePasswordRequest {
+  old_password: string;
+  new_password: string;
+}
+
 /* ── Favorite Locations ── */
 
 export interface FavoriteLocation {

--- a/frontend/src/services/profileService.test.ts
+++ b/frontend/src/services/profileService.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { profileService } from './profileService';
+
+vi.mock('@/config/api', () => ({
+  API_BASE_URL: 'http://api.test',
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('profileService.changePassword', () => {
+  it('posts the authenticated password endpoint with old and new password', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+
+    await profileService.changePassword({
+      old_password: 'old-password-123',
+      new_password: 'new-password-456',
+    }, 'access-token');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/me/change-password', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        old_password: 'old-password-123',
+        new_password: 'new-password-456',
+      }),
+    }));
+  });
+});

--- a/frontend/src/services/profileService.ts
+++ b/frontend/src/services/profileService.ts
@@ -3,6 +3,7 @@ import {
   UserProfile,
   EventSummary,
   UpdateProfileRequest,
+  ChangePasswordRequest,
   ImageUploadInitResponse,
   ImageUploadConfirmRequest,
   FavoriteLocation,
@@ -25,6 +26,10 @@ export const profileService = {
 
   async updateMyProfile(data: UpdateProfileRequest, token: string): Promise<void> {
     return apiPatchAuth<void>('/me', data, token);
+  },
+
+  async changePassword(data: ChangePasswordRequest, token: string): Promise<void> {
+    return apiPostAuth<void>('/me/change-password', data, token);
   },
 
   async getHostedEvents(token: string): Promise<EventSummary[]> {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -798,6 +798,7 @@ body {
 :root[data-theme='dark'] .ed-join-disabled-banner,
 :root[data-theme='dark'] .fallback-content,
 :root[data-theme='dark'] .profile-history-empty,
+:root[data-theme='dark'] .change-password-form,
 :root[data-theme='dark'] .bo-sidebar,
 :root[data-theme='dark'] .bo-filter-bar,
 :root[data-theme='dark'] .bo-table-wrap,
@@ -863,6 +864,44 @@ body {
   background: #2b2b2b !important;
   border-color: #686868 !important;
   color: #e3e3e3 !important;
+}
+
+:root[data-theme='dark'] .change-password-section {
+  border-top-color: #4f4f4f !important;
+}
+
+:root[data-theme='dark'] .change-password-title {
+  color: #e8e8e8 !important;
+}
+
+:root[data-theme='dark'] .change-password-subtitle {
+  color: #c6c6c6 !important;
+}
+
+:root[data-theme='dark'] .change-password-toggle,
+:root[data-theme='dark'] .password-visibility-btn {
+  background: #2b2b2b !important;
+  border-color: #686868 !important;
+  color: #e3e3e3 !important;
+}
+
+:root[data-theme='dark'] .change-password-toggle:hover:not(:disabled),
+:root[data-theme='dark'] .password-visibility-btn:hover:not(:disabled) {
+  background: #333333 !important;
+  border-color: #8a8a8a !important;
+  color: #e8e8e8 !important;
+}
+
+:root[data-theme='dark'] .change-password-error {
+  background: rgba(127, 29, 29, 0.34) !important;
+  border-color: #7f1d1d !important;
+  color: #fecaca !important;
+}
+
+:root[data-theme='dark'] .change-password-success {
+  background: rgba(20, 83, 45, 0.32) !important;
+  border-color: #166534 !important;
+  color: #bbf7d0 !important;
 }
 
 :root[data-theme='dark'] .dc-filter-toggle.active,

--- a/frontend/src/styles/profile.css
+++ b/frontend/src/styles/profile.css
@@ -357,6 +357,130 @@
   background: #f3f4f6;
 }
 
+/* ── Change Password ── */
+
+.change-password-section {
+  margin-top: 2.25rem;
+  padding-top: 2rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.change-password-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.change-password-title {
+  margin: 0;
+  color: #111827;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.change-password-subtitle {
+  margin: 0.35rem 0 0;
+  color: #6b7280;
+  font-size: 0.92rem;
+}
+
+.change-password-toggle {
+  flex-shrink: 0;
+  padding: 0.55rem 0.95rem;
+  border-radius: 6px;
+  border: 1px solid #111827;
+  background: #ffffff;
+  color: #111827;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, opacity 0.15s;
+}
+
+.change-password-toggle:hover:not(:disabled) {
+  background: #111827;
+  color: #ffffff;
+}
+
+.change-password-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.change-password-form {
+  margin-top: 1.25rem;
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.password-input-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.password-input-row input {
+  flex: 1;
+  min-width: 0;
+}
+
+.password-visibility-btn {
+  flex-shrink: 0;
+  min-width: 64px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #374151;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.password-visibility-btn:hover:not(:disabled) {
+  background: #f3f4f6;
+}
+
+.password-visibility-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.change-password-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.25rem;
+}
+
+.change-password-error,
+.change-password-success {
+  margin-top: 1rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.change-password-error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #dc2626;
+}
+
+.change-password-success {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #16a34a;
+}
+
+.field-error {
+  margin: 0.25rem 0 0;
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
 /* Responsive */
 @media (max-width: 600px) {
   .profile-container {
@@ -398,6 +522,17 @@
 
   .form-actions {
     flex-direction: column;
+  }
+
+  .change-password-header,
+  .change-password-actions,
+  .password-input-row {
+    flex-direction: column;
+  }
+
+  .change-password-toggle,
+  .password-visibility-btn {
+    width: 100%;
   }
 
   .save-btn,

--- a/frontend/src/viewmodels/profile/useProfileViewModel.ts
+++ b/frontend/src/viewmodels/profile/useProfileViewModel.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
+import { ApiError } from '@/services/api';
 import { EventSummary, UserProfile, UpdateProfileRequest } from '../../models/profile';
 import { profileService } from '../../services/profileService';
 import { prepareAvatarBlobs } from '../../utils/imageResize';
@@ -9,6 +10,18 @@ import { shouldShowProfileEvent } from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
 
 const SEARCH_DEBOUNCE_MS = 300;
+const MIN_PASSWORD_LENGTH = 8;
+
+type ChangePasswordErrors = {
+  currentPassword?: string;
+  newPassword?: string;
+  confirmPassword?: string;
+};
+
+function getBackendValidationMessage(err: ApiError): string {
+  const details = err.details ? Object.values(err.details).filter(Boolean) : [];
+  return details.length > 0 ? details.join(' ') : err.message;
+}
 
 export function useProfileViewModel(token: string | null) {
   const { setProfileSummary } = useAuth();
@@ -37,6 +50,17 @@ export function useProfileViewModel(token: string | null) {
   const [isSearchingLocation, setIsSearchingLocation] = useState(false);
   const [locationCleared, setLocationCleared] = useState(false);
   const locationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Change password states
+  const [isPasswordFormOpen, setIsPasswordFormOpen] = useState(false);
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordErrors, setPasswordErrors] = useState<ChangePasswordErrors>({});
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordSuccess, setPasswordSuccess] = useState<string | null>(null);
+  const passwordSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchProfile = useCallback(async () => {
     if (!token) return;
@@ -88,6 +112,7 @@ export function useProfileViewModel(token: string | null) {
   useEffect(
     () => () => {
       if (successTimerRef.current) clearTimeout(successTimerRef.current);
+      if (passwordSuccessTimerRef.current) clearTimeout(passwordSuccessTimerRef.current);
       if (locationTimerRef.current) clearTimeout(locationTimerRef.current);
     },
     [],
@@ -230,6 +255,93 @@ export function useProfileViewModel(token: string | null) {
     }
   };
 
+  const resetPasswordForm = useCallback(() => {
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setPasswordErrors({});
+    setPasswordError(null);
+  }, []);
+
+  const togglePasswordForm = useCallback(() => {
+    setIsPasswordFormOpen((open) => {
+      if (open) resetPasswordForm();
+      setPasswordSuccess(null);
+      return !open;
+    });
+  }, [resetPasswordForm]);
+
+  const validateChangePassword = useCallback((): boolean => {
+    const nextErrors: ChangePasswordErrors = {};
+
+    if (!currentPassword) {
+      nextErrors.currentPassword = 'Current password is required.';
+    }
+
+    if (!newPassword) {
+      nextErrors.newPassword = 'New password is required.';
+    } else if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      nextErrors.newPassword = `New password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+    }
+
+    if (!confirmPassword) {
+      nextErrors.confirmPassword = 'Confirm new password is required.';
+    } else if (newPassword && newPassword !== confirmPassword) {
+      nextErrors.confirmPassword = 'New password and confirmation must match.';
+    }
+
+    if (currentPassword && newPassword && currentPassword === newPassword) {
+      nextErrors.newPassword = 'New password must differ from current password.';
+    }
+
+    setPasswordErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  }, [confirmPassword, currentPassword, newPassword]);
+
+  const handleChangePassword = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    setPasswordError(null);
+    setPasswordSuccess(null);
+
+    if (!validateChangePassword()) return;
+
+    if (!token) {
+      setPasswordError('Authentication token is missing.');
+      return;
+    }
+
+    setIsChangingPassword(true);
+    try {
+      await profileService.changePassword({
+        old_password: currentPassword,
+        new_password: newPassword,
+      }, token);
+
+      resetPasswordForm();
+      setIsPasswordFormOpen(false);
+      setPasswordSuccess('Password changed successfully.');
+      if (passwordSuccessTimerRef.current) clearTimeout(passwordSuccessTimerRef.current);
+      passwordSuccessTimerRef.current = setTimeout(() => {
+        setPasswordSuccess(null);
+        passwordSuccessTimerRef.current = null;
+      }, 5000);
+    } catch (err: unknown) {
+      if (err instanceof ApiError) {
+        if (err.status === 401 || err.status === 403) {
+          setPasswordError('Current password is incorrect');
+        } else if (err.status === 400) {
+          setPasswordError(getBackendValidationMessage(err));
+        } else {
+          setPasswordError(err.message);
+        }
+      } else {
+        setPasswordError(err instanceof Error ? err.message : 'Failed to change password');
+      }
+    } finally {
+      setIsChangingPassword(false);
+    }
+  }, [currentPassword, newPassword, resetPasswordForm, token, validateChangePassword]);
+
   return {
     profile,
     hostedEvents,
@@ -256,5 +368,19 @@ export function useProfileViewModel(token: string | null) {
     clearLocation,
     isSearchingLocation,
     locationCleared,
+    // Change password
+    isPasswordFormOpen,
+    togglePasswordForm,
+    currentPassword,
+    setCurrentPassword,
+    newPassword,
+    setNewPassword,
+    confirmPassword,
+    setConfirmPassword,
+    passwordErrors,
+    passwordError,
+    passwordSuccess,
+    isChangingPassword,
+    handleChangePassword,
   };
 }

--- a/frontend/src/views/profile/ProfilePage.tsx
+++ b/frontend/src/views/profile/ProfilePage.tsx
@@ -13,6 +13,7 @@ const ACCEPTED_TYPES = 'image/jpeg,image/png,image/webp';
 const MAX_SIZE_MB = 10;
 
 type ProfileHistoryTab = 'hosted' | 'attended';
+type PasswordFieldKey = 'current' | 'new' | 'confirm';
 
 function formatDate(iso: string): string {
   const d = new Date(iso);
@@ -86,6 +87,184 @@ function ProfileHistoryCard({ event }: { event: EventSummary }) {
   );
 }
 
+type ChangePasswordSectionProps = {
+  isPasswordFormOpen: boolean;
+  togglePasswordForm: () => void;
+  currentPassword: string;
+  setCurrentPassword: (value: string) => void;
+  newPassword: string;
+  setNewPassword: (value: string) => void;
+  confirmPassword: string;
+  setConfirmPassword: (value: string) => void;
+  passwordErrors: {
+    currentPassword?: string;
+    newPassword?: string;
+    confirmPassword?: string;
+  };
+  passwordError: string | null;
+  passwordSuccess: string | null;
+  isChangingPassword: boolean;
+  handleChangePassword: (e: React.FormEvent) => void;
+};
+
+function ChangePasswordSection({
+  isPasswordFormOpen,
+  togglePasswordForm,
+  currentPassword,
+  setCurrentPassword,
+  newPassword,
+  setNewPassword,
+  confirmPassword,
+  setConfirmPassword,
+  passwordErrors,
+  passwordError,
+  passwordSuccess,
+  isChangingPassword,
+  handleChangePassword,
+}: ChangePasswordSectionProps) {
+  const [visiblePasswords, setVisiblePasswords] = useState<Record<PasswordFieldKey, boolean>>({
+    current: false,
+    new: false,
+    confirm: false,
+  });
+
+  const togglePasswordVisibility = (field: PasswordFieldKey) => {
+    setVisiblePasswords((current) => ({ ...current, [field]: !current[field] }));
+  };
+
+  return (
+    <section className="change-password-section">
+      <div className="change-password-header">
+        <div>
+          <h2 className="change-password-title">Change Password</h2>
+          <p className="change-password-subtitle">Update your account password without changing profile details.</p>
+        </div>
+        <button
+          type="button"
+          className="change-password-toggle"
+          onClick={togglePasswordForm}
+          disabled={isChangingPassword}
+          aria-expanded={isPasswordFormOpen}
+        >
+          {isPasswordFormOpen ? 'Close' : 'Change Password'}
+        </button>
+      </div>
+
+      {passwordSuccess && (
+        <div className="change-password-success" role="status">
+          {passwordSuccess}
+        </div>
+      )}
+
+      {passwordError && (
+        <div className="change-password-error" role="alert">
+          {passwordError}
+        </div>
+      )}
+
+      {isPasswordFormOpen && (
+        <form className="change-password-form" onSubmit={handleChangePassword}>
+          <div className="form-group">
+            <label htmlFor="current-password">Current password</label>
+            <div className="password-input-row">
+              <input
+                id="current-password"
+                type={visiblePasswords.current ? 'text' : 'password'}
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                disabled={isChangingPassword}
+                autoComplete="current-password"
+                aria-invalid={Boolean(passwordErrors.currentPassword)}
+              />
+              <button
+                type="button"
+                className="password-visibility-btn"
+                onClick={() => togglePasswordVisibility('current')}
+                disabled={isChangingPassword}
+              >
+                {visiblePasswords.current ? 'Hide' : 'Show'}
+              </button>
+            </div>
+            {passwordErrors.currentPassword && (
+              <p className="field-error">{passwordErrors.currentPassword}</p>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="new-password">New password</label>
+            <div className="password-input-row">
+              <input
+                id="new-password"
+                type={visiblePasswords.new ? 'text' : 'password'}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                disabled={isChangingPassword}
+                autoComplete="new-password"
+                aria-invalid={Boolean(passwordErrors.newPassword)}
+              />
+              <button
+                type="button"
+                className="password-visibility-btn"
+                onClick={() => togglePasswordVisibility('new')}
+                disabled={isChangingPassword}
+              >
+                {visiblePasswords.new ? 'Hide' : 'Show'}
+              </button>
+            </div>
+            {passwordErrors.newPassword && (
+              <p className="field-error">{passwordErrors.newPassword}</p>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="confirm-new-password">Confirm new password</label>
+            <div className="password-input-row">
+              <input
+                id="confirm-new-password"
+                type={visiblePasswords.confirm ? 'text' : 'password'}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                disabled={isChangingPassword}
+                autoComplete="new-password"
+                aria-invalid={Boolean(passwordErrors.confirmPassword)}
+              />
+              <button
+                type="button"
+                className="password-visibility-btn"
+                onClick={() => togglePasswordVisibility('confirm')}
+                disabled={isChangingPassword}
+              >
+                {visiblePasswords.confirm ? 'Hide' : 'Show'}
+              </button>
+            </div>
+            {passwordErrors.confirmPassword && (
+              <p className="field-error">{passwordErrors.confirmPassword}</p>
+            )}
+          </div>
+
+          <div className="change-password-actions">
+            <button
+              type="button"
+              className="cancel-btn"
+              onClick={togglePasswordForm}
+              disabled={isChangingPassword}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="save-btn"
+              disabled={isChangingPassword}
+            >
+              {isChangingPassword ? 'Updating...' : 'Update Password'}
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
 export default function ProfilePage() {
   const { token } = useAuth();
   const {
@@ -113,6 +292,19 @@ export default function ProfilePage() {
     clearLocation,
     isSearchingLocation,
     locationCleared,
+    isPasswordFormOpen,
+    togglePasswordForm,
+    currentPassword,
+    setCurrentPassword,
+    newPassword,
+    setNewPassword,
+    confirmPassword,
+    setConfirmPassword,
+    passwordErrors,
+    passwordError,
+    passwordSuccess,
+    isChangingPassword,
+    handleChangePassword,
   } = useProfileViewModel(token);
   const [activeHistoryTab, setActiveHistoryTab] = useState<ProfileHistoryTab>('hosted');
 
@@ -147,6 +339,23 @@ export default function ProfilePage() {
 
   const displayAvatar = avatarPreview ?? profile.avatar_url;
   const activeHistoryEvents = activeHistoryTab === 'hosted' ? hostedEvents : attendedEvents;
+  const changePasswordSection = (
+    <ChangePasswordSection
+      isPasswordFormOpen={isPasswordFormOpen}
+      togglePasswordForm={togglePasswordForm}
+      currentPassword={currentPassword}
+      setCurrentPassword={setCurrentPassword}
+      newPassword={newPassword}
+      setNewPassword={setNewPassword}
+      confirmPassword={confirmPassword}
+      setConfirmPassword={setConfirmPassword}
+      passwordErrors={passwordErrors}
+      passwordError={passwordError}
+      passwordSuccess={passwordSuccess}
+      isChangingPassword={isChangingPassword}
+      handleChangePassword={handleChangePassword}
+    />
+  );
 
   return (
     <div className="profile-container">
@@ -221,6 +430,8 @@ export default function ProfilePage() {
             )}
           </div>
         </div>
+
+        {changePasswordSection}
 
         <section className="profile-history">
           <div className="profile-history-header">
@@ -392,6 +603,8 @@ export default function ProfilePage() {
               </button>
             </div>
           </form>
+
+          {changePasswordSection}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 📋 Summary
Adds a Change Password section to the profile page so authenticated users can update their password from the web frontend.

## 🔄 Changes
- Added a collapsible Change Password section between profile info and participation history
- Added current password, new password, and confirm new password fields
- Added show/hide toggles for all password fields
- Added client-side validation for required fields, minimum password length, password mismatch, and unchanged password
- Added loading, success, and error states for password updates
- Connected the form to `POST /api/me/change-password`
- Added a profile service method and request model for password changes
- Added styling for light and dark mode
- Added a focused service test for the password-change request

## 🧪 Testing
- Ran `npm test -- profileService.test.ts AppShell.test.tsx`
- Ran `npm run build`
- Manually verified the form opens from the profile page and submits to the backend endpoint

## 🔗 Related
Related to #432 
