### PR TITLE
feat(frontend): add private event invitations page for invited users

### DIFF
--- a/frontend/src/models/invitation.ts
+++ b/frontend/src/models/invitation.ts
@@ -1,0 +1,91 @@
+/* ── Participant-side invitations (received) ── */
+
+export type InvitationStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'CANCELLED' | 'EXPIRED';
+
+export interface InvitationEventSummary {
+  id: string;
+  title: string;
+  image_url?: string | null;
+  start_time: string;
+  end_time?: string | null;
+  status: 'ACTIVE' | 'IN_PROGRESS';
+  privacy_level: 'PRIVATE';
+  approved_participant_count: number;
+}
+
+export interface InvitationHostSummary {
+  id: string;
+  username: string;
+  display_name?: string | null;
+  avatar_url?: string | null;
+}
+
+export interface ReceivedInvitation {
+  invitation_id: string;
+  status: InvitationStatus;
+  message: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  event: InvitationEventSummary;
+  host: InvitationHostSummary;
+}
+
+export interface ReceivedInvitationsResponse {
+  items: ReceivedInvitation[];
+}
+
+export interface AcceptInvitationResponse {
+  invitation_id: string;
+  event_id: string;
+  invitation_status: 'ACCEPTED';
+  participation_id: string;
+  participation_status: 'APPROVED';
+  updated_at: string;
+}
+
+export interface DeclineInvitationResponse {
+  invitation_id: string;
+  event_id: string;
+  status: 'DECLINED';
+  updated_at: string;
+  cooldown_ends_at: string;
+}
+
+/* ── Host-side invitation creation ── */
+
+export type InvitationFailureCode =
+  | 'ALREADY_INVITED'
+  | 'ALREADY_PARTICIPATING'
+  | 'HOST_USER'
+  | 'DECLINE_COOLDOWN_ACTIVE'
+  | 'CAPACITY_EXCEEDED'
+  | 'DUPLICATE_USERNAME';
+
+export interface EventInvitationFailure {
+  username: string;
+  code: InvitationFailureCode;
+}
+
+export interface CreatedEventInvitation {
+  invitation_id: string;
+  event_id: string;
+  invited_user_id: string;
+  username: string;
+  status: 'PENDING';
+  created_at: string;
+}
+
+export interface CreateEventInvitationsRequest {
+  usernames: string[];
+  message?: string | null;
+}
+
+export interface CreateEventInvitationsResponse {
+  success_count: number;
+  invalid_username_count: number;
+  failed_count: number;
+  successful_invitations: CreatedEventInvitation[];
+  invalid_usernames: string[];
+  failed: EventInvitationFailure[];
+}

--- a/frontend/src/services/invitationService.ts
+++ b/frontend/src/services/invitationService.ts
@@ -1,0 +1,32 @@
+import { apiGetAuth, apiPostAuth } from './api';
+import type {
+  AcceptInvitationResponse,
+  DeclineInvitationResponse,
+  ReceivedInvitationsResponse,
+} from '@/models/invitation';
+
+export function listMyInvitations(token: string): Promise<ReceivedInvitationsResponse> {
+  return apiGetAuth<ReceivedInvitationsResponse>('/me/invitations', token);
+}
+
+export function acceptInvitation(
+  invitationId: string,
+  token: string,
+): Promise<AcceptInvitationResponse> {
+  return apiPostAuth<AcceptInvitationResponse>(
+    `/me/invitations/${invitationId}/accept`,
+    {},
+    token,
+  );
+}
+
+export function declineInvitation(
+  invitationId: string,
+  token: string,
+): Promise<DeclineInvitationResponse> {
+  return apiPostAuth<DeclineInvitationResponse>(
+    `/me/invitations/${invitationId}/decline`,
+    {},
+    token,
+  );
+}

--- a/frontend/src/styles/invitations.css
+++ b/frontend/src/styles/invitations.css
@@ -1,0 +1,288 @@
+.inv-page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 20px 40px;
+}
+
+.inv-page-header {
+  margin-bottom: 24px;
+}
+
+.inv-page-title {
+  margin: 0 0 4px;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.inv-page-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+/* States */
+
+.inv-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 64px 0;
+  color: #64748b;
+}
+
+.inv-empty {
+  text-align: center;
+  padding: 64px 24px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+}
+
+.inv-empty h2 {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.inv-empty p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.inv-error {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 18px;
+  border-radius: 10px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}
+
+.inv-error-dismiss {
+  background: none;
+  border: none;
+  color: #b91c1c;
+  font-size: 1.3rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+/* List */
+
+.inv-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Card */
+
+.inv-card {
+  display: flex;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04);
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.inv-card:hover {
+  border-color: #cbd5e1;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
+}
+
+.inv-card-cover {
+  position: relative;
+  width: 160px;
+  flex-shrink: 0;
+  background: #f1f5f9;
+}
+
+.inv-card-cover-img,
+.inv-card-cover > div {
+  width: 100%;
+  height: 100%;
+}
+
+.inv-card-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.inv-card-privacy {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  padding: 3px 8px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #ffffff;
+  background: #dc2626;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+}
+
+.inv-card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 14px 16px;
+  min-width: 0;
+}
+
+.inv-card-header {
+  margin-bottom: 8px;
+}
+
+.inv-card-title {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.3;
+}
+
+.inv-card-meta {
+  font-size: 0.8rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.inv-card-host {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.inv-card-host-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.inv-card-host-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #0f172a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.inv-card-host-username {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.inv-card-message {
+  margin: 0 0 12px;
+  padding: 8px 12px;
+  border-left: 3px solid #cbd5e1;
+  background: #f8fafc;
+  border-radius: 0 8px 8px 0;
+  font-size: 0.85rem;
+  color: #475569;
+  font-style: italic;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.inv-card-quote {
+  font-weight: 700;
+  color: #94a3b8;
+}
+
+.inv-card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: auto;
+  flex-wrap: wrap;
+}
+
+.inv-card-btn {
+  flex: 1;
+  min-width: 0;
+  padding: 0.55rem 0.9rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.inv-card-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.inv-card-accept {
+  background: #111827;
+  color: #ffffff;
+}
+
+.inv-card-accept:hover:not(:disabled) {
+  background: #000000;
+}
+
+.inv-card-decline {
+  background: #ffffff;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+}
+
+.inv-card-decline:hover:not(:disabled) {
+  background: #fef2f2;
+  border-color: #fca5a5;
+}
+
+.inv-card-view {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.inv-card-view:hover:not(:disabled) {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+/* Mobile */
+
+@media (max-width: 600px) {
+  .inv-page {
+    padding: 16px 14px 40px;
+  }
+
+  .inv-card {
+    flex-direction: column;
+  }
+
+  .inv-card-cover {
+    width: 100%;
+    height: 160px;
+  }
+
+  .inv-card-actions {
+    flex-direction: column;
+  }
+
+  .inv-card-btn {
+    flex: none;
+    width: 100%;
+  }
+}

--- a/frontend/src/viewmodels/invitations/useInvitationsViewModel.ts
+++ b/frontend/src/viewmodels/invitations/useInvitationsViewModel.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  acceptInvitation,
+  declineInvitation,
+  listMyInvitations,
+} from '@/services/invitationService';
+import type { ReceivedInvitation } from '@/models/invitation';
+import { ApiError } from '@/services/api';
+
+export interface InvitationsViewModel {
+  invitations: ReceivedInvitation[];
+  isLoading: boolean;
+  isActionLoading: string | null;
+  error: string | null;
+  fetchInvitations: () => Promise<void>;
+  handleAccept: (invitationId: string) => Promise<{ event_id: string } | null>;
+  handleDecline: (invitationId: string) => Promise<void>;
+  dismissError: () => void;
+}
+
+export function useInvitationsViewModel(): InvitationsViewModel {
+  const { token } = useAuth();
+  const [invitations, setInvitations] = useState<ReceivedInvitation[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isActionLoading, setIsActionLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchInvitations = useCallback(async () => {
+    if (!token) {
+      setInvitations([]);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await listMyInvitations(token);
+      setInvitations(response.items ?? []);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load invitations');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  const handleAccept = useCallback(
+    async (invitationId: string): Promise<{ event_id: string } | null> => {
+      if (!token) return null;
+      setIsActionLoading(invitationId);
+      setError(null);
+      try {
+        const response = await acceptInvitation(invitationId, token);
+        setInvitations((prev) => prev.filter((i) => i.invitation_id !== invitationId));
+        return { event_id: response.event_id };
+      } catch (err) {
+        setError(err instanceof ApiError ? err.message : 'Failed to accept invitation');
+        return null;
+      } finally {
+        setIsActionLoading(null);
+      }
+    },
+    [token],
+  );
+
+  const handleDecline = useCallback(
+    async (invitationId: string) => {
+      if (!token) return;
+      setIsActionLoading(invitationId);
+      setError(null);
+      try {
+        await declineInvitation(invitationId, token);
+        setInvitations((prev) => prev.filter((i) => i.invitation_id !== invitationId));
+      } catch (err) {
+        setError(err instanceof ApiError ? err.message : 'Failed to decline invitation');
+      } finally {
+        setIsActionLoading(null);
+      }
+    },
+    [token],
+  );
+
+  useEffect(() => {
+    fetchInvitations();
+  }, [fetchInvitations]);
+
+  const dismissError = useCallback(() => setError(null), []);
+
+  return {
+    invitations,
+    isLoading,
+    isActionLoading,
+    error,
+    fetchInvitations,
+    handleAccept,
+    handleDecline,
+    dismissError,
+  };
+}

--- a/frontend/src/views/invitations/InvitationsPage.test.tsx
+++ b/frontend/src/views/invitations/InvitationsPage.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReceivedInvitation } from '@/models/invitation';
+import InvitationsPage from './InvitationsPage';
+
+const mockUseInvitationsViewModel = vi.fn();
+
+vi.mock('@/viewmodels/invitations/useInvitationsViewModel', () => ({
+  useInvitationsViewModel: (...args: unknown[]) => mockUseInvitationsViewModel(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeInvitation(overrides: Partial<ReceivedInvitation> = {}): ReceivedInvitation {
+  return {
+    invitation_id: 'inv-1',
+    status: 'PENDING',
+    message: 'Hope you can make it!',
+    expires_at: null,
+    created_at: '2026-04-10T10:00:00Z',
+    updated_at: '2026-04-10T10:00:00Z',
+    event: {
+      id: 'event-1',
+      title: 'Sunset Walk',
+      image_url: null,
+      start_time: '2026-05-01T18:00:00Z',
+      end_time: null,
+      status: 'ACTIVE',
+      privacy_level: 'PRIVATE',
+      approved_participant_count: 5,
+    },
+    host: {
+      id: 'host-1',
+      username: 'hostuser',
+      display_name: 'Host User',
+      avatar_url: null,
+    },
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <InvitationsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('InvitationsPage', () => {
+  it('shows loading state while fetching', () => {
+    mockUseInvitationsViewModel.mockReturnValue({
+      invitations: [],
+      isLoading: true,
+      isActionLoading: null,
+      error: null,
+      fetchInvitations: vi.fn(),
+      handleAccept: vi.fn(),
+      handleDecline: vi.fn(),
+      dismissError: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText(/loading invitations/i)).toBeDefined();
+  });
+
+  it('shows empty state when there are no invitations', () => {
+    mockUseInvitationsViewModel.mockReturnValue({
+      invitations: [],
+      isLoading: false,
+      isActionLoading: null,
+      error: null,
+      fetchInvitations: vi.fn(),
+      handleAccept: vi.fn(),
+      handleDecline: vi.fn(),
+      dismissError: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText(/no invitations yet/i)).toBeDefined();
+  });
+
+  it('renders pending invitation with accept and decline actions', () => {
+    const invitation = makeInvitation();
+    mockUseInvitationsViewModel.mockReturnValue({
+      invitations: [invitation],
+      isLoading: false,
+      isActionLoading: null,
+      error: null,
+      fetchInvitations: vi.fn(),
+      handleAccept: vi.fn(),
+      handleDecline: vi.fn(),
+      dismissError: vi.fn(),
+    });
+    renderPage();
+
+    expect(screen.getByText('Sunset Walk')).toBeDefined();
+    expect(screen.getByText(/Host User/)).toBeDefined();
+    expect(screen.getByText(/hope you can make it/i)).toBeDefined();
+    expect(screen.getByRole('button', { name: /accept/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /decline/i })).toBeDefined();
+  });
+
+  it('calls handleAccept when Accept is clicked', () => {
+    const handleAccept = vi.fn().mockResolvedValue({ event_id: 'event-1' });
+    const invitation = makeInvitation();
+    mockUseInvitationsViewModel.mockReturnValue({
+      invitations: [invitation],
+      isLoading: false,
+      isActionLoading: null,
+      error: null,
+      fetchInvitations: vi.fn(),
+      handleAccept,
+      handleDecline: vi.fn(),
+      dismissError: vi.fn(),
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('accept-inv-1'));
+    expect(handleAccept).toHaveBeenCalledWith('inv-1');
+  });
+
+  it('renders an error message and dismiss button', () => {
+    const dismissError = vi.fn();
+    mockUseInvitationsViewModel.mockReturnValue({
+      invitations: [],
+      isLoading: false,
+      isActionLoading: null,
+      error: 'Failed to load invitations',
+      fetchInvitations: vi.fn(),
+      handleAccept: vi.fn(),
+      handleDecline: vi.fn(),
+      dismissError,
+    });
+    renderPage();
+
+    expect(screen.getByText(/failed to load invitations/i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss error/i }));
+    expect(dismissError).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/views/invitations/InvitationsPage.tsx
+++ b/frontend/src/views/invitations/InvitationsPage.tsx
@@ -1,8 +1,179 @@
-export default function InvitationsPage() {
+import { useNavigate } from 'react-router-dom';
+import { useInvitationsViewModel } from '@/viewmodels/invitations/useInvitationsViewModel';
+import { UserAvatar } from '@/components/UserAvatar';
+import { EventCoverImage } from '@/components/EventCoverImage';
+import type { ReceivedInvitation } from '@/models/invitation';
+import '@/styles/invitations.css';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function InvitationCard({
+  invitation,
+  isLoading,
+  onAccept,
+  onDecline,
+  onView,
+}: {
+  invitation: ReceivedInvitation;
+  isLoading: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+  onView: () => void;
+}) {
+  const hostName = invitation.host.display_name ?? invitation.host.username;
+
   return (
-    <div className="placeholder-page">
-      <h1>Invitations &amp; Requests</h1>
-      <p>Manage your event invitations and join requests.</p>
+    <article className="inv-card" data-testid={`invitation-${invitation.invitation_id}`}>
+      <div className="inv-card-cover">
+        <EventCoverImage
+          src={invitation.event.image_url ?? undefined}
+          alt={invitation.event.title}
+          imgClassName="inv-card-cover-img"
+          variant="card"
+        />
+        <span className="inv-card-privacy">Private</span>
+      </div>
+
+      <div className="inv-card-body">
+        <div className="inv-card-header">
+          <h2 className="inv-card-title">{invitation.event.title}</h2>
+          <span className="inv-card-meta">
+            {formatDate(invitation.event.start_time)} &middot; {formatTime(invitation.event.start_time)}
+          </span>
+        </div>
+
+        <div className="inv-card-host">
+          <UserAvatar
+            username={invitation.host.username}
+            displayName={invitation.host.display_name ?? null}
+            avatarUrl={invitation.host.avatar_url ?? null}
+            size="sm"
+            variant="muted"
+          />
+          <div className="inv-card-host-info">
+            <span className="inv-card-host-name">{hostName}</span>
+            <span className="inv-card-host-username">@{invitation.host.username}</span>
+          </div>
+        </div>
+
+        {invitation.message && (
+          <blockquote className="inv-card-message">
+            <span className="inv-card-quote">&ldquo;</span>
+            {invitation.message}
+            <span className="inv-card-quote">&rdquo;</span>
+          </blockquote>
+        )}
+
+        <div className="inv-card-actions">
+          <button
+            type="button"
+            className="inv-card-btn inv-card-decline"
+            onClick={onDecline}
+            disabled={isLoading}
+          >
+            Decline
+          </button>
+          <button
+            type="button"
+            className="inv-card-btn inv-card-accept"
+            onClick={onAccept}
+            disabled={isLoading}
+            data-testid={`accept-${invitation.invitation_id}`}
+          >
+            {isLoading ? <span className="spinner" /> : 'Accept'}
+          </button>
+          <button
+            type="button"
+            className="inv-card-btn inv-card-view"
+            onClick={onView}
+            disabled={isLoading}
+          >
+            View Event
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default function InvitationsPage() {
+  const navigate = useNavigate();
+  const vm = useInvitationsViewModel();
+
+  const handleAccept = async (invitationId: string) => {
+    const result = await vm.handleAccept(invitationId);
+    if (result) {
+      navigate(`/events/${result.event_id}`);
+    }
+  };
+
+  return (
+    <div className="inv-page">
+      <header className="inv-page-header">
+        <h1 className="inv-page-title">Invitations</h1>
+        <p className="inv-page-subtitle">
+          Private event invitations sent to you by hosts.
+        </p>
+      </header>
+
+      {vm.error && (
+        <div className="inv-error" role="alert">
+          <span>{vm.error}</span>
+          <button
+            type="button"
+            className="inv-error-dismiss"
+            onClick={vm.dismissError}
+            aria-label="Dismiss error"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
+      {vm.isLoading && vm.invitations.length === 0 && (
+        <div className="inv-loading">
+          <span className="spinner" />
+          <p>Loading invitations...</p>
+        </div>
+      )}
+
+      {!vm.isLoading && vm.invitations.length === 0 && !vm.error && (
+        <div className="inv-empty">
+          <h2>No invitations yet</h2>
+          <p>When a host invites you to a private event, it will show up here.</p>
+        </div>
+      )}
+
+      {vm.invitations.length > 0 && (
+        <div className="inv-list">
+          {vm.invitations.map((inv) => (
+            <InvitationCard
+              key={inv.invitation_id}
+              invitation={inv}
+              isLoading={vm.isActionLoading === inv.invitation_id}
+              onAccept={() => handleAccept(inv.invitation_id)}
+              onDecline={() => vm.handleDecline(inv.invitation_id)}
+              onView={() => navigate(`/events/${inv.event.id}`)}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📋 Summary
Replaces the `/invitations` placeholder with a full invitation inbox where users can review pending private-event invitations they received, accept (which navigates to the event detail page), or decline them.

## 🔄 Changes
- **`models/invitation.ts`** *(new)* — `ReceivedInvitation`, `InvitationStatus`, `InvitationEventSummary`, `InvitationHostSummary`, `AcceptInvitationResponse`, `DeclineInvitationResponse`, plus host-side types reserved for the sibling host PR
- **`services/invitationService.ts`** *(new)* — `listMyInvitations`, `acceptInvitation`, `declineInvitation` calling `GET/POST /me/invitations*`
- **`viewmodels/invitations/useInvitationsViewModel.ts`** *(new)* — fetches the invitation list on mount, exposes `isLoading`, per-item `isActionLoading`, `error` (with `dismissError`), and `handleAccept` / `handleDecline` that optimistically remove the row and surface backend errors
- **`views/invitations/InvitationsPage.tsx`** — replaced placeholder with a full inbox: cards with cover image, "Private" pill, event title, date/time, host info, optional message, and Accept / Decline / View Event actions; loading, empty, and error states
- **`styles/invitations.css`** *(new)* — card layout, action buttons (dark Accept, red-outline Decline), responsive layout that stacks on mobile
- **`views/invitations/InvitationsPage.test.tsx`** *(new)* — 5 tests covering loading state, empty state, pending render, accept call dispatches with the correct id, error display + dismiss

## 🧪 Testing
1. `cd frontend && npm install && npm test` → confirm the new `InvitationsPage.test.tsx` tests are listed and pass when the jsdom env is healthy
2. `npm run dev` → log in and navigate to `/invitations`
3. With no invitations: confirm "No invitations yet" empty state
4. With pending invitations from the backend: confirm each card shows event title, host name + @username, the host's optional message in italics, and three actions
5. Click **Accept** on a pending invitation → invitation disappears from the list and the page navigates to `/events/<event_id>` (the just-joined event detail)
6. Click **Decline** on another pending invitation → invitation disappears (no navigation)
7. Click **View Event** → navigates to `/events/<event_id>` without changing invitation state
8. Force a backend error (e.g. block the network request) → confirm the inline error banner appears with a working dismiss button
9. Mobile viewport: confirm the cover image stretches to full width, info stacks below, and buttons stack vertically full-width


## 🔗 Related
Related to #455 
