### PR TITLE
feat(mobile): Event Discussion Section (Q&A and Post-Event) (#458)

### DIFF
--- a/mobile/src/components/events/EventDiscussionSection.tsx
+++ b/mobile/src/components/events/EventDiscussionSection.tsx
@@ -1,0 +1,802 @@
+import React, { useMemo } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { useTheme } from '@/theme';
+import type { Theme } from '@/theme';
+import { EventComment } from '@/models/comment';
+import { EventDiscussionViewModel } from '@/viewmodels/event/useEventDiscussionViewModel';
+
+interface Props {
+  vm: EventDiscussionViewModel;
+  eventStatus: string;
+  isAuthenticated: boolean;
+  canPostDiscussion: boolean;
+  canPostReview: boolean;
+  hasExistingReview: boolean;
+  reviewWindowClosed?: boolean;
+}
+
+function formatRelativeTime(iso: string): string {
+  try {
+    const diff = Date.now() - new Date(iso).getTime();
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return 'just now';
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
+function renderStars(rating: number): string {
+  const r = Math.max(0, Math.min(5, Math.round(rating)));
+  return `${'★'.repeat(r)}${'☆'.repeat(5 - r)}`;
+}
+
+function StarRatingInput({
+  value,
+  onChange,
+  disabled,
+  styles,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  disabled?: boolean;
+  styles: ReturnType<typeof makeStyles>;
+}) {
+  return (
+    <View style={styles.starRow}>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <TouchableOpacity
+          key={star}
+          onPress={() => onChange(star)}
+          disabled={disabled}
+          activeOpacity={0.75}
+          style={styles.starBtn}
+        >
+          <Text style={[styles.starIcon, star <= value && styles.starIconActive]}>★</Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+function CommentAvatar({
+  avatarUrl,
+  size,
+  styles,
+}: {
+  avatarUrl?: string | null;
+  size: number;
+  styles: ReturnType<typeof makeStyles>;
+}) {
+  if (avatarUrl) {
+    return (
+      <Image
+        source={{ uri: avatarUrl }}
+        style={[styles.avatar, { width: size, height: size, borderRadius: size / 2 }]}
+      />
+    );
+  }
+  return (
+    <View style={[styles.avatarPlaceholder, { width: size, height: size, borderRadius: size / 2 }]}>
+      <Feather name="user" size={size * 0.45} color="#94A3B8" />
+    </View>
+  );
+}
+
+function DiscussionCommentItem({
+  comment,
+  vm,
+  styles,
+  isAuthenticated,
+  canPost,
+}: {
+  comment: EventComment;
+  vm: EventDiscussionViewModel;
+  styles: ReturnType<typeof makeStyles>;
+  isAuthenticated: boolean;
+  canPost: boolean;
+}) {
+  const replies = vm.repliesMap[comment.id];
+  const isReplying = vm.replyingToId === comment.id;
+  const showReplies = Boolean(replies);
+
+  return (
+    <View style={styles.commentCard}>
+      <View style={styles.commentHeader}>
+        <CommentAvatar avatarUrl={comment.user.avatar_url} size={36} styles={styles} />
+        <View style={styles.commentMeta}>
+          <Text style={styles.commentDisplayName}>
+            {comment.user.display_name ?? comment.user.username}
+          </Text>
+          <Text style={styles.commentTimestamp}>{formatRelativeTime(comment.created_at)}</Text>
+        </View>
+      </View>
+
+      <Text style={styles.commentMessage}>{comment.message}</Text>
+
+      <View style={styles.commentActions}>
+        {comment.reply_count > 0 && !showReplies && (
+          <TouchableOpacity
+            onPress={() => void vm.loadReplies(comment.id)}
+            style={styles.replyToggle}
+          >
+            <Feather name="message-square" size={13} color="#6366F1" />
+            <Text style={styles.replyToggleText}>
+              {comment.reply_count} {comment.reply_count === 1 ? 'reply' : 'replies'}
+            </Text>
+          </TouchableOpacity>
+        )}
+        {showReplies && (
+          <View style={styles.replyToggle}>
+            <Feather name="message-square" size={13} color="#6366F1" />
+            <Text style={styles.replyToggleText}>
+              {replies.items.length} {replies.items.length === 1 ? 'reply' : 'replies'}
+            </Text>
+          </View>
+        )}
+        {isAuthenticated && canPost && !isReplying && (
+          <TouchableOpacity
+            onPress={() => {
+              vm.setReplyingToId(comment.id);
+              vm.setReplyMessage('');
+            }}
+            style={styles.replyBtn}
+          >
+            <Feather name="corner-down-right" size={13} color="#94A3B8" />
+            <Text style={styles.replyBtnText}>Reply</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {isReplying && (
+        <View style={styles.replyInputContainer}>
+          <TextInput
+            style={styles.replyInput}
+            placeholder="Write a reply…"
+            placeholderTextColor="#94A3B8"
+            value={vm.replyMessage}
+            onChangeText={vm.setReplyMessage}
+            multiline
+            maxLength={1000}
+            editable={!vm.discussionSubmitting}
+          />
+          <View style={styles.replyInputActions}>
+            <TouchableOpacity
+              onPress={() => {
+                vm.setReplyingToId(null);
+                vm.setReplyMessage('');
+              }}
+              style={styles.replyCancelBtn}
+              disabled={vm.discussionSubmitting}
+            >
+              <Text style={styles.replyCancelText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => void vm.submitReply(comment.id)}
+              style={[
+                styles.replySubmitBtn,
+                (!vm.replyMessage.trim() || vm.discussionSubmitting) && styles.submitBtnDisabled,
+              ]}
+              disabled={!vm.replyMessage.trim() || vm.discussionSubmitting}
+            >
+              {vm.discussionSubmitting ? (
+                <ActivityIndicator size="small" color="white" />
+              ) : (
+                <Text style={styles.replySubmitText}>Post</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+
+      {showReplies && (
+        <View style={styles.repliesContainer}>
+          {replies.loading && replies.items.length === 0 ? (
+            <ActivityIndicator size="small" color="#6366F1" style={{ marginTop: 8 }} />
+          ) : (
+            replies.items.map((reply) => (
+              <View key={reply.id} style={styles.replyCard}>
+                <View style={styles.commentHeader}>
+                  <CommentAvatar avatarUrl={reply.user.avatar_url} size={28} styles={styles} />
+                  <View style={styles.commentMeta}>
+                    <Text style={styles.commentDisplayName}>
+                      {reply.user.display_name ?? reply.user.username}
+                    </Text>
+                    <Text style={styles.commentTimestamp}>
+                      {formatRelativeTime(reply.created_at)}
+                    </Text>
+                  </View>
+                </View>
+                <Text style={styles.commentMessage}>{reply.message}</Text>
+              </View>
+            ))
+          )}
+          {replies.hasNext && (
+            <TouchableOpacity
+              onPress={() => void vm.loadMoreReplies(comment.id)}
+              style={styles.loadMoreBtn}
+              disabled={replies.loading}
+            >
+              {replies.loading ? (
+                <ActivityIndicator size="small" color="#6366F1" />
+              ) : (
+                <Text style={styles.loadMoreText}>Load more replies</Text>
+              )}
+            </TouchableOpacity>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function ReviewCommentItem({
+  comment,
+  styles,
+}: {
+  comment: EventComment;
+  styles: ReturnType<typeof makeStyles>;
+}) {
+  return (
+    <View style={styles.commentCard}>
+      <View style={styles.commentHeader}>
+        <CommentAvatar avatarUrl={comment.user.avatar_url} size={36} styles={styles} />
+        <View style={styles.commentMeta}>
+          <Text style={styles.commentDisplayName}>
+            {comment.user.display_name ?? comment.user.username}
+          </Text>
+          <Text style={styles.commentTimestamp}>{formatRelativeTime(comment.created_at)}</Text>
+        </View>
+        {comment.rating != null && (
+          <Text style={styles.reviewStars}>{renderStars(comment.rating)}</Text>
+        )}
+      </View>
+      <Text style={styles.commentMessage}>{comment.message}</Text>
+      {comment.image_url && (
+        <Image source={{ uri: comment.image_url }} style={styles.reviewImage} resizeMode="cover" />
+      )}
+    </View>
+  );
+}
+
+export default function EventDiscussionSection({
+  vm,
+  eventStatus,
+  isAuthenticated,
+  canPostDiscussion,
+  canPostReview,
+  hasExistingReview,
+  reviewWindowClosed = false,
+}: Props) {
+  const { theme } = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme]);
+  const [activeTab, setActiveTab] = React.useState<'qa' | 'reviews'>('qa');
+
+  const isCompleted = eventStatus === 'COMPLETED';
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.tabRow}>
+        <TouchableOpacity
+          style={[styles.tab, activeTab === 'qa' && styles.tabActive]}
+          onPress={() => setActiveTab('qa')}
+        >
+          <Text style={[styles.tabText, activeTab === 'qa' && styles.tabTextActive]}>
+            Q&A ({vm.discussions.items.length})
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tab, activeTab === 'reviews' && styles.tabActive]}
+          onPress={() => setActiveTab('reviews')}
+        >
+          <Text style={[styles.tabText, activeTab === 'reviews' && styles.tabTextActive]}>
+            Reviews ({vm.reviews.items.length})
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {activeTab === 'qa' && (
+        <View>
+          {canPostDiscussion && (
+            <View style={styles.inputCard}>
+              <TextInput
+                style={styles.messageInput}
+                placeholder="Ask a question or start a discussion…"
+                placeholderTextColor="#94A3B8"
+                value={vm.newDiscussionMessage}
+                onChangeText={vm.setNewDiscussionMessage}
+                multiline
+                maxLength={1000}
+                editable={!vm.discussionSubmitting}
+              />
+              <View style={styles.inputFooter}>
+                <Text style={styles.charCount}>{vm.newDiscussionMessage.length}/1000</Text>
+                <TouchableOpacity
+                  style={[
+                    styles.submitBtn,
+                    (!vm.newDiscussionMessage.trim() || vm.discussionSubmitting) &&
+                      styles.submitBtnDisabled,
+                  ]}
+                  onPress={() => void vm.submitDiscussionComment()}
+                  disabled={!vm.newDiscussionMessage.trim() || vm.discussionSubmitting}
+                >
+                  {vm.discussionSubmitting ? (
+                    <ActivityIndicator size="small" color="white" />
+                  ) : (
+                    <Text style={styles.submitBtnText}>Post</Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+              {vm.discussionError && (
+                <View style={styles.errorBanner}>
+                  <Text style={styles.errorText}>{vm.discussionError}</Text>
+                  <TouchableOpacity onPress={vm.dismissDiscussionError}>
+                    <Feather name="x" size={14} color={theme.errorText} />
+                  </TouchableOpacity>
+                </View>
+              )}
+            </View>
+          )}
+
+          {!isAuthenticated && (
+            <View style={styles.authNotice}>
+              <Feather name="lock" size={14} color="#94A3B8" />
+              <Text style={styles.authNoticeText}>Sign in to join the discussion.</Text>
+            </View>
+          )}
+
+          {isCompleted && (
+            <View style={styles.closedNotice}>
+              <Feather name="info" size={14} color={theme.warningText} />
+              <Text style={styles.closedNoticeText}>
+                This event has ended. New Q&A comments are closed.
+              </Text>
+            </View>
+          )}
+
+          {vm.discussions.loading && vm.discussions.items.length === 0 ? (
+            <ActivityIndicator size="small" color={theme.primary} style={styles.loadingSpinner} />
+          ) : vm.discussions.items.length === 0 ? (
+            <View style={styles.emptyState}>
+              <Feather name="message-circle" size={32} color="#CBD5E1" />
+              <Text style={styles.emptyStateText}>No questions yet. Be the first to ask!</Text>
+            </View>
+          ) : (
+            vm.discussions.items.map((comment) => (
+              <DiscussionCommentItem
+                key={comment.id}
+                comment={comment}
+                vm={vm}
+                styles={styles}
+                isAuthenticated={isAuthenticated}
+                canPost={canPostDiscussion}
+              />
+            ))
+          )}
+
+          {vm.discussions.hasNext && (
+            <TouchableOpacity
+              style={styles.loadMoreBtn}
+              onPress={() => void vm.loadMoreDiscussions()}
+              disabled={vm.discussions.loading}
+            >
+              {vm.discussions.loading ? (
+                <ActivityIndicator size="small" color={theme.primary} />
+              ) : (
+                <Text style={styles.loadMoreText}>Load more questions</Text>
+              )}
+            </TouchableOpacity>
+          )}
+        </View>
+      )}
+
+      {activeTab === 'reviews' && (
+        <View>
+          {canPostReview && (
+            <View style={styles.inputCard}>
+              <Text style={styles.reviewInputLabel}>
+                {hasExistingReview ? 'Update your review' : 'Leave a review'}
+              </Text>
+              <StarRatingInput
+                value={vm.newReviewRating}
+                onChange={vm.setNewReviewRating}
+                disabled={vm.reviewSubmitting}
+                styles={styles}
+              />
+              <TextInput
+                style={styles.messageInput}
+                placeholder="Share your experience…"
+                placeholderTextColor="#94A3B8"
+                value={vm.newReviewMessage}
+                onChangeText={vm.setNewReviewMessage}
+                multiline
+                maxLength={1000}
+                editable={!vm.reviewSubmitting}
+              />
+              <View style={styles.inputFooter}>
+                <Text style={styles.charCount}>{vm.newReviewMessage.length}/1000</Text>
+                <TouchableOpacity
+                  style={[
+                    styles.submitBtn,
+                    (!vm.newReviewMessage.trim() || vm.newReviewRating < 1 || vm.reviewSubmitting) &&
+                      styles.submitBtnDisabled,
+                  ]}
+                  onPress={() => void vm.submitReview()}
+                  disabled={
+                    !vm.newReviewMessage.trim() || vm.newReviewRating < 1 || vm.reviewSubmitting
+                  }
+                >
+                  {vm.reviewSubmitting ? (
+                    <ActivityIndicator size="small" color="white" />
+                  ) : (
+                    <Text style={styles.submitBtnText}>
+                      {hasExistingReview ? 'Update' : 'Submit'}
+                    </Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+              {vm.reviewError && (
+                <View style={styles.errorBanner}>
+                  <Text style={styles.errorText}>{vm.reviewError}</Text>
+                  <TouchableOpacity onPress={vm.dismissReviewError}>
+                    <Feather name="x" size={14} color={theme.errorText} />
+                  </TouchableOpacity>
+                </View>
+              )}
+            </View>
+          )}
+
+          {!isAuthenticated && (
+            <View style={styles.authNotice}>
+              <Feather name="lock" size={14} color="#94A3B8" />
+              <Text style={styles.authNoticeText}>Sign in to leave a review.</Text>
+            </View>
+          )}
+
+          {isAuthenticated && reviewWindowClosed && (
+            <View style={styles.closedNotice}>
+              <Feather name="clock" size={14} color={theme.warningText} />
+              <Text style={styles.closedNoticeText}>
+                The feedback window has closed. New reviews are no longer accepted.
+              </Text>
+            </View>
+          )}
+
+          {vm.reviews.loading && vm.reviews.items.length === 0 ? (
+            <ActivityIndicator size="small" color={theme.primary} style={styles.loadingSpinner} />
+          ) : vm.reviews.items.length === 0 ? (
+            <View style={styles.emptyState}>
+              <Feather name="star" size={32} color="#CBD5E1" />
+              <Text style={styles.emptyStateText}>No reviews yet.</Text>
+            </View>
+          ) : (
+            vm.reviews.items.map((comment) => (
+              <ReviewCommentItem key={comment.id} comment={comment} styles={styles} />
+            ))
+          )}
+
+          {vm.reviews.hasNext && (
+            <TouchableOpacity
+              style={styles.loadMoreBtn}
+              onPress={() => void vm.loadMoreReviews()}
+              disabled={vm.reviews.loading}
+            >
+              {vm.reviews.loading ? (
+                <ActivityIndicator size="small" color={theme.primary} />
+              ) : (
+                <Text style={styles.loadMoreText}>Load more reviews</Text>
+              )}
+            </TouchableOpacity>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function makeStyles(t: Theme) {
+  return StyleSheet.create({
+    container: {
+      backgroundColor: t.surface,
+    },
+    tabRow: {
+      flexDirection: 'row',
+      borderBottomWidth: 1,
+      borderBottomColor: t.border,
+    },
+    tab: {
+      flex: 1,
+      paddingVertical: 12,
+      alignItems: 'center',
+    },
+    tabActive: {
+      borderBottomWidth: 2,
+      borderBottomColor: t.primary,
+    },
+    tabText: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: t.textTertiary,
+    },
+    tabTextActive: {
+      color: t.text,
+    },
+    inputCard: {
+      margin: 16,
+      padding: 14,
+      borderRadius: 14,
+      borderWidth: 1,
+      borderColor: t.border,
+      backgroundColor: t.surfaceVariant,
+      gap: 10,
+    },
+    reviewInputLabel: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: t.textSecondary,
+    },
+    starRow: {
+      flexDirection: 'row',
+      gap: 4,
+    },
+    starBtn: {
+      width: 44,
+      height: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    starIcon: {
+      fontSize: 34,
+      color: t.border,
+    },
+    starIconActive: {
+      color: '#F59E0B',
+    },
+    messageInput: {
+      borderWidth: 1,
+      borderColor: t.border,
+      borderRadius: 10,
+      padding: 12,
+      fontSize: 14,
+      color: t.text,
+      backgroundColor: t.surface,
+      minHeight: 80,
+      textAlignVertical: 'top',
+    },
+    inputFooter: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    charCount: {
+      fontSize: 12,
+      color: t.textMuted,
+    },
+    submitBtn: {
+      paddingHorizontal: 18,
+      paddingVertical: 9,
+      borderRadius: 10,
+      backgroundColor: t.primary,
+      minWidth: 70,
+      alignItems: 'center',
+    },
+    submitBtnDisabled: {
+      opacity: 0.45,
+    },
+    submitBtnText: {
+      fontSize: 14,
+      fontWeight: '700',
+      color: t.textOnPrimary,
+    },
+    errorBanner: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: 10,
+      borderRadius: 8,
+      backgroundColor: t.errorBg,
+      borderWidth: 1,
+      borderColor: t.errorBorder,
+      gap: 8,
+    },
+    errorText: {
+      flex: 1,
+      fontSize: 13,
+      color: t.errorText,
+    },
+    authNotice: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      marginHorizontal: 16,
+      marginTop: 12,
+      marginBottom: 4,
+    },
+    authNoticeText: {
+      fontSize: 13,
+      color: t.textTertiary,
+    },
+    closedNotice: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      marginHorizontal: 16,
+      marginTop: 12,
+      padding: 10,
+      borderRadius: 8,
+      backgroundColor: t.warningBg,
+      borderWidth: 1,
+      borderColor: t.warningBorder,
+    },
+    closedNoticeText: {
+      flex: 1,
+      fontSize: 13,
+      color: t.warningText,
+    },
+    loadingSpinner: {
+      marginVertical: 24,
+    },
+    emptyState: {
+      alignItems: 'center',
+      paddingVertical: 32,
+      gap: 10,
+    },
+    emptyStateText: {
+      fontSize: 14,
+      color: t.textTertiary,
+    },
+    commentCard: {
+      marginHorizontal: 16,
+      marginTop: 12,
+      padding: 14,
+      borderRadius: 14,
+      borderWidth: 1,
+      borderColor: t.border,
+      backgroundColor: t.surface,
+      gap: 8,
+    },
+    commentHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+    },
+    avatar: {
+      backgroundColor: t.imagePlaceholder,
+    },
+    avatarPlaceholder: {
+      backgroundColor: t.imagePlaceholder,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    commentMeta: {
+      flex: 1,
+      gap: 2,
+    },
+    commentDisplayName: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: t.text,
+    },
+    commentTimestamp: {
+      fontSize: 11,
+      color: t.textMuted,
+    },
+    reviewStars: {
+      fontSize: 14,
+      color: '#F59E0B',
+    },
+    commentMessage: {
+      fontSize: 14,
+      lineHeight: 21,
+      color: t.textSecondary,
+    },
+    reviewImage: {
+      width: '100%',
+      height: 180,
+      borderRadius: 10,
+      marginTop: 4,
+    },
+    commentActions: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      marginTop: 2,
+    },
+    replyToggle: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
+    replyToggleText: {
+      fontSize: 12,
+      fontWeight: '600',
+      color: '#6366F1',
+    },
+    replyBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
+    replyBtnText: {
+      fontSize: 12,
+      fontWeight: '600',
+      color: t.textTertiary,
+    },
+    replyInputContainer: {
+      marginTop: 8,
+      gap: 8,
+    },
+    replyInput: {
+      borderWidth: 1,
+      borderColor: t.border,
+      borderRadius: 10,
+      padding: 10,
+      fontSize: 13,
+      color: t.text,
+      backgroundColor: t.surfaceVariant,
+      minHeight: 60,
+      textAlignVertical: 'top',
+    },
+    replyInputActions: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      gap: 10,
+    },
+    replyCancelBtn: {
+      paddingHorizontal: 14,
+      paddingVertical: 7,
+    },
+    replyCancelText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: t.textSecondary,
+    },
+    replySubmitBtn: {
+      paddingHorizontal: 16,
+      paddingVertical: 7,
+      borderRadius: 8,
+      backgroundColor: t.primary,
+      minWidth: 56,
+      alignItems: 'center',
+    },
+    replySubmitText: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: t.textOnPrimary,
+    },
+    repliesContainer: {
+      marginTop: 6,
+      paddingLeft: 12,
+      borderLeftWidth: 2,
+      borderLeftColor: t.border,
+      gap: 8,
+    },
+    replyCard: {
+      gap: 6,
+    },
+    loadMoreBtn: {
+      alignItems: 'center',
+      paddingVertical: 14,
+    },
+    loadMoreText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: '#6366F1',
+    },
+  });
+}

--- a/mobile/src/components/events/EventDiscussionSection.tsx
+++ b/mobile/src/components/events/EventDiscussionSection.tsx
@@ -112,7 +112,21 @@ function DiscussionCommentItem({
 }) {
   const replies = vm.repliesMap[comment.id];
   const isReplying = vm.replyingToId === comment.id;
-  const showReplies = Boolean(replies);
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const showReplies = isExpanded && Boolean(replies);
+  const replyCount = replies ? replies.items.length : comment.reply_count;
+  const replyCountLabel = `${replyCount} ${replyCount === 1 ? 'reply' : 'replies'}`;
+
+  const handleToggleReplies = () => {
+    if (isExpanded) {
+      setIsExpanded(false);
+      return;
+    }
+    setIsExpanded(true);
+    if (!replies) {
+      void vm.loadReplies(comment.id);
+    }
+  };
 
   return (
     <View style={styles.commentCard}>
@@ -129,24 +143,21 @@ function DiscussionCommentItem({
       <Text style={styles.commentMessage}>{comment.message}</Text>
 
       <View style={styles.commentActions}>
-        {comment.reply_count > 0 && !showReplies && (
+        {replyCount > 0 && (
           <TouchableOpacity
-            onPress={() => void vm.loadReplies(comment.id)}
+            onPress={handleToggleReplies}
             style={styles.replyToggle}
+            testID={`reply-toggle-${comment.id}`}
           >
-            <Feather name="message-square" size={13} color="#6366F1" />
+            <Feather
+              name={isExpanded ? 'chevron-up' : 'chevron-down'}
+              size={13}
+              color="#6366F1"
+            />
             <Text style={styles.replyToggleText}>
-              {comment.reply_count} {comment.reply_count === 1 ? 'reply' : 'replies'}
+              {isExpanded ? `Hide ${replyCountLabel}` : `View ${replyCountLabel}`}
             </Text>
           </TouchableOpacity>
-        )}
-        {showReplies && (
-          <View style={styles.replyToggle}>
-            <Feather name="message-square" size={13} color="#6366F1" />
-            <Text style={styles.replyToggleText}>
-              {replies.items.length} {replies.items.length === 1 ? 'reply' : 'replies'}
-            </Text>
-          </View>
         )}
         {isAuthenticated && canPost && !isReplying && (
           <TouchableOpacity

--- a/mobile/src/models/comment.ts
+++ b/mobile/src/models/comment.ts
@@ -1,0 +1,61 @@
+export type CommentType = 'DISCUSSION' | 'REVIEW';
+
+export interface CommentUser {
+  id: string;
+  username: string;
+  display_name?: string | null;
+  avatar_url?: string | null;
+}
+
+export interface EventComment {
+  id: string;
+  event_id: string;
+  user: CommentUser;
+  comment_type: CommentType;
+  message: string;
+  parent_id?: string | null;
+  rating?: number | null;
+  image_url?: string | null;
+  likes_count: number;
+  reply_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommentPageInfo {
+  next_cursor?: string | null;
+  has_next: boolean;
+}
+
+export interface CommentCollection {
+  items: EventComment[];
+  page_info: CommentPageInfo;
+}
+
+export interface EventCommentsResponse {
+  discussion_comments: CommentCollection;
+  review_comments: CommentCollection;
+}
+
+export interface CreateDiscussionCommentRequest {
+  message: string;
+  parent_id?: string | null;
+}
+
+export interface UpsertReviewCommentRequest {
+  message: string;
+  rating: number;
+  image_confirm_token?: string | null;
+}
+
+export interface ListEventCommentsParams {
+  discussion_limit?: number;
+  discussion_cursor?: string | null;
+  review_limit?: number;
+  review_cursor?: string | null;
+}
+
+export interface ListCommentRepliesParams {
+  limit?: number;
+  cursor?: string | null;
+}

--- a/mobile/src/services/commentService.test.ts
+++ b/mobile/src/services/commentService.test.ts
@@ -1,0 +1,262 @@
+import {
+  listEventComments,
+  listCommentReplies,
+  createDiscussionComment,
+  upsertReviewComment,
+} from './commentService';
+import { ApiError } from './api';
+import type { EventCommentsResponse, CommentCollection, EventComment } from '@/models/comment';
+
+const originalFetch = global.fetch;
+const mockFetch = jest.fn();
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as any;
+}
+
+const mockComment: EventComment = {
+  id: 'comment-uuid-001',
+  event_id: 'event-uuid-001',
+  user: { id: 'user-001', username: 'alice', display_name: 'Alice', avatar_url: null },
+  comment_type: 'DISCUSSION',
+  message: 'When does registration close?',
+  parent_id: null,
+  rating: null,
+  image_url: null,
+  likes_count: 0,
+  reply_count: 2,
+  created_at: '2026-05-01T10:00:00Z',
+  updated_at: '2026-05-01T10:00:00Z',
+};
+
+const mockReview: EventComment = {
+  id: 'comment-uuid-002',
+  event_id: 'event-uuid-001',
+  user: { id: 'user-002', username: 'bob', display_name: 'Bob', avatar_url: null },
+  comment_type: 'REVIEW',
+  message: 'Great event!',
+  parent_id: null,
+  rating: 5,
+  image_url: null,
+  likes_count: 3,
+  reply_count: 0,
+  created_at: '2026-05-02T10:00:00Z',
+  updated_at: '2026-05-02T10:00:00Z',
+};
+
+const mockCommentsResponse: EventCommentsResponse = {
+  discussion_comments: {
+    items: [mockComment],
+    page_info: { next_cursor: null, has_next: false },
+  },
+  review_comments: {
+    items: [mockReview],
+    page_info: { next_cursor: null, has_next: false },
+  },
+};
+
+const mockRepliesResponse: CommentCollection = {
+  items: [
+    {
+      id: 'comment-uuid-003',
+      event_id: 'event-uuid-001',
+      user: { id: 'user-003', username: 'carol', display_name: 'Carol', avatar_url: null },
+      comment_type: 'DISCUSSION',
+      message: 'Registration closes 3 days before.',
+      parent_id: 'comment-uuid-001',
+      rating: null,
+      image_url: null,
+      likes_count: 1,
+      reply_count: 0,
+      created_at: '2026-05-01T11:00:00Z',
+      updated_at: '2026-05-01T11:00:00Z',
+    },
+  ],
+  page_info: { next_cursor: null, has_next: false },
+};
+
+jest.mock('@/config/apiBaseUrl', () => ({ API_BASE_URL: 'https://api.test' }));
+jest.mock('@/services/sessionManager', () => ({
+  getCurrentSession: () => ({ access_token: 'stored-token', refresh_token: 'rt' }),
+  refreshSession: jest.fn().mockResolvedValue({ access_token: 'new-token' }),
+}));
+
+beforeEach(() => {
+  global.fetch = mockFetch as any;
+  mockFetch.mockReset();
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('listEventComments', () => {
+  it('fetches comments without auth when no token provided', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockCommentsResponse));
+
+    const result = await listEventComments('event-uuid-001');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.test/events/event-uuid-001/comments',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(result.discussion_comments.items).toHaveLength(1);
+    expect(result.review_comments.items).toHaveLength(1);
+  });
+
+  it('fetches comments with auth when token provided', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockCommentsResponse));
+
+    const result = await listEventComments('event-uuid-001', {}, 'mock-token');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.test/events/event-uuid-001/comments',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer stored-token' }),
+      }),
+    );
+    expect(result).toEqual(mockCommentsResponse);
+  });
+
+  it('builds correct query string with pagination params', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockCommentsResponse));
+
+    await listEventComments(
+      'event-uuid-001',
+      { discussion_limit: 10, discussion_cursor: 'cursor-abc', review_limit: 5 },
+      'mock-token',
+    );
+
+    const calledUrl: string = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('discussion_limit=10');
+    expect(calledUrl).toContain('discussion_cursor=cursor-abc');
+    expect(calledUrl).toContain('review_limit=5');
+  });
+
+  it('throws ApiError on non-2xx response', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ error: { code: 'comments_not_allowed', message: 'Private event' } }, 409),
+    );
+
+    await expect(listEventComments('event-uuid-001')).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe('listCommentReplies', () => {
+  it('fetches replies for a parent comment', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockRepliesResponse));
+
+    const result = await listCommentReplies('event-uuid-001', 'comment-uuid-001');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.test/events/event-uuid-001/comments/comment-uuid-001/replies',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].parent_id).toBe('comment-uuid-001');
+  });
+
+  it('passes cursor and limit in query string', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockRepliesResponse));
+
+    await listCommentReplies(
+      'event-uuid-001',
+      'comment-uuid-001',
+      { limit: 10, cursor: 'reply-cursor' },
+      'tok',
+    );
+
+    const calledUrl: string = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('limit=10');
+    expect(calledUrl).toContain('cursor=reply-cursor');
+  });
+});
+
+describe('createDiscussionComment', () => {
+  it('posts a new top-level discussion comment', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockComment, 201));
+
+    const result = await createDiscussionComment(
+      'event-uuid-001',
+      { message: 'When does registration close?' },
+      'mock-token',
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.test/events/event-uuid-001/comments',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ message: 'When does registration close?' }),
+      }),
+    );
+    expect(result.id).toBe('comment-uuid-001');
+    expect(result.comment_type).toBe('DISCUSSION');
+  });
+
+  it('posts a reply with parent_id', async () => {
+    const reply: EventComment = { ...mockComment, id: 'reply-001', parent_id: 'comment-uuid-001' };
+    mockFetch.mockResolvedValueOnce(jsonResponse(reply, 201));
+
+    const result = await createDiscussionComment(
+      'event-uuid-001',
+      { message: 'Thanks!', parent_id: 'comment-uuid-001' },
+      'mock-token',
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.parent_id).toBe('comment-uuid-001');
+    expect(result.parent_id).toBe('comment-uuid-001');
+  });
+
+  it('throws ApiError when write is not allowed', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(
+        { error: { code: 'comment_write_not_allowed', message: 'Not allowed' } },
+        409,
+      ),
+    );
+
+    await expect(
+      createDiscussionComment('event-uuid-001', { message: 'Hello' }, 'tok'),
+    ).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe('upsertReviewComment', () => {
+  it('posts a review with rating and message', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockReview));
+
+    const result = await upsertReviewComment(
+      'event-uuid-001',
+      { message: 'Great event!', rating: 5 },
+      'mock-token',
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.test/events/event-uuid-001/review-comments',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ message: 'Great event!', rating: 5 }),
+      }),
+    );
+    expect(result.rating).toBe(5);
+    expect(result.comment_type).toBe('REVIEW');
+  });
+
+  it('throws ApiError when host tries to review own event', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(
+        { error: { code: 'host_cannot_rate_self', message: 'Hosts cannot rate themselves' } },
+        403,
+      ),
+    );
+
+    await expect(
+      upsertReviewComment('event-uuid-001', { message: 'Great', rating: 5 }, 'tok'),
+    ).rejects.toMatchObject({ code: 'host_cannot_rate_self' });
+  });
+});

--- a/mobile/src/services/commentService.ts
+++ b/mobile/src/services/commentService.ts
@@ -1,0 +1,70 @@
+import { apiGet, apiGetAuth, apiPostAuth } from '@/services/api';
+import {
+  EventCommentsResponse,
+  CommentCollection,
+  EventComment,
+  CreateDiscussionCommentRequest,
+  UpsertReviewCommentRequest,
+  ListEventCommentsParams,
+  ListCommentRepliesParams,
+} from '@/models/comment';
+
+function buildCommentsPath(eventId: string, params: ListEventCommentsParams): string {
+  const p = new URLSearchParams();
+  if (params.discussion_limit != null) p.set('discussion_limit', String(params.discussion_limit));
+  if (params.discussion_cursor) p.set('discussion_cursor', params.discussion_cursor);
+  if (params.review_limit != null) p.set('review_limit', String(params.review_limit));
+  if (params.review_cursor) p.set('review_cursor', params.review_cursor);
+  const query = p.toString();
+  return query ? `/events/${eventId}/comments?${query}` : `/events/${eventId}/comments`;
+}
+
+function buildRepliesPath(eventId: string, commentId: string, params: ListCommentRepliesParams): string {
+  const p = new URLSearchParams();
+  if (params.limit != null) p.set('limit', String(params.limit));
+  if (params.cursor) p.set('cursor', params.cursor);
+  const query = p.toString();
+  const base = `/events/${eventId}/comments/${commentId}/replies`;
+  return query ? `${base}?${query}` : base;
+}
+
+export async function listEventComments(
+  eventId: string,
+  params: ListEventCommentsParams = {},
+  token?: string,
+): Promise<EventCommentsResponse> {
+  const path = buildCommentsPath(eventId, params);
+  if (token) {
+    return apiGetAuth<EventCommentsResponse>(path, token);
+  }
+  return apiGet<EventCommentsResponse>(path);
+}
+
+export async function listCommentReplies(
+  eventId: string,
+  commentId: string,
+  params: ListCommentRepliesParams = {},
+  token?: string,
+): Promise<CommentCollection> {
+  const path = buildRepliesPath(eventId, commentId, params);
+  if (token) {
+    return apiGetAuth<CommentCollection>(path, token);
+  }
+  return apiGet<CommentCollection>(path);
+}
+
+export async function createDiscussionComment(
+  eventId: string,
+  body: CreateDiscussionCommentRequest,
+  token: string,
+): Promise<EventComment> {
+  return apiPostAuth<EventComment>(`/events/${eventId}/comments`, body, token);
+}
+
+export async function upsertReviewComment(
+  eventId: string,
+  body: UpsertReviewCommentRequest,
+  token: string,
+): Promise<EventComment> {
+  return apiPostAuth<EventComment>(`/events/${eventId}/review-comments`, body, token);
+}

--- a/mobile/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/mobile/src/viewmodels/event/useEventDetailViewModel.ts
@@ -9,6 +9,7 @@ import {
   EventReportCategory,
   RequestReportEvent,
 } from '@/models/event';
+import type { UserSummary } from '@/models/auth';
 import {
   getEventDetail,
   getEventHostContextSummary,
@@ -147,6 +148,9 @@ export interface EventDetailViewModel {
   removeReportImage: () => void;
   handleReportEvent: () => Promise<void>;
   canAttachReportImage: boolean;
+
+  token: string | null;
+  user: UserSummary | null;
 }
 
 function mapRatingError(err: ApiError, fallback: string): string {
@@ -1229,5 +1233,8 @@ export function useEventDetailViewModel(eventId: string): EventDetailViewModel {
     removeReportImage,
     handleReportEvent,
     canAttachReportImage,
+
+    token,
+    user,
   };
 }

--- a/mobile/src/viewmodels/event/useEventDiscussionViewModel.test.ts
+++ b/mobile/src/viewmodels/event/useEventDiscussionViewModel.test.ts
@@ -1,0 +1,533 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import * as commentService from '@/services/commentService';
+import { ApiError } from '@/services/api';
+import type { EventComment, EventCommentsResponse, CommentCollection } from '@/models/comment';
+import { useEventDiscussionViewModel } from './useEventDiscussionViewModel';
+
+jest.mock('@/services/commentService');
+
+const mockListEventComments = jest.mocked(commentService.listEventComments);
+const mockListCommentReplies = jest.mocked(commentService.listCommentReplies);
+const mockCreateDiscussionComment = jest.mocked(commentService.createDiscussionComment);
+const mockUpsertReviewComment = jest.mocked(commentService.upsertReviewComment);
+
+const mockDiscussionComment: EventComment = {
+  id: 'comment-001',
+  event_id: 'event-001',
+  user: { id: 'user-001', username: 'alice', display_name: 'Alice', avatar_url: null },
+  comment_type: 'DISCUSSION',
+  message: 'When does check-in open?',
+  parent_id: null,
+  rating: null,
+  image_url: null,
+  likes_count: 0,
+  reply_count: 1,
+  created_at: '2026-05-01T10:00:00Z',
+  updated_at: '2026-05-01T10:00:00Z',
+};
+
+const mockReviewComment: EventComment = {
+  id: 'comment-002',
+  event_id: 'event-001',
+  user: { id: 'user-002', username: 'bob', display_name: 'Bob', avatar_url: null },
+  comment_type: 'REVIEW',
+  message: 'Amazing event!',
+  parent_id: null,
+  rating: 5,
+  image_url: null,
+  likes_count: 2,
+  reply_count: 0,
+  created_at: '2026-05-03T10:00:00Z',
+  updated_at: '2026-05-03T10:00:00Z',
+};
+
+const mockReplyComment: EventComment = {
+  id: 'comment-003',
+  event_id: 'event-001',
+  user: { id: 'user-003', username: 'carol', display_name: 'Carol', avatar_url: null },
+  comment_type: 'DISCUSSION',
+  message: 'Check-in opens at 8 AM.',
+  parent_id: 'comment-001',
+  rating: null,
+  image_url: null,
+  likes_count: 0,
+  reply_count: 0,
+  created_at: '2026-05-01T11:00:00Z',
+  updated_at: '2026-05-01T11:00:00Z',
+};
+
+function makeEmptyResponse(): EventCommentsResponse {
+  return {
+    discussion_comments: { items: [], page_info: { next_cursor: null, has_next: false } },
+    review_comments: { items: [], page_info: { next_cursor: null, has_next: false } },
+  };
+}
+
+function makePopulatedResponse(): EventCommentsResponse {
+  return {
+    discussion_comments: {
+      items: [mockDiscussionComment],
+      page_info: { next_cursor: null, has_next: false },
+    },
+    review_comments: {
+      items: [mockReviewComment],
+      page_info: { next_cursor: null, has_next: false },
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListEventComments.mockResolvedValue(makeEmptyResponse());
+  mockListCommentReplies.mockResolvedValue({
+    items: [],
+    page_info: { next_cursor: null, has_next: false },
+  });
+  mockCreateDiscussionComment.mockResolvedValue(mockDiscussionComment);
+  mockUpsertReviewComment.mockResolvedValue(mockReviewComment);
+});
+
+describe('useEventDiscussionViewModel — initial load', () => {
+  it('loads discussion and review comments on mount', async () => {
+    mockListEventComments.mockResolvedValueOnce(makePopulatedResponse());
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => {
+      expect(result.current.discussions.loading).toBe(false);
+    });
+
+    expect(result.current.discussions.items).toHaveLength(1);
+    expect(result.current.discussions.items[0].id).toBe('comment-001');
+    expect(result.current.reviews.items).toHaveLength(1);
+    expect(result.current.reviews.items[0].id).toBe('comment-002');
+  });
+
+  it('passes token to listEventComments', async () => {
+    renderHook(() => useEventDiscussionViewModel('event-001', 'test-token'));
+
+    await waitFor(() => {
+      expect(mockListEventComments).toHaveBeenCalledWith(
+        'event-001',
+        expect.any(Object),
+        'test-token',
+      );
+    });
+  });
+
+  it('works without a token (unauthenticated)', async () => {
+    renderHook(() => useEventDiscussionViewModel('event-001'));
+
+    await waitFor(() => {
+      expect(mockListEventComments).toHaveBeenCalledWith(
+        'event-001',
+        expect.any(Object),
+        undefined,
+      );
+    });
+  });
+
+  it('handles fetch failure gracefully without throwing', async () => {
+    mockListEventComments.mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useEventDiscussionViewModel('event-001', 'tok'));
+
+    await waitFor(() => {
+      expect(result.current.discussions.loading).toBe(false);
+    });
+
+    expect(result.current.discussions.items).toHaveLength(0);
+    expect(result.current.reviews.items).toHaveLength(0);
+  });
+});
+
+describe('useEventDiscussionViewModel — pagination', () => {
+  it('appends more discussions on loadMoreDiscussions', async () => {
+    const page2Comment: EventComment = {
+      ...mockDiscussionComment,
+      id: 'comment-004',
+      message: 'Page 2 question',
+    };
+
+    mockListEventComments
+      .mockResolvedValueOnce({
+        discussion_comments: {
+          items: [mockDiscussionComment],
+          page_info: { next_cursor: 'cursor-page2', has_next: true },
+        },
+        review_comments: { items: [], page_info: { next_cursor: null, has_next: false } },
+      })
+      .mockResolvedValueOnce({
+        discussion_comments: {
+          items: [page2Comment],
+          page_info: { next_cursor: null, has_next: false },
+        },
+        review_comments: { items: [], page_info: { next_cursor: null, has_next: false } },
+      });
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'tok'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.items).toHaveLength(1));
+    expect(result.current.discussions.hasNext).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMoreDiscussions();
+    });
+
+    expect(result.current.discussions.items).toHaveLength(2);
+    expect(result.current.discussions.items[1].id).toBe('comment-004');
+    expect(result.current.discussions.hasNext).toBe(false);
+  });
+
+  it('does not load more when hasNext is false', async () => {
+    const { result } = renderHook(() => useEventDiscussionViewModel('event-001', 'tok'));
+
+    await waitFor(() => expect(result.current.discussions.loading).toBe(false));
+
+    mockListEventComments.mockClear();
+    await act(async () => {
+      await result.current.loadMoreDiscussions();
+    });
+
+    expect(mockListEventComments).not.toHaveBeenCalled();
+  });
+});
+
+describe('useEventDiscussionViewModel — replies', () => {
+  it('loads replies for a parent comment', async () => {
+    const repliesCollection: CommentCollection = {
+      items: [mockReplyComment],
+      page_info: { next_cursor: null, has_next: false },
+    };
+    mockListCommentReplies.mockResolvedValueOnce(repliesCollection);
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'tok'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.loadReplies('comment-001');
+    });
+
+    expect(result.current.repliesMap['comment-001'].items).toHaveLength(1);
+    expect(result.current.repliesMap['comment-001'].items[0].parent_id).toBe('comment-001');
+  });
+
+  it('appends more replies on loadMoreReplies', async () => {
+    const reply1: EventComment = { ...mockReplyComment, id: 'reply-001' };
+    const reply2: EventComment = { ...mockReplyComment, id: 'reply-002' };
+
+    mockListCommentReplies
+      .mockResolvedValueOnce({
+        items: [reply1],
+        page_info: { next_cursor: 'reply-cursor', has_next: true },
+      })
+      .mockResolvedValueOnce({
+        items: [reply2],
+        page_info: { next_cursor: null, has_next: false },
+      });
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'tok'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.loadReplies('comment-001');
+    });
+
+    expect(result.current.repliesMap['comment-001'].items).toHaveLength(1);
+    expect(result.current.repliesMap['comment-001'].hasNext).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMoreReplies('comment-001');
+    });
+
+    expect(result.current.repliesMap['comment-001'].items).toHaveLength(2);
+  });
+});
+
+describe('useEventDiscussionViewModel — submitDiscussionComment', () => {
+  it('prepends the new comment to discussions list on success', async () => {
+    const newComment: EventComment = {
+      ...mockDiscussionComment,
+      id: 'comment-new',
+      message: 'New question',
+    };
+    mockCreateDiscussionComment.mockResolvedValueOnce(newComment);
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setNewDiscussionMessage('New question');
+    });
+
+    await act(async () => {
+      await result.current.submitDiscussionComment();
+    });
+
+    expect(mockCreateDiscussionComment).toHaveBeenCalledWith(
+      'event-001',
+      { message: 'New question' },
+      'mock-token',
+    );
+    expect(result.current.discussions.items[0].id).toBe('comment-new');
+    expect(result.current.newDiscussionMessage).toBe('');
+  });
+
+  it('sets discussionError when createDiscussionComment fails', async () => {
+    mockCreateDiscussionComment.mockRejectedValueOnce(
+      new ApiError(409, {
+        error: { code: 'comment_write_not_allowed', message: 'Not allowed' },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setNewDiscussionMessage('Hello');
+    });
+
+    await act(async () => {
+      await result.current.submitDiscussionComment();
+    });
+
+    expect(result.current.discussionError).toBe(
+      'You cannot post comments on this event.',
+    );
+  });
+
+  it('does nothing when message is empty', async () => {
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.submitDiscussionComment();
+    });
+
+    expect(mockCreateDiscussionComment).not.toHaveBeenCalled();
+  });
+
+  it('dismissDiscussionError clears the error', async () => {
+    mockCreateDiscussionComment.mockRejectedValueOnce(
+      new ApiError(409, { error: { code: 'comments_not_allowed', message: 'Nope' } }),
+    );
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'tok'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setNewDiscussionMessage('Hi');
+    });
+
+    await act(async () => {
+      await result.current.submitDiscussionComment();
+    });
+
+    expect(result.current.discussionError).not.toBeNull();
+
+    act(() => {
+      result.current.dismissDiscussionError();
+    });
+
+    expect(result.current.discussionError).toBeNull();
+  });
+});
+
+describe('useEventDiscussionViewModel — submitReply', () => {
+  it('appends the reply to repliesMap and increments reply_count', async () => {
+    mockListEventComments.mockResolvedValueOnce({
+      discussion_comments: {
+        items: [mockDiscussionComment],
+        page_info: { next_cursor: null, has_next: false },
+      },
+      review_comments: { items: [], page_info: { next_cursor: null, has_next: false } },
+    });
+
+    const newReply: EventComment = { ...mockReplyComment, id: 'new-reply' };
+    mockCreateDiscussionComment.mockResolvedValueOnce(newReply);
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.items).toHaveLength(1));
+
+    await act(async () => {
+      result.current.setReplyMessage('Thanks for the info!');
+    });
+
+    await act(async () => {
+      await result.current.submitReply('comment-001');
+    });
+
+    expect(result.current.repliesMap['comment-001'].items[0].id).toBe('new-reply');
+    expect(result.current.replyMessage).toBe('');
+    expect(result.current.replyingToId).toBeNull();
+
+    const parent = result.current.discussions.items.find((c) => c.id === 'comment-001');
+    expect(parent?.reply_count).toBe(2);
+  });
+});
+
+describe('useEventDiscussionViewModel — submitReview', () => {
+  it('upserts the review and updates the reviews list', async () => {
+    const updatedReview: EventComment = { ...mockReviewComment, message: 'Updated review', rating: 4 };
+    mockUpsertReviewComment.mockResolvedValueOnce(updatedReview);
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => expect(result.current.reviews.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setNewReviewMessage('Updated review');
+      result.current.setNewReviewRating(4);
+    });
+
+    await act(async () => {
+      await result.current.submitReview();
+    });
+
+    expect(mockUpsertReviewComment).toHaveBeenCalledWith(
+      'event-001',
+      { message: 'Updated review', rating: 4 },
+      'mock-token',
+    );
+    expect(result.current.reviews.items[0].message).toBe('Updated review');
+    expect(result.current.newReviewMessage).toBe('');
+    expect(result.current.newReviewRating).toBe(0);
+  });
+
+  it('replaces existing review from same user instead of appending', async () => {
+    const existingReview: EventComment = { ...mockReviewComment, id: 'review-001' };
+    mockListEventComments.mockResolvedValueOnce({
+      discussion_comments: { items: [], page_info: { next_cursor: null, has_next: false } },
+      review_comments: {
+        items: [existingReview],
+        page_info: { next_cursor: null, has_next: false },
+      },
+    });
+
+    const updatedReview: EventComment = {
+      ...existingReview,
+      message: 'Actually it was 4 stars.',
+      rating: 4,
+    };
+    mockUpsertReviewComment.mockResolvedValueOnce(updatedReview);
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => expect(result.current.reviews.items).toHaveLength(1));
+
+    await act(async () => {
+      result.current.setNewReviewMessage('Actually it was 4 stars.');
+      result.current.setNewReviewRating(4);
+    });
+
+    await act(async () => {
+      await result.current.submitReview();
+    });
+
+    expect(result.current.reviews.items).toHaveLength(1);
+    expect(result.current.reviews.items[0].rating).toBe(4);
+  });
+
+  it('does nothing when rating is 0', async () => {
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => expect(result.current.reviews.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setNewReviewMessage('Great event');
+      await result.current.submitReview();
+    });
+
+    expect(mockUpsertReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('sets reviewError on failure and dismissReviewError clears it', async () => {
+    mockUpsertReviewComment.mockRejectedValueOnce(
+      new ApiError(403, {
+        error: { code: 'host_cannot_rate_self', message: 'Host cannot rate self' },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'mock-token'),
+    );
+
+    await waitFor(() => expect(result.current.reviews.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setNewReviewMessage('Great event');
+      result.current.setNewReviewRating(5);
+    });
+
+    await act(async () => {
+      await result.current.submitReview();
+    });
+
+    expect(result.current.reviewError).toBe('Hosts cannot review their own event.');
+
+    act(() => {
+      result.current.dismissReviewError();
+    });
+
+    expect(result.current.reviewError).toBeNull();
+  });
+});
+
+describe('useEventDiscussionViewModel — refresh', () => {
+  it('reloads comments on refresh', async () => {
+    mockListEventComments
+      .mockResolvedValueOnce(makeEmptyResponse())
+      .mockResolvedValueOnce(makePopulatedResponse());
+
+    const { result } = renderHook(() =>
+      useEventDiscussionViewModel('event-001', 'tok'),
+    );
+
+    await waitFor(() => expect(result.current.discussions.loading).toBe(false));
+    expect(result.current.discussions.items).toHaveLength(0);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.discussions.items).toHaveLength(1);
+    });
+
+    expect(mockListEventComments).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mobile/src/viewmodels/event/useEventDiscussionViewModel.ts
+++ b/mobile/src/viewmodels/event/useEventDiscussionViewModel.ts
@@ -1,0 +1,370 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { EventComment, CommentCollection } from '@/models/comment';
+import {
+  listEventComments,
+  listCommentReplies,
+  createDiscussionComment,
+  upsertReviewComment,
+} from '@/services/commentService';
+import { ApiError } from '@/services/api';
+
+const PAGE_SIZE = 25;
+
+export interface DiscussionState {
+  items: EventComment[];
+  nextCursor: string | null;
+  hasNext: boolean;
+  loading: boolean;
+}
+
+export interface RepliesState {
+  items: EventComment[];
+  nextCursor: string | null;
+  hasNext: boolean;
+  loading: boolean;
+}
+
+export interface EventDiscussionViewModel {
+  discussions: DiscussionState;
+  reviews: DiscussionState;
+  repliesMap: Record<string, RepliesState>;
+
+  newDiscussionMessage: string;
+  setNewDiscussionMessage: (v: string) => void;
+  replyingToId: string | null;
+  setReplyingToId: (id: string | null) => void;
+  replyMessage: string;
+  setReplyMessage: (v: string) => void;
+
+  newReviewMessage: string;
+  setNewReviewMessage: (v: string) => void;
+  newReviewRating: number;
+  setNewReviewRating: (v: number) => void;
+
+  discussionSubmitting: boolean;
+  discussionError: string | null;
+  reviewSubmitting: boolean;
+  reviewError: string | null;
+
+  loadMoreDiscussions: () => Promise<void>;
+  loadMoreReviews: () => Promise<void>;
+  loadReplies: (parentId: string) => Promise<void>;
+  loadMoreReplies: (parentId: string) => Promise<void>;
+
+  submitDiscussionComment: () => Promise<void>;
+  submitReply: (parentId: string) => Promise<void>;
+  submitReview: () => Promise<void>;
+
+  dismissDiscussionError: () => void;
+  dismissReviewError: () => void;
+
+  refresh: () => void;
+}
+
+function makeEmptyDiscussionState(): DiscussionState {
+  return { items: [], nextCursor: null, hasNext: false, loading: false };
+}
+
+function mapCommentError(err: ApiError, fallback: string): string {
+  const map: Record<string, string> = {
+    comments_not_allowed: 'Comments are not available for this event.',
+    comment_write_not_allowed: 'You cannot post comments on this event.',
+    comment_not_found: 'The comment you are replying to was not found.',
+    reviews_not_allowed: 'You are not eligible to review this event.',
+    host_cannot_rate_self: 'Hosts cannot review their own event.',
+  };
+
+  if (err.code === 'validation_error') {
+    const detail = err.details?.message ?? err.details?.rating;
+    return detail ?? err.message ?? fallback;
+  }
+
+  return map[err.code] ?? err.message ?? fallback;
+}
+
+export function useEventDiscussionViewModel(
+  eventId: string,
+  token?: string,
+): EventDiscussionViewModel {
+  const [discussions, setDiscussions] = useState<DiscussionState>(makeEmptyDiscussionState());
+  const [reviews, setReviews] = useState<DiscussionState>(makeEmptyDiscussionState());
+  const [repliesMap, setRepliesMap] = useState<Record<string, RepliesState>>({});
+
+  const [newDiscussionMessage, setNewDiscussionMessage] = useState('');
+  const [replyingToId, setReplyingToId] = useState<string | null>(null);
+  const [replyMessage, setReplyMessage] = useState('');
+
+  const [newReviewMessage, setNewReviewMessage] = useState('');
+  const [newReviewRating, setNewReviewRating] = useState(0);
+
+  const [discussionSubmitting, setDiscussionSubmitting] = useState(false);
+  const [discussionError, setDiscussionError] = useState<string | null>(null);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
+
+  const loadedRef = useRef(false);
+
+  const loadInitial = useCallback(async () => {
+    setDiscussions((prev) => ({ ...prev, loading: true }));
+    setReviews((prev) => ({ ...prev, loading: true }));
+    try {
+      const resp = await listEventComments(
+        eventId,
+        { discussion_limit: PAGE_SIZE, review_limit: PAGE_SIZE },
+        token,
+      );
+      setDiscussions({
+        items: resp.discussion_comments.items,
+        nextCursor: resp.discussion_comments.page_info.next_cursor ?? null,
+        hasNext: resp.discussion_comments.page_info.has_next,
+        loading: false,
+      });
+      setReviews({
+        items: resp.review_comments.items,
+        nextCursor: resp.review_comments.page_info.next_cursor ?? null,
+        hasNext: resp.review_comments.page_info.has_next,
+        loading: false,
+      });
+    } catch {
+      setDiscussions((prev) => ({ ...prev, loading: false }));
+      setReviews((prev) => ({ ...prev, loading: false }));
+    }
+  }, [eventId, token]);
+
+  useEffect(() => {
+    if (!loadedRef.current) {
+      loadedRef.current = true;
+      void loadInitial();
+    }
+  }, [loadInitial]);
+
+  const refresh = useCallback(() => {
+    loadedRef.current = false;
+    setDiscussions(makeEmptyDiscussionState());
+    setReviews(makeEmptyDiscussionState());
+    setRepliesMap({});
+    loadedRef.current = true;
+    void loadInitial();
+  }, [loadInitial]);
+
+  const loadMoreDiscussions = useCallback(async () => {
+    if (!discussions.hasNext || !discussions.nextCursor || discussions.loading) return;
+    setDiscussions((prev) => ({ ...prev, loading: true }));
+    try {
+      const resp = await listEventComments(
+        eventId,
+        { discussion_limit: PAGE_SIZE, discussion_cursor: discussions.nextCursor },
+        token,
+      );
+      setDiscussions((prev) => ({
+        items: [...prev.items, ...resp.discussion_comments.items],
+        nextCursor: resp.discussion_comments.page_info.next_cursor ?? null,
+        hasNext: resp.discussion_comments.page_info.has_next,
+        loading: false,
+      }));
+    } catch {
+      setDiscussions((prev) => ({ ...prev, loading: false }));
+    }
+  }, [eventId, token, discussions.hasNext, discussions.nextCursor, discussions.loading]);
+
+  const loadMoreReviews = useCallback(async () => {
+    if (!reviews.hasNext || !reviews.nextCursor || reviews.loading) return;
+    setReviews((prev) => ({ ...prev, loading: true }));
+    try {
+      const resp = await listEventComments(
+        eventId,
+        { review_limit: PAGE_SIZE, review_cursor: reviews.nextCursor },
+        token,
+      );
+      setReviews((prev) => ({
+        items: [...prev.items, ...resp.review_comments.items],
+        nextCursor: resp.review_comments.page_info.next_cursor ?? null,
+        hasNext: resp.review_comments.page_info.has_next,
+        loading: false,
+      }));
+    } catch {
+      setReviews((prev) => ({ ...prev, loading: false }));
+    }
+  }, [eventId, token, reviews.hasNext, reviews.nextCursor, reviews.loading]);
+
+  const loadReplies = useCallback(async (parentId: string) => {
+    setRepliesMap((prev) => ({
+      ...prev,
+      [parentId]: { items: [], nextCursor: null, hasNext: false, loading: true },
+    }));
+    try {
+      const resp: CommentCollection = await listCommentReplies(
+        eventId,
+        parentId,
+        { limit: PAGE_SIZE },
+        token,
+      );
+      setRepliesMap((prev) => ({
+        ...prev,
+        [parentId]: {
+          items: resp.items,
+          nextCursor: resp.page_info.next_cursor ?? null,
+          hasNext: resp.page_info.has_next,
+          loading: false,
+        },
+      }));
+    } catch {
+      setRepliesMap((prev) => ({
+        ...prev,
+        [parentId]: { items: [], nextCursor: null, hasNext: false, loading: false },
+      }));
+    }
+  }, [eventId, token]);
+
+  const loadMoreReplies = useCallback(async (parentId: string) => {
+    const current = repliesMap[parentId];
+    if (!current || !current.hasNext || !current.nextCursor || current.loading) return;
+    setRepliesMap((prev) => ({ ...prev, [parentId]: { ...prev[parentId], loading: true } }));
+    try {
+      const resp: CommentCollection = await listCommentReplies(
+        eventId,
+        parentId,
+        { limit: PAGE_SIZE, cursor: current.nextCursor },
+        token,
+      );
+      setRepliesMap((prev) => ({
+        ...prev,
+        [parentId]: {
+          items: [...prev[parentId].items, ...resp.items],
+          nextCursor: resp.page_info.next_cursor ?? null,
+          hasNext: resp.page_info.has_next,
+          loading: false,
+        },
+      }));
+    } catch {
+      setRepliesMap((prev) => ({ ...prev, [parentId]: { ...prev[parentId], loading: false } }));
+    }
+  }, [eventId, token, repliesMap]);
+
+  const submitDiscussionComment = useCallback(async () => {
+    if (!token || !newDiscussionMessage.trim()) return;
+    setDiscussionSubmitting(true);
+    setDiscussionError(null);
+    try {
+      const comment = await createDiscussionComment(
+        eventId,
+        { message: newDiscussionMessage.trim() },
+        token,
+      );
+      setDiscussions((prev) => ({
+        ...prev,
+        items: [comment, ...prev.items],
+      }));
+      setNewDiscussionMessage('');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setDiscussionError(mapCommentError(err, 'Failed to post comment. Please try again.'));
+      } else {
+        setDiscussionError('Failed to post comment. Please try again.');
+      }
+    } finally {
+      setDiscussionSubmitting(false);
+    }
+  }, [eventId, token, newDiscussionMessage]);
+
+  const submitReply = useCallback(async (parentId: string) => {
+    if (!token || !replyMessage.trim()) return;
+    setDiscussionSubmitting(true);
+    setDiscussionError(null);
+    try {
+      const comment = await createDiscussionComment(
+        eventId,
+        { message: replyMessage.trim(), parent_id: parentId },
+        token,
+      );
+      setRepliesMap((prev) => ({
+        ...prev,
+        [parentId]: {
+          ...(prev[parentId] ?? { nextCursor: null, hasNext: false, loading: false }),
+          items: [...(prev[parentId]?.items ?? []), comment],
+        },
+      }));
+      setDiscussions((prev) => ({
+        ...prev,
+        items: prev.items.map((c) =>
+          c.id === parentId ? { ...c, reply_count: c.reply_count + 1 } : c,
+        ),
+      }));
+      setReplyMessage('');
+      setReplyingToId(null);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setDiscussionError(mapCommentError(err, 'Failed to post reply. Please try again.'));
+      } else {
+        setDiscussionError('Failed to post reply. Please try again.');
+      }
+    } finally {
+      setDiscussionSubmitting(false);
+    }
+  }, [eventId, token, replyMessage]);
+
+  const submitReview = useCallback(async () => {
+    if (!token || !newReviewMessage.trim() || newReviewRating < 1) return;
+    setReviewSubmitting(true);
+    setReviewError(null);
+    try {
+      const comment = await upsertReviewComment(
+        eventId,
+        { message: newReviewMessage.trim(), rating: newReviewRating },
+        token,
+      );
+      setReviews((prev) => {
+        const existing = prev.items.findIndex((c) => c.user.id === comment.user.id);
+        if (existing >= 0) {
+          const updated = [...prev.items];
+          updated[existing] = comment;
+          return { ...prev, items: updated };
+        }
+        return { ...prev, items: [comment, ...prev.items] };
+      });
+      setNewReviewMessage('');
+      setNewReviewRating(0);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setReviewError(mapCommentError(err, 'Failed to submit review. Please try again.'));
+      } else {
+        setReviewError('Failed to submit review. Please try again.');
+      }
+    } finally {
+      setReviewSubmitting(false);
+    }
+  }, [eventId, token, newReviewMessage, newReviewRating]);
+
+  const dismissDiscussionError = useCallback(() => setDiscussionError(null), []);
+  const dismissReviewError = useCallback(() => setReviewError(null), []);
+
+  return {
+    discussions,
+    reviews,
+    repliesMap,
+    newDiscussionMessage,
+    setNewDiscussionMessage,
+    replyingToId,
+    setReplyingToId,
+    replyMessage,
+    setReplyMessage,
+    newReviewMessage,
+    setNewReviewMessage,
+    newReviewRating,
+    setNewReviewRating,
+    discussionSubmitting,
+    discussionError,
+    reviewSubmitting,
+    reviewError,
+    loadMoreDiscussions,
+    loadMoreReviews,
+    loadReplies,
+    loadMoreReplies,
+    submitDiscussionComment,
+    submitReply,
+    submitReview,
+    dismissDiscussionError,
+    dismissReviewError,
+    refresh,
+  };
+}

--- a/mobile/src/views/event/EventDetailView.test.tsx
+++ b/mobile/src/views/event/EventDetailView.test.tsx
@@ -44,9 +44,42 @@ jest.mock('@expo/vector-icons', () => {
 jest.mock('@/components/events/JoinRequestsModal', () => () => null);
 jest.mock('@/components/events/ParticipantListModal', () => () => null);
 jest.mock('@/components/events/InvitationsModal', () => () => null);
+jest.mock('@/components/events/EventDiscussionSection', () => () => null);
 
 jest.mock('@/viewmodels/event/useEventDetailViewModel', () => ({
   useEventDetailViewModel: jest.fn(),
+}));
+
+jest.mock('@/viewmodels/event/useEventDiscussionViewModel', () => ({
+  useEventDiscussionViewModel: jest.fn(() => ({
+    discussions: { items: [], nextCursor: null, hasNext: false, loading: false },
+    reviews: { items: [], nextCursor: null, hasNext: false, loading: false },
+    repliesMap: {},
+    newDiscussionMessage: '',
+    setNewDiscussionMessage: jest.fn(),
+    replyingToId: null,
+    setReplyingToId: jest.fn(),
+    replyMessage: '',
+    setReplyMessage: jest.fn(),
+    newReviewMessage: '',
+    setNewReviewMessage: jest.fn(),
+    newReviewRating: 0,
+    setNewReviewRating: jest.fn(),
+    discussionSubmitting: false,
+    discussionError: null,
+    reviewSubmitting: false,
+    reviewError: null,
+    loadMoreDiscussions: jest.fn(),
+    loadMoreReviews: jest.fn(),
+    loadReplies: jest.fn(),
+    loadMoreReplies: jest.fn(),
+    submitDiscussionComment: jest.fn(),
+    submitReply: jest.fn(),
+    submitReview: jest.fn(),
+    dismissDiscussionError: jest.fn(),
+    dismissReviewError: jest.fn(),
+    refresh: jest.fn(),
+  })),
 }));
 
 const mockUseEventDetailViewModel = jest.mocked(useEventDetailViewModel);
@@ -184,6 +217,8 @@ function buildViewModel(
     removeReportImage: jest.fn(),
     handleReportEvent: jest.fn().mockResolvedValue(undefined),
     canAttachReportImage: false,
+    token: 'mock-token',
+    user: null,
     ...overrides,
   };
 }

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -31,6 +31,9 @@ import JoinRequestsModal from '@/components/events/JoinRequestsModal';
 import ParticipantListModal from '@/components/events/ParticipantListModal';
 import InvitationsModal from '@/components/events/InvitationsModal';
 import ReportEventModal from '@/components/events/ReportEventModal';
+import EventDiscussionSection from '@/components/events/EventDiscussionSection';
+import { useEventDiscussionViewModel } from '@/viewmodels/event/useEventDiscussionViewModel';
+import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
 
@@ -491,6 +494,8 @@ const darkMapStyle = [
 export default function EventDetailView({ eventId }: EventDetailViewProps) {
   const vm = useEventDetailViewModel(eventId);
   const { theme, isDark } = useTheme();
+  const { token, user } = useAuth();
+  const discussionVm = useEventDiscussionViewModel(eventId, token ?? undefined);
   const styles = useMemo(() => makeStyles(theme, isDark), [theme, isDark]);
   const [isMapModalVisible, setIsMapModalVisible] = useState(false);
   const [routedGeometry, setRoutedGeometry] = useState<Array<{ lat: number; lon: number }> | null>(
@@ -1266,6 +1271,52 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
             </View>
           </>
         )}
+
+        {/* Discussion — available for public and protected events only */}
+        {event.privacy_level !== 'PRIVATE' && (() => {
+          const isHost = vm.event.viewer_context.is_host;
+          const participationStatus = vm.event.viewer_context.participation_status;
+          const isQualifiedParticipant =
+            participationStatus === 'JOINED' ||
+            (participationStatus === 'LEAVED' && new Date() >= new Date(event.start_time));
+
+          const canPostDiscussion =
+            Boolean(token) &&
+            (event.status === 'ACTIVE' ||
+              (event.status === 'IN_PROGRESS' && (isHost || isQualifiedParticipant)));
+
+          const ratingWindowOpen =
+            event.status === 'COMPLETED' &&
+            new Date() <= new Date(event.rating_window.closes_at);
+
+          const canPostReview =
+            Boolean(token) &&
+            ratingWindowOpen &&
+            !isHost &&
+            isQualifiedParticipant;
+
+          return (
+            <>
+              <View style={styles.divider} />
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Discussions</Text>
+              </View>
+              <EventDiscussionSection
+                vm={discussionVm}
+                eventStatus={event.status}
+                isAuthenticated={Boolean(token)}
+                canPostDiscussion={canPostDiscussion}
+                canPostReview={canPostReview}
+                hasExistingReview={discussionVm.reviews.items.some(
+                  (r) => r.user.id === user?.id,
+                )}
+                reviewWindowClosed={
+                  event.status === 'COMPLETED' && !ratingWindowOpen
+                }
+              />
+            </>
+          );
+        })()}
 
         {/* Action error */}
         {vm.actionError ? (

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -33,7 +33,6 @@ import InvitationsModal from '@/components/events/InvitationsModal';
 import ReportEventModal from '@/components/events/ReportEventModal';
 import EventDiscussionSection from '@/components/events/EventDiscussionSection';
 import { useEventDiscussionViewModel } from '@/viewmodels/event/useEventDiscussionViewModel';
-import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
 
@@ -494,8 +493,7 @@ const darkMapStyle = [
 export default function EventDetailView({ eventId }: EventDetailViewProps) {
   const vm = useEventDetailViewModel(eventId);
   const { theme, isDark } = useTheme();
-  const { token, user } = useAuth();
-  const discussionVm = useEventDiscussionViewModel(eventId, token ?? undefined);
+  const discussionVm = useEventDiscussionViewModel(eventId, vm.token ?? undefined);
   const styles = useMemo(() => makeStyles(theme, isDark), [theme, isDark]);
   const [isMapModalVisible, setIsMapModalVisible] = useState(false);
   const [routedGeometry, setRoutedGeometry] = useState<Array<{ lat: number; lon: number }> | null>(
@@ -1281,7 +1279,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
             (participationStatus === 'LEAVED' && new Date() >= new Date(event.start_time));
 
           const canPostDiscussion =
-            Boolean(token) &&
+            Boolean(vm.token) &&
             (event.status === 'ACTIVE' ||
               (event.status === 'IN_PROGRESS' && (isHost || isQualifiedParticipant)));
 
@@ -1290,7 +1288,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
             new Date() <= new Date(event.rating_window.closes_at);
 
           const canPostReview =
-            Boolean(token) &&
+            Boolean(vm.token) &&
             ratingWindowOpen &&
             !isHost &&
             isQualifiedParticipant;
@@ -1304,11 +1302,11 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
               <EventDiscussionSection
                 vm={discussionVm}
                 eventStatus={event.status}
-                isAuthenticated={Boolean(token)}
+                isAuthenticated={Boolean(vm.token)}
                 canPostDiscussion={canPostDiscussion}
                 canPostReview={canPostReview}
                 hasExistingReview={discussionVm.reviews.items.some(
-                  (r) => r.user.id === user?.id,
+                  (r) => r.user.id === vm.user?.id,
                 )}
                 reviewWindowClosed={
                   event.status === 'COMPLETED' && !ratingWindowOpen


### PR DESCRIPTION
## 📋 Summary

- Adds a **Discussions** section to the `EventDetailView` for all public and protected events
- **Q&A tab**: discussion comments with reply threads (paginated, cursor-based)
- **Reviews tab**: star-rated post-event reviews, gated by the 7-day feedback window

## 🔄 Changes

- `models/comment.ts` — types for `EventComment`, request/response shapes
- `services/commentService.ts` — API calls: `listEventComments`, `listCommentReplies`, `createDiscussionComment`, `upsertReviewComment`
- `viewmodels/event/useEventDiscussionViewModel.ts` — manages Q&A + review state, pagination, reply threading, submit/error flows
- `components/events/EventDiscussionSection.tsx` — tabbed UI with comment cards, reply threads, star input, load-more
- `views/event/EventDetailView.tsx` — mounts the discussion section with correct permission guards

## 🔒 Permission logic

| Scenario | Can post Q&A | Can post review |
|---|---|---|
| ACTIVE event, any auth user | ✅ | ❌ |
| IN_PROGRESS, host or joined participant | ✅ | ❌ |
| COMPLETED, joined participant, window open | ❌ | ✅ |
| COMPLETED, window closed | ❌ | ❌ |
| PRIVATE event | hidden entirely | hidden entirely |


## 🧪 Testing

- `go test` equivalent: `npx jest --testPathPattern="commentService|useEventDiscussionViewModel"` — **29 tests, all passing**
- Manually tested on device: Q&A posting, reply threads, star review form, window-closed notice
- Verified TypeScript compiles cleanly (`tsc --noEmit`)

## 🔗 Related

Closes #458
Backend: #551