### PR TITLE
feat(frontend): add mini map and Get directions button on event detail

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,11 @@
       "name": "social-event-mapper-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@types/leaflet": "^1.9.21",
+        "leaflet": "^1.9.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.1.0"
       },
       "devDependencies": {
@@ -121,7 +124,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -468,7 +470,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -517,7 +518,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1001,6 +1001,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1413,7 +1423,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1480,12 +1491,24 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1495,7 +1518,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1505,7 +1527,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1651,6 +1672,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1661,6 +1683,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1729,7 +1752,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1909,7 +1931,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.328",
@@ -2089,7 +2112,6 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -2159,6 +2181,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmmirror.com/loupe/-/loupe-3.2.1.tgz",
@@ -2181,6 +2208,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -2283,7 +2311,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2325,6 +2352,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2348,7 +2376,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2357,7 +2384,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2370,7 +2396,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2757,7 +2797,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,11 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@types/leaflet": "^1.9.21",
+    "leaflet": "^1.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -1386,6 +1386,74 @@
   color: #374151;
 }
 
+/* ── Mini map panel ── */
+
+.ed-map-panel {
+  margin-top: 14px;
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  background: #f1f5f9;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.ed-map-surface {
+  height: 240px;
+  width: 100%;
+  z-index: 0;
+}
+
+.ed-map-placeholder {
+  height: 240px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.ed-directions-btn {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0.55rem 0.95rem;
+  background: #111827;
+  color: #ffffff !important;
+  border: none;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
+  transition: background 0.15s, transform 0.05s;
+  z-index: 500;
+}
+
+.ed-directions-btn:hover {
+  background: #000000;
+}
+
+.ed-directions-btn:active {
+  transform: scale(0.97);
+}
+
+.ed-map-fallback {
+  margin: 14px 0 0;
+  padding: 12px 14px;
+  font-size: 0.85rem;
+  color: #64748b;
+  background: #f8fafc;
+  border: 1px dashed #cbd5e1;
+  border-radius: 10px;
+}
+
 /* Responsive */
 @media (max-width: 600px) {
   .ed-hero {
@@ -1470,5 +1538,17 @@
 
   .ed-description {
     font-size: 14px;
+  }
+
+  .ed-map-surface,
+  .ed-map-placeholder {
+    height: 200px;
+  }
+
+  .ed-directions-btn {
+    bottom: 10px;
+    right: 10px;
+    padding: 0.5rem 0.85rem;
+    font-size: 0.8rem;
   }
 }

--- a/frontend/src/views/events/EventDetailMiniMap.tsx
+++ b/frontend/src/views/events/EventDetailMiniMap.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { MapContainer, Marker, Polyline, TileLayer } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import type { EventDetailLocation } from '@/models/event';
+
+interface EventDetailMiniMapProps {
+  location: EventDetailLocation;
+}
+
+const markerIcon = L.icon({
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+export default function EventDetailMiniMap({ location }: EventDetailMiniMapProps) {
+  const anchor = useMemo(() => {
+    if (location.type === 'POINT' && location.point) {
+      return { lat: location.point.lat, lon: location.point.lon };
+    }
+    if (location.type === 'ROUTE' && location.route_points.length > 0) {
+      return { lat: location.route_points[0].lat, lon: location.route_points[0].lon };
+    }
+    return null;
+  }, [location]);
+
+  if (!anchor) {
+    return null;
+  }
+
+  const polylinePositions: [number, number][] =
+    location.type === 'ROUTE'
+      ? location.route_points.map((p) => [p.lat, p.lon])
+      : [];
+
+  return (
+    <MapContainer
+      center={[anchor.lat, anchor.lon]}
+      zoom={14}
+      scrollWheelZoom={false}
+      className="ed-map-surface"
+      attributionControl
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <Marker position={[anchor.lat, anchor.lon]} icon={markerIcon} />
+      {polylinePositions.length > 1 && (
+        <Polyline positions={polylinePositions} pathOptions={{ color: '#7c3aed', weight: 4 }} />
+      )}
+    </MapContainer>
+  );
+}

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type { EventDetailResponse } from '@/models/event';
-import EventDetailPage from './EventDetailPage';
+import EventDetailPage, { buildDirectionsUrl } from './EventDetailPage';
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({ token: 'token' }),
@@ -210,6 +210,47 @@ describe('EventDetailPage ratings', () => {
     expect(screen.getByText(/4\/5/i)).toBeDefined();
     expect(screen.getByText(/reliable and easy to coordinate with\./i)).toBeDefined();
     expect(screen.getByRole('button', { name: /edit rating/i })).toBeDefined();
+  });
+
+  it('renders the directions link with the event coordinates when location is a POINT', () => {
+    const event = makeBaseEvent();
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    const link = screen.getByTestId('ed-directions-link') as HTMLAnchorElement;
+    expect(link).toBeDefined();
+    expect(link.href).toContain(
+      'https://www.google.com/maps/dir/?api=1&destination=',
+    );
+    expect(link.href).toContain(encodeURIComponent('40.98,29.03'));
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toContain('noopener');
+  });
+
+  it('shows the map fallback and hides the directions link when coordinates are missing', () => {
+    const event = makeBaseEvent();
+    event.location = {
+      type: 'POINT',
+      address: 'No coordinates here',
+      point: null,
+      route_points: [],
+    };
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByText(/map unavailable for this event/i)).toBeDefined();
+    expect(screen.queryByTestId('ed-directions-link')).toBeNull();
+  });
+
+  it('builds a Google Maps directions URL with encoded destination coordinates', () => {
+    const url = buildDirectionsUrl(40.98, 29.03);
+    expect(url).toBe(
+      `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent('40.98,29.03')}`,
+    );
   });
 
   it('shows a pending join-request banner instead of join actions', () => {

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useEventDetailViewModel } from '@/viewmodels/event/useEventDetailViewModel';
@@ -15,6 +15,14 @@ import { getEventLifecyclePresentation, getEventStatusPresentation } from '@/uti
 import NotFoundView from '../fallback/NotFoundView';
 import AccessDeniedView from '../fallback/AccessDeniedView';
 import '@/styles/event-detail.css';
+
+const EventDetailMiniMap = lazy(() => import('./EventDetailMiniMap'));
+
+export function buildDirectionsUrl(lat: number, lon: number): string {
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
+    `${lat},${lon}`,
+  )}`;
+}
 
 const FEEDBACK_MIN_LENGTH = 10;
 const FEEDBACK_MAX_LENGTH = 100;
@@ -154,6 +162,81 @@ function PrivacyBadge({ level }: { level: string }) {
     <span className={`ed-privacy-badge ed-privacy-${level.toLowerCase()}`}>
       {label}
     </span>
+  );
+}
+
+function LocationSection({ location }: { location: EventDetailResponse['location'] }) {
+  const anchor = useMemo(() => {
+    if (location.type === 'POINT' && location.point) {
+      return { lat: location.point.lat, lon: location.point.lon };
+    }
+    if (location.type === 'ROUTE' && location.route_points.length > 0) {
+      return { lat: location.route_points[0].lat, lon: location.route_points[0].lon };
+    }
+    return null;
+  }, [location]);
+
+  const hasMap = anchor !== null;
+
+  return (
+    <div className="ed-section">
+      <h2 className="ed-section-title">Location</h2>
+      <div className="ed-info-row">
+        <span className="ed-info-icon">&#128205;</span>
+        <div>
+          {location.address ? (
+            <p className="ed-info-primary">{location.address}</p>
+          ) : (
+            <p className="ed-info-secondary">No address provided</p>
+          )}
+          <p className="ed-info-secondary">
+            {location.type === 'ROUTE' ? 'Route-based event' : 'Point location'}
+            {location.point && (
+              <> &middot; {location.point.lat.toFixed(4)}, {location.point.lon.toFixed(4)}</>
+            )}
+          </p>
+        </div>
+      </div>
+
+      {hasMap ? (
+        <div className="ed-map-panel">
+          <Suspense
+            fallback={
+              <div className="ed-map-placeholder" role="status" aria-live="polite">
+                <span className="spinner" />
+                <p>Loading map...</p>
+              </div>
+            }
+          >
+            <EventDetailMiniMap location={location} />
+          </Suspense>
+          <a
+            className="ed-directions-btn"
+            href={buildDirectionsUrl(anchor.lat, anchor.lon)}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="ed-directions-link"
+          >
+            <svg
+              width={16}
+              height={16}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <polygon points="3 11 22 2 13 21 11 13 3 11" />
+            </svg>
+            Get directions
+          </a>
+        </div>
+      ) : (
+        <p className="ed-map-fallback">Map unavailable for this event.</p>
+      )}
+    </div>
   );
 }
 
@@ -1093,25 +1176,7 @@ function EventContent({
         </div>
 
         {/* Location */}
-        <div className="ed-section">
-          <h2 className="ed-section-title">Location</h2>
-          <div className="ed-info-row">
-            <span className="ed-info-icon">&#128205;</span>
-            <div>
-              {event.location.address ? (
-                <p className="ed-info-primary">{event.location.address}</p>
-              ) : (
-                <p className="ed-info-secondary">No address provided</p>
-              )}
-              <p className="ed-info-secondary">
-                {event.location.type === 'ROUTE' ? 'Route-based event' : 'Point location'}
-                {event.location.point && (
-                  <> &middot; {event.location.point.lat.toFixed(4)}, {event.location.point.lon.toFixed(4)}</>
-                )}
-              </p>
-            </div>
-          </div>
-        </div>
+        <LocationSection location={event.location} />
 
         {/* Description */}
         {event.description && (


### PR DESCRIPTION
## 📋 Summary
Adds a compact embedded Leaflet map to the event detail page anchored on the event's coordinates, plus a floating "Get directions" button that opens Google Maps in a new tab prefilled with the destination. The map component is lazy-loaded into its own chunk so Leaflet stays out of the main bundle.

## 🔄 Changes
- **`views/events/EventDetailMiniMap.tsx`** *(new)* — Lazy-loaded react-leaflet map. Marker at `location.point` for POINT events; marker at first route point + violet polyline connecting all route points for ROUTE events. Scroll-wheel zoom disabled for a "preview" feel; pan/zoom controls remain available
- **`views/events/EventDetailPage.tsx`** — Replaced the inline Location section with a new `LocationSection` component that renders the address/coordinates row, a `<Suspense>`-wrapped mini map, a floating "Get directions" link, and a fallback message when coordinates are missing. Also exports `buildDirectionsUrl(lat, lon)` for testability
- **`styles/event-detail.css`** — Added `.ed-map-panel`, `.ed-map-surface` (240px tall, 200px on mobile), `.ed-map-placeholder`, `.ed-directions-btn` (pill-shaped, anchored bottom-right of the map with a subtle shadow), and `.ed-map-fallback` (dashed-border note)
- **`views/events/EventDetailPage.test.tsx`** — Added 3 tests:
  - Renders the directions link with encoded coordinates when location is a POINT
  - Shows the map fallback and hides the directions link when coordinates are missing
  - Pure unit test on `buildDirectionsUrl`
- **`package.json` / `package-lock.json`** — Added `leaflet@^1.9.4`, `react-leaflet@^5.0.0` (React 19 compatible, no `--legacy-peer-deps` needed for Docker), `@types/leaflet`

## 🧪 Testing
1. `cd frontend && npm install && npm run build` → confirm a clean build with **no peer-dep errors** and that the bundle output shows a separate chunk like `EventDetailMiniMap-*.js` (~150 KB) — proves the map is lazy-loaded out of the main bundle
2. `npm run dev` → open any event detail page (e.g. `/events/<id>`)
3. POINT event with coordinates: confirm the mini map renders below the address with a single marker on the event location
4. ROUTE event: confirm a violet polyline traces the route and the marker sits at the start point
5. Get directions: click the floating "Get directions" pill in the bottom-right of the map → a new tab opens to Google Maps with the destination pre-filled (`https://www.google.com/maps/dir/?api=1&destination=<lat>,<lng>`); on mobile web the OS may offer to open the native Google/Apple Maps app
6. No coordinates: temporarily edit a test fixture (or a backend response) so `location.point` is `null` → confirm "Map unavailable for this event" appears and the directions button is gone
7. Lazy load: open DevTools Network tab, navigate to the event detail page → confirm `EventDetailMiniMap-*.js` is fetched only when the page loads (not on app boot)
8. Mobile responsive: shrink to a phone viewport → map height shrinks to 200px and the directions pill stays readable in the bottom-right
9. (When the jsdom env is fixed) `npm test` → all 3 new tests in `EventDetailPage.test.tsx` pass

## 🔗 Related
Related to #468 
