### PR TITLE
fix(backend): change response ordering for comment replies

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -9,6 +9,8 @@ on:
       - "frontend/**"
       - "deploy/**"
       - "nginx/**"
+      - "docs/openapi/**"
+      - "docs/swagger-ui/**"
       - ".github/workflows/deploy-dev.yml"
   release:
     types:
@@ -129,7 +131,7 @@ jobs:
               printf '%s=%s\n' "$1" "$2" >> "$env_file"
             }
 
-            sudo mkdir -p /opt/sem/deploy /opt/sem/nginx
+            sudo mkdir -p /opt/sem/deploy /opt/sem/nginx /opt/sem/docs
             sudo chown -R "$(id -un)":"$(id -gn)" /opt/sem
 
             install -m 600 /dev/null "$env_file"
@@ -167,6 +169,15 @@ jobs:
           target: /opt/sem/nginx
           strip_components: 1
 
+      - name: Upload API documentation assets
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_DEV_IP_ADDRESS }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: docs/openapi,docs/swagger-ui
+          target: /opt/sem
+
       - name: Pull images and restart services
         uses: appleboy/ssh-action@v1.2.0
         env:
@@ -199,6 +210,8 @@ jobs:
 
             echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             $compose_cmd config -q
+            test -f docs/swagger-ui/index.html
+            test -f docs/openapi/auth.yaml
 
             postgres_id="$($compose_cmd ps -q postgres || true)"
             if [ -n "$postgres_id" ] && [ "$(docker inspect --format '{{.State.Running}}' "$postgres_id")" = "true" ]; then
@@ -243,18 +256,14 @@ jobs:
               exit 1
             }
 
-            nginx_id="$($compose_cmd ps -q nginx || true)"
-            if [ -n "$nginx_id" ] && [ "$(docker inspect --format '{{.State.Running}}' "$nginx_id")" = "true" ]; then
-              docker exec "$nginx_id" nginx -t
-              docker exec "$nginx_id" nginx -s reload
-            else
-              $compose_cmd up -d nginx
-            fi
+            $compose_cmd up -d nginx
 
             nginx_id="$(wait_for_container_running nginx 30)" || {
               echo "nginx container did not reach running state" >&2
               exit 1
             }
+            docker exec "$nginx_id" nginx -t
+            docker exec "$nginx_id" nginx -s reload
 
             for attempt in $(seq 1 30); do
               if docker exec "$nginx_id" wget -q -O /dev/null http://backend:8080/health; then
@@ -287,6 +296,19 @@ jobs:
               fi
               if [ "$attempt" -eq 30 ]; then
                 echo "nginx ingress smoke check failed" >&2
+                docker logs "$nginx_id"
+                exit 1
+              fi
+              sleep 2
+            done
+
+            for attempt in $(seq 1 30); do
+              if docker exec "$nginx_id" wget -q -O /dev/null --no-check-certificate https://127.0.0.1/api/docs/ && \
+                 docker exec "$nginx_id" wget -q -O /dev/null --no-check-certificate https://127.0.0.1/api/docs/openapi/auth.yaml; then
+                break
+              fi
+              if [ "$attempt" -eq 30 ]; then
+                echo "swagger docs ingress smoke check failed" >&2
                 docker logs "$nginx_id"
                 exit 1
               fi

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Useful local details:
 
 - Postgres is exposed at `127.0.0.1:5433` for local tools.
 - The dev-server compose file is different: [`deploy/docker-compose.dev.yml`](deploy/docker-compose.dev.yml) is for the remote droplet, not local development.
-- API docs are local-only; the shared dev deployment does not expose `/api/docs`.
+- API docs are exposed by both local Compose and the shared dev deployment at `/api/docs/`.
 
 `deploy/docker-compose.dev.yml` is different: on the dev host, Postgres is published on **127.0.0.1:5432** for manual inspection and SSH tunneling, still with user `postgres`, database `sem`, and password from `deploy/.env`. That exposure is dev-only and loopback-bound, not a production pattern. If host `5432` is already in use on the dev machine, use a local Compose override file for that machine instead of changing the shared dev compose file; [`docs/deploy.md`](docs/deploy.md) shows the pattern.
 

--- a/backend/internal/adapter/in/postgres/comment_repo.go
+++ b/backend/internal/adapter/in/postgres/comment_repo.go
@@ -30,6 +30,11 @@ func NewCommentRepository(pool *pgxpool.Pool) *CommentRepository {
 
 var _ commentapp.Repository = (*CommentRepository)(nil)
 
+const (
+	commentCursorBefore = "<"
+	commentCursorAfter  = ">"
+)
+
 func (r *CommentRepository) GetEventCommentContext(ctx context.Context, eventID uuid.UUID, viewerUserID *uuid.UUID) (*commentapp.EventCommentContext, error) {
 	var (
 		record                  commentapp.EventCommentContext
@@ -154,7 +159,7 @@ func (r *CommentRepository) GetDiscussionParentContext(ctx context.Context, even
 
 func (r *CommentRepository) ListTopLevelComments(ctx context.Context, eventID uuid.UUID, params commentapp.ListCommentsParams) ([]commentapp.CommentRecord, error) {
 	args := []any{eventID, string(params.CommentType)}
-	cursorClause := buildCommentCursorClause(params, &args, "ec.created_at", "ec.id")
+	cursorClause := buildCommentCursorClause(params, &args, "ec.created_at", "ec.id", commentCursorBefore)
 	args = append(args, params.RepositoryFetchLimit)
 
 	rows, err := r.db.Query(ctx, fmt.Sprintf(`
@@ -194,7 +199,7 @@ func (r *CommentRepository) ListTopLevelComments(ctx context.Context, eventID uu
 
 func (r *CommentRepository) ListReplies(ctx context.Context, eventID, parentID uuid.UUID, params commentapp.ListCommentsParams) ([]commentapp.CommentRecord, error) {
 	args := []any{eventID, parentID, string(domain.CommentTypeDiscussion)}
-	cursorClause := buildCommentCursorClause(params, &args, "ec.created_at", "ec.id")
+	cursorClause := buildCommentCursorClause(params, &args, "ec.created_at", "ec.id", commentCursorAfter)
 	args = append(args, params.RepositoryFetchLimit)
 
 	rows, err := r.db.Query(ctx, fmt.Sprintf(`
@@ -221,7 +226,7 @@ func (r *CommentRepository) ListReplies(ctx context.Context, eventID, parentID u
 		  AND ec.parent_id = $2
 		  AND ec.comment_type = $3
 		  %s
-		ORDER BY ec.created_at DESC, ec.id DESC
+		ORDER BY ec.created_at ASC, ec.id ASC
 		LIMIT $%d
 	`, cursorClause, len(args)), args...)
 	if err != nil {
@@ -310,14 +315,14 @@ func (r *CommentRepository) DeleteReviewComment(ctx context.Context, eventID, us
 	return tag.RowsAffected() == 1, nil
 }
 
-func buildCommentCursorClause(params commentapp.ListCommentsParams, args *[]any, createdAtColumn, idColumn string) string {
+func buildCommentCursorClause(params commentapp.ListCommentsParams, args *[]any, createdAtColumn, idColumn, comparator string) string {
 	if params.DecodedCursor == nil {
 		return ""
 	}
 	*args = append(*args, params.DecodedCursor.CreatedAt, params.DecodedCursor.CommentID)
 	createdAtIndex := len(*args) - 1
 	idIndex := len(*args)
-	return fmt.Sprintf("AND (%s, %s) < ($%d, $%d)", createdAtColumn, idColumn, createdAtIndex, idIndex)
+	return fmt.Sprintf("AND (%s, %s) %s ($%d, $%d)", createdAtColumn, idColumn, comparator, createdAtIndex, idIndex)
 }
 
 func scanCommentRecords(rows pgx.Rows, operation string) ([]commentapp.CommentRecord, error) {

--- a/backend/internal/adapter/in/postgres/comment_repo_test.go
+++ b/backend/internal/adapter/in/postgres/comment_repo_test.go
@@ -1,0 +1,30 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	commentapp "github.com/bounswe/bounswe2026group11/backend/internal/application/comment"
+	"github.com/google/uuid"
+)
+
+func TestBuildCommentCursorClauseUsesComparator(t *testing.T) {
+	// given
+	cursor := &commentapp.CommentCursor{
+		Collection: "REPLIES",
+		CreatedAt:  time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC),
+		CommentID:  uuid.New(),
+	}
+	args := []any{"event-id", "parent-id"}
+
+	// when
+	clause := buildCommentCursorClause(commentapp.ListCommentsParams{DecodedCursor: cursor}, &args, "ec.created_at", "ec.id", commentCursorAfter)
+
+	// then
+	if clause != "AND (ec.created_at, ec.id) > ($3, $4)" {
+		t.Fatalf("expected ascending cursor clause, got %q", clause)
+	}
+	if len(args) != 4 || args[2] != cursor.CreatedAt || args[3] != cursor.CommentID {
+		t.Fatalf("expected cursor args to be appended, got %#v", args)
+	}
+}

--- a/backend/internal/application/comment/service_dto.go
+++ b/backend/internal/application/comment/service_dto.go
@@ -78,8 +78,9 @@ type ListCommentsParams struct {
 	DecodedCursor        *CommentCursor
 }
 
-// CommentCursor is the opaque keyset cursor payload for comments ordered by
-// created_at DESC, id DESC.
+// CommentCursor is the opaque keyset cursor payload for comment collections.
+// Top-level collections use newest-first ordering; replies use oldest-first
+// ordering so a conversation reads chronologically.
 type CommentCursor struct {
 	Collection string    `json:"collection"`
 	CreatedAt  time.Time `json:"created_at"`

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -610,7 +610,8 @@ paths:
         The response always contains two independently paginated collections:
         `discussion_comments` and `review_comments`, both ordered by latest comment first.
         Child comments are not embedded; use `GET /events/{id}/comments/{commentId}/replies`
-        when the user chooses to see replies.
+        when the user chooses to see replies. Reply collections are ordered by oldest reply first
+        so threaded conversations read chronologically.
 
         PRIVATE events do not expose comments. If the authenticated caller can otherwise see
         the private event, the API returns `409 comments_not_allowed`; if not visible, it returns
@@ -751,7 +752,7 @@ paths:
     get:
       tags: [Events]
       summary: List replies for a discussion comment
-      description: Returns replies for a top-level DISCUSSION comment, ordered latest first.
+      description: Returns replies for a top-level DISCUSSION comment, ordered oldest first.
       operationId: listEventCommentReplies
       security:
         - bearerAuth: []


### PR DESCRIPTION
## 📋 Summary
Fixes event comment reply ordering and fixes Swagger UI availability on the dev deployment.

## 🔄 Changes
- Changed event comment replies to return oldest-first so threaded replies render chronologically.
- Kept top-level discussion and review comments newest-first.
- Updated reply pagination cursor behavior for ascending reply order.
- Added a focused backend test for reply cursor comparison.
- Updated OpenAPI docs to document oldest-first reply ordering.
- Updated dev deploy workflow to upload Swagger/OpenAPI assets to the server.
- Added `/api/docs/` and raw OpenAPI smoke checks after deploy.
- Updated README to reflect that API docs are exposed on dev.

## 🧪 Testing
- `go test ./internal/application/comment ./internal/adapter/in/postgres`
- Parsed `.github/workflows/deploy-dev.yml` successfully.
- `./shipcheck.sh` was run but failed at `govulncheck` due existing Go `1.26.2` standard library advisories fixed in Go `1.26.3`, unrelated to this change.

## 🔗 Related
Related to comment reply ordering UI bug and dev Swagger UI availability.
