### PR TITLE
feat(mobile): polish map view layout, category markers, and event cal…

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -7,6 +7,18 @@ const { withPodfile, withPodfileProperties } = require('@expo/config-plugins');
 const rnFirebaseStaticFrameworkLine = '$RNFirebaseAsStaticFramework = true';
 const expoConstantsScriptPatchFunctionName =
   'patch_expo_constants_script_phase_for_spaces';
+const alignPodDeploymentTargetsDef = `
+def align_pod_deployment_targets(installer)
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      deployment_target = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET']
+      if deployment_target.nil? || deployment_target.to_f < 15.1
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.1'
+      end
+    end
+  end
+end`;
+
 const expoConstantsScriptPatchFunction = `
 def ${expoConstantsScriptPatchFunctionName}(installer)
   installer.pods_project.targets.each do |target|
@@ -19,6 +31,7 @@ def ${expoConstantsScriptPatchFunctionName}(installer)
     end
   end
 end
+${alignPodDeploymentTargetsDef}
 `;
 
 const withIosPodBuildSettings = (config) =>
@@ -56,14 +69,27 @@ const withRnFirebaseStaticFramework = (config) =>
         "ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR']",
         `${expoConstantsScriptPatchFunction}\nENV['EX_DEV_CLIENT_NETWORK_INSPECTOR']`,
       );
+    } else if (!contents.includes('def align_pod_deployment_targets')) {
+      contents = contents.replace(
+        "ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR']",
+        `${alignPodDeploymentTargetsDef}\nENV['EX_DEV_CLIENT_NETWORK_INSPECTOR']`,
+      );
     }
 
-    const postInstallCall = `    ${expoConstantsScriptPatchFunctionName}(installer)\n`;
-    if (!contents.includes(postInstallCall)) {
-      contents = contents.replace(
-        '    )\n  end',
-        `    )\n\n${postInstallCall}  end`,
-      );
+    const postInstallCalls = `    ${expoConstantsScriptPatchFunctionName}(installer)
+    align_pod_deployment_targets(installer)
+`;
+    const postInstallCallLegacy = `    ${expoConstantsScriptPatchFunctionName}(installer)\n`;
+
+    if (!contents.includes('align_pod_deployment_targets(installer)')) {
+      if (contents.includes(postInstallCallLegacy)) {
+        contents = contents.replace(postInstallCallLegacy, postInstallCalls);
+      } else {
+        contents = contents.replace(
+          '    )\n  end',
+          `    )\n\n${postInstallCalls}  end`,
+        );
+      }
     }
 
     config.modResults.contents = contents;

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -21,6 +21,7 @@
     ],
     "ios": {
       "bundleIdentifier": "com.bounswe2026group11.socialeventmapper",
+      "deploymentTarget": "15.1",
       "googleServicesFile": "./firebase/GoogleService-Info.plist",
       "infoPlist": {
         "UIBackgroundModes": [

--- a/mobile/jest/mocks/react-native-maps.js
+++ b/mobile/jest/mocks/react-native-maps.js
@@ -14,6 +14,15 @@ const MAP_ONLY_PROPS = new Set([
   'initialRegion',
   'coordinate',
   'provider',
+  'mapPadding',
+  'anchor',
+  'tracksViewChanges',
+  'tooltip',
+  'identifier',
+  'zIndex',
+  'onDeselect',
+  'stopPropagation',
+  'onPress',
 ]);
 
 function stripMapOnlyProps(props) {
@@ -21,6 +30,10 @@ function stripMapOnlyProps(props) {
     return props;
   }
   const out = {};
+  if (typeof props.onPress === 'function') {
+    out.onClick = props.onPress;
+  }
+
   for (const key of Object.keys(props)) {
     if (!MAP_ONLY_PROPS.has(key)) {
       out[key] = props[key];
@@ -48,12 +61,14 @@ function createMockComponent(tagName) {
 
 const MapView = createMockComponent('div');
 const Marker = createMockComponent('div');
+const Callout = createMockComponent('div');
 const Polyline = createMockComponent('div');
 
 module.exports = {
   __esModule: true,
   default: MapView,
   Marker,
+  Callout,
   Polyline,
   PROVIDER_GOOGLE: 'google',
 };

--- a/mobile/src/components/events/EventCard.tsx
+++ b/mobile/src/components/events/EventCard.tsx
@@ -5,6 +5,7 @@ import { EventSummary } from '@/models/event';
 import { getFavoriteCountForDisplay } from '@/utils/eventFavoriteCount';
 import { formatEventDateLabel } from '@/utils/eventDate';
 import { formatEventLocation } from '@/utils/eventLocation';
+import { getEventCategoryPresentation } from '@/utils/eventCategoryPresentation';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
 
@@ -18,8 +19,12 @@ function formatPrivacyLabel(value: EventSummary['privacy_level']) {
 }
 
 export default function EventCard({ event, onPress }: EventCardProps) {
-  const { theme } = useTheme();
+  const { theme, isDark } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
+  const categoryPresentation = getEventCategoryPresentation(
+    event.category_name,
+    isDark,
+  );
 
   const favoriteCount = getFavoriteCountForDisplay(event);
   const ratingLabel =
@@ -80,8 +85,21 @@ export default function EventCard({ event, onPress }: EventCardProps) {
           </View>
 
           <View style={styles.imageBottomRow}>
-            <View style={styles.categoryBadge}>
-              <Text style={styles.categoryBadgeText}>{event.category_name}</Text>
+            <View
+              style={[
+                styles.categoryBadge,
+                { backgroundColor: categoryPresentation.color },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.categoryBadgeText,
+                  { color: categoryPresentation.textColor },
+                ]}
+                numberOfLines={1}
+              >
+                {categoryPresentation.emoji} {categoryPresentation.label}
+              </Text>
             </View>
           </View>
         </View>
@@ -190,13 +208,12 @@ function makeStyles(t: Theme) {
       fontWeight: '700',
     },
     categoryBadge: {
-      backgroundColor: 'rgba(15, 23, 42, 0.72)',
+      maxWidth: '100%',
       paddingHorizontal: 14,
       paddingVertical: 8,
       borderRadius: 999,
     },
     categoryBadgeText: {
-      color: '#FFFFFF',
       fontSize: 13,
       fontWeight: '700',
     },

--- a/mobile/src/components/home/EventMapView.test.tsx
+++ b/mobile/src/components/home/EventMapView.test.tsx
@@ -2,15 +2,22 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import EventMapView from './EventMapView';
 import type { MapRegion } from './EventMapView';
 import type { EventSummary } from '@/models/event';
+
+var mockImagePrefetch: jest.Mock<Promise<boolean>, [string]>;
+var mockRedrawCallout: jest.Mock;
+var mockShowCallout: jest.Mock;
 
 // ── react-native mock ──────────────────────────────────────────────────────────
 
 jest.mock('react-native', () => {
   const ReactLocal = require('react');
+  mockImagePrefetch = jest.fn<Promise<boolean>, [string]>(() =>
+    Promise.resolve(true),
+  );
 
   const rnProps = new Set([
     'accessibilityLabel',
@@ -81,9 +88,34 @@ jest.mock('react-native', () => {
         children,
       );
 
+  const MockImage = ({
+    source,
+    style,
+    testID,
+    onLoad,
+    onError,
+  }: {
+    source?: { uri?: string };
+    style?: unknown;
+    testID?: string;
+    onLoad?: () => void;
+    onError?: () => void;
+  }) =>
+    ReactLocal.createElement('img', {
+      'data-testid': testID,
+      alt: '',
+      src: source?.uri ?? '',
+      style: mergeStyle(style),
+      onLoad,
+      onError,
+    });
+
+  MockImage.prefetch = (imageUrl: string) => mockImagePrefetch(imageUrl);
+
   return {
     ActivityIndicator: ({ testID }: { testID?: string }) =>
       ReactLocal.createElement('div', { 'data-testid': testID ?? 'activity-indicator', role: 'progressbar' }),
+    Image: MockImage,
     Platform: { OS: 'ios' },
     StyleSheet: { create: <T,>(s: T) => s },
     Text: container('span'),
@@ -96,24 +128,64 @@ jest.mock('react-native', () => {
 
 jest.mock('react-native-maps', () => {
   const ReactLocal = require('react');
+  mockRedrawCallout = jest.fn();
+  mockShowCallout = jest.fn();
 
   const MapView = ({
     children,
     testID,
+    mapPadding,
+    onPress,
   }: {
     children?: React.ReactNode;
     testID?: string;
+    mapPadding?: unknown;
+    onPress?: () => void;
   }) =>
-    ReactLocal.createElement('div', { 'data-testid': testID ?? 'map-surface' }, children);
+    ReactLocal.createElement(
+      'div',
+      {
+        'data-testid': testID ?? 'map-surface',
+        'data-map-padding': mapPadding ? JSON.stringify(mapPadding) : undefined,
+        onClick: onPress,
+      },
+      children,
+    );
 
-  const Marker = ({
-    children,
-    testID,
-  }: {
-    children?: React.ReactNode;
-    testID?: string;
-  }) =>
-    ReactLocal.createElement('div', { 'data-testid': testID }, children);
+  const Marker = ReactLocal.forwardRef(
+    (
+      {
+        children,
+        testID,
+        coordinate,
+        onPress,
+      }: {
+        children?: React.ReactNode;
+        testID?: string;
+        coordinate?: { latitude: number; longitude: number };
+        onPress?: () => void;
+      },
+      ref: React.Ref<unknown>,
+    ) => {
+      ReactLocal.useImperativeHandle(ref, () => ({
+        redrawCallout: mockRedrawCallout,
+        showCallout: mockShowCallout,
+      }));
+
+      return ReactLocal.createElement(
+        'div',
+        {
+          'data-testid': testID,
+          'data-coordinate': coordinate ? JSON.stringify(coordinate) : undefined,
+          onClick: (event: React.MouseEvent) => {
+            event.stopPropagation();
+            onPress?.();
+          },
+        },
+        children,
+      );
+    },
+  );
 
   const Callout = ({
     children,
@@ -126,7 +198,13 @@ jest.mock('react-native-maps', () => {
   }) =>
     ReactLocal.createElement(
       'div',
-      { 'data-testid': testID, onClick: onPress },
+      {
+        'data-testid': testID,
+        onClick: (event: React.MouseEvent) => {
+          event.stopPropagation();
+          onPress?.();
+        },
+      },
       children,
     );
 
@@ -143,13 +221,22 @@ jest.mock('react-native-maps', () => {
 
 jest.mock('@/theme', () => ({
   useTheme: () => ({
+    isDark: false,
     theme: {
       primary: '#111827',
       text: '#111827',
       textSecondary: '#6B7280',
+      textTertiary: '#9CA3AF',
+      textMuted: '#64748B',
       textOnPrimary: '#FFFFFF',
       surface: '#FFFFFF',
+      surfaceVariant: '#F9FAFB',
+      surfaceAlt: '#F1F5F9',
+      border: '#E5E7EB',
+      borderStrong: '#D1D5DB',
+      divider: '#E5E7EB',
       errorText: '#DC2626',
+      imagePlaceholder: '#E5E7EB',
     },
   }),
 }));
@@ -179,9 +266,18 @@ function makeEvent(overrides: Partial<EventSummary> = {}): EventSummary {
   };
 }
 
+function selectMarker(eventId = 'evt-1'): void {
+  fireEvent.click(screen.getByTestId(`marker-${eventId}`));
+}
+
 // ── tests ──────────────────────────────────────────────────────────────────────
 
 describe('EventMapView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockImagePrefetch.mockResolvedValue(true);
+  });
+
   describe('loading state', () => {
     it('renders a loading indicator and hides the map surface', () => {
       render(
@@ -291,7 +387,7 @@ describe('EventMapView', () => {
       expect(screen.queryByTestId('map-empty')).toBeNull();
     });
 
-    it('displays the event title in the callout', () => {
+    it('displays the event title in the native callout after a marker is selected', () => {
       render(
         <EventMapView
           events={[makeEvent({ title: 'Trail Run' })]}
@@ -302,7 +398,55 @@ describe('EventMapView', () => {
         />,
       );
 
+      selectMarker();
+
       expect(screen.getByText('Trail Run')).toBeTruthy();
+    });
+
+    it('uses a category-colored emoji marker for events', () => {
+      render(
+        <EventMapView
+          events={[makeEvent({ id: 'evt-sports', category_name: 'Sports' })]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      const markerBubble = screen.getByTestId('marker-bubble-evt-sports');
+
+      expect(screen.getAllByText('🏃').length).toBeGreaterThan(0);
+      expect(markerBubble.getAttribute('style')).toContain(
+        'background-color: rgb(37, 99, 235)',
+      );
+    });
+
+    it('offsets markers that share the same dense coordinate area', () => {
+      render(
+        <EventMapView
+          events={[
+            makeEvent({ id: 'evt-1', location_lat: 41.0422, location_lon: 29.0083 }),
+            makeEvent({ id: 'evt-2', location_lat: 41.04221, location_lon: 29.00831 }),
+          ]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      const firstCoordinate = screen
+        .getByTestId('marker-evt-1')
+        .getAttribute('data-coordinate');
+      const secondCoordinate = screen
+        .getByTestId('marker-evt-2')
+        .getAttribute('data-coordinate');
+
+      expect(firstCoordinate).toBeTruthy();
+      expect(secondCoordinate).toBeTruthy();
+      expect(firstCoordinate).not.toEqual(secondCoordinate);
+      expect(screen.getAllByText('2').length).toBeGreaterThan(0);
     });
 
     it('shows participant count and capacity when both are present', () => {
@@ -321,6 +465,8 @@ describe('EventMapView', () => {
         />,
       );
 
+      selectMarker();
+
       expect(screen.getByText(/8.*20.*going/s)).toBeTruthy();
     });
 
@@ -334,6 +480,8 @@ describe('EventMapView', () => {
           onMarkerPress={jest.fn()}
         />,
       );
+
+      selectMarker();
 
       expect(screen.getByText(/5.*going/s)).toBeTruthy();
       expect(screen.queryByText(/\//)).toBeNull();
@@ -353,15 +501,15 @@ describe('EventMapView', () => {
         />,
       );
 
-      const callout = screen.getByTestId('callout-evt-42');
-      fireEvent.click(callout);
+      selectMarker('evt-42');
+      fireEvent.click(screen.getByTestId('callout-evt-42'));
 
       expect(onMarkerPress).toHaveBeenCalledWith('evt-42');
     });
   });
 
   describe('callout content', () => {
-    it('shows category name in the callout', () => {
+    it('shows category name in the native callout', () => {
       render(
         <EventMapView
           events={[makeEvent({ category_name: 'Sports' })]}
@@ -371,6 +519,8 @@ describe('EventMapView', () => {
           onMarkerPress={jest.fn()}
         />,
       );
+
+      selectMarker();
 
       expect(screen.getByText('Sports')).toBeTruthy();
     });
@@ -386,7 +536,104 @@ describe('EventMapView', () => {
         />,
       );
 
+      selectMarker();
+
       expect(screen.getByText(/Belgrad Forest/)).toBeTruthy();
+    });
+
+    it('shows a small event image in the native callout when available', async () => {
+      render(
+        <EventMapView
+          events={[
+            makeEvent({
+              id: 'evt-image',
+              image_url: 'https://example.com/event.jpg',
+            }),
+          ]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      selectMarker('evt-image');
+      const image = await screen.findByTestId('callout-image-evt-image');
+
+      expect(image).toBeTruthy();
+      expect(image.getAttribute('src')).toBe('https://example.com/event.jpg');
+      expect(mockImagePrefetch).toHaveBeenCalledWith('https://example.com/event.jpg');
+      expect(screen.queryByTestId('callout-image-placeholder-evt-image')).toBeNull();
+      await waitFor(() => expect(mockRedrawCallout).toHaveBeenCalled());
+    });
+
+    it('falls back to the category placeholder when image prefetch fails', async () => {
+      mockImagePrefetch.mockResolvedValue(false);
+
+      render(
+        <EventMapView
+          events={[
+            makeEvent({
+              id: 'evt-broken-prefetch',
+              image_url: 'https://example.com/missing.jpg',
+            }),
+          ]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      selectMarker('evt-broken-prefetch');
+
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('callout-image-placeholder-evt-broken-prefetch'),
+        ).toBeTruthy(),
+      );
+      expect(screen.queryByTestId('callout-image-evt-broken-prefetch')).toBeNull();
+    });
+
+    it('falls back to the category placeholder when the callout image fails', async () => {
+      render(
+        <EventMapView
+          events={[
+            makeEvent({
+              id: 'evt-broken-image',
+              image_url: 'https://example.com/missing.jpg',
+            }),
+          ]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      selectMarker('evt-broken-image');
+      const image = await screen.findByTestId('callout-image-evt-broken-image');
+      fireEvent.error(image);
+
+      expect(screen.getByTestId('callout-image-placeholder-evt-broken-image')).toBeTruthy();
+      expect(screen.queryByTestId('callout-image-evt-broken-image')).toBeNull();
+    });
+
+    it('uses a category placeholder when the callout has no image', () => {
+      render(
+        <EventMapView
+          events={[makeEvent({ id: 'evt-no-image', image_url: null })]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      selectMarker('evt-no-image');
+
+      expect(screen.getByTestId('callout-image-placeholder-evt-no-image')).toBeTruthy();
+      expect(screen.queryByTestId('callout-image-evt-no-image')).toBeNull();
     });
 
     it('omits location line when address is not set', () => {
@@ -399,6 +646,8 @@ describe('EventMapView', () => {
           onMarkerPress={jest.fn()}
         />,
       );
+
+      selectMarker();
 
       expect(screen.queryByText(/📍/)).toBeNull();
     });

--- a/mobile/src/components/home/EventMapView.tsx
+++ b/mobile/src/components/home/EventMapView.tsx
@@ -44,7 +44,7 @@ interface MappableEvent {
     latitude: number;
     longitude: number;
   };
-  presentation: EventCategoryPresentation;
+  presentation: EventCategoryPresentation; 
   groupSize: number;
 }
 
@@ -166,7 +166,10 @@ function EventMapMarker({
   const [isImageLoaded, setIsImageLoaded] = useState(false);
   const { event, coordinate, presentation, groupSize } = item;
   const imageUrl = getImageUrl(event);
-  const calloutImageUrl = imageUrl && !hasImageRenderError ? imageUrl : null;
+  // Hide the callout image if the render raised an error OR the prefetch
+  // explicitly failed (resolved to false) — show the category placeholder instead.
+  const calloutImageUrl =
+    imageUrl && !hasImageRenderError && imageStatus !== 'FAILED' ? imageUrl : null;
 
   useEffect(() => {
     setHasImageRenderError(false);
@@ -185,6 +188,14 @@ function EventMapMarker({
     const t = setTimeout(() => markerRef.current?.showCallout?.(), 40);
     return () => clearTimeout(t);
   }, [isSelected, imageStatus, imageUrl]);
+
+  // On iOS, once the prefetch settles as READY, redraw the callout so the
+  // native bubble snapshot reflects the freshly loaded image.
+  useEffect(() => {
+    if (!isSelected || Platform.OS === 'android') return;
+    if (!imageUrl || imageStatus !== 'READY') return;
+    markerRef.current?.redrawCallout?.();
+  }, [isSelected, imageUrl, imageStatus]);
 
   // Re-show callout when the screen regains focus while this marker is still
   // selected (e.g. returning from the event detail screen).
@@ -269,7 +280,7 @@ function EventMapMarker({
                   // On Android the callout is only opened after the image is
                   // prefetched, so no refresh is needed here.
                   if (Platform.OS !== 'android') {
-                    markerRef.current?.showCallout?.();
+                    markerRef.current?.redrawCallout?.();
                   }
                 }}
                 onError={() => setHasImageRenderError(true)}
@@ -383,8 +394,8 @@ export default function EventMapView({
     urls.forEach((url) => {
       if (imageStatusByUrl[url]) return;
       Image.prefetch(url)
-        .then(() => {
-          setImageStatusByUrl((prev) => ({ ...prev, [url]: 'READY' }));
+        .then((success) => {
+          setImageStatusByUrl((prev) => ({ ...prev, [url]: success ? 'READY' : 'FAILED' }));
         })
         .catch(() => {
           setImageStatusByUrl((prev) => ({ ...prev, [url]: 'FAILED' }));

--- a/mobile/src/components/home/EventMapView.tsx
+++ b/mobile/src/components/home/EventMapView.tsx
@@ -1,15 +1,27 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
+  Image,
   Platform,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
-import MapView, { Callout, Marker, PROVIDER_GOOGLE, Region } from 'react-native-maps';
+import MapView, {
+  Callout,
+  Marker,
+  PROVIDER_GOOGLE,
+  type MapMarker,
+} from 'react-native-maps';
+import { useFocusEffect } from 'expo-router';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
 import type { EventSummary } from '@/models/event';
+import { formatEventDateLabel } from '@/utils/eventDate';
+import {
+  getEventCategoryPresentation,
+  type EventCategoryPresentation,
+} from '@/utils/eventCategoryPresentation';
 
 export interface MapRegion {
   latitude: number;
@@ -26,18 +38,311 @@ interface EventMapViewProps {
   onMarkerPress: (eventId: string) => void;
 }
 
-function formatStartTime(isoString: string): string {
-  try {
-    const date = new Date(isoString);
-    return date.toLocaleDateString(undefined, {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return isoString;
+interface MappableEvent {
+  event: EventSummary;
+  coordinate: {
+    latitude: number;
+    longitude: number;
+  };
+  presentation: EventCategoryPresentation;
+  groupSize: number;
+}
+
+type EventWithCoordinates = EventSummary & {
+  location_lat: number;
+  location_lon: number;
+};
+
+const DISCOVERY_MAP_PADDING = {
+  top: 224,
+  right: 20,
+  bottom: 96,
+  left: 20,
+};
+
+function hasMappableCoordinate(
+  event: EventSummary,
+): event is EventWithCoordinates {
+  return (
+    typeof event.location_lat === 'number' &&
+    typeof event.location_lon === 'number' &&
+    Number.isFinite(event.location_lat) &&
+    Number.isFinite(event.location_lon)
+  );
+}
+
+function getDenseCoordinateKey(event: {
+  location_lat: number;
+  location_lon: number;
+}): string {
+  return `${event.location_lat.toFixed(4)}:${event.location_lon.toFixed(4)}`;
+}
+
+function getDenseMarkerOffset(
+  groupIndex: number,
+  groupSize: number,
+  region: MapRegion,
+): { latitude: number; longitude: number } {
+  if (groupSize <= 1) {
+    return { latitude: 0, longitude: 0 };
   }
+
+  const markersPerRing = 8;
+  const ring = Math.floor(groupIndex / markersPerRing) + 1;
+  const ringPosition = groupIndex % markersPerRing;
+  const visibleInRing = Math.min(groupSize, markersPerRing);
+  const angle = (Math.PI * 2 * ringPosition) / visibleInRing - Math.PI / 2;
+  const regionScale = Math.min(region.latitudeDelta, region.longitudeDelta);
+  const baseRadius = Math.min(Math.max(regionScale * 0.002, 0.00006), 0.00035);
+  const radius = baseRadius * Math.min(ring, 2.5);
+
+  return {
+    latitude: Math.sin(angle) * radius,
+    longitude: Math.cos(angle) * radius,
+  };
+}
+
+function buildMappableEvents(
+  events: EventSummary[],
+  region: MapRegion,
+  isDark: boolean,
+): MappableEvent[] {
+  const eventsWithCoordinates = events.filter(hasMappableCoordinate);
+  const denseGroups = new Map<string, EventWithCoordinates[]>();
+
+  eventsWithCoordinates.forEach((event) => {
+    const key = getDenseCoordinateKey(event);
+    const group = denseGroups.get(key) ?? [];
+    group.push(event);
+    denseGroups.set(key, group);
+  });
+
+  return eventsWithCoordinates.map((event) => {
+    const group = denseGroups.get(getDenseCoordinateKey(event)) ?? [event];
+    const groupIndex = group.indexOf(event);
+    const offset = getDenseMarkerOffset(groupIndex, group.length, region);
+
+    return {
+      event,
+      coordinate: {
+        latitude: event.location_lat + offset.latitude,
+        longitude: event.location_lon + offset.longitude,
+      },
+      presentation: getEventCategoryPresentation(event.category_name, isDark),
+      groupSize: group.length,
+    };
+  });
+}
+
+function getImageUrl(event: EventSummary): string | null {
+  const imageUrl = event.image_url?.trim();
+  return imageUrl && imageUrl.length > 0 ? imageUrl : null;
+}
+
+type ImageStatus = 'READY' | 'FAILED';
+
+interface EventMapMarkerProps {
+  item: MappableEvent;
+  styles: ReturnType<typeof makeStyles>;
+  isSelected: boolean;
+  imageStatus: ImageStatus | undefined;
+  onSelect: (eventId: string) => void;
+  onOpen: (eventId: string) => void;
+}
+
+function EventMapMarker({
+  item,
+  styles,
+  isSelected,
+  imageStatus,
+  onSelect,
+  onOpen,
+}: EventMapMarkerProps) {
+  const markerRef = useRef<MapMarker | null>(null);
+  // Prevents the deselect that fires during outgoing navigation from clearing selection.
+  const suppressNextDeselectRef = useRef(false);
+  const [hasImageRenderError, setHasImageRenderError] = useState(false);
+  // Tracks whether the image inside the callout has finished loading.
+  const [isImageLoaded, setIsImageLoaded] = useState(false);
+  const { event, coordinate, presentation, groupSize } = item;
+  const imageUrl = getImageUrl(event);
+  const calloutImageUrl = imageUrl && !hasImageRenderError ? imageUrl : null;
+
+  useEffect(() => {
+    setHasImageRenderError(false);
+    setIsImageLoaded(false);
+  }, [imageUrl]);
+
+  // Show callout when this marker is selected.
+  // On Android, defer until imageStatus is resolved so the InfoWindow
+  // bitmap snapshot captures the already-loaded image.
+  // On iOS the callout is a live view, so open immediately.
+  useEffect(() => {
+    if (!isSelected) return;
+    if (Platform.OS === 'android' && imageUrl && imageStatus === undefined) {
+      return; // wait — effect will re-run when imageStatus is set
+    }
+    const t = setTimeout(() => markerRef.current?.showCallout?.(), 40);
+    return () => clearTimeout(t);
+  }, [isSelected, imageStatus, imageUrl]);
+
+  // Re-show callout when the screen regains focus while this marker is still
+  // selected (e.g. returning from the event detail screen).
+  useFocusEffect(
+    useCallback(() => {
+      suppressNextDeselectRef.current = false;
+      if (!isSelected) return;
+      if (Platform.OS === 'android' && imageUrl && imageStatus === undefined) {
+        return;
+      }
+      const t = setTimeout(() => markerRef.current?.showCallout?.(), 200);
+      return () => clearTimeout(t);
+    }, [isSelected, imageStatus, imageUrl]),
+  );
+
+  return (
+    <Marker
+      ref={markerRef}
+      key={event.id}
+      identifier={event.id}
+      coordinate={coordinate}
+      anchor={{ x: 0.5, y: 1 }}
+      // Keep tracking until the callout image has loaded so the native bubble
+      // gets a chance to reflect the loaded image.
+      tracksViewChanges={isSelected && !isImageLoaded}
+      zIndex={isSelected ? 1000 : 1}
+      onPress={() => onSelect(event.id)}
+      onDeselect={() => {
+        // The deselect that fires as navigation begins must not clear selection;
+        // useFocusEffect resets this flag when the screen comes back into focus.
+        if (suppressNextDeselectRef.current) return;
+        onSelect('');
+      }}
+      stopPropagation
+      testID={`marker-${event.id}`}
+    >
+      <View style={styles.markerWrap}>
+        <View
+          style={[
+            styles.markerBubble,
+            { backgroundColor: presentation.color },
+            isSelected && styles.markerBubbleSelected,
+          ]}
+          testID={`marker-bubble-${event.id}`}
+        >
+          <Text style={styles.markerEmoji}>{presentation.emoji}</Text>
+          {groupSize > 1 ? (
+            <View style={styles.markerCountBadge}>
+              <Text style={styles.markerCountText}>{groupSize}</Text>
+            </View>
+          ) : null}
+        </View>
+        <View
+          style={[
+            styles.markerTail,
+            { borderTopColor: presentation.color },
+          ]}
+        />
+      </View>
+
+      <Callout
+        tooltip
+        onPress={() => {
+          // Mark that the next onDeselect should be suppressed — it fires as
+          // the navigation transition starts and must not clear the selection.
+          suppressNextDeselectRef.current = true;
+          onOpen(event.id);
+        }}
+        testID={`callout-${event.id}`}
+      >
+        <View style={styles.callout}>
+          <View style={styles.calloutMainRow}>
+            {calloutImageUrl ? (
+              <Image
+                source={{ uri: calloutImageUrl }}
+                style={styles.calloutImage}
+                resizeMode="cover"
+                onLoad={() => {
+                  setIsImageLoaded(true);
+                  // On iOS the callout is a live view — refresh it so the
+                  // loaded image replaces the loading placeholder.
+                  // On Android the callout is only opened after the image is
+                  // prefetched, so no refresh is needed here.
+                  if (Platform.OS !== 'android') {
+                    markerRef.current?.showCallout?.();
+                  }
+                }}
+                onError={() => setHasImageRenderError(true)}
+                testID={`callout-image-${event.id}`}
+              />
+            ) : (
+              <View
+                style={[
+                  styles.calloutImagePlaceholder,
+                  {
+                    backgroundColor: presentation.tintColor,
+                    borderColor: presentation.color,
+                  },
+                ]}
+                testID={`callout-image-placeholder-${event.id}`}
+              >
+                <Text style={styles.calloutImageEmoji}>
+                  {presentation.emoji}
+                </Text>
+              </View>
+            )}
+
+            <View style={styles.calloutBody}>
+              <View
+                style={[
+                  styles.calloutCategoryPill,
+                  {
+                    backgroundColor: presentation.tintColor,
+                    borderColor: presentation.color,
+                  },
+                ]}
+              >
+                <Text style={styles.calloutCategoryEmoji}>
+                  {presentation.emoji}
+                </Text>
+                <Text
+                  style={[
+                    styles.calloutCategoryText,
+                    { color: presentation.color },
+                  ]}
+                  numberOfLines={1}
+                >
+                  {presentation.label}
+                </Text>
+              </View>
+
+              <Text style={styles.calloutTitle} numberOfLines={2}>
+                {event.title}
+              </Text>
+            </View>
+          </View>
+
+          <View style={styles.calloutMetaGroup}>
+            <Text style={styles.calloutMeta} numberOfLines={1}>
+              🗓 {formatEventDateLabel(event.start_time, event.end_time)}
+            </Text>
+            {event.location_address ? (
+              <Text style={styles.calloutMeta} numberOfLines={1}>
+                📍 {event.location_address}
+              </Text>
+            ) : null}
+            <Text style={styles.calloutMeta}>
+              👥 {event.approved_participant_count}
+              {event.capacity != null ? ` / ${event.capacity}` : ''} going
+            </Text>
+          </View>
+
+          <View style={styles.calloutDivider} />
+          <Text style={styles.calloutHint}>Tap to view details →</Text>
+        </View>
+      </Callout>
+    </Marker>
+  );
 }
 
 export default function EventMapView({
@@ -47,16 +352,51 @@ export default function EventMapView({
   region,
   onMarkerPress,
 }: EventMapViewProps) {
-  const { theme } = useTheme();
+  const { theme, isDark } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const [imageStatusByUrl, setImageStatusByUrl] = useState<
+    Record<string, ImageStatus>
+  >({});
 
   const mappableEvents = useMemo(
-    () =>
-      events.filter(
-        (e) => e.location_lat != null && e.location_lon != null,
-      ),
-    [events],
+    () => buildMappableEvents(events, region, isDark),
+    [events, region, isDark],
   );
+
+  const selectedEvent = useMemo(
+    () =>
+      mappableEvents.find((item) => item.event.id === selectedEventId) ?? null,
+    [mappableEvents, selectedEventId],
+  );
+
+  // Eagerly prefetch event images so the Android InfoWindow bitmap snapshot
+  // always captures a fully-loaded image when the callout is first opened.
+  useEffect(() => {
+    const urls = Array.from(
+      new Set(
+        mappableEvents
+          .map((item) => getImageUrl(item.event))
+          .filter((url): url is string => url !== null),
+      ),
+    );
+    urls.forEach((url) => {
+      if (imageStatusByUrl[url]) return;
+      Image.prefetch(url)
+        .then(() => {
+          setImageStatusByUrl((prev) => ({ ...prev, [url]: 'READY' }));
+        })
+        .catch(() => {
+          setImageStatusByUrl((prev) => ({ ...prev, [url]: 'FAILED' }));
+        });
+    });
+  }, [imageStatusByUrl, mappableEvents]);
+
+  useEffect(() => {
+    if (selectedEventId && !selectedEvent) {
+      setSelectedEventId(null);
+    }
+  }, [selectedEvent, selectedEventId]);
 
   if (isLoading) {
     return (
@@ -80,49 +420,24 @@ export default function EventMapView({
         style={styles.map}
         provider={Platform.OS === 'android' ? PROVIDER_GOOGLE : undefined}
         region={region}
+        mapPadding={DISCOVERY_MAP_PADDING}
+        onPress={() => setSelectedEventId(null)}
         testID="map-surface"
       >
-        {mappableEvents.map((event) => (
-          <Marker
-            key={event.id}
-            identifier={event.id}
-            coordinate={{
-              latitude: event.location_lat as number,
-              longitude: event.location_lon as number,
-            }}
-            pinColor={theme.primary}
-            testID={`marker-${event.id}`}
-          >
-            <Callout
-              tooltip
-              onPress={() => onMarkerPress(event.id)}
-              testID={`callout-${event.id}`}
-            >
-              <View style={styles.callout}>
-                <Text style={styles.calloutCategory}>
-                  {event.category_name}
-                </Text>
-                <Text style={styles.calloutTitle} numberOfLines={2}>
-                  {event.title}
-                </Text>
-                <Text style={styles.calloutMeta}>
-                  🗓 {formatStartTime(event.start_time)}
-                </Text>
-                {event.location_address ? (
-                  <Text style={styles.calloutMeta} numberOfLines={1}>
-                    📍 {event.location_address}
-                  </Text>
-                ) : null}
-                <Text style={styles.calloutMeta}>
-                  👥 {event.approved_participant_count}
-                  {event.capacity != null ? ` / ${event.capacity}` : ''} going
-                </Text>
-                <View style={styles.calloutDivider} />
-                <Text style={styles.calloutHint}>Tap to view details →</Text>
-              </View>
-            </Callout>
-          </Marker>
-        ))}
+        {mappableEvents.map((item) => {
+          const imgUrl = getImageUrl(item.event);
+          return (
+            <EventMapMarker
+              key={item.event.id}
+              item={item}
+              styles={styles}
+              isSelected={item.event.id === selectedEventId}
+              imageStatus={imgUrl ? imageStatusByUrl[imgUrl] : 'READY'}
+              onSelect={(eventId) => setSelectedEventId(eventId || null)}
+              onOpen={onMarkerPress}
+            />
+          );
+        })}
       </MapView>
 
       {!isLoading && mappableEvents.length === 0 && (
@@ -158,13 +473,15 @@ function makeStyles(t: Theme) {
     },
     emptyOverlay: {
       position: 'absolute',
-      bottom: 32,
+      bottom: 24,
       left: 20,
       right: 20,
       backgroundColor: t.surface,
-      borderRadius: 12,
+      borderRadius: 16,
       padding: 16,
       alignItems: 'center',
+      borderWidth: 1,
+      borderColor: t.border,
       shadowColor: '#000',
       shadowOffset: { width: 0, height: 2 },
       shadowOpacity: 0.12,
@@ -182,37 +499,140 @@ function makeStyles(t: Theme) {
       color: t.textSecondary,
       textAlign: 'center',
     },
-    callout: {
-      width: 240,
+    markerWrap: {
+      alignItems: 'center',
+    },
+    markerBubble: {
+      width: 42,
+      height: 42,
+      borderRadius: 21,
+      borderWidth: 3,
+      borderColor: t.surface,
+      alignItems: 'center',
+      justifyContent: 'center',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 5 },
+      shadowOpacity: 0.24,
+      shadowRadius: 8,
+      elevation: 6,
+    },
+    markerBubbleSelected: {
+      borderWidth: 4,
+      shadowOpacity: 0.34,
+      shadowRadius: 12,
+      elevation: 8,
+      // Transform only the bubble (not the tail), so the pin tip stays
+      // exactly over the coordinate while the bubble pops up.
+      transform: [{ translateY: -5 }, { scale: 1.1 }],
+    },
+    markerEmoji: {
+      fontSize: 22,
+      lineHeight: 26,
+    },
+    markerTail: {
+      width: 0,
+      height: 0,
+      marginTop: -3,
+      borderLeftWidth: 7,
+      borderRightWidth: 7,
+      borderTopWidth: 10,
+      borderLeftColor: 'transparent',
+      borderRightColor: 'transparent',
+    },
+    markerCountBadge: {
+      position: 'absolute',
+      top: -6,
+      right: -6,
+      minWidth: 19,
+      height: 19,
+      borderRadius: 10,
+      paddingHorizontal: 4,
       backgroundColor: t.surface,
-      borderRadius: 12,
       borderWidth: 1,
       borderColor: t.border,
-      padding: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    markerCountText: {
+      fontSize: 10,
+      fontWeight: '800',
+      color: t.text,
+    },
+    callout: {
+      width: 296,
+      backgroundColor: t.surface,
+      borderRadius: 16,
+      borderWidth: 1,
+      borderColor: t.border,
+      padding: 12,
       shadowColor: '#000',
       shadowOffset: { width: 0, height: 4 },
       shadowOpacity: 0.15,
       shadowRadius: 8,
       elevation: 6,
     },
-    calloutCategory: {
+    calloutMainRow: {
+      flexDirection: 'row',
+      gap: 12,
+      alignItems: 'flex-start',
+    },
+    calloutImage: {
+      width: 78,
+      height: 78,
+      borderRadius: 12,
+      backgroundColor: t.imagePlaceholder,
+    },
+    calloutImagePlaceholder: {
+      width: 78,
+      height: 78,
+      borderRadius: 12,
+      borderWidth: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    calloutImageEmoji: {
+      fontSize: 32,
+      lineHeight: 38,
+    },
+    calloutBody: {
+      flex: 1,
+      minWidth: 0,
+    },
+    calloutCategoryPill: {
+      alignSelf: 'flex-start',
+      maxWidth: '100%',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      borderWidth: 1,
+      borderRadius: 999,
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      marginBottom: 7,
+    },
+    calloutCategoryEmoji: {
+      fontSize: 12,
+      lineHeight: 14,
+    },
+    calloutCategoryText: {
+      flexShrink: 1,
       fontSize: 11,
-      fontWeight: '600',
-      color: t.primary,
-      textTransform: 'uppercase',
-      letterSpacing: 0.5,
-      marginBottom: 4,
+      fontWeight: '800',
     },
     calloutTitle: {
-      fontSize: 15,
+      fontSize: 16,
       fontWeight: '700',
       color: t.text,
-      marginBottom: 6,
+      lineHeight: 21,
+    },
+    calloutMetaGroup: {
+      marginTop: 10,
     },
     calloutMeta: {
-      fontSize: 12,
+      fontSize: 13,
       color: t.textSecondary,
-      marginBottom: 3,
+      lineHeight: 18,
+      marginBottom: 4,
     },
     calloutDivider: {
       height: 1,
@@ -220,7 +640,7 @@ function makeStyles(t: Theme) {
       marginVertical: 8,
     },
     calloutHint: {
-      fontSize: 12,
+      fontSize: 13,
       fontWeight: '600',
       color: t.primary,
       textAlign: 'right',

--- a/mobile/src/components/home/EventMapView.tsx
+++ b/mobile/src/components/home/EventMapView.tsx
@@ -36,6 +36,8 @@ interface EventMapViewProps {
   apiError: string | null;
   region: MapRegion;
   onMarkerPress: (eventId: string) => void;
+  /** Extra top pixels to add to map padding (e.g. safe-area inset when map is full-screen). */
+  headerTopInset?: number;
 }
 
 interface MappableEvent {
@@ -53,8 +55,8 @@ type EventWithCoordinates = EventSummary & {
   location_lon: number;
 };
 
-const DISCOVERY_MAP_PADDING = {
-  top: 224,
+const DISCOVERY_MAP_PADDING_BASE = {
+  top: 120,
   right: 20,
   bottom: 96,
   left: 20,
@@ -362,9 +364,14 @@ export default function EventMapView({
   apiError,
   region,
   onMarkerPress,
+  headerTopInset = 0,
 }: EventMapViewProps) {
   const { theme, isDark } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
+  const mapPadding = useMemo(
+    () => ({ ...DISCOVERY_MAP_PADDING_BASE, top: DISCOVERY_MAP_PADDING_BASE.top + headerTopInset }),
+    [headerTopInset],
+  );
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [imageStatusByUrl, setImageStatusByUrl] = useState<
     Record<string, ImageStatus>
@@ -431,7 +438,7 @@ export default function EventMapView({
         style={styles.map}
         provider={Platform.OS === 'android' ? PROVIDER_GOOGLE : undefined}
         region={region}
-        mapPadding={DISCOVERY_MAP_PADDING}
+        mapPadding={mapPadding}
         onPress={() => setSelectedEventId(null)}
         testID="map-surface"
       >

--- a/mobile/src/components/home/HomeHeader.test.tsx
+++ b/mobile/src/components/home/HomeHeader.test.tsx
@@ -116,6 +116,21 @@ describe('HomeHeader', () => {
     expect(onPressNotifications).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the notification bell as the rightmost header action', () => {
+    render(
+      <HomeHeader
+        locationLabel="Beşiktaş, Istanbul"
+        onPressLocation={jest.fn()}
+        onPressNotifications={jest.fn()}
+      />,
+    );
+
+    const buttons = screen.getAllByRole('button');
+    const bellButton = screen.getByRole('button', { name: 'Open notifications' });
+
+    expect(buttons[buttons.length - 1]).toBe(bellButton);
+  });
+
   it('shows a badge when unreadNotificationCount is greater than zero', () => {
     render(
       <HomeHeader

--- a/mobile/src/components/home/HomeHeader.test.tsx
+++ b/mobile/src/components/home/HomeHeader.test.tsx
@@ -18,6 +18,7 @@ jest.mock('react-native', () => {
     const out = { ...props };
     if (out.accessibilityLabel) out['aria-label'] = out.accessibilityLabel;
     if (out.accessibilityRole) out['role'] = out.accessibilityRole;
+    if (out.testID) out['data-testid'] = out.testID;
     rnProps.forEach((p) => delete out[p]);
     return out;
   };
@@ -65,47 +66,24 @@ jest.mock('@expo/vector-icons', () => {
   };
 });
 
+const defaultProps = {
+  isDark: false,
+  onPressThemeToggle: jest.fn(),
+};
+
 describe('HomeHeader', () => {
-  it('renders the SEM logo on the left and the location button on the right', () => {
-    const onPressLocation = jest.fn();
-    render(
-      <HomeHeader
-        locationLabel="Beşiktaş, Istanbul"
-        onPressLocation={onPressLocation}
-      />,
-    );
+  beforeEach(() => jest.clearAllMocks());
 
+  it('renders the SEM logo on the left', () => {
+    render(<HomeHeader {...defaultProps} />);
     expect(screen.getByTestId('sem-logo')).toBeTruthy();
-
-    const locationButton = screen.getByRole('button', {
-      name: 'Select location',
-    });
-    expect(locationButton).toBeTruthy();
-
-    fireEvent.click(locationButton);
-    expect(onPressLocation).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders the location label with bold italic emphasis', () => {
-    render(
-      <HomeHeader
-        locationLabel="Kadikoy, Istanbul"
-        onPressLocation={jest.fn()}
-      />,
-    );
-
-    const label = screen.getByText('Kadikoy, Istanbul');
-    expect((label as HTMLElement).style.fontStyle).toBe('italic');
-    expect((label as HTMLElement).style.fontWeight).toBe('800');
-    expect((label as HTMLElement).style.fontSize).toBe('12px');
   });
 
   it('calls onPressNotifications when the bell button is pressed', () => {
     const onPressNotifications = jest.fn();
     render(
       <HomeHeader
-        locationLabel="Beşiktaş, Istanbul"
-        onPressLocation={jest.fn()}
+        {...defaultProps}
         onPressNotifications={onPressNotifications}
       />,
     );
@@ -116,54 +94,42 @@ describe('HomeHeader', () => {
     expect(onPressNotifications).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the notification bell as the rightmost header action', () => {
-    render(
-      <HomeHeader
-        locationLabel="Beşiktaş, Istanbul"
-        onPressLocation={jest.fn()}
-        onPressNotifications={jest.fn()}
-      />,
-    );
+  it('calls onPressThemeToggle when the theme button is pressed', () => {
+    const onPressThemeToggle = jest.fn();
+    render(<HomeHeader isDark={false} onPressThemeToggle={onPressThemeToggle} />);
 
+    const themeButton = screen.getByTestId('theme-toggle');
+    fireEvent.click(themeButton);
+    expect(onPressThemeToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a moon icon in light mode and a sun icon in dark mode', () => {
+    const { rerender } = render(<HomeHeader {...defaultProps} isDark={false} />);
+    expect(screen.getByTestId('theme-toggle').querySelector('[data-icon="moon"]')).toBeTruthy();
+
+    rerender(<HomeHeader {...defaultProps} isDark={true} />);
+    expect(screen.getByTestId('theme-toggle').querySelector('[data-icon="sun"]')).toBeTruthy();
+  });
+
+  it('theme toggle is the rightmost header action', () => {
+    render(<HomeHeader {...defaultProps} onPressNotifications={jest.fn()} />);
     const buttons = screen.getAllByRole('button');
-    const bellButton = screen.getByRole('button', { name: 'Open notifications' });
-
-    expect(buttons[buttons.length - 1]).toBe(bellButton);
+    const themeToggle = screen.getByTestId('theme-toggle');
+    expect(buttons[buttons.length - 1]).toBe(themeToggle);
   });
 
   it('shows a badge when unreadNotificationCount is greater than zero', () => {
-    render(
-      <HomeHeader
-        locationLabel="Beşiktaş, Istanbul"
-        onPressLocation={jest.fn()}
-        unreadNotificationCount={5}
-      />,
-    );
-
+    render(<HomeHeader {...defaultProps} unreadNotificationCount={5} />);
     expect(screen.getByText('5')).toBeTruthy();
   });
 
   it('caps the badge at 99+', () => {
-    render(
-      <HomeHeader
-        locationLabel="Beşiktaş, Istanbul"
-        onPressLocation={jest.fn()}
-        unreadNotificationCount={150}
-      />,
-    );
-
+    render(<HomeHeader {...defaultProps} unreadNotificationCount={150} />);
     expect(screen.getByText('99+')).toBeTruthy();
   });
 
   it('does not show a badge when unreadNotificationCount is zero', () => {
-    render(
-      <HomeHeader
-        locationLabel="Beşiktaş, Istanbul"
-        onPressLocation={jest.fn()}
-        unreadNotificationCount={0}
-      />,
-    );
-
+    render(<HomeHeader {...defaultProps} unreadNotificationCount={0} />);
     expect(screen.queryByText('0')).toBeNull();
   });
 });

--- a/mobile/src/components/home/HomeHeader.tsx
+++ b/mobile/src/components/home/HomeHeader.tsx
@@ -1,26 +1,26 @@
 import React, { forwardRef, useMemo } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { Feather } from '@expo/vector-icons';
-import { Ionicons } from '@expo/vector-icons';
+import { Feather, Ionicons } from '@expo/vector-icons';
 import SemLogo from '@/components/common/SemLogo';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
 
 interface HomeHeaderProps {
-  locationLabel: string;
-  onPressLocation?: () => void;
+  /** Whether dark mode is currently active — determines the sun/moon icon. */
+  isDark: boolean;
+  onPressThemeToggle: () => void;
   onPressNotifications?: () => void;
   unreadNotificationCount?: number;
 }
 
 const HomeHeader = forwardRef<any, HomeHeaderProps>(function HomeHeader(
   {
-    locationLabel,
-    onPressLocation,
+    isDark,
+    onPressThemeToggle,
     onPressNotifications,
     unreadNotificationCount = 0,
   },
-  locationButtonRef,
+  _ref,
 ) {
   const { theme } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
@@ -28,28 +28,13 @@ const HomeHeader = forwardRef<any, HomeHeaderProps>(function HomeHeader(
   return (
     <View style={styles.container}>
       <View style={styles.logoWrap}>
-        <SemLogo height={56} color={theme.text} />
+        <SemLogo height={52} color={theme.text} />
       </View>
 
       <View style={styles.rightWrap}>
-        <View ref={locationButtonRef} collapsable={false} style={styles.locationWrap}>
-          <TouchableOpacity
-            style={styles.locationButton}
-            activeOpacity={0.85}
-            onPress={onPressLocation}
-            accessibilityRole="button"
-            accessibilityLabel="Select location"
-          >
-            <Feather name="map-pin" size={16} color={theme.textOnPrimary} />
-            <Text style={styles.locationButtonText} numberOfLines={1}>
-              {locationLabel}
-            </Text>
-            <Feather name="chevron-down" size={16} color={theme.textOnPrimary} />
-          </TouchableOpacity>
-        </View>
-
+        {/* Bell */}
         <TouchableOpacity
-          style={styles.bellButton}
+          style={styles.iconButton}
           activeOpacity={0.75}
           onPress={onPressNotifications}
           accessibilityRole="button"
@@ -59,12 +44,22 @@ const HomeHeader = forwardRef<any, HomeHeaderProps>(function HomeHeader(
           {unreadNotificationCount > 0 ? (
             <View style={styles.badge}>
               <Text style={styles.badgeText}>
-                {unreadNotificationCount > 99
-                  ? '99+'
-                  : String(unreadNotificationCount)}
+                {unreadNotificationCount > 99 ? '99+' : String(unreadNotificationCount)}
               </Text>
             </View>
           ) : null}
+        </TouchableOpacity>
+
+        {/* Theme toggle */}
+        <TouchableOpacity
+          style={styles.iconButton}
+          activeOpacity={0.75}
+          onPress={onPressThemeToggle}
+          accessibilityRole="button"
+          accessibilityLabel={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+          testID="theme-toggle"
+        >
+          <Feather name={isDark ? 'sun' : 'moon'} size={20} color={theme.text} />
         </TouchableOpacity>
       </View>
     </View>
@@ -74,35 +69,31 @@ const HomeHeader = forwardRef<any, HomeHeaderProps>(function HomeHeader(
 function makeStyles(t: Theme) {
   return StyleSheet.create({
     container: {
-      marginTop: 20,
-      marginBottom: 14,
+      marginTop: 12,
+      marginBottom: 10,
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
     },
     logoWrap: {
       flexShrink: 0,
-      marginRight: 8,
     },
     rightWrap: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 10,
-      flexShrink: 1,
-      minWidth: 0,
+      gap: 4,
     },
-    bellButton: {
-      width: 38,
-      height: 38,
-      borderRadius: 19,
+    iconButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
       alignItems: 'center',
       justifyContent: 'center',
-      flexShrink: 0,
     },
     badge: {
       position: 'absolute',
-      top: 2,
-      right: 2,
+      top: 4,
+      right: 4,
       minWidth: 16,
       height: 16,
       borderRadius: 8,
@@ -116,30 +107,6 @@ function makeStyles(t: Theme) {
       fontSize: 9,
       fontWeight: '700',
       lineHeight: 12,
-    },
-    locationWrap: {
-      flexShrink: 1,
-      minWidth: 0,
-      maxWidth: '80%',
-      alignItems: 'flex-end',
-    },
-    locationButton: {
-      maxWidth: '100%',
-      minWidth: 0,
-      flexDirection: 'row',
-      alignItems: 'center',
-      backgroundColor: t.primary,
-      borderRadius: 999,
-      paddingHorizontal: 14,
-      paddingVertical: 10,
-    },
-    locationButtonText: {
-      color: t.textOnPrimary,
-      fontSize: 12,
-      fontWeight: '800',
-      fontStyle: 'italic',
-      marginHorizontal: 8,
-      flexShrink: 1,
     },
   });
 }

--- a/mobile/src/components/profile/ProfileEventCard.test.tsx
+++ b/mobile/src/components/profile/ProfileEventCard.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ProfileEventCard from './ProfileEventCard';
+
+jest.mock('@expo/vector-icons', () => {
+  const ReactLocal = require('react');
+
+  return {
+    Feather: ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', { 'data-icon': name }),
+  };
+});
+
+describe('ProfileEventCard', () => {
+  it('uses the shared category color and emoji presentation', () => {
+    render(
+      <ProfileEventCard
+        title="Forest Walk"
+        imageUrl={null}
+        categoryLabel="Outdoors"
+        startTime="2026-04-09T14:00:00+03:00"
+        locationAddress="Belgrad Forest, Istanbul"
+        status="ACTIVE"
+        privacyLevel="PUBLIC"
+        onPress={jest.fn()}
+      />,
+    );
+
+    const badge = screen.getByTestId('profile-event-category-badge');
+
+    expect(screen.getByText('🌲 Outdoors')).toBeTruthy();
+    expect(badge.getAttribute('style')).toContain(
+      'background-color: rgb(5, 150, 105)',
+    );
+  });
+});

--- a/mobile/src/components/profile/ProfileEventCard.tsx
+++ b/mobile/src/components/profile/ProfileEventCard.tsx
@@ -13,6 +13,7 @@ import {
   formatEventStatusLabel,
   getEventStatusBadgeColors,
 } from '@/utils/eventStatus';
+import { getEventCategoryPresentation } from '@/utils/eventCategoryPresentation';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
 
@@ -41,10 +42,14 @@ export default function ProfileEventCard({
   privacyLevel,
   onPress,
 }: ProfileEventCardProps) {
-  const { theme } = useTheme();
+  const { theme, isDark } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
 
   const statusColors = getEventStatusBadgeColors(status);
+  const categoryPresentation = getEventCategoryPresentation(
+    categoryLabel,
+    isDark,
+  );
 
   let privacyBg = theme.badgePublicBg;
   let privacyText = theme.badgePublicText;
@@ -95,8 +100,22 @@ export default function ProfileEventCard({
           </View>
 
           <View style={styles.imageBottomRow}>
-            <View style={styles.categoryBadge}>
-              <Text style={styles.categoryBadgeText}>{categoryLabel}</Text>
+            <View
+              style={[
+                styles.categoryBadge,
+                { backgroundColor: categoryPresentation.color },
+              ]}
+              testID="profile-event-category-badge"
+            >
+              <Text
+                style={[
+                  styles.categoryBadgeText,
+                  { color: categoryPresentation.textColor },
+                ]}
+                numberOfLines={1}
+              >
+                {categoryPresentation.emoji} {categoryPresentation.label}
+              </Text>
             </View>
 
             <View
@@ -191,13 +210,12 @@ function makeStyles(t: Theme) {
     },
     categoryBadge: {
       alignSelf: 'flex-start',
-      backgroundColor: 'rgba(15, 23, 42, 0.72)',
+      maxWidth: '70%',
       paddingHorizontal: 14,
       paddingVertical: 8,
       borderRadius: 999,
     },
     categoryBadgeText: {
-      color: '#FFFFFF',
       fontSize: 13,
       fontWeight: '700',
     },

--- a/mobile/src/utils/eventCategoryPresentation.test.ts
+++ b/mobile/src/utils/eventCategoryPresentation.test.ts
@@ -1,0 +1,26 @@
+import { getEventCategoryPresentation } from './eventCategoryPresentation';
+
+describe('getEventCategoryPresentation', () => {
+  it('keeps outdoors and volunteering visually distinct', () => {
+    const outdoors = getEventCategoryPresentation('Outdoors', false);
+    const volunteering = getEventCategoryPresentation('Volunteering', false);
+
+    expect(outdoors.color).toBe('#059669');
+    expect(volunteering.color).toBe('#BE123C');
+    expect(outdoors.color).not.toBe(volunteering.color);
+  });
+
+  it('normalizes category names with punctuation', () => {
+    const presentation = getEventCategoryPresentation('Food & Drink', false);
+
+    expect(presentation.emoji).toBe('🍽️');
+    expect(presentation.color).toBe('#C2410C');
+  });
+
+  it('returns readable foreground text for bright dark-theme colors', () => {
+    const presentation = getEventCategoryPresentation('Books & Literature', true);
+
+    expect(presentation.color).toBe('#FCD34D');
+    expect(presentation.textColor).toBe('#0F172A');
+  });
+});

--- a/mobile/src/utils/eventCategoryPresentation.ts
+++ b/mobile/src/utils/eventCategoryPresentation.ts
@@ -1,0 +1,88 @@
+export interface EventCategoryPresentation {
+  label: string;
+  emoji: string;
+  color: string;
+  tintColor: string;
+  textColor: string;
+}
+
+interface EventCategoryPresentationConfig {
+  emoji: string;
+  lightColor: string;
+  darkColor: string;
+}
+
+const CATEGORY_PRESENTATION_BY_NAME: Record<string, EventCategoryPresentationConfig> = {
+  sports: { emoji: '🏃', lightColor: '#2563EB', darkColor: '#60A5FA' },
+  music: { emoji: '🎵', lightColor: '#DB2777', darkColor: '#F472B6' },
+  education: { emoji: '🎓', lightColor: '#7C3AED', darkColor: '#A78BFA' },
+  technology: { emoji: '💻', lightColor: '#0891B2', darkColor: '#22D3EE' },
+  art: { emoji: '🎨', lightColor: '#EA580C', darkColor: '#FB923C' },
+  fooddrink: { emoji: '🍽️', lightColor: '#C2410C', darkColor: '#FDBA74' },
+  outdoors: { emoji: '🌲', lightColor: '#059669', darkColor: '#34D399' },
+  fitness: { emoji: '💪', lightColor: '#DC2626', darkColor: '#F87171' },
+  networking: { emoji: '🤝', lightColor: '#4F46E5', darkColor: '#818CF8' },
+  gaming: { emoji: '🎮', lightColor: '#9333EA', darkColor: '#C084FC' },
+  charity: { emoji: '💛', lightColor: '#B45309', darkColor: '#FBBF24' },
+  photography: { emoji: '📷', lightColor: '#0284C7', darkColor: '#38BDF8' },
+  travel: { emoji: '✈️', lightColor: '#0D9488', darkColor: '#2DD4BF' },
+  workshops: { emoji: '🛠️', lightColor: '#475569', darkColor: '#CBD5E1' },
+  conferences: { emoji: '🎤', lightColor: '#4338CA', darkColor: '#A5B4FC' },
+  moviescinema: { emoji: '🎬', lightColor: '#B91C1C', darkColor: '#FCA5A5' },
+  theatre: { emoji: '🎭', lightColor: '#C026D3', darkColor: '#E879F9' },
+  booksliterature: { emoji: '📚', lightColor: '#D97706', darkColor: '#FCD34D' },
+  wellness: { emoji: '🧘', lightColor: '#65A30D', darkColor: '#A3E635' },
+  volunteering: { emoji: '🙌', lightColor: '#BE123C', darkColor: '#FB7185' },
+  social: { emoji: '🤗', lightColor: '#0D9488', darkColor: '#5EEAD4' },
+  culture: { emoji: '🏛️', lightColor: '#7C2D12', darkColor: '#FDBA74' },
+  entertainment: { emoji: '🎉', lightColor: '#C026D3', darkColor: '#E879F9' },
+};
+
+const FALLBACK_CATEGORY_PRESENTATIONS: EventCategoryPresentationConfig[] = [
+  { emoji: '📍', lightColor: '#2563EB', darkColor: '#60A5FA' },
+  { emoji: '✨', lightColor: '#7C3AED', darkColor: '#A78BFA' },
+  { emoji: '📌', lightColor: '#0D9488', darkColor: '#2DD4BF' },
+  { emoji: '🎟️', lightColor: '#B45309', darkColor: '#FBBF24' },
+];
+
+function normalizeCategoryName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function hashString(value: string): number {
+  return value.split('').reduce((hash, char) => {
+    return (hash * 31 + char.charCodeAt(0)) >>> 0;
+  }, 0);
+}
+
+function getReadableTextColor(backgroundColor: string): string {
+  const normalized = backgroundColor.replace('#', '');
+  const red = parseInt(normalized.slice(0, 2), 16);
+  const green = parseInt(normalized.slice(2, 4), 16);
+  const blue = parseInt(normalized.slice(4, 6), 16);
+  const luminance = (0.299 * red + 0.587 * green + 0.114 * blue) / 255;
+
+  return luminance > 0.62 ? '#0F172A' : '#FFFFFF';
+}
+
+export function getEventCategoryPresentation(
+  categoryName: string,
+  isDark: boolean,
+): EventCategoryPresentation {
+  const label = categoryName.trim() || 'Event';
+  const normalizedName = normalizeCategoryName(label);
+  const config =
+    CATEGORY_PRESENTATION_BY_NAME[normalizedName] ??
+    FALLBACK_CATEGORY_PRESENTATIONS[
+      hashString(normalizedName) % FALLBACK_CATEGORY_PRESENTATIONS.length
+    ];
+  const color = isDark ? config.darkColor : config.lightColor;
+
+  return {
+    label,
+    emoji: config.emoji,
+    color,
+    tintColor: `${color}${isDark ? '30' : '18'}`,
+    textColor: getReadableTextColor(color),
+  };
+}

--- a/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
+++ b/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
@@ -122,7 +122,7 @@ const defaultFallbackListEventsQuery = {
   start_from: undefined,
   start_to: undefined,
   sort_by: 'START_TIME',
-  limit: 2,
+  limit: 50,
   cursor: undefined,
 };
 

--- a/mobile/src/viewmodels/home/useHomeViewModel.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.ts
@@ -20,7 +20,7 @@ import { getMyProfile } from '@/services/profileService';
 import { formatEventLocation } from '@/utils/eventLocation';
 import { useAuth } from '@/contexts/AuthContext';
 
-const PAGE_SIZE = 2;
+const PAGE_SIZE = 50;
 const MAX_FAVORITE_LOCATION_OPTIONS = 3;
 
 const DEFAULT_LOCATION = {

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -24,6 +24,7 @@ import {
   getEventStatusBadgeColors,
 } from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
+import { getEventCategoryPresentation } from '@/utils/eventCategoryPresentation';
 import { EventDetail } from '@/models/event';
 import JoinRequestsModal from '@/components/events/JoinRequestsModal';
 import ParticipantListModal from '@/components/events/ParticipantListModal';
@@ -732,6 +733,9 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
     event.capacity != null
       ? `${event.approved_participant_count} / ${event.capacity}`
       : `${event.approved_participant_count}`;
+  const categoryPresentation = event.category
+    ? getEventCategoryPresentation(event.category.name, isDark)
+    : null;
 
   return (
     <SafeAreaView edges={['top', 'left', 'right']} style={styles.safeArea}>
@@ -788,9 +792,22 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
 
         {/* Core info */}
         <View style={styles.section}>
-          {event.category && (
-            <View style={styles.categoryChip}>
-              <Text style={styles.categoryChipText}>{event.category.name}</Text>
+          {categoryPresentation && (
+            <View
+              style={[
+                styles.categoryChip,
+                { backgroundColor: categoryPresentation.color },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.categoryChipText,
+                  { color: categoryPresentation.textColor },
+                ]}
+                numberOfLines={1}
+              >
+                {categoryPresentation.emoji} {categoryPresentation.label}
+              </Text>
             </View>
           )}
 
@@ -1341,7 +1358,7 @@ function makeStyles(t: Theme, isDark: boolean) {
     /* Category chip */
     categoryChip: {
       alignSelf: 'flex-start',
-      backgroundColor: 'rgba(15, 23, 42, 0.72)',
+      maxWidth: '100%',
       paddingHorizontal: 12,
       paddingVertical: 4,
       borderRadius: 999,
@@ -1350,7 +1367,6 @@ function makeStyles(t: Theme, isDark: boolean) {
     categoryChipText: {
       fontSize: 12,
       fontWeight: '700',
-      color: '#FFFFFF',
     },
 
     /* Event title */

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -4,11 +4,13 @@ import {
   FlatList,
   StyleSheet,
   Text,
+  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import { router, useFocusEffect, type Href } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import HomeHeader from '@/components/home/HomeHeader';
 import SearchSection from '@/components/home/SearchSection';
 import EmptyState from '@/components/home/EmptyState';
@@ -28,9 +30,10 @@ const MIN_DELTA = 0.02;
 export default function HomeView() {
   const vm = useHomeViewModel();
   const { unreadCount, refresh: refreshUnreadCount } = useUnreadNotificationCount();
-  const { theme } = useTheme();
-  const styles = useMemo(() => makeStyles(theme), [theme]);
+  const { theme, isDark } = useTheme();
+  const styles = useMemo(() => makeStyles(theme, isDark), [theme, isDark]);
   const isMapMode = vm.viewMode === 'MAP';
+  const insets = useSafeAreaInsets();
 
   useFocusEffect(
     useCallback(() => {
@@ -69,116 +72,194 @@ export default function HomeView() {
   }, [vm.activeLocation, vm.filterDraft.radiusKm]);
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={styles.safeArea}>
-      <View style={[styles.container, isMapMode && styles.mapContainer]}>
-        <View style={[styles.topSection, isMapMode && styles.mapTopSection]}>
-          <HomeHeader
-            ref={locationButtonRef}
-            locationLabel={vm.locationLabel}
-            onPressLocation={handleOpenLocationPicker}
-            onPressNotifications={() => router.push('/notifications' as Href)}
-            unreadNotificationCount={unreadCount}
+    <SafeAreaView
+      edges={isMapMode ? [] : ['top', 'left', 'right']}
+      style={styles.safeArea}
+    >
+      {isMapMode ? (
+        <>
+          <EventMapView
+            events={vm.events}
+            isLoading={vm.isLoading}
+            apiError={vm.apiError}
+            region={mapRegion}
+            onMarkerPress={(id) => router.push(`/event/${id}` as Href)}
+            headerTopInset={insets.top}
           />
 
-          <SearchSection
-            query={vm.searchText}
-            onChangeQuery={vm.updateSearchText}
-            onSubmitSearch={vm.submitSearch}
-            onPressFilter={vm.openFilterModal}
-          />
+          {/* Floating overlay — search, location and list toggle above the map */}
+          <View
+            style={[styles.mapOverlay, { top: insets.top + 12 }]}
+            pointerEvents="box-none"
+          >
+            {/* Row 1: location pill + list toggle */}
+            <View style={styles.mapOverlayRow}>
+              <View ref={locationButtonRef} collapsable={false}>
+                <TouchableOpacity
+                  style={styles.mapLocationPill}
+                  onPress={handleOpenLocationPicker}
+                  accessibilityRole="button"
+                  accessibilityLabel="Select location"
+                >
+                  <Feather name="map-pin" size={14} color={styles.mapLocationIconColor.color} />
+                  <Text style={styles.mapLocationText} numberOfLines={1}>
+                    {vm.locationLabel}
+                  </Text>
+                  <Feather name="chevron-down" size={14} color={styles.mapLocationIconColor.color} />
+                </TouchableOpacity>
+              </View>
 
-          <View style={[styles.viewToggleRow, isMapMode && styles.mapViewToggleRow]}>
-            <TouchableOpacity
-              style={[
-                styles.viewToggleButton,
-                styles.viewToggleLeft,
-                vm.viewMode === 'LIST' && styles.viewToggleActive,
-              ]}
-              onPress={() => vm.viewMode !== 'LIST' && vm.toggleViewMode()}
-              accessibilityRole="button"
-              accessibilityLabel="List view"
-              accessibilityState={{ selected: vm.viewMode === 'LIST' }}
-              testID="toggle-list"
-            >
-              <Text
-                style={[
-                  styles.viewToggleText,
-                  vm.viewMode === 'LIST' && styles.viewToggleTextActive,
-                ]}
-              >
-                List
-              </Text>
-            </TouchableOpacity>
+              <View style={styles.mapOverlayRowSpacer} />
 
-            <TouchableOpacity
-              style={[
-                styles.viewToggleButton,
-                styles.viewToggleRight,
-                vm.viewMode === 'MAP' && styles.viewToggleActive,
-              ]}
-              onPress={() => vm.viewMode !== 'MAP' && vm.toggleViewMode()}
-              accessibilityRole="button"
-              accessibilityLabel="Map view"
-              accessibilityState={{ selected: vm.viewMode === 'MAP' }}
-              testID="toggle-map"
-            >
-              <Text
-                style={[
-                  styles.viewToggleText,
-                  vm.viewMode === 'MAP' && styles.viewToggleTextActive,
-                ]}
+              <TouchableOpacity
+                style={styles.mapFloatingBtn}
+                onPress={vm.toggleViewMode}
+                accessibilityRole="button"
+                accessibilityLabel="Switch to list view"
+                testID="toggle-list"
               >
-                Map
-              </Text>
-            </TouchableOpacity>
+                <Feather name="list" size={15} color={theme.text} />
+                <Text style={styles.mapFloatingBtnText}>List</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Row 2: search bar + filter button */}
+            <View style={styles.mapSearchRow}>
+              <View style={styles.mapSearchContainer}>
+                <Feather
+                  name="search"
+                  size={18}
+                  color={theme.textSecondary}
+                  style={styles.mapSearchIcon}
+                />
+                <TextInput
+                  value={vm.searchText}
+                  onChangeText={vm.updateSearchText}
+                  onSubmitEditing={vm.submitSearch}
+                  placeholder="Search events on map…"
+                  placeholderTextColor={theme.placeholder}
+                  style={styles.mapSearchInput}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  returnKeyType="search"
+                />
+              </View>
+
+              <TouchableOpacity
+                style={styles.mapFilterBtn}
+                onPress={vm.openFilterModal}
+                accessibilityRole="button"
+                accessibilityLabel="Open filters"
+                testID="map-filter-btn"
+              >
+                <Feather name="sliders" size={20} color={styles.mapLocationIconColor.color} />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </>
+      ) : (
+        <View style={styles.container}>
+          <View style={styles.topSection}>
+            <HomeHeader
+              ref={locationButtonRef}
+              locationLabel={vm.locationLabel}
+              onPressLocation={handleOpenLocationPicker}
+              onPressNotifications={() => router.push('/notifications' as Href)}
+              unreadNotificationCount={unreadCount}
+            />
+
+            <SearchSection
+              query={vm.searchText}
+              onChangeQuery={vm.updateSearchText}
+              onSubmitSearch={vm.submitSearch}
+              onPressFilter={vm.openFilterModal}
+            />
+
+            <View style={styles.viewToggleRow}>
+              <TouchableOpacity
+                style={[
+                  styles.viewToggleButton,
+                  styles.viewToggleLeft,
+                  vm.viewMode === 'LIST' && styles.viewToggleActive,
+                ]}
+                onPress={() => vm.viewMode !== 'LIST' && vm.toggleViewMode()}
+                accessibilityRole="button"
+                accessibilityLabel="List view"
+                accessibilityState={{ selected: vm.viewMode === 'LIST' }}
+                testID="toggle-list"
+              >
+                <Text
+                  style={[
+                    styles.viewToggleText,
+                    vm.viewMode === 'LIST' && styles.viewToggleTextActive,
+                  ]}
+                >
+                  List
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={[
+                  styles.viewToggleButton,
+                  styles.viewToggleRight,
+                  vm.viewMode === 'MAP' && styles.viewToggleActive,
+                ]}
+                onPress={() => vm.viewMode !== 'MAP' && vm.toggleViewMode()}
+                accessibilityRole="button"
+                accessibilityLabel="Map view"
+                accessibilityState={{ selected: vm.viewMode === 'MAP' }}
+                testID="toggle-map"
+              >
+                <Text
+                  style={[
+                    styles.viewToggleText,
+                    vm.viewMode === 'MAP' && styles.viewToggleTextActive,
+                  ]}
+                >
+                  Map
+                </Text>
+              </TouchableOpacity>
+            </View>
+
+            {vm.apiError ? (
+              <View style={styles.errorBanner}>
+                <Text style={styles.errorBannerText}>{vm.apiError}</Text>
+              </View>
+            ) : null}
           </View>
 
-          {vm.apiError && vm.viewMode === 'LIST' ? (
-            <View style={styles.errorBanner}>
-              <Text style={styles.errorBannerText}>{vm.apiError}</Text>
-            </View>
-          ) : null}
+          <View style={styles.listWrapper}>
+            {vm.isLoading ? (
+              <LoadingState />
+            ) : (
+              <FlatList
+                data={vm.events}
+                keyExtractor={(item) => item.id}
+                renderItem={({ item }) => (
+                  <EventCard
+                    event={item}
+                    onPress={(id) => router.push(`/event/${id}` as Href)}
+                  />
+                )}
+                showsVerticalScrollIndicator={false}
+                onEndReachedThreshold={0.35}
+                onEndReached={vm.loadMoreEvents}
+                onRefresh={vm.refreshEvents}
+                refreshing={vm.isRefreshing}
+                contentContainerStyle={styles.listContent}
+                ListEmptyComponent={<EmptyState />}
+                ListFooterComponent={
+                  vm.isLoadingMore ? (
+                    <View style={styles.footerLoader}>
+                      <ActivityIndicator size="small" color={theme.text} />
+                    </View>
+                  ) : null
+                }
+              />
+            )}
+          </View>
         </View>
-
-        <View style={[styles.listWrapper, isMapMode && styles.mapWrapper]}>
-          {isMapMode ? (
-            <EventMapView
-              events={vm.events}
-              isLoading={vm.isLoading}
-              apiError={vm.apiError}
-              region={mapRegion}
-              onMarkerPress={(id) => router.push(`/event/${id}` as Href)}
-            />
-          ) : vm.isLoading ? (
-            <LoadingState />
-          ) : (
-            <FlatList
-              data={vm.events}
-              keyExtractor={(item) => item.id}
-              renderItem={({ item }) => (
-                <EventCard
-                  event={item}
-                  onPress={(id) => router.push(`/event/${id}` as Href)}
-                />
-              )}
-              showsVerticalScrollIndicator={false}
-              onEndReachedThreshold={0.35}
-              onEndReached={vm.loadMoreEvents}
-              onRefresh={vm.refreshEvents}
-              refreshing={vm.isRefreshing}
-              contentContainerStyle={styles.listContent}
-              ListEmptyComponent={<EmptyState />}
-              ListFooterComponent={
-                vm.isLoadingMore ? (
-                  <View style={styles.footerLoader}>
-                    <ActivityIndicator size="small" color={theme.text} />
-                  </View>
-                ) : null
-              }
-            />
-          )}
-        </View>
-      </View>
+      )}
 
       <FiltersBottomSheet
         visible={vm.isFilterModalOpen}
@@ -219,7 +300,7 @@ export default function HomeView() {
   );
 }
 
-function makeStyles(t: Theme) {
+function makeStyles(t: Theme, isDark: boolean) {
   return StyleSheet.create({
     safeArea: {
       flex: 1,
@@ -229,36 +310,12 @@ function makeStyles(t: Theme) {
       flex: 1,
       paddingHorizontal: 20,
     },
-    mapContainer: {
-      paddingHorizontal: 0,
-      backgroundColor: t.surfaceAlt,
-    },
     topSection: {
       paddingTop: 8,
-    },
-    mapTopSection: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      zIndex: 10,
-      paddingHorizontal: 16,
-      paddingBottom: 10,
-      backgroundColor: t.surface,
-      borderBottomWidth: 1,
-      borderBottomColor: t.border,
-      shadowColor: '#000',
-      shadowOpacity: 0.1,
-      shadowRadius: 12,
-      shadowOffset: { width: 0, height: 4 },
-      elevation: 6,
     },
     listWrapper: {
       flex: 1,
       marginTop: 6,
-    },
-    mapWrapper: {
-      marginTop: 0,
     },
     listContent: {
       paddingBottom: 20,
@@ -289,10 +346,6 @@ function makeStyles(t: Theme) {
       borderColor: t.border,
       overflow: 'hidden',
     },
-    mapViewToggleRow: {
-      marginTop: 0,
-      marginBottom: 0,
-    },
     viewToggleButton: {
       paddingHorizontal: 24,
       paddingVertical: 8,
@@ -316,6 +369,114 @@ function makeStyles(t: Theme) {
     },
     viewToggleTextActive: {
       color: t.textOnPrimary,
+    },
+    // ── full-screen map floating overlay ─────────────────────────────────────
+    mapOverlay: {
+      position: 'absolute',
+      left: 14,
+      right: 14,
+      zIndex: 20,
+      gap: 8,
+    },
+    mapOverlayRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    mapOverlayRowSpacer: {
+      flex: 1,
+    },
+    mapLocationPill: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      paddingHorizontal: 14,
+      paddingVertical: 9,
+      borderRadius: 999,
+      backgroundColor: isDark ? t.surface : t.primary,
+      borderWidth: isDark ? 1 : 0,
+      borderColor: t.border,
+      maxWidth: 220,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.18,
+      shadowRadius: 6,
+      elevation: 4,
+    },
+    mapLocationText: {
+      color: isDark ? t.text : t.textOnPrimary,
+      fontSize: 13,
+      fontWeight: '700',
+      flexShrink: 1,
+    },
+    mapLocationIconColor: {
+      color: isDark ? t.text : t.textOnPrimary,
+    },
+    mapFloatingBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      paddingHorizontal: 14,
+      paddingVertical: 9,
+      borderRadius: 999,
+      backgroundColor: t.surface,
+      borderWidth: 1,
+      borderColor: t.border,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.15,
+      shadowRadius: 6,
+      elevation: 4,
+    },
+    mapFloatingBtnText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: t.text,
+    },
+    mapSearchRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+    },
+    mapSearchContainer: {
+      flex: 1,
+      height: 50,
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 14,
+      borderRadius: 16,
+      backgroundColor: t.surface,
+      borderWidth: 1,
+      borderColor: t.border,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.12,
+      shadowRadius: 6,
+      elevation: 4,
+    },
+    mapSearchIcon: {
+      marginRight: 8,
+    },
+    mapSearchInput: {
+      flex: 1,
+      fontSize: 15,
+      color: t.text,
+      paddingVertical: 0,
+    },
+    mapFilterBtn: {
+      width: 50,
+      height: 50,
+      borderRadius: 16,
+      backgroundColor: isDark ? t.surface : t.primary,
+      borderWidth: isDark ? 1 : 0,
+      borderColor: t.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.18,
+      shadowRadius: 6,
+      elevation: 4,
     },
   });
 }

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -12,6 +12,7 @@ import { Feather } from '@expo/vector-icons';
 import { router, useFocusEffect, type Href } from 'expo-router';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import HomeHeader from '@/components/home/HomeHeader';
+import SemLogo from '@/components/common/SemLogo';
 import SearchSection from '@/components/home/SearchSection';
 import EmptyState from '@/components/home/EmptyState';
 import LoadingState from '@/components/home/LoadingState';
@@ -30,7 +31,7 @@ const MIN_DELTA = 0.02;
 export default function HomeView() {
   const vm = useHomeViewModel();
   const { unreadCount, refresh: refreshUnreadCount } = useUnreadNotificationCount();
-  const { theme, isDark } = useTheme();
+  const { theme, isDark, setThemePreference } = useTheme();
   const styles = useMemo(() => makeStyles(theme, isDark), [theme, isDark]);
   const isMapMode = vm.viewMode === 'MAP';
   const insets = useSafeAreaInsets();
@@ -43,6 +44,10 @@ export default function HomeView() {
 
   const locationButtonRef = useRef<any>(null);
   const [locationPopupTop, setLocationPopupTop] = useState(140);
+
+  const handleThemeToggle = useCallback(() => {
+    void setThemePreference(isDark ? 'light' : 'dark');
+  }, [isDark, setThemePreference]);
 
   const handleOpenLocationPicker = () => {
     if (locationButtonRef.current?.measureInWindow) {
@@ -92,8 +97,10 @@ export default function HomeView() {
             style={[styles.mapOverlay, { top: insets.top + 12 }]}
             pointerEvents="box-none"
           >
-            {/* Row 1: location pill + list toggle */}
+            {/* Row 1: logo + location pill + bell + theme toggle + list toggle */}
             <View style={styles.mapOverlayRow}>
+              <SemLogo height={36} color={theme.text} />
+
               <View ref={locationButtonRef} collapsable={false}>
                 <TouchableOpacity
                   style={styles.mapLocationPill}
@@ -112,14 +119,32 @@ export default function HomeView() {
               <View style={styles.mapOverlayRowSpacer} />
 
               <TouchableOpacity
-                style={styles.mapFloatingBtn}
+                style={styles.mapIconBtn}
+                onPress={() => router.push('/notifications' as Href)}
+                accessibilityRole="button"
+                accessibilityLabel="Open notifications"
+              >
+                <Feather name="bell" size={18} color={theme.text} />
+                {unreadCount > 0 ? <View style={styles.mapIconBadge} /> : null}
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.mapIconBtn}
+                onPress={handleThemeToggle}
+                accessibilityRole="button"
+                accessibilityLabel={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+              >
+                <Feather name={isDark ? 'sun' : 'moon'} size={18} color={theme.text} />
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.mapIconBtn}
                 onPress={vm.toggleViewMode}
                 accessibilityRole="button"
                 accessibilityLabel="Switch to list view"
                 testID="toggle-list"
               >
-                <Feather name="list" size={15} color={theme.text} />
-                <Text style={styles.mapFloatingBtnText}>List</Text>
+                <Feather name="list" size={20} color={theme.text} />
               </TouchableOpacity>
             </View>
 
@@ -161,12 +186,28 @@ export default function HomeView() {
         <View style={styles.container}>
           <View style={styles.topSection}>
             <HomeHeader
-              ref={locationButtonRef}
-              locationLabel={vm.locationLabel}
-              onPressLocation={handleOpenLocationPicker}
+              isDark={isDark}
+              onPressThemeToggle={handleThemeToggle}
               onPressNotifications={() => router.push('/notifications' as Href)}
               unreadNotificationCount={unreadCount}
             />
+
+            {/* Location row */}
+            <View ref={locationButtonRef} collapsable={false} style={styles.locationRow}>
+              <TouchableOpacity
+                style={styles.locationPill}
+                onPress={handleOpenLocationPicker}
+                activeOpacity={0.85}
+                accessibilityRole="button"
+                accessibilityLabel="Select location"
+              >
+                <Feather name="map-pin" size={14} color={isDark ? theme.text : theme.textOnPrimary} />
+                <Text style={styles.locationPillText} numberOfLines={1}>
+                  {vm.locationLabel}
+                </Text>
+                <Feather name="chevron-down" size={14} color={isDark ? theme.text : theme.textOnPrimary} />
+              </TouchableOpacity>
+            </View>
 
             <SearchSection
               query={vm.searchText}
@@ -313,6 +354,29 @@ function makeStyles(t: Theme, isDark: boolean) {
     topSection: {
       paddingTop: 8,
     },
+    locationRow: {
+      marginBottom: 10,
+    },
+    locationPill: {
+      alignSelf: 'flex-start',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      paddingHorizontal: 14,
+      paddingVertical: 8,
+      borderRadius: 999,
+      backgroundColor: isDark ? t.surface : t.primary,
+      borderWidth: isDark ? 1 : 0,
+      borderColor: t.border,
+      maxWidth: '80%',
+    },
+    locationPillText: {
+      color: isDark ? t.text : t.textOnPrimary,
+      fontSize: 13,
+      fontWeight: '700',
+      fontStyle: 'italic',
+      flexShrink: 1,
+    },
     listWrapper: {
       flex: 1,
       marginTop: 6,
@@ -396,7 +460,7 @@ function makeStyles(t: Theme, isDark: boolean) {
       backgroundColor: isDark ? t.surface : t.primary,
       borderWidth: isDark ? 1 : 0,
       borderColor: t.border,
-      maxWidth: 220,
+      maxWidth: 150,
       shadowColor: '#000',
       shadowOffset: { width: 0, height: 2 },
       shadowOpacity: 0.18,
@@ -411,6 +475,30 @@ function makeStyles(t: Theme, isDark: boolean) {
     },
     mapLocationIconColor: {
       color: isDark ? t.text : t.textOnPrimary,
+    },
+    mapIconBtn: {
+      width: 38,
+      height: 38,
+      borderRadius: 19,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: t.surface,
+      borderWidth: 1,
+      borderColor: t.border,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.15,
+      shadowRadius: 6,
+      elevation: 4,
+    },
+    mapIconBadge: {
+      position: 'absolute',
+      top: 6,
+      right: 6,
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+      backgroundColor: t.notificationBadge,
     },
     mapFloatingBtn: {
       flexDirection: 'row',

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -30,6 +30,7 @@ export default function HomeView() {
   const { unreadCount, refresh: refreshUnreadCount } = useUnreadNotificationCount();
   const { theme } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
+  const isMapMode = vm.viewMode === 'MAP';
 
   useFocusEffect(
     useCallback(() => {
@@ -69,8 +70,8 @@ export default function HomeView() {
 
   return (
     <SafeAreaView edges={['top', 'left', 'right']} style={styles.safeArea}>
-      <View style={styles.container}>
-        <View style={styles.topSection}>
+      <View style={[styles.container, isMapMode && styles.mapContainer]}>
+        <View style={[styles.topSection, isMapMode && styles.mapTopSection]}>
           <HomeHeader
             ref={locationButtonRef}
             locationLabel={vm.locationLabel}
@@ -86,7 +87,7 @@ export default function HomeView() {
             onPressFilter={vm.openFilterModal}
           />
 
-          <View style={styles.viewToggleRow}>
+          <View style={[styles.viewToggleRow, isMapMode && styles.mapViewToggleRow]}>
             <TouchableOpacity
               style={[
                 styles.viewToggleButton,
@@ -139,8 +140,8 @@ export default function HomeView() {
           ) : null}
         </View>
 
-        <View style={styles.listWrapper}>
-          {vm.viewMode === 'MAP' ? (
+        <View style={[styles.listWrapper, isMapMode && styles.mapWrapper]}>
+          {isMapMode ? (
             <EventMapView
               events={vm.events}
               isLoading={vm.isLoading}
@@ -228,12 +229,36 @@ function makeStyles(t: Theme) {
       flex: 1,
       paddingHorizontal: 20,
     },
+    mapContainer: {
+      paddingHorizontal: 0,
+      backgroundColor: t.surfaceAlt,
+    },
     topSection: {
       paddingTop: 8,
+    },
+    mapTopSection: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      zIndex: 10,
+      paddingHorizontal: 16,
+      paddingBottom: 10,
+      backgroundColor: t.surface,
+      borderBottomWidth: 1,
+      borderBottomColor: t.border,
+      shadowColor: '#000',
+      shadowOpacity: 0.1,
+      shadowRadius: 12,
+      shadowOffset: { width: 0, height: 4 },
+      elevation: 6,
     },
     listWrapper: {
       flex: 1,
       marginTop: 6,
+    },
+    mapWrapper: {
+      marginTop: 0,
     },
     listContent: {
       paddingBottom: 20,
@@ -263,6 +288,10 @@ function makeStyles(t: Theme) {
       borderWidth: 1,
       borderColor: t.border,
       overflow: 'hidden',
+    },
+    mapViewToggleRow: {
+      marginTop: 0,
+      marginBottom: 0,
     },
     viewToggleButton: {
       paddingHorizontal: 24,

--- a/mobile/src/views/profile/ProfileView.tsx
+++ b/mobile/src/views/profile/ProfileView.tsx
@@ -28,7 +28,7 @@ export default function ProfileView() {
   const vm = useProfileViewModel();
   const notificationSettings = usePushNotificationPreference();
   const [activeTab, setActiveTab] = useState<ProfileEventTab>('hosted');
-  const { theme } = useTheme();
+  const { theme, isDark, setThemePreference } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
 
   const { isLoggingOut, logoutError, handleLogout } = useLogoutViewModel(
@@ -279,6 +279,34 @@ export default function ProfileView() {
                 {notificationSettings.errorMessage}
               </Text>
             ) : null}
+
+            <View style={styles.menuDivider} />
+
+            <View style={styles.settingRow}>
+              <View style={styles.menuRowLeft}>
+                <Ionicons
+                  name={isDark ? 'moon-outline' : 'sunny-outline'}
+                  size={20}
+                  color={theme.text}
+                />
+                <View style={styles.settingTextBlock}>
+                  <Text style={styles.menuRowText}>Dark Mode</Text>
+                  <Text style={styles.settingSubtitle}>
+                    {isDark ? 'Dark theme is on' : 'Light theme is on'}
+                  </Text>
+                </View>
+              </View>
+              <Switch
+                value={isDark}
+                onValueChange={(enabled) =>
+                  void setThemePreference(enabled ? 'dark' : 'light')
+                }
+                trackColor={{ false: theme.switchTrackFalse, true: theme.switchTrackTrue }}
+                thumbColor={isDark ? theme.switchThumbTrue : theme.switchThumbFalse}
+                ios_backgroundColor={theme.switchIosBg}
+                accessibilityLabel="Toggle dark mode"
+              />
+            </View>
 
             <View style={styles.menuDivider} />
 


### PR DESCRIPTION
## 📋 Summary

Overhauls the map view with custom category-aware markers, rich event callouts with image previews, dense-coordinate jitter logic, and a floating header layout.

Also introduces a shared `eventCategoryPresentation` utility that drives consistently colored and emoji-labeled category badges across cards, the detail screen, and map callouts.

## 🔄 Changes

- Added `src/utils/eventCategoryPresentation.ts`
  - Maps 23 known category names to emoji + light/dark color pairs
  - Uses a hash-based fallback for unknown categories
  - Computes a WCAG-friendly text color from the background luminance

- Replaced plain pin markers in `EventMapView` with custom `EventMapMarker` components:
  - Emoji bubble with category color
  - Pointer tail
  - Group-size badge for stacked coordinates
  - Selection state with scale + shadow pop

- Added coordinate jitter via `getDenseMarkerOffset`
  - Events sharing the same location now spread into a ring instead of stacking invisibly

- Replaced the plain text callout with a rich card:
  - Event image with placeholder fallback on load error
  - Category pill
  - Title
  - Date, address, and participant meta
  - `"Tap to view"` hint

- Eagerly prefetches event images with `Image.prefetch`
  - Helps the Android `InfoWindow` bitmap snapshot capture a fully-loaded image before the callout opens

- Defers `showCallout` on Android until image prefetch resolves
  - `useFocusEffect` re-shows the callout when returning from the detail screen
  - Guarded by a `suppressNextDeselect` ref to prevent the outgoing navigation deselect from clearing state

- Introduced map padding via `DISCOVERY_MAP_PADDING`
  - Clears the floating header and bottom tab bar from the map's usable region

- Made the Home view header float as an absolutely positioned overlay in map mode:
  - `mapTopSection`
  - `mapContainer`
  - `mapWrapper`

- The map now extends edge-to-edge behind the floating header

- Applied `getEventCategoryPresentation` to category badges in:
  - `EventCard`
  - `ProfileEventCard`
  - `EventDetailView`

- Replaced the hardcoded `rgba(15, 23, 42, 0.72)` dark overlay with per-category colors and emoji labels

- Added `jest/mocks/react-native-maps.js`

- Added comprehensive tests:
  - `EventMapView.test.tsx`
    - Rendering
    - Marker selection
    - Callout open
    - Image prefetch
    - Jitter
    - Empty/loading states
  - `ProfileEventCard.test.tsx`
  - `eventCategoryPresentation.test.ts`

## ⚠️ Known Android Limitations

- **Callout image flicker on Android**
  - The `InfoWindow` is rendered as a static bitmap snapshot.
  - Even with eager prefetching, fast consecutive taps or slow networks can produce a blank image slot before the prefetch resolves.
  - The workaround, deferring `showCallout` until `imageStatus !== undefined`, mitigates but does not fully eliminate this.

- **`tracksViewChanges` performance**
  - Keeping `tracksViewChanges={true}` until the callout image loads causes Android to re-snapshot the native marker on every frame during that window.
  - This can visibly drop frame rate when many markers are selected simultaneously or image loading is slow.

- **Callout tap area on Android**
  - The `onPress` inside a `<Callout tooltip>` has a smaller hit area on Android than on iOS due to the `InfoWindow` intercept layer.
  - Tapping near the edges of the callout may not register.

- **`useFocusEffect` callout re-show**
  - On some Android versions, the 200 ms delay in `useFocusEffect` is not always sufficient after a back-navigation animation.
  - The callout may briefly not appear on return from the event detail screen.

## 🧪 Testing

```bash
cd mobile
npm test
```


## Manual Verification

- Map launches with colored emoji markers
- Dense pins spread into a ring
- Tapping a marker pops the bubble and shows the rich callout card with image
- Tapping the callout navigates to event detail
- Returning to the map re-shows the callout
- All category badges on event cards, profile cards, and the detail screen show the correct emoji and color in both light and dark mode

## 🔗 Related

Closes #553