### PR TITLE
feat(mobile): replace Nominatim with Photon for location search (#466)

### DIFF
--- a/mobile/src/services/eventService.test.ts
+++ b/mobile/src/services/eventService.test.ts
@@ -1,5 +1,5 @@
 import * as FileSystem from 'expo-file-system/legacy';
-import { listMyEvents, uploadFileToPresignedUrl } from './eventService';
+import { listMyEvents, searchLocation, uploadFileToPresignedUrl } from './eventService';
 
 jest.mock('expo-file-system/legacy');
 
@@ -269,5 +269,191 @@ describe('uploadFileToPresignedUrl', () => {
       hosted_events: [],
       attended_events: [],
     });
+  });
+});
+
+describe('searchLocation', () => {
+  beforeEach(() => {
+    global.fetch = mockFetch as any;
+    mockFetch.mockReset();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns [] without calling fetch when query is shorter than 2 chars', async () => {
+    const result = await searchLocation('a');
+    expect(result).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns [] for whitespace-only queries', async () => {
+    const result = await searchLocation('   ');
+    expect(result).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('hits the Photon endpoint with the expected query params', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ features: [] }));
+
+    await searchLocation('Istanbul');
+
+    const calledUrl: string = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('https://photon.komoot.io/api?');
+    expect(calledUrl).toContain('q=Istanbul');
+    expect(calledUrl).toContain('limit=5');
+    expect(calledUrl).toContain('lang=en');
+  });
+
+  it('does NOT hit the legacy Nominatim endpoint', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ features: [] }));
+
+    await searchLocation('Kadikoy');
+
+    const calledUrl: string = mockFetch.mock.calls[0][0];
+    expect(calledUrl).not.toContain('nominatim');
+  });
+
+  it('maps Photon GeoJSON features to LocationSuggestion shape', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        features: [
+          {
+            geometry: { type: 'Point', coordinates: [28.9784, 41.0082] },
+            properties: {
+              name: 'Istanbul',
+              city: 'Istanbul',
+              state: 'Marmara',
+              country: 'Turkey',
+              type: 'city',
+            },
+          },
+          {
+            geometry: { type: 'Point', coordinates: [29.0376, 41.0014] },
+            properties: {
+              name: 'Kadikoy',
+              city: 'Istanbul',
+              country: 'Turkey',
+            },
+          },
+        ],
+      }),
+    );
+
+    const result = await searchLocation('Istanbul');
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      display_name: 'Istanbul, Marmara, Turkey',
+      lat: '41.0082',
+      lon: '28.9784',
+    });
+    expect(result[1]).toEqual({
+      display_name: 'Kadikoy, Istanbul, Turkey',
+      lat: '41.0014',
+      lon: '29.0376',
+    });
+  });
+
+  it('combines street and house number into display_name when present', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        features: [
+          {
+            geometry: { coordinates: [29.0, 41.0] },
+            properties: {
+              street: 'Bagdat Caddesi',
+              housenumber: '42',
+              city: 'Istanbul',
+              country: 'Turkey',
+            },
+          },
+        ],
+      }),
+    );
+
+    const result = await searchLocation('Bagdat');
+
+    expect(result[0].display_name).toBe('Bagdat Caddesi 42, Istanbul, Turkey');
+  });
+
+  it('skips features with missing or invalid coordinates', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        features: [
+          { geometry: { coordinates: [29.0, 41.0] }, properties: { name: 'Valid', country: 'Turkey' } },
+          { geometry: undefined, properties: { name: 'Bad' } },
+          { geometry: { coordinates: [] }, properties: { name: 'Empty coords' } },
+          { geometry: { coordinates: ['x', 'y'] }, properties: { name: 'Non-numeric' } },
+        ],
+      }),
+    );
+
+    const result = await searchLocation('test');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].display_name).toBe('Valid, Turkey');
+  });
+
+  it('skips features whose properties produce an empty display_name', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        features: [
+          { geometry: { coordinates: [29.0, 41.0] }, properties: {} },
+        ],
+      }),
+    );
+
+    const result = await searchLocation('blank');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] on non-2xx HTTP response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503, json: jest.fn() });
+
+    const result = await searchLocation('Istanbul');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when fetch rejects (network error)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network down'));
+
+    const result = await searchLocation('Istanbul');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when response body is not valid JSON', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockRejectedValue(new SyntaxError('bad json')),
+    });
+
+    const result = await searchLocation('Istanbul');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when response shape is missing features array', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ unexpected: 'shape' }));
+
+    const result = await searchLocation('Istanbul');
+    expect(result).toEqual([]);
+  });
+
+  it('deduplicates repeated parts in display_name', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        features: [
+          {
+            geometry: { coordinates: [29.0, 41.0] },
+            properties: { name: 'Istanbul', city: 'Istanbul', country: 'Turkey' },
+          },
+        ],
+      }),
+    );
+
+    const result = await searchLocation('Istanbul');
+    expect(result[0].display_name).toBe('Istanbul, Turkey');
   });
 });

--- a/mobile/src/services/eventService.ts
+++ b/mobile/src/services/eventService.ts
@@ -28,7 +28,7 @@ import {
 import { shouldShowProfileEvent } from '@/utils/eventStatus';
 
 
-const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
+const PHOTON_BASE = 'https://photon.komoot.io';
 type SupportedUploadMethod = 'POST' | 'PUT' | 'PATCH';
 
 interface BackendEventSummary {
@@ -194,6 +194,45 @@ export async function upsertParticipantRating(
   );
 }
 
+interface PhotonProperties {
+  name?: string;
+  street?: string;
+  housenumber?: string;
+  postcode?: string;
+  district?: string;
+  city?: string;
+  county?: string;
+  state?: string;
+  country?: string;
+}
+
+interface PhotonFeature {
+  geometry?: { coordinates?: [number, number] };
+  properties?: PhotonProperties;
+}
+
+function buildPhotonDisplayName(props: PhotonProperties): string {
+  const parts = [
+    [props.name, props.street && props.housenumber ? `${props.street} ${props.housenumber}` : props.street].filter(Boolean).join(' '),
+    props.district,
+    props.city,
+    props.state,
+    props.country,
+  ];
+
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const part of parts) {
+    const value = (part ?? '').trim();
+    if (!value) continue;
+    const key = value.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(value);
+  }
+  return deduped.join(', ');
+}
+
 export async function searchLocation(
   query: string,
 ): Promise<LocationSuggestion[]> {
@@ -201,25 +240,39 @@ export async function searchLocation(
 
   const params = new URLSearchParams({
     q: query,
-    format: 'json',
-    addressdetails: '1',
     limit: '5',
+    lang: 'en',
   });
 
-  const response = await fetch(`${NOMINATIM_BASE}/search?${params}`, {
-    headers: { 'User-Agent': 'BounSWE2026Group11MobileApp' },
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${PHOTON_BASE}/api?${params}`);
+  } catch {
+    return [];
+  }
 
   if (!response.ok) return [];
 
-  const data = await response.json();
-  return data.map(
-    (item: { display_name: string; lat: string; lon: string }) => ({
-      display_name: item.display_name,
-      lat: item.lat,
-      lon: item.lon,
-    }),
-  );
+  const data = await response.json().catch(() => null);
+  if (!data || !Array.isArray(data.features)) return [];
+
+  return (data.features as PhotonFeature[])
+    .map((feature): LocationSuggestion | null => {
+      const coords = feature.geometry?.coordinates;
+      if (!Array.isArray(coords) || coords.length < 2) return null;
+      const [lon, lat] = coords;
+      if (typeof lon !== 'number' || typeof lat !== 'number') return null;
+
+      const displayName = buildPhotonDisplayName(feature.properties ?? {});
+      if (!displayName) return null;
+
+      return {
+        display_name: displayName,
+        lat: String(lat),
+        lon: String(lon),
+      };
+    })
+    .filter((s): s is LocationSuggestion => s !== null);
 }
 
 export async function listCategories(): Promise<ListCategoriesResponse> {


### PR DESCRIPTION
## 📋 Summary

- Replaces **Nominatim** (public OSM instance) with **Photon** (komoot.io) as the location autocomplete provider in the mobile app
- Photon is keyless, OSM-backed, has no aggressive rate limits on its public instance, and handles TR/EN locality queries better than Nominatim
- No backend changes required; no API keys shipped in the bundle

## 🔄 Changes

- `services/eventService.ts`:
  - Replaced `NOMINATIM_BASE` with `PHOTON_BASE`
  - Rewrote `searchLocation()` to call `https://photon.komoot.io/api?q=…&limit=5&lang=en` and map the GeoJSON `FeatureCollection` response to the existing `LocationSuggestion` shape (`{ display_name, lat, lon }`)
  - Added `buildPhotonDisplayName()` helper that composes a Nominatim-like `display_name` from Photon's `properties` (name, street + housenumber, district, city, state, country) with deduplication
  - Graceful error handling: returns `[]` on network errors, non-2xx responses, malformed JSON, missing `features` array, or invalid coordinates
- `services/eventService.test.ts`: added 13 unit tests covering query-length guard, URL construction, GeoJSON mapping, street/housenumber composition, dedup, invalid features, and all error paths

## 🔒 Decision rationale (vs. #464)

#464 hadn't merged a decision yet. Considered:

| Provider | API key | Backend proxy needed | Pick? |
|---|---|---|---|
| Photon (public) | ❌ none | ❌ no | ✅ |
| Mapbox / Geoapify / Google Places | ✅ required | ✅ yes | larger blast radius — out of scope for a mobile-only PR |

Photon is the smallest, lowest-risk swap that hits every acceptance criterion in #466. If the team later picks a paid provider for #464, the mobile side can re-coordinate behind the existing `searchLocation()` signature.

## ✅ Acceptance criteria

- [x] Decision aligned (Photon — see rationale above)
- [x] `NOMINATIM_BASE` references removed
- [x] Autocomplete calls routed through Photon
- [x] No provider API keys shipped inside the mobile bundle
- [x] Debouncing (existing 300 ms in viewmodels) and error handling preserved
- [x] Manually QA'd on iOS with TR/EN queries (Kadıköy, Beşiktaş, Istanbul)
- [x] Unit tests for the service layer added (13 new tests)

## 🧪 Testing

- `npx jest src/services/eventService.test.ts` — **18 tests pass** (5 pre-existing + 13 new)
- Full suite: 472 tests pass, 45 suites
- TypeScript: clean

## 🔗 Related

Closes #466
Coordinated with: #464 (frontend counterpart)