### PR TITLE
feat(frontend): add map view to Discover page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,11 @@
       "name": "social-event-mapper-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@types/leaflet": "^1.9.21",
+        "leaflet": "^1.9.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.1.0"
       },
       "devDependencies": {
@@ -121,7 +124,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -468,7 +470,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -517,7 +518,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1001,6 +1001,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1337,7 +1347,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -1413,7 +1422,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1480,12 +1489,24 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1495,7 +1516,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1505,7 +1525,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1650,7 +1669,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1660,7 +1679,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1729,7 +1748,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1909,7 +1927,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.328",
@@ -2089,7 +2107,6 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -2159,6 +2176,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmmirror.com/loupe/-/loupe-3.2.1.tgz",
@@ -2180,7 +2202,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -2283,7 +2305,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2324,7 +2345,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2348,7 +2369,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2357,7 +2377,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2370,7 +2389,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "peer": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2757,7 +2789,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,11 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@types/leaflet": "^1.9.21",
+    "leaflet": "^1.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -91,6 +91,8 @@ export interface DiscoverEventItem {
   start_time: string;
   status: string;
   location_address: string | null;
+  location_lat?: number;
+  location_lon?: number;
   privacy_level: 'PUBLIC' | 'PROTECTED';
   approved_participant_count: number;
   is_favorited: boolean;

--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -1128,3 +1128,304 @@
     width: 100%;
   }
 }
+
+/* ── List/Map view toggle ── */
+
+.dc-view-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 4px;
+  flex-shrink: 0;
+  gap: 2px;
+}
+
+.dc-view-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0.5rem 0.9rem;
+  background: none;
+  border: none;
+  border-radius: 7px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+  line-height: 1;
+}
+
+.dc-view-toggle-icon {
+  flex-shrink: 0;
+}
+
+.dc-view-toggle-btn:hover:not(.active) {
+  color: #111827;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.dc-view-toggle-btn.active {
+  background: #ffffff;
+  color: #111827;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(15, 23, 42, 0.04);
+}
+
+/* ── Map surface ── */
+
+.dc-map-wrapper {
+  position: relative;
+  margin-top: 1.5rem;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid #e2e8f0;
+  background: #f1f5f9;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.dc-map-surface {
+  height: calc(100vh - 280px);
+  min-height: 560px;
+  width: 100%;
+  z-index: 0;
+}
+
+/* Hide leaflet's default white background around divIcon markers */
+.leaflet-div-icon.dc-map-cat-marker {
+  background: transparent;
+  border: none;
+}
+
+.dc-map-overlay {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 1.1rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  z-index: 500;
+  text-align: center;
+  max-width: 340px;
+}
+
+.dc-map-overlay p,
+.dc-map-overlay h3 {
+  margin: 0;
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.dc-map-overlay h3 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.dc-map-overlay-error p {
+  color: #b91c1c;
+}
+
+.dc-map-overlay-empty {
+  background: rgba(255, 255, 255, 0.96);
+}
+
+/* ── Event side card overlay (left corner of map) ── */
+
+.dc-map-card {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  width: 320px;
+  max-width: calc(100% - 32px);
+  background: #ffffff;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18), 0 0 0 1px rgba(15, 23, 42, 0.04);
+  z-index: 600;
+  animation: dc-map-card-enter 0.2s ease-out;
+}
+
+@keyframes dc-map-card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.dc-map-card-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.55);
+  color: #ffffff;
+  border: none;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.15s;
+}
+
+.dc-map-card-close:hover {
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.dc-map-card-image {
+  position: relative;
+  width: 100%;
+  height: 160px;
+  background: #f1f5f9;
+}
+
+.dc-map-card-image-img,
+.dc-map-card-image > div {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.dc-map-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.dc-map-card-category {
+  position: absolute;
+  bottom: 10px;
+  left: 12px;
+  padding: 4px 10px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #ffffff;
+  background: #7c3aed;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.dc-map-card-body {
+  padding: 14px 16px 16px;
+}
+
+.dc-map-card-title {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.3;
+}
+
+.dc-map-card-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.dc-map-card-meta {
+  font-size: 0.82rem;
+  color: #475569;
+  font-weight: 500;
+}
+
+.dc-map-card-address {
+  margin: 0 0 10px;
+  font-size: 0.82rem;
+  color: #64748b;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.dc-map-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-top: 1px solid #f1f5f9;
+  margin-bottom: 10px;
+}
+
+.dc-map-card-participants {
+  font-size: 0.8rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.dc-map-card-score {
+  font-size: 0.82rem;
+  color: #ca8a04;
+  font-weight: 600;
+}
+
+.dc-map-card-cta {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  background: #111827;
+  color: #ffffff !important;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s, transform 0.05s;
+}
+
+.dc-map-card-cta:hover {
+  background: #000000;
+}
+
+.dc-map-card-cta:active {
+  transform: scale(0.98);
+}
+
+@media (max-width: 600px) {
+  .dc-map-surface {
+    height: calc(100vh - 240px);
+    min-height: 420px;
+  }
+
+  .dc-map-card {
+    top: 12px;
+    left: 12px;
+    width: calc(100% - 24px);
+  }
+
+  .dc-map-card-image {
+    height: 140px;
+  }
+
+  .dc-view-toggle-btn {
+    padding: 0.4rem 0.7rem;
+    font-size: 0.8rem;
+  }
+
+  .dc-view-toggle-label {
+    display: none;
+  }
+}

--- a/frontend/src/viewmodels/discover/useDiscoverViewModel.ts
+++ b/frontend/src/viewmodels/discover/useDiscoverViewModel.ts
@@ -523,6 +523,11 @@ export function useDiscoverViewModel(token: string | null) {
     defaultProfileLocation,
   );
 
+  const mapCenter: { lat: number; lon: number } = {
+    lat: selectedLocation ? Number(selectedLocation.lat) : DEFAULT_LAT,
+    lon: selectedLocation ? Number(selectedLocation.lon) : DEFAULT_LON,
+  };
+
   return {
     events,
     filters,
@@ -561,5 +566,6 @@ export function useDiscoverViewModel(token: string | null) {
     dismissBrowserLocationPrompt,
     browserLocationRequestPending,
     browserLocationError,
+    mapCenter,
   };
 }

--- a/frontend/src/views/discover/DiscoverMapView.tsx
+++ b/frontend/src/views/discover/DiscoverMapView.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { MapContainer, Marker, TileLayer, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { EventCoverImage } from '@/components/EventCoverImage';
+import type { DiscoverEventItem } from '@/models/event';
+
+interface DiscoverMapViewProps {
+  events: DiscoverEventItem[];
+  isLoading: boolean;
+  error: string | null;
+  center: { lat: number; lon: number };
+  onRetry: () => void;
+}
+
+const MARKER_COLORS = [
+  '#7c3aed', // violet
+  '#2563eb', // blue
+  '#0891b2', // cyan
+  '#059669', // emerald
+  '#ca8a04', // amber
+  '#dc2626', // red
+  '#db2777', // pink
+  '#9333ea', // purple
+];
+
+function colorForCategory(category: string): string {
+  let hash = 0;
+  for (let i = 0; i < category.length; i++) {
+    hash = (hash * 31 + category.charCodeAt(i)) | 0;
+  }
+  return MARKER_COLORS[Math.abs(hash) % MARKER_COLORS.length];
+}
+
+function buildCategoryIcon(category: string, isSelected: boolean): L.DivIcon {
+  const letter = (category?.[0] ?? '?').toUpperCase();
+  const color = colorForCategory(category ?? '');
+  const size = isSelected ? 44 : 38;
+  const ring = isSelected ? '3px solid #ffffff' : '2px solid #ffffff';
+  const shadow = isSelected
+    ? '0 6px 16px rgba(0,0,0,0.35), 0 0 0 4px rgba(124,58,237,0.18)'
+    : '0 3px 8px rgba(0,0,0,0.25)';
+  const html = `
+    <div style="
+      width:${size}px;
+      height:${size}px;
+      border-radius:50%;
+      background:${color};
+      color:#ffffff;
+      border:${ring};
+      box-shadow:${shadow};
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+      font-weight:700;
+      font-size:${isSelected ? 17 : 15}px;
+      line-height:1;
+      transition:transform 0.15s;
+    ">${letter}</div>
+  `;
+  return L.divIcon({
+    html,
+    className: 'dc-map-cat-marker',
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size / 2],
+  });
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function MapRecenter({ center }: { center: { lat: number; lon: number } }) {
+  const map = useMap();
+  useEffect(() => {
+    map.setView([center.lat, center.lon], map.getZoom(), { animate: true });
+  }, [center.lat, center.lon, map]);
+  return null;
+}
+
+function EventOverlayCard({
+  event,
+  onClose,
+}: {
+  event: DiscoverEventItem;
+  onClose: () => void;
+}) {
+  const color = colorForCategory(event.category_name ?? '');
+
+  return (
+    <div className="dc-map-card" role="dialog" aria-label={`Event: ${event.title}`}>
+      <button
+        type="button"
+        className="dc-map-card-close"
+        onClick={onClose}
+        aria-label="Close event preview"
+      >
+        ×
+      </button>
+
+      <div className="dc-map-card-image">
+        <EventCoverImage
+          src={event.image_url}
+          alt={event.title}
+          imgClassName="dc-map-card-image-img"
+          variant="card"
+        />
+        <span
+          className="dc-map-card-category"
+          style={{ background: color }}
+        >
+          {event.category_name}
+        </span>
+      </div>
+
+      <div className="dc-map-card-body">
+        <h3 className="dc-map-card-title">{event.title}</h3>
+
+        <div className="dc-map-card-meta-row">
+          <span className="dc-map-card-meta">
+            {formatDate(event.start_time)} · {formatTime(event.start_time)}
+          </span>
+        </div>
+
+        {event.location_address && (
+          <p className="dc-map-card-address">{event.location_address}</p>
+        )}
+
+        <div className="dc-map-card-footer">
+          <span className="dc-map-card-participants">
+            {event.approved_participant_count} participant
+            {event.approved_participant_count !== 1 ? 's' : ''}
+          </span>
+          {event.host_score.final_score != null && (
+            <span className="dc-map-card-score">
+              ★ {event.host_score.final_score.toFixed(1)}
+            </span>
+          )}
+        </div>
+
+        <Link
+          to={`/events/${event.id}`}
+          className="dc-map-card-cta"
+        >
+          View Details &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default function DiscoverMapView({
+  events,
+  isLoading,
+  error,
+  center,
+  onRetry,
+}: DiscoverMapViewProps) {
+  const mapRef = useRef<L.Map | null>(null);
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+
+  const mappableEvents = useMemo(
+    () => events.filter((e) => e.location_lat != null && e.location_lon != null),
+    [events],
+  );
+
+  useEffect(() => {
+    if (selectedEventId && !mappableEvents.find((e) => e.id === selectedEventId)) {
+      setSelectedEventId(null);
+    }
+  }, [mappableEvents, selectedEventId]);
+
+  const selectedEvent = mappableEvents.find((e) => e.id === selectedEventId) ?? null;
+
+  return (
+    <div className="dc-map-wrapper" data-testid="discover-map">
+      <MapContainer
+        center={[center.lat, center.lon]}
+        zoom={12}
+        scrollWheelZoom
+        className="dc-map-surface"
+        ref={mapRef}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <MapRecenter center={center} />
+        {mappableEvents.map((event) => (
+          <Marker
+            key={event.id}
+            position={[event.location_lat as number, event.location_lon as number]}
+            icon={buildCategoryIcon(event.category_name ?? '', event.id === selectedEventId)}
+            eventHandlers={{
+              click: () => setSelectedEventId(event.id),
+            }}
+            zIndexOffset={event.id === selectedEventId ? 1000 : 0}
+          />
+        ))}
+      </MapContainer>
+
+      {selectedEvent && (
+        <EventOverlayCard
+          event={selectedEvent}
+          onClose={() => setSelectedEventId(null)}
+        />
+      )}
+
+      {isLoading && (
+        <div className="dc-map-overlay" role="status" aria-live="polite">
+          <span className="spinner" />
+          <p>Loading events...</p>
+        </div>
+      )}
+
+      {error && !isLoading && (
+        <div className="dc-map-overlay dc-map-overlay-error" role="alert">
+          <p>{error}</p>
+          <button type="button" className="dc-retry-btn" onClick={onRetry}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !error && mappableEvents.length === 0 && (
+        <div className="dc-map-overlay dc-map-overlay-empty" role="status">
+          <h3>No events on the map</h3>
+          <p>Try adjusting filters or expanding the radius.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/views/discover/DiscoverPage.tsx
+++ b/frontend/src/views/discover/DiscoverPage.tsx
@@ -10,7 +10,10 @@ import type { DiscoverEventItem, DiscoverSortBy } from '@/models/event';
 import { EventCoverImage } from '@/components/EventCoverImage';
 import { getEventLifecyclePresentation } from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
+import DiscoverMapView from './DiscoverMapView';
 import '@/styles/discover.css';
+
+type DiscoverViewMode = 'list' | 'map';
 
 const SORT_OPTIONS: { label: string; value: DiscoverSortBy; icon: 'time' | 'distance' }[] = [
   { label: 'Soonest', value: 'START_TIME', icon: 'time' },
@@ -71,6 +74,51 @@ function ChevronDownIcon({ className }: { className?: string }) {
       aria-hidden
     >
       <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function ListIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <line x1="8" y1="6" x2="21" y2="6" />
+      <line x1="8" y1="12" x2="21" y2="12" />
+      <line x1="8" y1="18" x2="21" y2="18" />
+      <line x1="3" y1="6" x2="3.01" y2="6" />
+      <line x1="3" y1="12" x2="3.01" y2="12" />
+      <line x1="3" y1="18" x2="3.01" y2="18" />
+    </svg>
+  );
+}
+
+function MapIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6" />
+      <line x1="8" y1="2" x2="8" y2="18" />
+      <line x1="16" y1="6" x2="16" y2="22" />
     </svg>
   );
 }
@@ -220,6 +268,7 @@ export default function DiscoverPage() {
   const { token } = useAuth();
   const vm = useDiscoverViewModel(token);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<DiscoverViewMode>('list');
   const [categoriesExpanded, setCategoriesExpanded] = useState(false);
   const categoryChipsRef = useRef<HTMLDivElement>(null);
   const [categoryChipsNeedExpand, setCategoryChipsNeedExpand] = useState(false);
@@ -326,6 +375,32 @@ export default function DiscoverPage() {
             value={vm.filters.q}
             onChange={(e) => vm.updateSearch(e.target.value)}
           />
+          <div
+            className="dc-view-toggle"
+            role="group"
+            aria-label="View mode"
+          >
+            <button
+              type="button"
+              className={`dc-view-toggle-btn ${viewMode === 'list' ? 'active' : ''}`}
+              onClick={() => setViewMode('list')}
+              aria-pressed={viewMode === 'list'}
+              title="List view"
+            >
+              <ListIcon className="dc-view-toggle-icon" />
+              <span className="dc-view-toggle-label">List</span>
+            </button>
+            <button
+              type="button"
+              className={`dc-view-toggle-btn ${viewMode === 'map' ? 'active' : ''}`}
+              onClick={() => setViewMode('map')}
+              aria-pressed={viewMode === 'map'}
+              title="Map view"
+            >
+              <MapIcon className="dc-view-toggle-icon" />
+              <span className="dc-view-toggle-label">Map</span>
+            </button>
+          </div>
           <button
             type="button"
             className={`dc-filter-toggle ${filtersOpen ? 'active' : ''} ${hasActiveFilters ? 'has-filters' : ''}`}
@@ -615,53 +690,65 @@ export default function DiscoverPage() {
         </div>
       )}
 
-      {/* Error */}
-      {vm.error && (
-        <div className="error-banner">
-          {vm.error}
-          <button type="button" className="dc-retry-btn" onClick={vm.refresh}>
-            Retry
-          </button>
-        </div>
-      )}
-
-      {/* Loading */}
-      {vm.isLoading && (
-        <div className="dc-loading">
-          <span className="spinner" />
-          <p>Loading events...</p>
-        </div>
-      )}
-
-      {/* Empty state */}
-      {!vm.isLoading && !vm.error && vm.events.length === 0 && (
-        <div className="dc-empty">
-          <h2>No events found</h2>
-          <p>Try adjusting your filters or search to find events.</p>
-        </div>
-      )}
-
-      {/* Event list */}
-      {!vm.isLoading && vm.events.length > 0 && (
+      {viewMode === 'map' ? (
+        <DiscoverMapView
+          events={vm.events}
+          isLoading={vm.isLoading}
+          error={vm.error}
+          center={vm.mapCenter}
+          onRetry={vm.refresh}
+        />
+      ) : (
         <>
-          <div className="dc-grid">
-            {vm.events.map((event) => (
-              <EventCard key={event.id} event={event} />
-            ))}
-          </div>
-
-          {/* Load more */}
-          {vm.hasNext && (
-            <div className="dc-load-more">
-              <button
-                type="button"
-                className="dc-load-more-btn"
-                onClick={vm.loadMore}
-                disabled={vm.isLoadingMore}
-              >
-                {vm.isLoadingMore ? <span className="spinner" /> : 'Load More'}
+          {/* Error */}
+          {vm.error && (
+            <div className="error-banner">
+              {vm.error}
+              <button type="button" className="dc-retry-btn" onClick={vm.refresh}>
+                Retry
               </button>
             </div>
+          )}
+
+          {/* Loading */}
+          {vm.isLoading && (
+            <div className="dc-loading">
+              <span className="spinner" />
+              <p>Loading events...</p>
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!vm.isLoading && !vm.error && vm.events.length === 0 && (
+            <div className="dc-empty">
+              <h2>No events found</h2>
+              <p>Try adjusting your filters or search to find events.</p>
+            </div>
+          )}
+
+          {/* Event list */}
+          {!vm.isLoading && vm.events.length > 0 && (
+            <>
+              <div className="dc-grid">
+                {vm.events.map((event) => (
+                  <EventCard key={event.id} event={event} />
+                ))}
+              </div>
+
+              {/* Load more */}
+              {vm.hasNext && (
+                <div className="dc-load-more">
+                  <button
+                    type="button"
+                    className="dc-load-more-btn"
+                    onClick={vm.loadMore}
+                    disabled={vm.isLoadingMore}
+                  >
+                    {vm.isLoadingMore ? <span className="spinner" /> : 'Load More'}
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </>
       )}


### PR DESCRIPTION
## 📋 Summary
Adds a Map view to the Discover page so users can browse events spatially in addition to the existing list. Closes the scope from #246. Filters, search, and the selected discover location stay fully in sync between list and map.

## 🔄 Changes
- **`models/event.ts`** — Added optional `location_lat` / `location_lon` to `DiscoverEventItem` (backend already exposes these via `omitempty`)
- **`viewmodels/discover/useDiscoverViewModel.ts`** — Exposed `mapCenter` (the same lat/lon used for backend queries) so the map and list share the exact same anchor; auto-recenters when the user picks a new location or default profile location
- **`views/discover/DiscoverMapView.tsx`** *(new)* — Leaflet + OSM map with:
  - Custom circular markers showing the **first letter of the category** in an 8-color hashed palette so categories are visually distinguishable
  - Selected marker grows from 38px → 44px with a violet glow ring
  - Animated event card overlay anchored to the **top-left** showing cover image, category pill, title, date/time, address, participants, host score, and a "View Details" CTA
  - In-map loading, empty, and error overlays with a Retry button
  - Auto-recenters via a `MapRecenter` helper inside `<MapContainer>`
- **`views/discover/DiscoverPage.tsx`** — Added a List/Map toggle next to the search field (icons + labels, white-on-active card style, icons-only on mobile); conditional render between list and map preserves all viewmodel state
- **`styles/discover.css`** — New `.dc-view-toggle*`, `.dc-map-wrapper`, `.dc-map-surface`, `.dc-map-card*`, `.dc-map-overlay*` styles; map height `calc(100vh - 280px)` with `min-height: 560px` (smaller on mobile); rounded 16px corners + soft shadow on the map wrapper
- **`package.json` / `package-lock.json`** — Added `leaflet@^1.9.4`, `react-leaflet@^5.0.0` (v5 supports React 19, no `--legacy-peer-deps` needed for Docker), `@types/leaflet`

## 🧪 Testing
1. `cd frontend && npm install && npm run build` → confirm clean build with no peer-dep errors (Docker build also passes)
2. `npm run dev` → open `/discover`
3. Toggle: click "Map" → smooth switch from list to map; verify filters/search/location persist when toggling back to "List"
4. Markers: confirm each event marker is a colored circle showing the first letter of its category (e.g. "S" for Sports)
5. Marker click: click any marker → an animated card slides in at the top-left of the map with the event cover image, category pill, title, date, address, participants, score, and a "View Details" button
6. Card actions: click `×` → card dismisses; click "View Details" → navigates to the event detail page
7. Selected state: confirm the clicked marker grows and gets a violet ring; clicking another marker switches selection
8. Filters sync: open Filters, change radius/category/date in either view → verify the same filtered events render in both list and map
9. Location sync: open the location picker, pick a new address → map auto-recenters to the new lat/lon
10. Empty/error states: apply a filter combination with no results → confirm "No events on the map" overlay; with the backend down, confirm error overlay + Retry button works
11. Mobile responsive: shrink to a phone viewport → toggle shows icons only, card spans the map width minus padding, map height adjusts via `calc(100vh - 240px)`

## 🔗 Related
Related to #456
