### PR TITLE
feat(mobile): show approximate-location indicator for protected events

### DIFF
--- a/mobile/jest/mocks/react-native-maps.js
+++ b/mobile/jest/mocks/react-native-maps.js
@@ -13,6 +13,11 @@ const MAP_ONLY_PROPS = new Set([
   'region',
   'initialRegion',
   'coordinate',
+  'center',
+  'radius',
+  'fillColor',
+  'strokeColor',
+  'strokeWidth',
   'provider',
   'mapPadding',
   'anchor',
@@ -20,6 +25,7 @@ const MAP_ONLY_PROPS = new Set([
   'tooltip',
   'identifier',
   'zIndex',
+  'opacity',
   'onDeselect',
   'stopPropagation',
   'onPress',
@@ -63,6 +69,7 @@ const MapView = createMockComponent('div');
 const Marker = createMockComponent('div');
 const Callout = createMockComponent('div');
 const Polyline = createMockComponent('div');
+const Circle = createMockComponent('div');
 
 module.exports = {
   __esModule: true,
@@ -70,5 +77,6 @@ module.exports = {
   Marker,
   Callout,
   Polyline,
+  Circle,
   PROVIDER_GOOGLE: 'google',
 };

--- a/mobile/src/models/event.ts
+++ b/mobile/src/models/event.ts
@@ -71,6 +71,7 @@ export interface EventSummary {
   capacity?: number;
   favorite_count?: number;
   status?: string;
+  is_location_approximate?: boolean | null;
 }
 
 export type MyEventStatus =
@@ -163,6 +164,8 @@ export interface EventDetailLocation {
   point?: EventDetailPoint | null;
   route_points?: EventDetailPoint[];
   meeting_instructions?: string | null;
+  /** True when the backend has fuzzed the coordinates for a PROTECTED event. */
+  is_location_approximate?: boolean;
 }
 
 export interface EventDetailRatingWindow {

--- a/mobile/src/views/event/EventDetailView.test.tsx
+++ b/mobile/src/views/event/EventDetailView.test.tsx
@@ -232,6 +232,88 @@ describe('EventDetailView', () => {
     expect(screen.queryByText('Get Directions')).toBeNull();
   });
 
+  // ── approximate-location UX ────────────────────────────────────────────────
+
+  it('shows approximate-location banner and hides Get Directions for PROTECTED non-participant', () => {
+    const approxEvent = makeEvent({
+      privacy_level: 'PROTECTED',
+      location: { type: 'POINT', address: 'Kadikoy, Istanbul', point: { lat: 40.99, lon: 29.03 }, route_points: [], is_location_approximate: true },
+      viewer_context: {
+        is_host: false,
+        is_favorited: false,
+        participation_status: 'NONE',
+      },
+    });
+    mockUseEventDetailViewModel.mockReturnValue(
+      buildViewModel({ event: approxEvent, participationStatus: 'NONE' }),
+    );
+
+    render(<EventDetailView eventId="event-1" />);
+
+    expect(screen.getByTestId('approx-map-callout')).toBeTruthy();
+    expect(screen.getByText("You're seeing an approximate location")).toBeTruthy();
+    expect(screen.queryByText('Get Directions')).toBeNull();
+  });
+
+  it('hides the approximate-location callout and shows Get Directions for an approved participant', () => {
+    const exactEvent = makeEvent({
+      privacy_level: 'PROTECTED',
+      location: { type: 'POINT', address: 'Kadikoy, Istanbul', point: { lat: 40.99, lon: 29.03 }, route_points: [], is_location_approximate: false },
+      viewer_context: {
+        is_host: false,
+        is_favorited: false,
+        participation_status: 'JOINED',
+      },
+    });
+    mockUseEventDetailViewModel.mockReturnValue(
+      buildViewModel({ event: exactEvent, participationStatus: 'JOINED' }),
+    );
+
+    render(<EventDetailView eventId="event-1" />);
+
+    expect(screen.queryByTestId('approx-map-callout')).toBeNull();
+    expect(screen.getByText('Get Directions')).toBeTruthy();
+  });
+
+  it('hides approximate-location callout for the event host', () => {
+    const hostEvent = makeEvent({
+      privacy_level: 'PROTECTED',
+      location: { type: 'POINT', address: 'Kadikoy, Istanbul', point: { lat: 40.99, lon: 29.03 }, route_points: [], is_location_approximate: false },
+      viewer_context: {
+        is_host: true,
+        is_favorited: false,
+        participation_status: 'NONE',
+      },
+    });
+    mockUseEventDetailViewModel.mockReturnValue(
+      buildViewModel({ event: hostEvent }),
+    );
+
+    render(<EventDetailView eventId="event-1" />);
+
+    expect(screen.queryByTestId('approx-map-callout')).toBeNull();
+  });
+
+  it('shows approximate-location callout for a pending-request viewer', () => {
+    const pendingEvent = makeEvent({
+      privacy_level: 'PROTECTED',
+      location: { type: 'POINT', address: 'Kadikoy, Istanbul', point: { lat: 40.99, lon: 29.03 }, route_points: [], is_location_approximate: true },
+      viewer_context: {
+        is_host: false,
+        is_favorited: false,
+        participation_status: 'PENDING',
+      },
+    });
+    mockUseEventDetailViewModel.mockReturnValue(
+      buildViewModel({ event: pendingEvent, participationStatus: 'PENDING' }),
+    );
+
+    render(<EventDetailView eventId="event-1" />);
+
+    expect(screen.getByTestId('approx-map-callout')).toBeTruthy();
+    expect(screen.queryByText('Get Directions')).toBeNull();
+  });
+
   it('renders meeting instructions when available', () => {
     const eventWithInstructions = makeEvent({
       location: {

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -13,7 +13,7 @@ import {
   View,
   Alert,
 } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView, { Circle, Marker } from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Feather, Ionicons, MaterialIcons } from '@expo/vector-icons';
@@ -367,6 +367,9 @@ function ParticipantRatingSection({
     </>
   );
 }
+
+/** Radius (metres) of the circle drawn around a fuzzed PROTECTED event location. */
+const APPROX_LOCATION_RADIUS_METERS = 500;
 
 const darkMapStyle = [
   { elementType: 'geometry', stylers: [{ color: '#242f3e' }] },
@@ -854,6 +857,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                 style={styles.miniMapContainer}
                 onPress={() => setIsMapModalVisible(true)}
                 activeOpacity={0.9}
+                testID="mini-map-touchable"
               >
                 <MapView
                   style={styles.miniMap}
@@ -861,33 +865,83 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                   region={{
                     latitude: event.location.point.lat,
                     longitude: event.location.point.lon,
-                    latitudeDelta: 0.005,
-                    longitudeDelta: 0.005,
+                    latitudeDelta:
+                      event.location.is_location_approximate &&
+                      !event.viewer_context.is_host &&
+                      event.viewer_context.participation_status !== 'JOINED'
+                        ? 0.04
+                        : 0.005,
+                    longitudeDelta:
+                      event.location.is_location_approximate &&
+                      !event.viewer_context.is_host &&
+                      event.viewer_context.participation_status !== 'JOINED'
+                        ? 0.04
+                        : 0.005,
                   }}
                   scrollEnabled={false}
                   zoomEnabled={false}
                   pitchEnabled={false}
                   rotateEnabled={false}
                 >
-                  <Marker
-                    coordinate={{
-                      latitude: event.location.point.lat,
-                      longitude: event.location.point.lon,
-                    }}
-                  />
+                  {(() => {
+                    const showApprox =
+                      event.location.is_location_approximate &&
+                      !event.viewer_context.is_host &&
+                      event.viewer_context.participation_status !== 'JOINED';
+                    return (
+                      <>
+                        <Marker
+                          coordinate={{
+                            latitude: event.location.point!.lat,
+                            longitude: event.location.point!.lon,
+                          }}
+                          opacity={showApprox ? 0.5 : 1}
+                        />
+                        {showApprox ? (
+                          <Circle
+                            center={{
+                              latitude: event.location.point!.lat,
+                              longitude: event.location.point!.lon,
+                            }}
+                            radius={APPROX_LOCATION_RADIUS_METERS}
+                            fillColor="rgba(251,191,36,0.15)"
+                            strokeColor="rgba(217,119,6,0.6)"
+                            strokeWidth={2}
+                            testID="approx-location-circle"
+                          />
+                        ) : null}
+                      </>
+                    );
+                  })()}
                 </MapView>
                 <View style={styles.miniMapOverlay}>
                   <Feather name="maximize-2" size={20} color="white" />
                 </View>
               </TouchableOpacity>
-              <TouchableOpacity
-                style={styles.directionsButton}
-                onPress={handleGetDirections}
-                activeOpacity={0.8}
-              >
-                <MaterialIcons name="directions" size={20} color={theme.primary} />
-                <Text style={styles.directionsButtonText}>Get Directions</Text>
-              </TouchableOpacity>
+              {event.location.is_location_approximate &&
+              !event.viewer_context.is_host &&
+              event.viewer_context.participation_status !== 'JOINED' ? (
+                <View style={styles.approxMapCallout} testID="approx-map-callout">
+                  <Feather name="alert-triangle" size={16} color={theme.warningText} />
+                  <View style={styles.approxMapCalloutBody}>
+                    <Text style={styles.approxMapCalloutTitle}>
+                      You're seeing an approximate location
+                    </Text>
+                    <Text style={styles.approxMapCalloutDesc}>
+                      The exact location will be revealed once you're approved to join.
+                    </Text>
+                  </View>
+                </View>
+              ) : (
+                <TouchableOpacity
+                  style={styles.directionsButton}
+                  onPress={handleGetDirections}
+                  activeOpacity={0.8}
+                >
+                  <MaterialIcons name="directions" size={20} color={theme.primary} />
+                  <Text style={styles.directionsButtonText}>Get Directions</Text>
+                </TouchableOpacity>
+              )}
             </View>
           )}
         </View>
@@ -1216,8 +1270,18 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
               initialRegion={{
                 latitude: vm.event.location.point.lat,
                 longitude: vm.event.location.point.lon,
-                latitudeDelta: 0.01,
-                longitudeDelta: 0.01,
+                latitudeDelta:
+                  vm.event.location.is_location_approximate &&
+                  !vm.event.viewer_context.is_host &&
+                  vm.event.viewer_context.participation_status !== 'JOINED'
+                    ? 0.05
+                    : 0.01,
+                longitudeDelta:
+                  vm.event.location.is_location_approximate &&
+                  !vm.event.viewer_context.is_host &&
+                  vm.event.viewer_context.participation_status !== 'JOINED'
+                    ? 0.05
+                    : 0.01,
               }}
             >
               <Marker
@@ -1227,7 +1291,28 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                 }}
                 title={vm.event.title}
                 description={vm.event.location.address || ''}
+                opacity={
+                  vm.event.location.is_location_approximate &&
+                  !vm.event.viewer_context.is_host &&
+                  vm.event.viewer_context.participation_status !== 'JOINED'
+                    ? 0.5
+                    : 1
+                }
               />
+              {vm.event.location.is_location_approximate &&
+              !vm.event.viewer_context.is_host &&
+              vm.event.viewer_context.participation_status !== 'JOINED' ? (
+                <Circle
+                  center={{
+                    latitude: vm.event.location.point.lat,
+                    longitude: vm.event.location.point.lon,
+                  }}
+                  radius={APPROX_LOCATION_RADIUS_METERS}
+                  fillColor="rgba(251,191,36,0.15)"
+                  strokeColor="rgba(217,119,6,0.6)"
+                  strokeWidth={2}
+                />
+              ) : null}
             </MapView>
 
             <SafeAreaView style={styles.fullMapHeader}>
@@ -1242,20 +1327,28 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                   {vm.event.title}
                 </Text>
                 <Text style={styles.fullMapSubtitle} numberOfLines={1}>
-                  {vm.event.location.address}
+                  {vm.event.location.is_location_approximate &&
+                  !vm.event.viewer_context.is_host &&
+                  vm.event.viewer_context.participation_status !== 'JOINED'
+                    ? 'Approximate location'
+                    : vm.event.location.address}
                 </Text>
               </View>
             </SafeAreaView>
 
-            <View style={styles.fullMapFooter}>
-              <TouchableOpacity
-                style={styles.fullMapDirectionsBtn}
-                onPress={handleGetDirections}
-              >
-                <MaterialIcons name="directions" size={24} color="white" />
-                <Text style={styles.fullMapDirectionsText}>Open in Navigation</Text>
-              </TouchableOpacity>
-            </View>
+            {(!vm.event.location.is_location_approximate ||
+              vm.event.viewer_context.is_host ||
+              vm.event.viewer_context.participation_status === 'JOINED') && (
+              <View style={styles.fullMapFooter}>
+                <TouchableOpacity
+                  style={styles.fullMapDirectionsBtn}
+                  onPress={handleGetDirections}
+                >
+                  <MaterialIcons name="directions" size={24} color="white" />
+                  <Text style={styles.fullMapDirectionsText}>Open in Navigation</Text>
+                </TouchableOpacity>
+              </View>
+            )}
           </View>
         </Modal>
       )}
@@ -1915,6 +2008,31 @@ function makeStyles(t: Theme, isDark: boolean) {
       fontSize: 14,
       fontWeight: '500',
       lineHeight: 20,
+    },
+    approxMapCallout: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: 10,
+      paddingHorizontal: 14,
+      paddingVertical: 12,
+      borderTopWidth: 1,
+      borderTopColor: t.warningBorder,
+      backgroundColor: t.warningBg,
+    },
+    approxMapCalloutBody: {
+      flex: 1,
+      gap: 2,
+    },
+    approxMapCalloutTitle: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: t.warningText,
+    },
+    approxMapCalloutDesc: {
+      fontSize: 12,
+      lineHeight: 17,
+      color: t.warningText,
+      opacity: 0.85,
     },
     errorBanner: {
       backgroundColor: t.errorBg,


### PR DESCRIPTION
## 📋 Summary

Implements the mobile counterpart of the approximate-location UX for Protected events.

Non-participant viewers now see a clear warning that the displayed map location is fuzzed, while hosts and approved participants always see the exact coordinates.

## 🔄 Changes

- Added `is_location_approximate?: boolean` to `EventDetailLocation` in `src/models/event.ts`
  - Matches the backend wire shape where the flag is nested inside the `location` object on the detail endpoint.

- Added `is_location_approximate?: boolean | null` to `EventSummary` in `src/models/event.ts`
  - Matches the top-level field returned by the discovery list endpoint.

- Updated `EventDetailView.tsx` to render approximate-location UX when `event.location.is_location_approximate` is `true` and the viewer is neither the host nor an approved participant:
  - Mini-map and full-screen map zoom out to show the fuzzy area.
  - Map marker is rendered at 50% opacity.
  - Circle overlay with a `500 m` radius and amber fill/stroke is drawn around the fuzzed coordinate.
  - Warning callout is shown inside the map card:

    > You're seeing an approximate location — The exact location will be revealed once you're approved to join.

  - `Get Directions` / `Open in Navigation` buttons are hidden because directions to a fuzzed point would be misleading.
  - Full-screen map subtitle shows `Approximate location` instead of the address.

- Suppressed all approximate-location elements for hosts and `JOINED` participants:
  - Exact coordinates are shown.
  - Directions remain available.
  - Pinpoint zoom is used.
  - No warning or fuzzy-area circle is displayed.

- Added `Circle` to `jest/mocks/react-native-maps.js`.

- Extended `MAP_ONLY_PROPS` with:
  - `center`
  - `radius`
  - `fillColor`
  - `strokeColor`
  - `strokeWidth`
  - `opacity`

  This ensures `Circle` props are stripped cleanly in `jsdom` tests.

## 🧪 Testing

```bash
cd mobile
npm test
```

Manual verification on device/simulator:

- Open a Protected event as a non-participant
  - Approximate warning callout is visible.
  - Directions are hidden.
  - Circle overlay appears on the map.

- Open the same event after being approved
  - Exact pin is shown.
  - Normal zoom is used.
  - Directions are available.
  - No warning is displayed.

- Open a Protected event as the host
  - Exact pin is shown.
  - No warning is displayed.
  - Directions are available.

- Public events are unaffected.

## 🔗 Related

Closes #491