### PR TITLE
feat(frontend): add host-side invitation management for private events

### DIFF
--- a/frontend/src/models/invitation.ts
+++ b/frontend/src/models/invitation.ts
@@ -1,0 +1,91 @@
+/* ── Participant-side invitations (received) ── */
+
+export type InvitationStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'CANCELLED' | 'EXPIRED';
+
+export interface InvitationEventSummary {
+  id: string;
+  title: string;
+  image_url?: string | null;
+  start_time: string;
+  end_time?: string | null;
+  status: 'ACTIVE' | 'IN_PROGRESS';
+  privacy_level: 'PRIVATE';
+  approved_participant_count: number;
+}
+
+export interface InvitationHostSummary {
+  id: string;
+  username: string;
+  display_name?: string | null;
+  avatar_url?: string | null;
+}
+
+export interface ReceivedInvitation {
+  invitation_id: string;
+  status: InvitationStatus;
+  message: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  event: InvitationEventSummary;
+  host: InvitationHostSummary;
+}
+
+export interface ReceivedInvitationsResponse {
+  items: ReceivedInvitation[];
+}
+
+export interface AcceptInvitationResponse {
+  invitation_id: string;
+  event_id: string;
+  invitation_status: 'ACCEPTED';
+  participation_id: string;
+  participation_status: 'APPROVED';
+  updated_at: string;
+}
+
+export interface DeclineInvitationResponse {
+  invitation_id: string;
+  event_id: string;
+  status: 'DECLINED';
+  updated_at: string;
+  cooldown_ends_at: string;
+}
+
+/* ── Host-side invitation creation ── */
+
+export type InvitationFailureCode =
+  | 'ALREADY_INVITED'
+  | 'ALREADY_PARTICIPATING'
+  | 'HOST_USER'
+  | 'DECLINE_COOLDOWN_ACTIVE'
+  | 'CAPACITY_EXCEEDED'
+  | 'DUPLICATE_USERNAME';
+
+export interface EventInvitationFailure {
+  username: string;
+  code: InvitationFailureCode;
+}
+
+export interface CreatedEventInvitation {
+  invitation_id: string;
+  event_id: string;
+  invited_user_id: string;
+  username: string;
+  status: 'PENDING';
+  created_at: string;
+}
+
+export interface CreateEventInvitationsRequest {
+  usernames: string[];
+  message?: string | null;
+}
+
+export interface CreateEventInvitationsResponse {
+  success_count: number;
+  invalid_username_count: number;
+  failed_count: number;
+  successful_invitations: CreatedEventInvitation[];
+  invalid_usernames: string[];
+  failed: EventInvitationFailure[];
+}

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -1,5 +1,9 @@
 import { apiDeleteAuth, apiPostAuth, apiPatchAuth, apiGet, apiGetAuth, apiPutAuth } from './api';
 import type { ImageUploadConfirmRequest, ImageUploadInitResponse } from '@/models/profile';
+import type {
+  CreateEventInvitationsRequest,
+  CreateEventInvitationsResponse,
+} from '@/models/invitation';
 import {
   CreateEventRequest,
   CreateEventResponse,
@@ -114,6 +118,18 @@ export function listEventInvitations(
 ): Promise<EventInvitationsResponse> {
   return apiGetAuth<EventInvitationsResponse>(
     buildCollectionPath(eventId, 'invitations', options.limit, options.cursor),
+    token,
+  );
+}
+
+export function createEventInvitations(
+  eventId: string,
+  body: CreateEventInvitationsRequest,
+  token: string,
+): Promise<CreateEventInvitationsResponse> {
+  return apiPostAuth<CreateEventInvitationsResponse>(
+    `/events/${eventId}/invitations`,
+    body,
     token,
   );
 }

--- a/frontend/src/styles/create-event.css
+++ b/frontend/src/styles/create-event.css
@@ -591,3 +591,10 @@
     flex-shrink: 0;
   }
 }
+
+.field-hint {
+  margin: 8px 0 0;
+  font-size: 0.8rem;
+  color: #64748b;
+  line-height: 1.4;
+}

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -1472,3 +1472,259 @@
     font-size: 14px;
   }
 }
+
+/* ── Generic primary/secondary buttons (host management) ── */
+
+.ed-primary-btn {
+  padding: 0.55rem 1rem;
+  background: #111827;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.ed-primary-btn:hover:not(:disabled) {
+  background: #000000;
+}
+
+.ed-primary-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.ed-secondary-btn {
+  padding: 0.55rem 1rem;
+  background: #ffffff;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  margin-top: 8px;
+}
+
+.ed-secondary-btn:hover:not(:disabled) {
+  background: #f8fafc;
+  border-color: #9ca3af;
+}
+
+.ed-secondary-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Management group header (with action button) ── */
+
+.ed-mgmt-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.ed-mgmt-action-btn {
+  flex-shrink: 0;
+}
+
+/* ── Invite Users modal ── */
+
+.ed-invite-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 600;
+  padding: 16px;
+}
+
+.ed-invite-modal {
+  background: #ffffff;
+  border-radius: 16px;
+  width: 100%;
+  max-width: 520px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.25);
+}
+
+.ed-invite-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.ed-invite-modal-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.ed-invite-modal-close {
+  background: none;
+  border: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: #64748b;
+  cursor: pointer;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+}
+
+.ed-invite-modal-close:hover:not(:disabled) {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+.ed-invite-form {
+  padding: 16px 20px 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.ed-invite-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #334155;
+  margin: 4px 0 6px;
+}
+
+.ed-invite-textarea {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  color: #0f172a;
+  resize: vertical;
+  min-height: 60px;
+  margin-bottom: 8px;
+}
+
+.ed-invite-textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.ed-invite-hint {
+  margin: 0 0 12px;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.ed-invite-error {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 10px 12px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  color: #b91c1c;
+  font-size: 0.85rem;
+}
+
+.ed-invite-error-dismiss {
+  background: none;
+  border: none;
+  color: #b91c1c;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.ed-invite-result {
+  margin: 8px 0;
+  padding: 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.ed-invite-result-line {
+  margin: 0 0 6px;
+}
+
+.ed-invite-result-success {
+  color: #15803d;
+  font-weight: 600;
+}
+
+.ed-invite-result-warn {
+  color: #b45309;
+}
+
+.ed-invite-result-failed-list {
+  margin: 6px 0 0;
+  padding: 0 0 0 18px;
+  color: #b91c1c;
+}
+
+.ed-invite-result-failed-list li {
+  margin-bottom: 2px;
+}
+
+.ed-invite-result-clear {
+  margin-top: 8px;
+  background: none;
+  border: none;
+  color: #2563eb;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.ed-invite-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+@media (max-width: 600px) {
+  .ed-mgmt-group-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ed-mgmt-action-btn {
+    width: 100%;
+  }
+
+  .ed-invite-modal {
+    border-radius: 12px;
+  }
+
+  .ed-invite-actions {
+    flex-direction: column-reverse;
+  }
+
+  .ed-invite-actions button {
+    width: 100%;
+  }
+}

--- a/frontend/src/viewmodels/event/useCreateEventViewModel.ts
+++ b/frontend/src/viewmodels/event/useCreateEventViewModel.ts
@@ -29,6 +29,7 @@ export const MAX_CONSTRAINTS = 5;
 export const PRIVACY_OPTIONS: { label: string; value: PrivacyLevel }[] = [
   { label: 'Public', value: 'PUBLIC' },
   { label: 'Protected', value: 'PROTECTED' },
+  { label: 'Private', value: 'PRIVATE' },
 ];
 
 export type ConstraintType = 'gender' | 'age' | 'capacity' | 'other';

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -9,6 +9,7 @@ import {
   listEventApprovedParticipants,
   listEventPendingJoinRequests,
   listEventInvitations,
+  createEventInvitations,
   approveJoinRequest,
   rejectJoinRequest,
   cancelEvent,
@@ -25,6 +26,7 @@ import type {
   EventDetailResponse,
   EventHostContextSummary,
 } from '@/models/event';
+import type { CreateEventInvitationsResponse } from '@/models/invitation';
 import { ApiError } from '@/services/api';
 import { prepareAvatarBlobs } from '@/utils/imageResize';
 
@@ -64,6 +66,9 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   const [coverImageError, setCoverImageError] = useState<string | null>(null);
   const [coverImageSuccessMessage, setCoverImageSuccessMessage] = useState<string | null>(null);
   const coverImageSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [inviteResult, setInviteResult] = useState<CreateEventInvitationsResponse | null>(null);
 
   useEffect(
     () => () => {
@@ -579,6 +584,35 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     refreshInvitations,
   ]);
 
+  const handleCreateInvitations = useCallback(
+    async (usernames: string[], message: string | null): Promise<CreateEventInvitationsResponse | null> => {
+      if (!eventId || !token) return null;
+      setInviteLoading(true);
+      setInviteError(null);
+      setInviteResult(null);
+      try {
+        const response = await createEventInvitations(
+          eventId,
+          { usernames, message: message ?? null },
+          token,
+        );
+        setInviteResult(response);
+        // Refresh invitations and host summary so counts and list update
+        await Promise.all([refreshInvitations(undefined, false), refreshHostContextSummary()]);
+        return response;
+      } catch (err) {
+        setInviteError(err instanceof ApiError ? err.message : 'Failed to send invitations');
+        return null;
+      } finally {
+        setInviteLoading(false);
+      }
+    },
+    [eventId, token, refreshInvitations, refreshHostContextSummary],
+  );
+
+  const dismissInviteError = useCallback(() => setInviteError(null), []);
+  const clearInviteResult = useCallback(() => setInviteResult(null), []);
+
   return {
     event,
     status,
@@ -594,6 +628,12 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     invitations,
     invitationsLoading,
     invitationsHasNext,
+    inviteLoading,
+    inviteError,
+    inviteResult,
+    handleCreateInvitations,
+    dismissInviteError,
+    clearInviteResult,
     joinLoading,
     joinError,
     leaveLoading,

--- a/frontend/src/views/events/CreateEventPage.tsx
+++ b/frontend/src/views/events/CreateEventPage.tsx
@@ -510,6 +510,13 @@ function CreateEventForm() {
               </button>
             ))}
           </div>
+          <p className="field-hint">
+            {vm.form.privacyLevel === 'PUBLIC'
+              ? 'Public events appear in discovery and anyone can join immediately.'
+              : vm.form.privacyLevel === 'PROTECTED'
+                ? 'Protected events appear in discovery but require host approval to join.'
+                : 'Private events are invite-based: only invited users can see and join. They do not appear in public discovery.'}
+          </p>
         </div>
 
         {/* Capacity */}

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -129,6 +129,12 @@ function makeReadyViewModel(event: EventDetailResponse) {
     loadMoreApprovedParticipants: vi.fn(),
     loadMorePendingJoinRequests: vi.fn(),
     loadMoreInvitations: vi.fn(),
+    inviteLoading: false,
+    inviteError: null,
+    inviteResult: null,
+    handleCreateInvitations: vi.fn(),
+    dismissInviteError: vi.fn(),
+    clearInviteResult: vi.fn(),
   };
 }
 
@@ -210,6 +216,67 @@ describe('EventDetailPage ratings', () => {
     expect(screen.getByText(/4\/5/i)).toBeDefined();
     expect(screen.getByText(/reliable and easy to coordinate with\./i)).toBeDefined();
     expect(screen.getByRole('button', { name: /edit rating/i })).toBeDefined();
+  });
+
+  it('shows the Invite Users button on private events for the host', () => {
+    const event = makeBaseEvent();
+    event.privacy_level = 'PRIVATE';
+    event.status = 'ACTIVE';
+    event.viewer_context = {
+      is_host: true,
+      is_favorited: false,
+      participation_status: 'NONE',
+    };
+    const vm = makeReadyViewModel(event);
+    vm.hostContextSummary = {
+      approved_participant_count: 0,
+      pending_join_request_count: 0,
+      invitation_count: 0,
+    };
+
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+    renderPage();
+
+    expect(screen.getByTestId('ed-invite-open')).toBeDefined();
+    expect(screen.getByText(/no invitations sent yet/i)).toBeDefined();
+  });
+
+  it('hides the Invite Users button on public events even for the host', () => {
+    const event = makeBaseEvent();
+    event.privacy_level = 'PUBLIC';
+    event.status = 'ACTIVE';
+    event.viewer_context = {
+      is_host: true,
+      is_favorited: false,
+      participation_status: 'NONE',
+    };
+    const vm = makeReadyViewModel(event);
+    vm.hostContextSummary = {
+      approved_participant_count: 0,
+      pending_join_request_count: 0,
+      invitation_count: 0,
+    };
+
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+    renderPage();
+
+    expect(screen.queryByTestId('ed-invite-open')).toBeNull();
+  });
+
+  it('hides the Invite Users button for non-host viewers on private events', () => {
+    const event = makeBaseEvent();
+    event.privacy_level = 'PRIVATE';
+    event.status = 'ACTIVE';
+    event.viewer_context = {
+      is_host: false,
+      is_favorited: false,
+      participation_status: 'NONE',
+    };
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+    renderPage();
+
+    expect(screen.queryByTestId('ed-invite-open')).toBeNull();
   });
 
   it('shows a pending join-request banner instead of join actions', () => {

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -9,6 +9,11 @@ import type {
   EventDetailResponse,
   EventHostContextSummary,
 } from '@/models/event';
+import type {
+  CreateEventInvitationsResponse,
+  EventInvitationFailure,
+  InvitationFailureCode,
+} from '@/models/invitation';
 import { EventCoverImage } from '@/components/EventCoverImage';
 import { UserAvatar } from '@/components/UserAvatar';
 import { getEventLifecyclePresentation, getEventStatusPresentation } from '@/utils/eventStatus';
@@ -154,6 +159,282 @@ function PrivacyBadge({ level }: { level: string }) {
     <span className={`ed-privacy-badge ed-privacy-${level.toLowerCase()}`}>
       {label}
     </span>
+  );
+}
+
+const FAILURE_CODE_LABELS: Record<InvitationFailureCode, string> = {
+  ALREADY_INVITED: 'Already invited',
+  ALREADY_PARTICIPATING: 'Already participating',
+  HOST_USER: 'Cannot invite the host',
+  DECLINE_COOLDOWN_ACTIVE: 'Recently declined — try again later',
+  CAPACITY_EXCEEDED: 'Event is full',
+  DUPLICATE_USERNAME: 'Duplicate username in batch',
+};
+
+function InviteUsersModal({
+  loading,
+  error,
+  result,
+  onClose,
+  onSubmit,
+  onDismissError,
+  onClearResult,
+}: {
+  loading: boolean;
+  error: string | null;
+  result: CreateEventInvitationsResponse | null;
+  onClose: () => void;
+  onSubmit: (usernames: string[], message: string | null) => Promise<CreateEventInvitationsResponse | null>;
+  onDismissError: () => void;
+  onClearResult: () => void;
+}) {
+  const [usernamesInput, setUsernamesInput] = useState('');
+  const [message, setMessage] = useState('');
+
+  const usernames = usernamesInput
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const canSubmit = usernames.length > 0 && usernames.length <= 100 && !loading;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    const res = await onSubmit(usernames, message.trim() || null);
+    if (res && res.success_count > 0 && res.failed_count === 0 && res.invalid_username_count === 0) {
+      // All succeeded — auto close
+      setUsernamesInput('');
+      setMessage('');
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="ed-invite-modal-overlay"
+      role="presentation"
+      onClick={loading ? undefined : onClose}
+    >
+      <div
+        className="ed-invite-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ed-invite-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="ed-invite-modal-header">
+          <h3 id="ed-invite-title">Invite Users</h3>
+          <button
+            type="button"
+            className="ed-invite-modal-close"
+            onClick={onClose}
+            disabled={loading}
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="ed-invite-form">
+          <label className="ed-invite-label" htmlFor="ed-invite-usernames">
+            Usernames
+          </label>
+          <textarea
+            id="ed-invite-usernames"
+            className="ed-invite-textarea"
+            placeholder="Enter usernames separated by commas, spaces, or new lines"
+            value={usernamesInput}
+            onChange={(e) => setUsernamesInput(e.target.value)}
+            disabled={loading}
+            rows={3}
+          />
+          <p className="ed-invite-hint">
+            {usernames.length === 0
+              ? 'Enter at least one username.'
+              : usernames.length > 100
+                ? `Too many — limit is 100 (you have ${usernames.length}).`
+                : `${usernames.length} username${usernames.length !== 1 ? 's' : ''} ready to invite.`}
+          </p>
+
+          <label className="ed-invite-label" htmlFor="ed-invite-message">
+            Message (optional)
+          </label>
+          <textarea
+            id="ed-invite-message"
+            className="ed-invite-textarea"
+            placeholder="Add a personal note for invitees..."
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            disabled={loading}
+            maxLength={300}
+            rows={2}
+          />
+
+          {error && (
+            <div className="ed-invite-error" role="alert">
+              <span>{error}</span>
+              <button type="button" className="ed-invite-error-dismiss" onClick={onDismissError}>
+                &times;
+              </button>
+            </div>
+          )}
+
+          {result && (
+            <div className="ed-invite-result">
+              {result.success_count > 0 && (
+                <p className="ed-invite-result-line ed-invite-result-success">
+                  &#10003; Sent {result.success_count} invitation
+                  {result.success_count !== 1 ? 's' : ''}.
+                </p>
+              )}
+              {result.invalid_usernames.length > 0 && (
+                <p className="ed-invite-result-line ed-invite-result-warn">
+                  Unknown username{result.invalid_usernames.length !== 1 ? 's' : ''}:{' '}
+                  <strong>{result.invalid_usernames.join(', ')}</strong>
+                </p>
+              )}
+              {result.failed.length > 0 && (
+                <ul className="ed-invite-result-failed-list">
+                  {result.failed.map((f: EventInvitationFailure) => (
+                    <li key={`${f.username}-${f.code}`}>
+                      <strong>@{f.username}</strong>: {FAILURE_CODE_LABELS[f.code] ?? f.code}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <button
+                type="button"
+                className="ed-invite-result-clear"
+                onClick={onClearResult}
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+
+          <div className="ed-invite-actions">
+            <button
+              type="button"
+              className="ed-secondary-btn"
+              onClick={onClose}
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="ed-primary-btn"
+              disabled={!canSubmit}
+            >
+              {loading ? <span className="spinner" /> : 'Send Invitations'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function InvitationsManagementSection({
+  invitations,
+  invitationsLoading,
+  invitationsHasNext,
+  hostContextSummary,
+  isCancelable,
+  inviteLoading,
+  inviteError,
+  inviteResult,
+  onLoadMoreInvitations,
+  onCreateInvitations,
+  onDismissInviteError,
+  onClearInviteResult,
+}: {
+  invitations: EventDetailInvitation[];
+  invitationsLoading: boolean;
+  invitationsHasNext: boolean;
+  hostContextSummary: EventHostContextSummary | null;
+  isCancelable: boolean;
+  inviteLoading: boolean;
+  inviteError: string | null;
+  inviteResult: CreateEventInvitationsResponse | null;
+  onLoadMoreInvitations: () => void;
+  onCreateInvitations: (usernames: string[], message: string | null) => Promise<CreateEventInvitationsResponse | null>;
+  onDismissInviteError: () => void;
+  onClearInviteResult: () => void;
+}) {
+  const [showModal, setShowModal] = useState(false);
+  const total = hostContextSummary?.invitation_count ?? invitations.length;
+
+  return (
+    <div className="ed-mgmt-group">
+      <div className="ed-mgmt-group-header">
+        <h3 className="ed-mgmt-title">Invitations ({total})</h3>
+        {isCancelable && (
+          <button
+            type="button"
+            className="ed-primary-btn ed-mgmt-action-btn"
+            onClick={() => setShowModal(true)}
+            data-testid="ed-invite-open"
+          >
+            + Invite Users
+          </button>
+        )}
+      </div>
+
+      {invitationsLoading && invitations.length === 0 ? (
+        <p className="ed-mgmt-empty">Loading invitations...</p>
+      ) : invitations.length === 0 ? (
+        <p className="ed-mgmt-empty">No invitations sent yet.</p>
+      ) : (
+        <ul className="ed-mgmt-list">
+          {invitations.map((inv) => (
+            <li key={inv.invitation_id} className="ed-mgmt-item">
+              <UserAvatar
+                username={inv.user.username}
+                displayName={inv.user.display_name}
+                avatarUrl={inv.user.avatar_url}
+                size="sm"
+                variant="muted"
+              />
+              <div className="ed-mgmt-user-info">
+                <span className="ed-mgmt-name">{inv.user.display_name ?? inv.user.username}</span>
+                <span className="ed-mgmt-username">@{inv.user.username}</span>
+              </div>
+              <span className={`ed-invitation-status ed-inv-${inv.status.toLowerCase()}`}>
+                {inv.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {invitationsHasNext && (
+        <button
+          type="button"
+          className="ed-secondary-btn"
+          onClick={onLoadMoreInvitations}
+          disabled={invitationsLoading}
+        >
+          {invitationsLoading ? 'Loading...' : 'Load More Invitations'}
+        </button>
+      )}
+
+      {showModal && (
+        <InviteUsersModal
+          loading={inviteLoading}
+          error={inviteError}
+          result={inviteResult}
+          onClose={() => {
+            setShowModal(false);
+            onClearInviteResult();
+          }}
+          onSubmit={onCreateInvitations}
+          onDismissError={onDismissInviteError}
+          onClearResult={onClearInviteResult}
+        />
+      )}
+    </div>
   );
 }
 
@@ -875,6 +1156,12 @@ function EventContent({
   onLoadMoreApprovedParticipants,
   onLoadMorePendingJoinRequests,
   onLoadMoreInvitations,
+  inviteLoading,
+  inviteError,
+  inviteResult,
+  onCreateInvitations,
+  onDismissInviteError,
+  onClearInviteResult,
   coverImageUploading,
   coverImageError,
   coverImageSuccessMessage,
@@ -925,6 +1212,12 @@ function EventContent({
   onLoadMoreApprovedParticipants: () => void;
   onLoadMorePendingJoinRequests: () => void;
   onLoadMoreInvitations: () => void;
+  inviteLoading: boolean;
+  inviteError: string | null;
+  inviteResult: CreateEventInvitationsResponse | null;
+  onCreateInvitations: (usernames: string[], message: string | null) => Promise<CreateEventInvitationsResponse | null>;
+  onDismissInviteError: () => void;
+  onClearInviteResult: () => void;
   coverImageUploading: boolean;
   coverImageError: string | null;
   coverImageSuccessMessage: string | null;
@@ -1344,47 +1637,22 @@ function EventContent({
               </div>
             )}
 
-            {/* Invitations */}
-            {(invitations.length > 0 || (hostContextSummary?.invitation_count ?? 0) > 0) && (
-              <div className="ed-mgmt-group">
-                <h3 className="ed-mgmt-title">
-                  Invitations ({hostContextSummary?.invitation_count ?? invitations.length})
-                </h3>
-                {invitationsLoading && invitations.length === 0 ? (
-                  <p className="ed-mgmt-empty">Loading invitations...</p>
-                ) : (
-                <ul className="ed-mgmt-list">
-                  {invitations.map((inv) => (
-                    <li key={inv.invitation_id} className="ed-mgmt-item">
-                      <UserAvatar
-                        username={inv.user.username}
-                        displayName={inv.user.display_name}
-                        avatarUrl={inv.user.avatar_url}
-                        size="sm"
-                        variant="muted"
-                      />
-                      <div className="ed-mgmt-user-info">
-                        <span className="ed-mgmt-name">{inv.user.display_name ?? inv.user.username}</span>
-                        <span className="ed-mgmt-username">@{inv.user.username}</span>
-                      </div>
-                      <span className={`ed-invitation-status ed-inv-${inv.status.toLowerCase()}`}>
-                        {inv.status}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-                )}
-                {invitationsHasNext && (
-                  <button
-                    type="button"
-                    className="ed-secondary-btn"
-                    onClick={onLoadMoreInvitations}
-                    disabled={invitationsLoading}
-                  >
-                    {invitationsLoading ? 'Loading...' : 'Load More Invitations'}
-                  </button>
-                )}
-              </div>
+            {/* Invitations (private events only) */}
+            {event.privacy_level === 'PRIVATE' && (
+              <InvitationsManagementSection
+                invitations={invitations}
+                invitationsLoading={invitationsLoading}
+                invitationsHasNext={invitationsHasNext}
+                hostContextSummary={hostContextSummary}
+                isCancelable={event.status === 'ACTIVE'}
+                inviteLoading={inviteLoading}
+                inviteError={inviteError}
+                inviteResult={inviteResult}
+                onLoadMoreInvitations={onLoadMoreInvitations}
+                onCreateInvitations={onCreateInvitations}
+                onDismissInviteError={onDismissInviteError}
+                onClearInviteResult={onClearInviteResult}
+              />
             )}
           </div>
         )}
@@ -1501,6 +1769,12 @@ export default function EventDetailPage() {
       onLoadMoreApprovedParticipants={vm.loadMoreApprovedParticipants}
       onLoadMorePendingJoinRequests={vm.loadMorePendingJoinRequests}
       onLoadMoreInvitations={vm.loadMoreInvitations}
+      inviteLoading={vm.inviteLoading}
+      inviteError={vm.inviteError}
+      inviteResult={vm.inviteResult}
+      onCreateInvitations={vm.handleCreateInvitations}
+      onDismissInviteError={vm.dismissInviteError}
+      onClearInviteResult={vm.clearInviteResult}
     />
   );
 }


### PR DESCRIPTION
## 📋 Summary
Allows hosts to create private events and invite users by username from the event detail page. Adds the Private privacy option with explanatory copy on the create-event form, an Invite Users button on the host-only invitations section, and a modal that surfaces the backend's per-user partial-success result so hosts know exactly which invites went through and which didn't.

## 🔄 Changes
- **`models/invitation.ts`** *(new — also added in the sibling user-side PR with identical content)* — host-side types `CreateEventInvitationsRequest`, `CreateEventInvitationsResponse`, `CreatedEventInvitation`, `EventInvitationFailure`, `InvitationFailureCode` (plus the participant types so the file is self-contained)
- **`services/eventService.ts`** — added `createEventInvitations(eventId, { usernames, message }, token)` calling `POST /events/:id/invitations`
- **`viewmodels/event/useEventDetailViewModel.ts`** — added `inviteLoading`, `inviteError`, `inviteResult`, `handleCreateInvitations`, `dismissInviteError`, `clearInviteResult`. After a successful create, refreshes the invitations list and host-context summary so counts and rows update without a full reload
- **`views/events/EventDetailPage.tsx`** — replaced the inline Invitations management block with a new `InvitationsManagementSection` that:
  - Only renders for `event.privacy_level === 'PRIVATE'`
  - Shows "+ Invite Users" only when `event.viewer_context.is_host` and the event is still active
  - Has an empty state ("No invitations sent yet") and inherits the existing list rendering and load-more
  Also adds a new `InviteUsersModal` that takes comma/space/newline-separated usernames + an optional message, validates the 1–100 username count, and renders the partial-success result inline: success count, unknown usernames, and a per-user failure list with friendly labels for `ALREADY_INVITED`, `ALREADY_PARTICIPATING`, `HOST_USER`, `DECLINE_COOLDOWN_ACTIVE`, `CAPACITY_EXCEEDED`, `DUPLICATE_USERNAME`. Auto-closes when every invite succeeded.
- **`viewmodels/event/useCreateEventViewModel.ts`** — added the `Private` option to `PRIVACY_OPTIONS` so hosts can create PRIVATE events
- **`views/events/CreateEventPage.tsx`** — added a `.field-hint` below the privacy chips that explains the selected level (`Public` / `Protected` / `Private`); the Private copy reads "Private events are invite-based: only invited users can see and join. They do not appear in public discovery."
- **`styles/event-detail.css`** — `.ed-primary-btn`, `.ed-secondary-btn`, `.ed-mgmt-group-header`, `.ed-mgmt-action-btn`, `.ed-invite-modal*`, `.ed-invite-form`, `.ed-invite-error`, `.ed-invite-result*` + mobile stacking
- **`styles/create-event.css`** — added `.field-hint`
- **`views/events/EventDetailPage.test.tsx`** — added 3 tests: invite button visible for the host on a private event, hidden for the host on a public event, hidden for non-host viewers on a private event; viewmodel mock extended with the new invite fields

## 🧪 Testing
1. `cd frontend && npm install && npm run build` → confirm the build is clean (no missing `models/invitation` import)
2. `npm run dev` → log in as a host
3. Go to `/events/create` → confirm the privacy row now shows three chips (Public / Protected / **Private**); selecting each updates the hint text below
4. Pick **Private**, fill out the form, and submit → confirm the event is created and you land on its detail page
5. On the new event's detail page (as host), scroll to host management → confirm the "Invitations (0)" group is shown with "No invitations sent yet" and a `+ Invite Users` button
6. Click **+ Invite Users** → modal opens; enter `@knownuser, @unknown_x, knownuser` (mix of valid, unknown, and a duplicate of the same valid user) plus an optional message → click **Send Invitations**
7. Confirm the inline result block appears with: the success count, the unknown username, and per-user failure rows for the duplicate (`Duplicate username in batch`) and any `ALREADY_INVITED` cases — and the new pending invitation appears in the Invitations list
8. With all invites succeeding for a fresh batch, confirm the modal auto-closes and the count updates
9. Open the event detail page as a non-host or on a public event → confirm the `+ Invite Users` button is **not** rendered
10. (When the jsdom env is fixed) `npm test` → the 3 new EventDetailPage tests pass

## 🔗 Related
Related to #453 
