### PR TITLE
feat(mobile): implement join request withdrawal and invitation revoca…

### DIFF
--- a/mobile/src/components/events/InvitationsModal.tsx
+++ b/mobile/src/components/events/InvitationsModal.tsx
@@ -13,6 +13,7 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  Alert,
 } from 'react-native';
 import { Feather, MaterialIcons } from '@expo/vector-icons';
 import { EventDetailInvitation } from '@/models/event';
@@ -26,6 +27,7 @@ interface InvitationsModalProps {
   onLoadMore: () => void;
   onClose: () => void;
   onInvite: (usernames: string[], message?: string) => Promise<void>;
+  onRevoke?: (invitationId: string) => Promise<void>;
   isInviting: boolean;
   userSearchQuery: string;
   setUserSearchQuery: (query: string) => void;
@@ -41,6 +43,7 @@ export default function InvitationsModal({
   onLoadMore,
   onClose,
   onInvite,
+  onRevoke,
   isInviting,
   userSearchQuery,
   setUserSearchQuery,
@@ -131,6 +134,8 @@ export default function InvitationsModal({
         return { bg: '#DCFCE7', text: '#16A34A', label: 'Accepted' };
       case 'DECLINED':
         return { bg: '#FEE2E2', text: '#DC2626', label: 'Declined' };
+      case 'CANCELED':
+        return { bg: '#F3F4F6', text: '#6B7280', label: 'Revoked' };
       default:
         return { bg: '#FEF3C7', text: '#D97706', label: 'Pending' };
     }
@@ -144,7 +149,7 @@ export default function InvitationsModal({
       onRequestClose={onClose}
     >
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={{ flex: 1 }}
       >
         <TouchableOpacity
@@ -261,6 +266,8 @@ export default function InvitationsModal({
               data={invitations}
               keyExtractor={(item) => item.invitation_id}
               contentContainerStyle={styles.list}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
               renderItem={({ item }) => {
                 const status = getStatusStyle(item.status);
                 return (
@@ -288,6 +295,28 @@ export default function InvitationsModal({
                         {status.label}
                       </Text>
                     </View>
+
+                    {item.status === 'PENDING' && !!onRevoke && (
+                      <TouchableOpacity
+                        style={styles.revokeBtn}
+                        onPress={() => {
+                          Alert.alert(
+                            'Revoke Invitation',
+                            `Are you sure you want to revoke the invitation for @${item.user.username}?`,
+                            [
+                              { text: 'Cancel', style: 'cancel' },
+                              {
+                                text: 'Revoke',
+                                style: 'destructive',
+                                onPress: () => void onRevoke(item.invitation_id),
+                              },
+                            ],
+                          );
+                        }}
+                      >
+                        <Feather name="trash-2" size={18} color="#DC2626" />
+                      </TouchableOpacity>
+                    )}
                   </View>
                 );
               }}
@@ -566,5 +595,14 @@ const styles = StyleSheet.create({
   loadMoreText: {
     color: '#7C3AED',
     fontWeight: '600',
+  },
+  revokeBtn: {
+    marginLeft: 12,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: '#FEF2F2',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/mobile/src/services/eventService.ts
+++ b/mobile/src/services/eventService.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiGetAuth, apiPostAuth, apiPatchAuth, apiPutAuth } from '@/services/api';
+import { apiGet, apiGetAuth, apiPostAuth, apiPatchAuth, apiPutAuth, apiDeleteAuth } from '@/services/api';
 import * as FileSystem from 'expo-file-system/legacy';
 import {
   PrivacyLevel,
@@ -170,6 +170,13 @@ export async function requestJoinEvent(
   token: string,
 ): Promise<RequestJoinResponse> {
   return apiPostAuth<RequestJoinResponse>(`/events/${id}/join-request`, body, token);
+}
+
+export async function withdrawJoinRequest(
+  eventId: string,
+  token: string,
+): Promise<void> {
+  return apiDeleteAuth<void>(`/events/${eventId}/join-requests/me`, token);
 }
 
 export async function approveJoinRequest(

--- a/mobile/src/services/invitationService.ts
+++ b/mobile/src/services/invitationService.ts
@@ -1,4 +1,4 @@
-import { apiGetAuth, apiPostAuth } from './api';
+import { apiGetAuth, apiPostAuth, apiDeleteAuth } from './api';
 import {
   AcceptInvitationResponse,
   DeclineInvitationResponse,
@@ -38,4 +38,15 @@ export async function declineInvitation(
     {},
     token,
   );
+}
+
+/**
+ * Revokes a pending invitation (Host only).
+ */
+export async function revokeInvitation(
+  eventId: string,
+  invitationId: string,
+  token: string,
+): Promise<void> {
+  return apiDeleteAuth<void>(`/events/${eventId}/invitations/${invitationId}`, token);
 }

--- a/mobile/src/viewmodels/event/useEventDetailViewModel.test.tsx
+++ b/mobile/src/viewmodels/event/useEventDetailViewModel.test.tsx
@@ -84,6 +84,8 @@ const mockAcceptInvitation = jest.mocked(invitationService.acceptInvitation);
 const mockDeclineInvitation = jest.mocked(invitationService.declineInvitation);
 const mockGetJoinRequestImageUploadUrl = jest.mocked(eventService.getJoinRequestImageUploadUrl);
 const mockUploadFileToPresignedUrl = jest.mocked(eventService.uploadFileToPresignedUrl);
+const mockWithdrawJoinRequest = jest.mocked(eventService.withdrawJoinRequest);
+const mockRevokeInvitation = jest.mocked(invitationService.revokeInvitation);
 
 const mockImagePicker = jest.mocked(ImagePicker);
 const mockImageManipulator = jest.mocked(ImageManipulator);
@@ -435,6 +437,8 @@ describe('useEventDetailViewModel', () => {
     mockDeclineInvitation.mockResolvedValue({
       message: 'Invitation declined',
     });
+    mockWithdrawJoinRequest.mockResolvedValue(undefined);
+    mockRevokeInvitation.mockResolvedValue(undefined);
   });
 
   // ─── Initial loading state ───
@@ -1684,12 +1688,6 @@ describe('useEventDetailViewModel', () => {
       const { result } = renderHook(() => useEventDetailViewModel('event-uuid-002'));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      // Manually set image (or use pickImage)
-      act(() => {
-        // We can't set it directly as it's not in the return object as a setter, 
-        // so we'll use pickImage mock
-      });
-      
       mockImagePicker.requestMediaLibraryPermissionsAsync.mockResolvedValueOnce({ status: 'granted' } as any);
       mockImagePicker.launchImageLibraryAsync.mockResolvedValueOnce({
         canceled: false,
@@ -1731,12 +1729,10 @@ describe('useEventDetailViewModel', () => {
       const { result } = renderHook(() => useEventDetailViewModel('event-uuid-002'));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      // 1. Pick image
       await act(async () => {
         await result.current.pickImage();
       });
 
-      // 2. Request join
       await act(async () => {
         await result.current.handleRequestJoin();
       });
@@ -1749,6 +1745,66 @@ describe('useEventDetailViewModel', () => {
         'mock-token',
       );
       expect(result.current.selectedImageUri).toBeNull();
+    });
+  });
+
+  describe('handleCancelJoinRequest', () => {
+    it('calls withdrawJoinRequest, clears status, and refreshes event', async () => {
+      const pendingEvent: EventDetail = {
+        ...protectedEventFixture,
+        viewer_context: { ...protectedEventFixture.viewer_context, participation_status: 'PENDING' },
+      };
+      mockGetEventDetail
+        .mockResolvedValueOnce(pendingEvent)
+        .mockResolvedValueOnce(protectedEventFixture); // back to none
+
+      const { result } = renderHook(() => useEventDetailViewModel(pendingEvent.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleCancelJoinRequest();
+      });
+
+      expect(mockWithdrawJoinRequest).toHaveBeenCalledWith(pendingEvent.id, 'mock-token');
+      expect(result.current.participationStatus).toBe('NONE');
+      expect(result.current.actionState).toBe('idle');
+    });
+
+    it('handles 409 conflict by refreshing and showing an error', async () => {
+      const pendingEvent: EventDetail = {
+        ...protectedEventFixture,
+        viewer_context: { ...protectedEventFixture.viewer_context, participation_status: 'PENDING' },
+      };
+      mockGetEventDetail.mockResolvedValue(pendingEvent);
+      mockWithdrawJoinRequest.mockRejectedValueOnce(new ApiError(409, { error: { code: 'not_pending', message: 'Not pending' } }));
+
+      const { result } = renderHook(() => useEventDetailViewModel(pendingEvent.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleCancelJoinRequest();
+      });
+
+      expect(result.current.actionError).toBe('This request is no longer pending.');
+      expect(mockGetEventDetail).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('handleRevokeInvitation', () => {
+    it('calls revokeInvitation and refreshes host context', async () => {
+      const eventId = hostedEventFixture.id;
+      mockGetEventDetail.mockResolvedValue(hostedEventFixture);
+
+      const { result } = renderHook(() => useEventDetailViewModel(eventId));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleRevokeInvitation('inv-123');
+      });
+
+      expect(mockRevokeInvitation).toHaveBeenCalledWith(eventId, 'inv-123', 'mock-token');
+      expect(mockGetEventHostContextSummary).toHaveBeenCalledTimes(3);
+      expect(result.current.actionState).toBe('idle');
     });
   });
 });

--- a/mobile/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/mobile/src/viewmodels/event/useEventDetailViewModel.ts
@@ -22,11 +22,13 @@ import {
   upsertParticipantRating,
   listEventInvitations,
   createEventInvitations,
+  withdrawJoinRequest,
 } from '@/services/eventService';
 import {
   acceptInvitation,
   declineInvitation,
   listMyInvitations,
+  revokeInvitation,
 } from '@/services/invitationService';
 import { addFavorite, removeFavorite } from '@/services/favoriteService';
 import { useAuth } from '@/contexts/AuthContext';
@@ -51,7 +53,9 @@ export type ActionState =
   | 'success_joined'
   | 'success_left'
   | 'success_requested'
-  | 'success_saved';
+  | 'success_saved'
+  | 'canceling_request'
+  | 'revoking_invitation';
 
 export interface EventDetailViewModel {
   event: EventDetail | null;
@@ -118,12 +122,13 @@ export interface EventDetailViewModel {
   handleApproveRequest: (joinRequestId: string) => Promise<void>;
   handleRejectRequest: (joinRequestId: string) => Promise<void>;
   handleCancelEvent: () => Promise<void>;
-
   selectedImageUri: string | null;
   isUploadingImage: boolean;
   imageError: string | null;
   pickImage: () => Promise<void>;
   removeImage: () => void;
+  handleCancelJoinRequest: () => Promise<void>;
+  handleRevokeInvitation: (invitationId: string) => Promise<void>;
 }
 
 function mapRatingError(err: ApiError, fallback: string): string {
@@ -656,6 +661,31 @@ export function useEventDetailViewModel(eventId: string): EventDetailViewModel {
     }
   }, [token, event, joinRequestMessage, selectedImageUri, uploadJoinRequestImage]);
 
+  const handleCancelJoinRequest = useCallback(async () => {
+    if (!token || !event) return;
+ 
+    setActionError(null);
+    setActionState('canceling_request');
+ 
+    try {
+      await withdrawJoinRequest(event.id, token);
+      setParticipationStatus(null);
+      await fetchEvent(true);
+      setActionState('idle');
+    } catch (err: unknown) {
+      setActionState('idle');
+      if (err instanceof ApiError && err.status === 409) {
+        // Request no longer pending
+        await fetchEvent(true);
+        setActionError('This request is no longer pending.');
+      } else if (err && typeof err === 'object' && 'message' in err) {
+        setActionError((err as { message: string }).message);
+      } else {
+        setActionError('Failed to cancel join request. Please try again.');
+      }
+    }
+  }, [token, event, fetchEvent]);
+ 
   const resolveCurrentInvitationID = useCallback(async () => {
     if (!token || !event) return null;
 
@@ -860,6 +890,30 @@ export function useEventDetailViewModel(eventId: string): EventDetailViewModel {
     }
   }, [token, event, fetchEvent]);
 
+  const handleRevokeInvitation = useCallback(async (invitationId: string) => {
+    if (!token || !event) return;
+
+    setActionError(null);
+    setActionState('revoking_invitation');
+
+    try {
+      await revokeInvitation(event.id, invitationId, token);
+      await refreshHostContextSummary();
+      setInvitations([]);
+      setInvitationsCursor(null);
+      setInvitationsHasNext(false);
+      await loadMoreInvitations();
+      setActionState('idle');
+    } catch (err: unknown) {
+      setActionState('idle');
+      if (err && typeof err === 'object' && 'message' in err) {
+        setActionError((err as { message: string }).message);
+      } else {
+        setActionError('Failed to revoke invitation.');
+      }
+    }
+  }, [token, event, refreshHostContextSummary, loadMoreInvitations]);
+
   const openJoinRequestModal = useCallback(() => {
     setActionError(null);
     setShowJoinRequestModal(true);
@@ -958,12 +1012,11 @@ export function useEventDetailViewModel(eventId: string): EventDetailViewModel {
     isFavorited,
     participationStatus,
     isQuotaFull,
+    constraintViolation,
     viewerRatingLoading,
     viewerRatingError,
     participantRatingLoadingId,
     participantRatingError,
-    canLeave,
-    constraintViolation,
     showJoinRequestModal,
     joinRequestMessage,
     selectedImageUri,
@@ -974,6 +1027,19 @@ export function useEventDetailViewModel(eventId: string): EventDetailViewModel {
     pickImage,
     removeImage,
     setJoinRequestMessage,
+    userSearchQuery,
+    setUserSearchQuery,
+    userSuggestions,
+    isSearchingUsers,
+    showInvitationsModal,
+    setShowInvitationsModal,
+    invitations,
+    invitationsLoading,
+    invitationsHasNext,
+    loadMoreInvitations,
+    handleInviteUsers,
+    isInviting,
+    canLeave,
     handleJoin,
     handleLeaveEvent,
     handleRequestJoin,
@@ -989,22 +1055,12 @@ export function useEventDetailViewModel(eventId: string): EventDetailViewModel {
     setShowRequestsModal,
     showAttendeesModal,
     setShowAttendeesModal,
-    showInvitationsModal,
-    setShowInvitationsModal,
-    invitations,
-    invitationsLoading,
-    invitationsHasNext,
-    loadMoreInvitations,
-    handleInviteUsers,
-    isInviting,
-    userSearchQuery,
-    setUserSearchQuery,
-    userSuggestions,
-    isSearchingUsers,
     loadMoreApprovedParticipants,
     loadMorePendingJoinRequests,
     handleApproveRequest,
     handleRejectRequest,
     handleCancelEvent,
+    handleCancelJoinRequest,
+    handleRevokeInvitation,
   };
 }

--- a/mobile/src/views/event/CreateEventView.test.tsx
+++ b/mobile/src/views/event/CreateEventView.test.tsx
@@ -58,6 +58,16 @@ jest.mock('@react-native-community/datetimepicker', () => {
   };
 });
 
+jest.mock('@/components/events/PointPickerMap', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'PointPickerMap' });
+});
+
+jest.mock('@/components/events/RoutePointsEditor', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'RoutePointsEditor' });
+});
+
 jest.mock('@/contexts/AuthContext', () => ({
   useAuth: jest.fn(),
 }));

--- a/mobile/src/views/event/EventDetailView.test.tsx
+++ b/mobile/src/views/event/EventDetailView.test.tsx
@@ -171,6 +171,8 @@ function buildViewModel(
     setUserSearchQuery: jest.fn(),
     userSuggestions: [],
     isSearchingUsers: false,
+    handleCancelJoinRequest: jest.fn().mockResolvedValue(undefined),
+    handleRevokeInvitation: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -585,7 +585,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
       return (
         <View>
           <View style={styles.statusChip}>
-            <Ionicons name="checkmark-circle" size={16} color="#059669" />
+            <Ionicons name="checkmark-circle" size={16} color={theme.successText} />
             <Text style={styles.statusChipTextGreen}>{attendedLabel}</Text>
           </View>
           {vm.canLeave && (
@@ -620,9 +620,42 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
 
     if (status_ === 'PENDING' || vm.actionState === 'success_requested') {
       return (
-        <View style={styles.statusChip}>
-          <Feather name="clock" size={16} color="#D97706" />
-          <Text style={styles.statusChipTextAmber}>Request sent — awaiting approval</Text>
+        <View>
+          <View style={styles.statusChip}>
+            <Feather name="clock" size={16} color={theme.warningText} />
+            <Text style={styles.statusChipTextAmber}>Request sent — awaiting approval</Text>
+          </View>
+          <TouchableOpacity
+            style={[
+              styles.leaveButton,
+              vm.actionState === 'canceling_request' && styles.actionButtonLoading,
+            ]}
+            onPress={() => {
+              Alert.alert(
+                'Cancel Request',
+                'Are you sure you want to withdraw your join request?',
+                [
+                  { text: 'No', style: 'cancel' },
+                  {
+                    text: 'Yes, Cancel',
+                    style: 'destructive',
+                    onPress: vm.handleCancelJoinRequest,
+                  },
+                ],
+              );
+            }}
+            disabled={vm.actionState === 'canceling_request'}
+            activeOpacity={0.8}
+          >
+            {vm.actionState === 'canceling_request' ? (
+              <ActivityIndicator color="#DC2626" size="small" />
+            ) : (
+              <>
+                <Feather name="x-circle" size={18} color="#DC2626" />
+                <Text style={styles.leaveButtonText}>Cancel Request</Text>
+              </>
+            )}
+          </TouchableOpacity>
         </View>
       );
     }
@@ -631,7 +664,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
       return (
         <View>
           <View style={styles.statusChip}>
-            <Feather name="mail" size={16} color="#111827" />
+            <Feather name="mail" size={16} color={theme.infoText} />
             <Text style={styles.statusChipTextBlue}>You&apos;re invited</Text>
           </View>
 
@@ -1357,6 +1390,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
             onLoadMore={vm.loadMoreInvitations}
             onClose={() => vm.setShowInvitationsModal(false)}
             onInvite={vm.handleInviteUsers}
+            onRevoke={vm.handleRevokeInvitation}
             isInviting={vm.isInviting}
             userSearchQuery={vm.userSearchQuery}
             setUserSearchQuery={vm.setUserSearchQuery}


### PR DESCRIPTION
# Implementing Join Request Cancellation and Invitation Revocation

## 📋 Summary

Implements the functional cycle for canceling event participation and managing invitations on mobile. Requesters can now withdraw their own pending join requests, and hosts can revoke pending invitations directly from the management modal.

## 🔄 Changes

- **Service Layer Updates:**
  - Added `withdrawJoinRequest` to `eventService.ts` targeting `DELETE /events/:id/join-requests/me`.
  - Added `revokeInvitation` to `invitationService.ts` targeting `DELETE /events/:id/invitations/:invitationId`.

- **ViewModel Logic (`useEventDetailViewModel.ts`):**
  - Integrated `handleCancelJoinRequest` and `handleRevokeInvitation` actions with full loading/error state management.
  - Implemented 409 Conflict handling to gracefully recover (by refreshing) if a request is no longer pending.
  - Optimized the invitation list refresh logic after revocation by resetting cursors and reloading the first page.

- **Participant UI Updates (`EventDetailView.tsx`):**
  - Added a "Cancel Request" button for pending join requests with a native `Alert` confirmation dialog.
  - Automatically resets local state to allow immediate re-application after withdrawal.

- **Host UI Updates (`InvitationsModal.tsx`):**
  - Added a "Revoke" action (trash icon) next to pending invitations with a native `Alert` confirmation.
  - Introduced a "Revoked" status label for canceled invitations to provide clear feedback.
  - Fixed modal jitter issues when typing on Android by adjusting `KeyboardAvoidingView` behavior.
  - Improved scroll interaction by adding `keyboardShouldPersistTaps` to the invitation list.

- **Design Polish:**
  - Standardized status chip icons (mail, clock, checkmark) to use theme-aware colors, resolving visibility issues in Dark Mode (specifically for the "You're invited" banner).

- **Test Coverage:**
  - Added unit tests for new actions in `useEventDetailViewModel.test.tsx`.
  - Resolved React `testID` warnings in `HomeHeader.test.tsx` by filtering DOM props in mocks.

## 🧪 Testing

```bash
cd mobile
npm test
```

### Manual verification on device/simulator:

- As Participant:

  - Send a join request -> "Cancel Request" button appears -> Click and confirm -> Status is withdrawn, and "Request to Join" button reappears.

- As Host:

  - Invite a user -> Open "Manage Invitations" -> Click trash icon on a pending user -> Confirm -> Status changes to "Revoked" and button disappears.

## 🔗 Related

Closes #463 