### PR TITLE
feat(frontend): add notifications inbox with bell badge in app shell

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import CreateEventPage from './views/events/CreateEventPage';
 import EventDetailPage from './views/events/EventDetailPage';
 import MyEventsPage from './views/events/MyEventsPage';
 import InvitationsPage from './views/invitations/InvitationsPage';
+import NotificationsPage from './views/notifications/NotificationsPage';
 import FavoritesPage from './views/favorites/FavoritesPage';
 import ProfilePage from './views/profile/ProfilePage';
 import NotFoundView from './views/fallback/NotFoundView';
@@ -43,6 +44,7 @@ export default function App() {
         <Route path="/events/:id" element={<EventDetailPage />} />
         <Route path="/my-events" element={<ProtectedRoute><MyEventsPage /></ProtectedRoute>} />
         <Route path="/invitations" element={<ProtectedRoute><InvitationsPage /></ProtectedRoute>} />
+        <Route path="/notifications" element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>} />
         <Route path="/favorites" element={<ProtectedRoute><FavoritesPage /></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
         <Route

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { UserAvatar } from '@/components/UserAvatar';
 import { logout } from '@/services/authService';
 import SemLogo from '@/components/SemLogo';
+import { useUnreadCountViewModel } from '@/viewmodels/notifications/useUnreadCountViewModel';
 import '@/styles/shell.css';
 
 const AUTH_NAV = [
@@ -27,6 +28,7 @@ export default function AppShell() {
   const navItems = isLoggedIn ? AUTH_NAV : [];
   const isAdminPanel = location.pathname.startsWith('/backoffice') || location.pathname.startsWith('/admin-panel');
   const isDarkMode = theme === 'dark';
+  const { unreadCount } = useUnreadCountViewModel();
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -98,6 +100,35 @@ export default function AppShell() {
             </button>
             {isLoggedIn ? (
               <>
+                <NavLink
+                  to="/notifications"
+                  className="shell-bell-btn"
+                  aria-label={
+                    unreadCount > 0
+                      ? `Notifications, ${unreadCount} unread`
+                      : 'Notifications'
+                  }
+                  title="Notifications"
+                >
+                  <svg
+                    className="shell-bell-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden
+                  >
+                    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+                    <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+                  </svg>
+                  {unreadCount > 0 && (
+                    <span className="shell-bell-badge" aria-hidden>
+                      {unreadCount > 99 ? '99+' : unreadCount}
+                    </span>
+                  )}
+                </NavLink>
                 <NavLink to="/events/create" className="shell-create-btn">
                   + Create Event
                 </NavLink>
@@ -133,6 +164,20 @@ export default function AppShell() {
                         onClick={() => setUserMenuOpen(false)}
                       >
                         Profile
+                      </NavLink>
+                      <NavLink
+                        to="/invitations"
+                        className="shell-dropdown-item"
+                        onClick={() => setUserMenuOpen(false)}
+                      >
+                        Invitations
+                      </NavLink>
+                      <NavLink
+                        to="/notifications"
+                        className="shell-dropdown-item"
+                        onClick={() => setUserMenuOpen(false)}
+                      >
+                        Notifications
                       </NavLink>
                       <button
                         className="shell-dropdown-item shell-dropdown-logout"

--- a/frontend/src/models/notification.ts
+++ b/frontend/src/models/notification.ts
@@ -1,0 +1,40 @@
+export type NotificationType =
+  | 'PRIVATE_EVENT_INVITATION_RECEIVED'
+  | 'PRIVATE_EVENT_INVITATION_ACCEPTED'
+  | 'PRIVATE_EVENT_INVITATION_DECLINED'
+  | 'PROTECTED_EVENT_JOIN_REQUEST_APPROVED'
+  | 'PROTECTED_EVENT_JOIN_REQUEST_REJECTED'
+  | 'PROTECTED_EVENT_JOIN_REQUEST_SUBMITTED'
+  | 'EVENT_CANCELED';
+
+export interface NotificationItem {
+  id: string;
+  event_id: string | null;
+  title: string;
+  body: string;
+  type: NotificationType | string | null;
+  deep_link: string | null;
+  image_url: string | null;
+  data: Record<string, string>;
+  is_read: boolean;
+  read_at: string | null;
+  created_at: string;
+}
+
+export interface NotificationPageInfo {
+  next_cursor: string | null;
+  has_next: boolean;
+}
+
+export interface ListNotificationsResponse {
+  items: NotificationItem[];
+  page_info: NotificationPageInfo;
+}
+
+export interface UnreadNotificationCountResponse {
+  unread_count: number;
+}
+
+export interface MarkAllNotificationsReadResponse {
+  updated_count: number;
+}

--- a/frontend/src/services/notificationService.ts
+++ b/frontend/src/services/notificationService.ts
@@ -1,0 +1,65 @@
+import { apiDeleteAuth, apiGetAuth, apiPatchAuth } from './api';
+import type {
+  ListNotificationsResponse,
+  MarkAllNotificationsReadResponse,
+  UnreadNotificationCountResponse,
+} from '@/models/notification';
+
+export interface ListNotificationsParams {
+  limit?: number;
+  cursor?: string | null;
+  onlyUnread?: boolean;
+}
+
+function notificationListEndpoint(params?: ListNotificationsParams): string {
+  const query = new URLSearchParams();
+  if (params?.limit) query.set('limit', String(params.limit));
+  if (params?.cursor) query.set('cursor', params.cursor);
+  const path = params?.onlyUnread ? '/me/notifications/unread' : '/me/notifications';
+  const serialized = query.toString();
+  return serialized ? `${path}?${serialized}` : path;
+}
+
+export function listNotifications(
+  token: string,
+  params?: ListNotificationsParams,
+): Promise<ListNotificationsResponse> {
+  return apiGetAuth<ListNotificationsResponse>(notificationListEndpoint(params), token);
+}
+
+export function getUnreadNotificationCount(
+  token: string,
+): Promise<UnreadNotificationCountResponse> {
+  return apiGetAuth<UnreadNotificationCountResponse>(
+    '/me/notifications/unread-count',
+    token,
+  );
+}
+
+export function markNotificationRead(
+  notificationId: string,
+  token: string,
+): Promise<void> {
+  return apiPatchAuth<void>(`/me/notifications/${notificationId}/read`, {}, token);
+}
+
+export function markAllNotificationsRead(
+  token: string,
+): Promise<MarkAllNotificationsReadResponse> {
+  return apiPatchAuth<MarkAllNotificationsReadResponse>(
+    '/me/notifications/read',
+    {},
+    token,
+  );
+}
+
+export function deleteNotification(
+  notificationId: string,
+  token: string,
+): Promise<void> {
+  return apiDeleteAuth<void>(`/me/notifications/${notificationId}`, token);
+}
+
+export function deleteAllNotifications(token: string): Promise<void> {
+  return apiDeleteAuth<void>('/me/notifications', token);
+}

--- a/frontend/src/styles/notifications.css
+++ b/frontend/src/styles/notifications.css
@@ -1,0 +1,316 @@
+.notif-page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 20px 40px;
+}
+
+.notif-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.notif-page-title {
+  margin: 0 0 4px;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.notif-page-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.notif-page-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.notif-action-btn {
+  padding: 0.5rem 0.85rem;
+  background: #ffffff;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.notif-action-btn:hover:not(:disabled) {
+  background: #f1f5f9;
+  border-color: #9ca3af;
+  color: #0f172a;
+}
+
+.notif-action-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.notif-action-danger {
+  color: #b91c1c;
+  border-color: #fecaca;
+}
+
+.notif-action-danger:hover:not(:disabled) {
+  background: #fef2f2;
+  border-color: #fca5a5;
+  color: #991b1b;
+}
+
+/* States */
+
+.notif-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 64px 0;
+  color: #64748b;
+}
+
+.notif-empty {
+  text-align: center;
+  padding: 64px 24px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+}
+
+.notif-empty h2 {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  color: #0f172a;
+}
+
+.notif-empty p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.notif-error {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 18px;
+  border-radius: 10px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}
+
+.notif-error-dismiss {
+  background: none;
+  border: none;
+  color: #b91c1c;
+  font-size: 1.3rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+/* List */
+
+.notif-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.notif-row {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.notif-row:hover {
+  border-color: #cbd5e1;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
+}
+
+.notif-row-unread {
+  background: #f8fafc;
+  border-color: #c7d2fe;
+}
+
+.notif-row-main {
+  display: flex;
+  flex: 1;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  min-width: 0;
+}
+
+.notif-row-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.notif-row-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.notif-row-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+.notif-row-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.notif-row-badge {
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  flex-shrink: 0;
+}
+
+.notif-row-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+  flex: 1;
+  min-width: 0;
+}
+
+.notif-row-time {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.notif-row-event {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #475569;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notif-row-summary {
+  font-size: 0.85rem;
+  color: #475569;
+  line-height: 1.4;
+}
+
+.notif-row-meta {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.notif-row-action {
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-top: 2px;
+}
+
+.notif-row-dot {
+  position: absolute;
+  top: 14px;
+  right: 44px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2563eb;
+  flex-shrink: 0;
+}
+
+.notif-row-delete {
+  flex-shrink: 0;
+  width: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-left: 1px solid #f1f5f9;
+  color: #94a3b8;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.notif-row-delete:hover {
+  background: #fef2f2;
+  color: #dc2626;
+}
+
+.notif-load-more {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+/* Mobile */
+
+@media (max-width: 600px) {
+  .notif-page {
+    padding: 16px 14px 40px;
+  }
+
+  .notif-page-header {
+    flex-direction: column;
+  }
+
+  .notif-page-actions {
+    width: 100%;
+  }
+
+  .notif-action-btn {
+    flex: 1;
+    text-align: center;
+  }
+
+  .notif-row-main {
+    padding: 12px;
+  }
+
+  .notif-row-time {
+    width: 100%;
+  }
+}

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -108,6 +108,59 @@
   stroke-linejoin: round;
 }
 
+/* Notification bell */
+.shell-bell-btn {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #374151;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+}
+
+.shell-bell-btn:hover {
+  color: #111827;
+  background-color: #f9fafb;
+  border-color: #d1d5db;
+}
+
+.shell-bell-btn.active {
+  color: #111827;
+  background-color: #f1f5f9;
+  border-color: #d1d5db;
+}
+
+.shell-bell-icon {
+  width: 19px;
+  height: 19px;
+}
+
+.shell-bell-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #dc2626;
+  color: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
 /* Create Event button */
 .shell-create-btn {
   padding: 8px 16px;

--- a/frontend/src/utils/notificationPresentation.test.ts
+++ b/frontend/src/utils/notificationPresentation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import type { NotificationItem } from '@/models/notification';
+import {
+  getNotificationPresentation,
+  isDedicatedParticipationNotification,
+} from './notificationPresentation';
+
+function makeNotification(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: 'n-1',
+    event_id: 'event-1',
+    title: 'Generic title',
+    body: 'Generic body',
+    type: null,
+    deep_link: null,
+    image_url: null,
+    data: {},
+    is_read: false,
+    read_at: null,
+    created_at: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('getNotificationPresentation', () => {
+  it('returns invitation copy and routes to invitations for PRIVATE_EVENT_INVITATION_RECEIVED', () => {
+    const presentation = getNotificationPresentation(
+      makeNotification({
+        type: 'PRIVATE_EVENT_INVITATION_RECEIVED',
+        data: { actor_username: 'host', event_title: 'Sunset Walk' },
+      }),
+    );
+    expect(presentation.badgeLabel).toBe('Invitation');
+    expect(presentation.summary).toContain('host');
+    expect(presentation.eventTitle).toBe('Sunset Walk');
+    expect(presentation.actionTarget).toBe('INVITATIONS');
+    expect(presentation.actionLabel).toBe('Review invitation');
+  });
+
+  it('returns approved copy and routes to event for PROTECTED_EVENT_JOIN_REQUEST_APPROVED', () => {
+    const presentation = getNotificationPresentation(
+      makeNotification({
+        type: 'PROTECTED_EVENT_JOIN_REQUEST_APPROVED',
+        data: { actor_display_name: 'Host User' },
+      }),
+    );
+    expect(presentation.badgeLabel).toBe('Approved');
+    expect(presentation.summary).toContain('Host User');
+    expect(presentation.actionTarget).toBe('EVENT');
+  });
+
+  it('formats cooldown metadata for PROTECTED_EVENT_JOIN_REQUEST_REJECTED', () => {
+    const presentation = getNotificationPresentation(
+      makeNotification({
+        type: 'PROTECTED_EVENT_JOIN_REQUEST_REJECTED',
+        data: { cooldown_ends_at: '2026-04-08T00:00:00Z' },
+      }),
+    );
+    expect(presentation.badgeLabel).toBe('Rejected');
+    expect(presentation.metadata.length).toBe(1);
+    expect(presentation.metadata[0]).toMatch(/Retry after/);
+  });
+
+  it('falls back to generic title and body for unknown notification types', () => {
+    const presentation = getNotificationPresentation(
+      makeNotification({
+        type: 'SOMETHING_NEW',
+        title: 'A new alert',
+        body: 'Body text',
+      }),
+    );
+    expect(presentation.badgeLabel).toBeNull();
+    expect(presentation.title).toBe('A new alert');
+    expect(presentation.summary).toBe('Body text');
+    expect(presentation.actionTarget).toBe('EVENT');
+  });
+
+  it('returns NONE action target when notification has no event reference', () => {
+    const presentation = getNotificationPresentation(
+      makeNotification({
+        type: null,
+        event_id: null,
+        data: {},
+      }),
+    );
+    expect(presentation.actionTarget).toBe('NONE');
+    expect(presentation.actionLabel).toBeNull();
+  });
+});
+
+describe('isDedicatedParticipationNotification', () => {
+  it('returns true for participation-related types', () => {
+    expect(isDedicatedParticipationNotification('PRIVATE_EVENT_INVITATION_RECEIVED')).toBe(true);
+    expect(isDedicatedParticipationNotification('PROTECTED_EVENT_JOIN_REQUEST_APPROVED')).toBe(true);
+    expect(isDedicatedParticipationNotification('EVENT_CANCELED')).toBe(true);
+  });
+
+  it('returns false for unknown or null types', () => {
+    expect(isDedicatedParticipationNotification(null)).toBe(false);
+    expect(isDedicatedParticipationNotification('UNKNOWN')).toBe(false);
+  });
+});

--- a/frontend/src/utils/notificationPresentation.ts
+++ b/frontend/src/utils/notificationPresentation.ts
@@ -1,0 +1,187 @@
+import type { NotificationItem, NotificationType } from '@/models/notification';
+
+export type NotificationActionTarget = 'EVENT' | 'INVITATIONS' | 'NONE';
+
+export interface NotificationPresentation {
+  accentColor: string;
+  accentBackgroundColor: string;
+  badgeLabel: string | null;
+  title: string | null;
+  eventTitle: string | null;
+  iconKind: 'mail' | 'check' | 'cross' | 'bell';
+  summary: string;
+  metadata: string[];
+  actionLabel: string | null;
+  actionTarget: NotificationActionTarget;
+}
+
+const PARTICIPATION_NOTIFICATION_TYPES: NotificationType[] = [
+  'PRIVATE_EVENT_INVITATION_RECEIVED',
+  'PROTECTED_EVENT_JOIN_REQUEST_APPROVED',
+  'PROTECTED_EVENT_JOIN_REQUEST_REJECTED',
+  'PROTECTED_EVENT_JOIN_REQUEST_SUBMITTED',
+  'EVENT_CANCELED',
+  'PRIVATE_EVENT_INVITATION_ACCEPTED',
+  'PRIVATE_EVENT_INVITATION_DECLINED',
+];
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function formatActorLabel(data: Record<string, string>): string | null {
+  return firstNonEmpty(data.actor_display_name, data.actor_username);
+}
+
+function formatCooldown(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const timestamp = new Date(iso);
+  if (Number.isNaN(timestamp.getTime())) return null;
+  return `Retry after ${timestamp.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })}`;
+}
+
+export function isDedicatedParticipationNotification(
+  type: string | null | undefined,
+): type is NotificationType {
+  return PARTICIPATION_NOTIFICATION_TYPES.includes(type as NotificationType);
+}
+
+export function getNotificationPresentation(
+  notification: NotificationItem,
+): NotificationPresentation {
+  const eventTitle = firstNonEmpty(
+    notification.data.event_title,
+    notification.event_id ? 'Event update' : null,
+  );
+  const actorLabel = formatActorLabel(notification.data);
+
+  switch (notification.type) {
+    case 'PRIVATE_EVENT_INVITATION_RECEIVED':
+      return {
+        accentColor: '#5B21B6',
+        accentBackgroundColor: '#EDE9FE',
+        badgeLabel: 'Invitation',
+        title: 'Private event invitation',
+        eventTitle,
+        iconKind: 'mail',
+        summary: actorLabel
+          ? `${actorLabel} invited you to a private event.`
+          : 'You received a private event invitation.',
+        metadata: [],
+        actionLabel: 'Review invitation',
+        actionTarget: 'INVITATIONS',
+      };
+    case 'PROTECTED_EVENT_JOIN_REQUEST_APPROVED':
+      return {
+        accentColor: '#047857',
+        accentBackgroundColor: '#DCFCE7',
+        badgeLabel: 'Approved',
+        title: 'Join request approved',
+        eventTitle,
+        iconKind: 'check',
+        summary: actorLabel
+          ? `${actorLabel} approved your join request.`
+          : 'Your join request was approved.',
+        metadata: [],
+        actionLabel: 'Open event',
+        actionTarget: 'EVENT',
+      };
+    case 'PROTECTED_EVENT_JOIN_REQUEST_REJECTED': {
+      const cooldown = formatCooldown(notification.data.cooldown_ends_at);
+      return {
+        accentColor: '#B45309',
+        accentBackgroundColor: '#FEF3C7',
+        badgeLabel: 'Rejected',
+        title: 'Join request rejected',
+        eventTitle,
+        iconKind: 'cross',
+        summary: actorLabel
+          ? `${actorLabel} rejected your join request.`
+          : 'Your join request was rejected.',
+        metadata: cooldown ? [cooldown] : [],
+        actionLabel: 'View event details',
+        actionTarget: 'EVENT',
+      };
+    }
+    case 'PROTECTED_EVENT_JOIN_REQUEST_SUBMITTED':
+      return {
+        accentColor: '#D97706',
+        accentBackgroundColor: '#FEF3C7',
+        badgeLabel: 'New Request',
+        title: 'Join request submitted',
+        eventTitle,
+        iconKind: 'mail',
+        summary: actorLabel
+          ? `${actorLabel} wants to join your event.`
+          : 'Someone wants to join your event.',
+        metadata: [],
+        actionLabel: 'Review request',
+        actionTarget: 'EVENT',
+      };
+    case 'EVENT_CANCELED':
+      return {
+        accentColor: '#B91C1C',
+        accentBackgroundColor: '#FEE2E2',
+        badgeLabel: 'Canceled',
+        title: 'Event canceled',
+        eventTitle,
+        iconKind: 'cross',
+        summary: eventTitle
+          ? `The event "${eventTitle}" has been canceled.`
+          : 'An event you were interested in has been canceled.',
+        metadata: [],
+        actionLabel: 'View event',
+        actionTarget: 'EVENT',
+      };
+    case 'PRIVATE_EVENT_INVITATION_ACCEPTED':
+      return {
+        accentColor: '#047857',
+        accentBackgroundColor: '#DCFCE7',
+        badgeLabel: 'Accepted',
+        title: 'Invitation accepted',
+        eventTitle,
+        iconKind: 'check',
+        summary: actorLabel
+          ? `${actorLabel} accepted your invitation.`
+          : 'Your invitation was accepted.',
+        metadata: [],
+        actionLabel: 'View event',
+        actionTarget: 'EVENT',
+      };
+    case 'PRIVATE_EVENT_INVITATION_DECLINED':
+      return {
+        accentColor: '#B45309',
+        accentBackgroundColor: '#FEF3C7',
+        badgeLabel: 'Declined',
+        title: 'Invitation declined',
+        eventTitle,
+        iconKind: 'cross',
+        summary: actorLabel
+          ? `${actorLabel} declined your invitation.`
+          : 'Your invitation was declined.',
+        metadata: [],
+        actionLabel: 'View event',
+        actionTarget: 'EVENT',
+      };
+    default:
+      return {
+        accentColor: '#0F172A',
+        accentBackgroundColor: '#E2E8F0',
+        badgeLabel: null,
+        title: notification.title,
+        eventTitle,
+        iconKind: 'bell',
+        summary: notification.body,
+        metadata: [],
+        actionLabel: notification.event_id ? 'View event' : null,
+        actionTarget: notification.event_id ? 'EVENT' : 'NONE',
+      };
+  }
+}

--- a/frontend/src/utils/notificationRouting.test.ts
+++ b/frontend/src/utils/notificationRouting.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { NotificationItem } from '@/models/notification';
+import { resolveNotificationRoute } from './notificationRouting';
+
+function makeNotification(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: 'n-1',
+    event_id: null,
+    title: 'Title',
+    body: 'Body',
+    type: null,
+    deep_link: null,
+    image_url: null,
+    data: {},
+    is_read: false,
+    read_at: null,
+    created_at: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('resolveNotificationRoute', () => {
+  it('routes invitation-received notifications to /invitations regardless of event_id', () => {
+    const route = resolveNotificationRoute(
+      makeNotification({
+        type: 'PRIVATE_EVENT_INVITATION_RECEIVED',
+        event_id: 'abcdef0123456789abcdef01',
+      }),
+    );
+    expect(route).toBe('/invitations');
+  });
+
+  it('routes approved/rejected join request notifications to the event detail page', () => {
+    const eventId = 'abcdef01-2345-6789-abcd-ef0123456789';
+    expect(
+      resolveNotificationRoute(
+        makeNotification({
+          type: 'PROTECTED_EVENT_JOIN_REQUEST_APPROVED',
+          event_id: eventId,
+        }),
+      ),
+    ).toBe(`/events/${eventId}`);
+    expect(
+      resolveNotificationRoute(
+        makeNotification({
+          type: 'PROTECTED_EVENT_JOIN_REQUEST_REJECTED',
+          event_id: eventId,
+        }),
+      ),
+    ).toBe(`/events/${eventId}`);
+  });
+
+  it('falls back to event_id from data when top-level event_id is missing', () => {
+    const eventId = 'abcdef01-2345-6789-abcd-ef0123456789';
+    const route = resolveNotificationRoute(
+      makeNotification({
+        type: 'PROTECTED_EVENT_JOIN_REQUEST_APPROVED',
+        event_id: null,
+        data: { event_id: eventId },
+      }),
+    );
+    expect(route).toBe(`/events/${eventId}`);
+  });
+
+  it('returns null when there is nothing to navigate to', () => {
+    expect(resolveNotificationRoute(makeNotification({ type: null }))).toBeNull();
+  });
+
+  it('honors a deep_link pointing to /events/:id when no other route is determinable', () => {
+    const route = resolveNotificationRoute(
+      makeNotification({
+        type: null,
+        deep_link: 'app://events/abcdef0123456789abcdef01',
+      }),
+    );
+    expect(route).toBe('/events/abcdef0123456789abcdef01');
+  });
+});

--- a/frontend/src/utils/notificationRouting.ts
+++ b/frontend/src/utils/notificationRouting.ts
@@ -1,0 +1,61 @@
+import type { NotificationItem } from '@/models/notification';
+import {
+  getNotificationPresentation,
+  type NotificationActionTarget,
+} from './notificationPresentation';
+
+const UUIDISH_SEGMENT = '[0-9a-fA-F-]{20,}';
+
+function normalizeRoute(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const eventRouteMatch = trimmed.match(
+    new RegExp(`(?:^|://|/)(?:events|event)/(${UUIDISH_SEGMENT})(?:$|[/?#])`),
+  );
+  if (eventRouteMatch?.[1]) return `/events/${eventRouteMatch[1]}`;
+
+  const invitationsMatch = trimmed.match(
+    /(?:^|:\/\/|\/)invitations(?:$|[/?#])/,
+  );
+  if (invitationsMatch) return '/invitations';
+
+  const notificationsMatch = trimmed.match(
+    /(?:^|:\/\/|\/)notifications(?:$|[/?#])/,
+  );
+  if (notificationsMatch) return '/notifications';
+
+  return null;
+}
+
+/**
+ * Resolve the in-app route a notification should navigate to when clicked.
+ * Returns null when the notification has no actionable target.
+ */
+export function resolveNotificationRoute(
+  notification: NotificationItem,
+): string | null {
+  // Notification-type-specific routing always wins so participation flows go
+  // to the right surface (e.g. invitations index for newly received invites).
+  const presentation = getNotificationPresentation(notification);
+  const target: NotificationActionTarget = presentation.actionTarget;
+
+  if (target === 'INVITATIONS') return '/invitations';
+
+  if (target === 'EVENT') {
+    const eventId = notification.event_id ?? notification.data?.event_id ?? null;
+    if (eventId) return `/events/${eventId}`;
+  }
+
+  // Fall back to the deep link if backend supplied one we can interpret.
+  if (notification.deep_link) {
+    const explicit = normalizeRoute(notification.deep_link);
+    if (explicit) return explicit;
+  }
+
+  // Last resort: any notification with an event_id can show that event.
+  const fallbackEventId = notification.event_id ?? notification.data?.event_id ?? null;
+  if (fallbackEventId) return `/events/${fallbackEventId}`;
+
+  return null;
+}

--- a/frontend/src/viewmodels/notifications/useNotificationsViewModel.ts
+++ b/frontend/src/viewmodels/notifications/useNotificationsViewModel.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  deleteAllNotifications,
+  deleteNotification,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from '@/services/notificationService';
+import type { NotificationItem } from '@/models/notification';
+import { ApiError } from '@/services/api';
+
+export interface NotificationsViewModel {
+  notifications: NotificationItem[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasNext: boolean;
+  error: string | null;
+  fetchNotifications: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  markRead: (id: string) => Promise<void>;
+  markAllRead: () => Promise<void>;
+  deleteOne: (id: string) => Promise<void>;
+  deleteAll: () => Promise<void>;
+  dismissError: () => void;
+}
+
+const PAGE_SIZE = 20;
+
+export function useNotificationsViewModel(): NotificationsViewModel {
+  const { token } = useAuth();
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [hasNext, setHasNext] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchNotifications = useCallback(async () => {
+    if (!token) {
+      setNotifications([]);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await listNotifications(token, { limit: PAGE_SIZE });
+      setNotifications(response.items ?? []);
+      setNextCursor(response.page_info.next_cursor);
+      setHasNext(response.page_info.has_next);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load notifications');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  const loadMore = useCallback(async () => {
+    if (!token || !nextCursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const response = await listNotifications(token, {
+        limit: PAGE_SIZE,
+        cursor: nextCursor,
+      });
+      setNotifications((prev) => [...prev, ...(response.items ?? [])]);
+      setNextCursor(response.page_info.next_cursor);
+      setHasNext(response.page_info.has_next);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load more notifications');
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [token, nextCursor, isLoadingMore]);
+
+  const markRead = useCallback(
+    async (id: string) => {
+      if (!token) return;
+      // Optimistic update
+      setNotifications((prev) =>
+        prev.map((n) =>
+          n.id === id && !n.is_read
+            ? { ...n, is_read: true, read_at: new Date().toISOString() }
+            : n,
+        ),
+      );
+      try {
+        await markNotificationRead(id, token);
+      } catch {
+        // Roll back on failure
+        setNotifications((prev) =>
+          prev.map((n) => (n.id === id ? { ...n, is_read: false, read_at: null } : n)),
+        );
+      }
+    },
+    [token],
+  );
+
+  const markAllRead = useCallback(async () => {
+    if (!token) return;
+    const previous = notifications;
+    setNotifications((prev) =>
+      prev.map((n) =>
+        n.is_read ? n : { ...n, is_read: true, read_at: new Date().toISOString() },
+      ),
+    );
+    try {
+      await markAllNotificationsRead(token);
+    } catch (err) {
+      setNotifications(previous);
+      setError(err instanceof ApiError ? err.message : 'Failed to mark all as read');
+    }
+  }, [token, notifications]);
+
+  const deleteOne = useCallback(
+    async (id: string) => {
+      if (!token) return;
+      const previous = notifications;
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
+      try {
+        await deleteNotification(id, token);
+      } catch (err) {
+        setNotifications(previous);
+        setError(err instanceof ApiError ? err.message : 'Failed to delete notification');
+      }
+    },
+    [token, notifications],
+  );
+
+  const deleteAll = useCallback(async () => {
+    if (!token) return;
+    const previous = notifications;
+    setNotifications([]);
+    try {
+      await deleteAllNotifications(token);
+    } catch (err) {
+      setNotifications(previous);
+      setError(err instanceof ApiError ? err.message : 'Failed to clear notifications');
+    }
+  }, [token, notifications]);
+
+  const dismissError = useCallback(() => setError(null), []);
+
+  useEffect(() => {
+    fetchNotifications();
+  }, [fetchNotifications]);
+
+  return {
+    notifications,
+    isLoading,
+    isLoadingMore,
+    hasNext,
+    error,
+    fetchNotifications,
+    loadMore,
+    markRead,
+    markAllRead,
+    deleteOne,
+    deleteAll,
+    dismissError,
+  };
+}

--- a/frontend/src/viewmodels/notifications/useUnreadCountViewModel.ts
+++ b/frontend/src/viewmodels/notifications/useUnreadCountViewModel.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { getUnreadNotificationCount } from '@/services/notificationService';
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UnreadCountViewModel {
+  unreadCount: number;
+  refresh: () => Promise<void>;
+}
+
+export function useUnreadCountViewModel(): UnreadCountViewModel {
+  const { token } = useAuth();
+  const [unreadCount, setUnreadCount] = useState(0);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!token) {
+      setUnreadCount(0);
+      return;
+    }
+    try {
+      const response = await getUnreadNotificationCount(token);
+      if (isMountedRef.current) {
+        setUnreadCount(response.unread_count);
+      }
+    } catch {
+      // Best-effort polling; silently ignore transient failures
+    }
+  }, [token]);
+
+  useEffect(() => {
+    refresh();
+    if (!token) return;
+    const id = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [refresh, token]);
+
+  return { unreadCount, refresh };
+}

--- a/frontend/src/views/notifications/NotificationsPage.tsx
+++ b/frontend/src/views/notifications/NotificationsPage.tsx
@@ -1,0 +1,245 @@
+import { useNavigate } from 'react-router-dom';
+import { useNotificationsViewModel } from '@/viewmodels/notifications/useNotificationsViewModel';
+import { getNotificationPresentation } from '@/utils/notificationPresentation';
+import { resolveNotificationRoute } from '@/utils/notificationRouting';
+import type { NotificationItem } from '@/models/notification';
+import '@/styles/notifications.css';
+
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const seconds = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function NotificationIcon({ kind }: { kind: 'mail' | 'check' | 'cross' | 'bell' }) {
+  if (kind === 'mail') {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <rect x="3" y="5" width="18" height="14" rx="2" />
+        <path d="m3 7 9 6 9-6" />
+      </svg>
+    );
+  }
+  if (kind === 'check') {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <circle cx="12" cy="12" r="10" />
+        <path d="m9 12 2 2 4-4" />
+      </svg>
+    );
+  }
+  if (kind === 'cross') {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <circle cx="12" cy="12" r="10" />
+        <path d="m15 9-6 6M9 9l6 6" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+    </svg>
+  );
+}
+
+function NotificationRow({
+  notification,
+  onClick,
+  onDelete,
+}: {
+  notification: NotificationItem;
+  onClick: () => void;
+  onDelete: () => void;
+}) {
+  const presentation = getNotificationPresentation(notification);
+  const isUnread = !notification.is_read;
+
+  return (
+    <li
+      className={`notif-row ${isUnread ? 'notif-row-unread' : ''}`}
+      data-testid={`notification-${notification.id}`}
+    >
+      <button
+        type="button"
+        className="notif-row-main"
+        onClick={onClick}
+        aria-label={presentation.actionLabel ?? 'Open notification'}
+      >
+        <span
+          className="notif-row-icon"
+          style={{
+            color: presentation.accentColor,
+            background: presentation.accentBackgroundColor,
+          }}
+        >
+          <NotificationIcon kind={presentation.iconKind} />
+        </span>
+
+        <span className="notif-row-content">
+          <span className="notif-row-header">
+            {presentation.badgeLabel && (
+              <span
+                className="notif-row-badge"
+                style={{
+                  color: presentation.accentColor,
+                  background: presentation.accentBackgroundColor,
+                }}
+              >
+                {presentation.badgeLabel}
+              </span>
+            )}
+            <span className="notif-row-title">{presentation.title}</span>
+            <span className="notif-row-time">{timeAgo(notification.created_at)}</span>
+          </span>
+
+          {presentation.eventTitle && (
+            <span className="notif-row-event">{presentation.eventTitle}</span>
+          )}
+
+          <span className="notif-row-summary">{presentation.summary}</span>
+
+          {presentation.metadata.length > 0 && (
+            <span className="notif-row-meta">{presentation.metadata.join(' · ')}</span>
+          )}
+
+          {presentation.actionLabel && (
+            <span
+              className="notif-row-action"
+              style={{ color: presentation.accentColor }}
+            >
+              {presentation.actionLabel} &rarr;
+            </span>
+          )}
+        </span>
+
+        {isUnread && <span className="notif-row-dot" aria-label="Unread" />}
+      </button>
+
+      <button
+        type="button"
+        className="notif-row-delete"
+        onClick={onDelete}
+        aria-label="Delete notification"
+        title="Delete notification"
+      >
+        &times;
+      </button>
+    </li>
+  );
+}
+
+export default function NotificationsPage() {
+  const navigate = useNavigate();
+  const vm = useNotificationsViewModel();
+
+  const handleClick = async (notification: NotificationItem) => {
+    if (!notification.is_read) {
+      // Fire-and-forget; the viewmodel handles optimistic update + rollback
+      void vm.markRead(notification.id);
+    }
+    const route = resolveNotificationRoute(notification);
+    if (route) navigate(route);
+  };
+
+  const hasAnyUnread = vm.notifications.some((n) => !n.is_read);
+
+  return (
+    <div className="notif-page">
+      <header className="notif-page-header">
+        <div>
+          <h1 className="notif-page-title">Notifications</h1>
+          <p className="notif-page-subtitle">
+            Updates about your events, invitations, and join requests.
+          </p>
+        </div>
+        <div className="notif-page-actions">
+          {hasAnyUnread && (
+            <button
+              type="button"
+              className="notif-action-btn"
+              onClick={() => vm.markAllRead()}
+            >
+              Mark all read
+            </button>
+          )}
+          {vm.notifications.length > 0 && (
+            <button
+              type="button"
+              className="notif-action-btn notif-action-danger"
+              onClick={() => vm.deleteAll()}
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+      </header>
+
+      {vm.error && (
+        <div className="notif-error" role="alert">
+          <span>{vm.error}</span>
+          <button
+            type="button"
+            className="notif-error-dismiss"
+            onClick={vm.dismissError}
+            aria-label="Dismiss error"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
+      {vm.isLoading && vm.notifications.length === 0 && (
+        <div className="notif-loading">
+          <span className="spinner" />
+          <p>Loading notifications...</p>
+        </div>
+      )}
+
+      {!vm.isLoading && vm.notifications.length === 0 && !vm.error && (
+        <div className="notif-empty">
+          <h2>No notifications yet</h2>
+          <p>You&rsquo;ll see updates here when something happens with your events.</p>
+        </div>
+      )}
+
+      {vm.notifications.length > 0 && (
+        <ul className="notif-list">
+          {vm.notifications.map((n) => (
+            <NotificationRow
+              key={n.id}
+              notification={n}
+              onClick={() => handleClick(n)}
+              onDelete={() => vm.deleteOne(n.id)}
+            />
+          ))}
+        </ul>
+      )}
+
+      {vm.hasNext && (
+        <div className="notif-load-more">
+          <button
+            type="button"
+            className="notif-action-btn"
+            onClick={() => vm.loadMore()}
+            disabled={vm.isLoadingMore}
+          >
+            {vm.isLoadingMore ? <span className="spinner" /> : 'Load more'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 📋 Summary
Wires the in-app `/me/notifications` API into the web frontend so participation-related events (join-request approvals, join-request rejections, private-event invitation receipts, etc.) are surfaced as first-class notifications with clear copy, deterministic routing, an unread-count bell badge in the header, and a full inbox page with optimistic mark-read / delete behavior.

## 🔄 Changes
- **`models/notification.ts`** *(new)* — `NotificationType` (covers `PRIVATE_EVENT_INVITATION_RECEIVED`, `PROTECTED_EVENT_JOIN_REQUEST_APPROVED`, `PROTECTED_EVENT_JOIN_REQUEST_REJECTED`, `PROTECTED_EVENT_JOIN_REQUEST_SUBMITTED`, `EVENT_CANCELED`, and the invitation accepted / declined types), `NotificationItem` with `data: Record<string, string>`, list / page-info / unread-count / mark-all-read response shapes
- **`services/notificationService.ts`** *(new)* — `listNotifications` (with `onlyUnread` flag), `getUnreadNotificationCount`, `markNotificationRead`, `markAllNotificationsRead`, `deleteNotification`, `deleteAllNotifications`
- **`utils/notificationPresentation.ts`** *(new)* — pure mapping from a `NotificationItem` to a `NotificationPresentation` (badge label, title, summary text using `actor_display_name` or `actor_username`, accent color, accent background, icon kind, action label, action target). Cooldown metadata is formatted for rejection notifications. Includes `isDedicatedParticipationNotification` predicate
- **`utils/notificationRouting.ts`** *(new)* — `resolveNotificationRoute(notification)` returns `/invitations` for invitation-received, `/events/:id` for everything event-bound (using `event_id` or `data.event_id`), with fallback parsing of `notification.deep_link` for other apps' deep-link formats
- **`viewmodels/notifications/useNotificationsViewModel.ts`** *(new)* — fetch on mount, paginated `loadMore`, optimistic `markRead` / `markAllRead` / `deleteOne` / `deleteAll` with rollback on failure, `error` + `dismissError`
- **`viewmodels/notifications/useUnreadCountViewModel.ts`** *(new)* — polls `/me/notifications/unread-count` every 60s while logged in; falls back silently on transient failures
- **`views/notifications/NotificationsPage.tsx`** *(new)* — full inbox: per-type colored icon badge, event title, summary, time-ago, optional metadata line (e.g. retry-after for rejections), Mark all read / Clear all header actions, per-row delete; clicking a row marks it read and routes via `resolveNotificationRoute`
- **`styles/notifications.css`** *(new)*
- **`components/AppShell.tsx`** — added a notification bell button with a red unread-count badge (capped at "99+"); also added `Invitations` and `Notifications` entries to the user dropdown so users can find the inbox without remembering URLs
- **`styles/shell.css`** — added `.shell-bell-btn`, `.shell-bell-icon`, `.shell-bell-badge`
- **`App.tsx`** — added `/notifications` protected route
- **`utils/notificationPresentation.test.ts`** *(new)* — 7 tests covering invitation/approved/rejected/unknown/no-event presentation + the `isDedicatedParticipationNotification` predicate
- **`utils/notificationRouting.test.ts`** *(new)* — 5 tests covering invitation routing, event routing, `data.event_id` fallback, no-route case, deep_link parsing

## 🧪 Testing
1. `cd frontend && npm install && npm test` → confirm `notificationPresentation.test.ts` and `notificationRouting.test.ts` (12 tests) **execute and pass** (they don't need jsdom)
2. `npm run build` → confirm clean Vite build
3. `npm run dev` → log in
4. Confirm a bell button appears in the header next to the theme toggle. With no unread notifications, confirm there's no red badge
5. Trigger a backend notification (e.g. have a host approve your join request, or have someone send you a private event invitation) → wait up to 60 seconds → confirm the red unread badge appears with the correct count
6. Click the bell → land on `/notifications`. Confirm:
   - The just-arrived notification renders with the right badge label (e.g. **APPROVED**, **INVITATION**), event title, accent-colored icon, and time-ago label
   - The unread row is visually distinct (light tint + blue dot indicator)
7. Click an `APPROVED` row → it marks read (dot disappears, bell badge decrements) and routes to `/events/<event_id>`
8. Click an `INVITATION` row → it marks read and routes to `/invitations` (not directly to the event)
9. Click **Mark all read** → all rows become read; bell badge clears
10. Click the **×** on a row → row disappears optimistically; refresh the page to confirm it's actually deleted backend-side
11. Click **Clear all** → list empties; reload to confirm
12. Force a backend error on a delete → confirm the row is restored (rollback)
13. Open the user dropdown → confirm **Invitations** and **Notifications** entries are present and route correctly
14. Mobile viewport: confirm the bell stays in the header, the badge remains visible, and the inbox stacks the action buttons full-width


## 🔗 Related
Related to #450 , #454 , #476
