### PR TITLE
feat(frontend): add tickets and cancel join request

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,8 @@ import EventDetailPage from './views/events/EventDetailPage';
 import MyEventsPage from './views/events/MyEventsPage';
 import InvitationsPage from './views/invitations/InvitationsPage';
 import NotificationsPage from './views/notifications/NotificationsPage';
+import TicketsPage from './views/tickets/TicketsPage';
+import TicketDetailPage from './views/tickets/TicketDetailPage';
 import FavoritesPage from './views/favorites/FavoritesPage';
 import ProfilePage from './views/profile/ProfilePage';
 import NotFoundView from './views/fallback/NotFoundView';
@@ -46,6 +48,8 @@ export default function App() {
         <Route path="/my-events" element={<ProtectedRoute><MyEventsPage /></ProtectedRoute>} />
         <Route path="/invitations" element={<ProtectedRoute><InvitationsPage /></ProtectedRoute>} />
         <Route path="/notifications" element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>} />
+        <Route path="/tickets" element={<ProtectedRoute><TicketsPage /></ProtectedRoute>} />
+        <Route path="/tickets/:ticketId" element={<ProtectedRoute><TicketDetailPage /></ProtectedRoute>} />
         <Route path="/favorites" element={<ProtectedRoute><FavoritesPage /></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
         <Route

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -179,6 +179,13 @@ export default function AppShell() {
                       >
                         Notifications
                       </NavLink>
+                      <NavLink
+                        to="/tickets"
+                        className="shell-dropdown-item"
+                        onClick={() => setUserMenuOpen(false)}
+                      >
+                        My Tickets
+                      </NavLink>
                       <button
                         className="shell-dropdown-item shell-dropdown-logout"
                         onClick={handleLogout}

--- a/frontend/src/models/ticket.ts
+++ b/frontend/src/models/ticket.ts
@@ -1,0 +1,65 @@
+export type TicketStatus = 'ACTIVE' | 'PENDING' | 'EXPIRED' | 'USED' | 'CANCELED';
+
+export type TicketParticipationStatus = 'APPROVED' | 'PENDING' | 'CANCELED' | 'LEAVED';
+
+export type TicketEventStatus = 'ACTIVE' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
+
+export interface TicketParticipation {
+  id: string;
+  status: TicketParticipationStatus;
+}
+
+export interface TicketEvent {
+  id: string;
+  title: string;
+  status: TicketEventStatus;
+  privacy_level: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
+  start_time: string;
+  end_time?: string | null;
+  location_type: 'POINT' | 'ROUTE';
+  address?: string | null;
+}
+
+export interface TicketListItem {
+  ticket_id: string;
+  status: TicketStatus;
+  expires_at: string;
+  event: TicketEvent;
+  participation: TicketParticipation;
+}
+
+export interface ListTicketsResponse {
+  items: TicketListItem[];
+}
+
+export interface TicketLocation {
+  type: 'POINT' | 'ROUTE';
+  address?: string | null;
+  anchor_lat: number;
+  anchor_lon: number;
+}
+
+export interface TicketQRAccess {
+  requires_location_permission: boolean;
+  requires_proximity: boolean;
+  proximity_meters: number;
+  eligible_now: boolean;
+  reason?: string;
+}
+
+export interface TicketDetail {
+  id: string;
+  status: TicketStatus;
+  expires_at: string;
+  used_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TicketDetailResponse {
+  ticket: TicketDetail;
+  participation: TicketParticipation;
+  event: TicketEvent;
+  location: TicketLocation;
+  qr_access: TicketQRAccess;
+}

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -235,6 +235,10 @@ export function getJoinRequestImageUploadUrl(
   );
 }
 
+export function cancelMyJoinRequest(eventId: string, token: string): Promise<void> {
+  return apiDeleteAuth<void>(`/events/${eventId}/join-requests/me`, token);
+}
+
 export function approveJoinRequest(
   eventId: string,
   joinRequestId: string,

--- a/frontend/src/services/ticketService.ts
+++ b/frontend/src/services/ticketService.ts
@@ -1,0 +1,13 @@
+import { apiGetAuth } from './api';
+import type { ListTicketsResponse, TicketDetailResponse } from '@/models/ticket';
+
+export function listMyTickets(token: string): Promise<ListTicketsResponse> {
+  return apiGetAuth<ListTicketsResponse>('/me/tickets', token);
+}
+
+export function getMyTicket(
+  ticketId: string,
+  token: string,
+): Promise<TicketDetailResponse> {
+  return apiGetAuth<TicketDetailResponse>(`/me/tickets/${ticketId}`, token);
+}

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -2016,6 +2016,65 @@
   }
 }
 
+/* View Ticket CTA */
+.ed-ticket-cta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  padding: 12px 14px;
+  background: linear-gradient(135deg, #ede9fe 0%, #f5f3ff 100%);
+  border: 1px solid #ddd6fe;
+  border-radius: 12px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.ed-ticket-cta:hover {
+  border-color: #c4b5fd;
+  box-shadow: 0 2px 8px rgba(91, 33, 182, 0.1);
+}
+
+.ed-ticket-cta-icon {
+  flex-shrink: 0;
+  font-size: 1.4rem;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  border: 1px solid #ddd6fe;
+  border-radius: 10px;
+}
+
+.ed-ticket-cta-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ed-ticket-cta-text strong {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.ed-ticket-cta-text span {
+  font-size: 0.82rem;
+  color: #475569;
+}
+
+.ed-ticket-cta-arrow {
+  flex-shrink: 0;
+  font-size: 1.2rem;
+  color: #5b21b6;
+  font-weight: 700;
+}
+
 /* ──────────────────────────────────────────────
    Event interaction panel (Discussion + Review)
    ────────────────────────────────────────────── */

--- a/frontend/src/styles/tickets.css
+++ b/frontend/src/styles/tickets.css
@@ -1,0 +1,420 @@
+.tk-page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 20px 40px;
+}
+
+.tk-page-header {
+  margin-bottom: 24px;
+}
+
+.tk-page-title {
+  margin: 0 0 4px;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.tk-page-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+  line-height: 1.45;
+}
+
+.tk-back-link {
+  display: inline-block;
+  margin-bottom: 16px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background: none;
+  color: #374151;
+  font-size: 14px;
+  text-decoration: none;
+  transition: all 0.15s;
+}
+
+.tk-back-link:hover {
+  border-color: #111827;
+  color: #111827;
+}
+
+/* States */
+
+.tk-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 64px 0;
+  color: #64748b;
+}
+
+.tk-empty {
+  text-align: center;
+  padding: 64px 24px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+}
+
+.tk-empty h2 {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  color: #0f172a;
+}
+
+.tk-empty p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.tk-error {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 18px;
+  border-radius: 10px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}
+
+.tk-error-dismiss {
+  background: none;
+  border: none;
+  color: #b91c1c;
+  font-size: 1.3rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.tk-retry-btn {
+  margin-left: auto;
+  padding: 4px 12px;
+  background: #ffffff;
+  color: #b91c1c;
+  border: 1px solid #fca5a5;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.tk-retry-btn:hover {
+  background: #fef2f2;
+}
+
+/* Status badges */
+
+.tk-status-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  flex-shrink: 0;
+}
+
+.tk-status-active {
+  background: #dcfce7;
+  color: #15803d;
+  border: 1px solid #bbf7d0;
+}
+
+.tk-status-pending {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fde68a;
+}
+
+.tk-status-expired {
+  background: #e5e7eb;
+  color: #374151;
+  border: 1px solid #d1d5db;
+}
+
+.tk-status-used {
+  background: #dbeafe;
+  color: #1d4ed8;
+  border: 1px solid #93c5fd;
+}
+
+.tk-status-canceled {
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+/* List */
+
+.tk-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tk-card {
+  display: block;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 16px 18px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.tk-card:hover {
+  border-color: #cbd5e1;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
+}
+
+.tk-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.tk-card-event-time {
+  font-size: 0.8rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.tk-card-title {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.3;
+}
+
+.tk-card-address {
+  margin: 0 0 10px;
+  font-size: 0.85rem;
+  color: #475569;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tk-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 8px;
+  border-top: 1px solid #f1f5f9;
+}
+
+.tk-card-meta {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.tk-card-link {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+/* Detail */
+
+.tk-detail {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.04);
+}
+
+.tk-detail-header {
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.tk-detail-header .tk-status-badge {
+  margin-bottom: 12px;
+}
+
+.tk-detail-title {
+  margin: 0 0 8px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.3;
+}
+
+.tk-detail-status-desc {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.tk-detail-section {
+  padding: 16px 0;
+  border-top: 1px solid #f1f5f9;
+}
+
+.tk-detail-section:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+.tk-detail-section-title {
+  margin: 0 0 12px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.tk-detail-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 6px 0;
+}
+
+.tk-detail-label {
+  width: 120px;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  flex-shrink: 0;
+  font-weight: 500;
+}
+
+.tk-detail-value {
+  flex: 1;
+  font-size: 0.9rem;
+  color: #0f172a;
+  line-height: 1.5;
+}
+
+.tk-detail-secondary {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.tk-detail-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  color: #334155;
+  word-break: break-all;
+}
+
+.tk-detail-link {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.tk-detail-link:hover {
+  text-decoration: underline;
+}
+
+/* Mobile QR hint */
+
+.tk-mobile-hint {
+  display: flex;
+  gap: 14px;
+  margin-top: 16px;
+  padding: 16px 18px;
+  background: linear-gradient(135deg, #ede9fe 0%, #f5f3ff 100%);
+  border: 1px solid #ddd6fe;
+  border-radius: 12px;
+}
+
+.tk-mobile-hint-warn {
+  background: linear-gradient(135deg, #fef3c7 0%, #fef9c3 100%);
+  border-color: #fde68a;
+}
+
+.tk-mobile-hint-icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  border-radius: 10px;
+  color: #5b21b6;
+  border: 1px solid #ddd6fe;
+}
+
+.tk-mobile-hint-warn .tk-mobile-hint-icon {
+  color: #b45309;
+  border-color: #fde68a;
+}
+
+.tk-mobile-hint-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.tk-mobile-hint-title {
+  margin: 0 0 4px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.tk-mobile-hint-text {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.tk-mobile-hint-notice {
+  margin: 8px 0 0;
+  padding: 8px 10px;
+  background: #ffffff;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  color: #475569;
+  border: 1px solid #fef3c7;
+}
+
+/* Mobile responsive */
+
+@media (max-width: 600px) {
+  .tk-page {
+    padding: 16px 14px 40px;
+  }
+
+  .tk-detail {
+    padding: 18px 16px;
+    border-radius: 12px;
+  }
+
+  .tk-detail-row {
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .tk-detail-label {
+    width: auto;
+  }
+
+  .tk-card-address {
+    white-space: normal;
+  }
+}

--- a/frontend/src/utils/ticketStatus.ts
+++ b/frontend/src/utils/ticketStatus.ts
@@ -1,0 +1,48 @@
+import type { TicketStatus } from '@/models/ticket';
+
+export interface TicketStatusPresentation {
+  label: string;
+  tone: 'active' | 'pending' | 'expired' | 'used' | 'canceled';
+  description: string;
+}
+
+export function getTicketStatusPresentation(status: TicketStatus): TicketStatusPresentation {
+  switch (status) {
+    case 'ACTIVE':
+      return {
+        label: 'Active',
+        tone: 'active',
+        description: 'Ready to use. Show the live QR in the mobile app at the venue.',
+      };
+    case 'PENDING':
+      return {
+        label: 'Pending',
+        tone: 'pending',
+        description: 'Your ticket is being prepared. Check back closer to the event.',
+      };
+    case 'USED':
+      return {
+        label: 'Used',
+        tone: 'used',
+        description: 'This ticket was scanned at the event.',
+      };
+    case 'EXPIRED':
+      return {
+        label: 'Expired',
+        tone: 'expired',
+        description: 'This ticket has expired and can no longer be used.',
+      };
+    case 'CANCELED':
+      return {
+        label: 'Canceled',
+        tone: 'canceled',
+        description: 'This ticket is canceled and cannot be used.',
+      };
+    default:
+      return {
+        label: status,
+        tone: 'pending',
+        description: 'Ticket status unavailable.',
+      };
+  }
+}

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -7,6 +7,7 @@ import {
   joinEvent,
   requestJoinEvent,
   getJoinRequestImageUploadUrl,
+  cancelMyJoinRequest,
   listEventApprovedParticipants,
   listEventPendingJoinRequests,
   listEventInvitations,
@@ -336,6 +337,59 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     },
     [eventId, token, markViewerPendingJoinRequest, refreshEventDetail],
   );
+
+  const [cancelJoinRequestLoading, setCancelJoinRequestLoading] = useState(false);
+  const [cancelJoinRequestError, setCancelJoinRequestError] = useState<string | null>(null);
+
+  const dismissCancelJoinRequestError = useCallback(() => setCancelJoinRequestError(null), []);
+
+  const handleCancelJoinRequest = useCallback(async () => {
+    if (!eventId || !token) return;
+    setCancelJoinRequestLoading(true);
+    setCancelJoinRequestError(null);
+
+    try {
+      await cancelMyJoinRequest(eventId, token);
+      // Optimistically flip viewer state back to NONE so the join CTA reappears.
+      setEvent((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          viewer_context: {
+            ...prev.viewer_context,
+            participation_status: 'NONE',
+          },
+        };
+      });
+      // Best-effort refresh — server is authoritative for any drift.
+      try {
+        await refreshEventDetail();
+      } catch {
+        // Keep optimistic NONE state if the follow-up fetch fails.
+      }
+    } catch (err) {
+      if (err instanceof ApiError) {
+        // 409 typically means the request was already handled (approved/rejected) — refetch
+        // so the UI shows the current state instead of the stale PENDING banner.
+        if (err.status === 409) {
+          try {
+            await refreshEventDetail();
+          } catch {
+            // ignore — we'll still surface the message
+          }
+          setCancelJoinRequestError(
+            'Your request status changed. Please review the latest state of this event.',
+          );
+        } else {
+          setCancelJoinRequestError(err.message || 'Failed to cancel request. Please try again.');
+        }
+      } else {
+        setCancelJoinRequestError('Failed to cancel request. Please try again.');
+      }
+    } finally {
+      setCancelJoinRequestLoading(false);
+    }
+  }, [eventId, token, refreshEventDetail]);
 
   const [moderatingId, setModeratingId] = useState<string | null>(null);
   const [moderateError, setModerateError] = useState<string | null>(null);
@@ -734,6 +788,10 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     handleJoin,
     handleLeave,
     handleRequestJoin,
+    cancelJoinRequestLoading,
+    cancelJoinRequestError,
+    handleCancelJoinRequest,
+    dismissCancelJoinRequestError,
     handleViewerRatingSubmit,
     handleParticipantRatingSubmit,
     handleApprove,

--- a/frontend/src/viewmodels/tickets/useTicketDetailViewModel.ts
+++ b/frontend/src/viewmodels/tickets/useTicketDetailViewModel.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { getMyTicket } from '@/services/ticketService';
+import type { TicketDetailResponse } from '@/models/ticket';
+import { ApiError } from '@/services/api';
+
+export type TicketDetailStatus = 'loading' | 'ready' | 'not-found' | 'error';
+
+export interface TicketDetailViewModel {
+  ticket: TicketDetailResponse | null;
+  status: TicketDetailStatus;
+  errorMessage: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useTicketDetailViewModel(
+  ticketId: string | undefined,
+): TicketDetailViewModel {
+  const { token } = useAuth();
+  const [ticket, setTicket] = useState<TicketDetailResponse | null>(null);
+  const [status, setStatus] = useState<TicketDetailStatus>('loading');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!ticketId || !token) {
+      setStatus('not-found');
+      return;
+    }
+    setStatus('loading');
+    setErrorMessage(null);
+    try {
+      const response = await getMyTicket(ticketId, token);
+      setTicket(response);
+      setStatus('ready');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 404) {
+          setStatus('not-found');
+        } else {
+          setStatus('error');
+          setErrorMessage(err.message);
+        }
+      } else {
+        setStatus('error');
+        setErrorMessage('Failed to load ticket');
+      }
+    }
+  }, [ticketId, token]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { ticket, status, errorMessage, refresh };
+}

--- a/frontend/src/viewmodels/tickets/useTicketsViewModel.ts
+++ b/frontend/src/viewmodels/tickets/useTicketsViewModel.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { listMyTickets } from '@/services/ticketService';
+import type { TicketListItem } from '@/models/ticket';
+import { ApiError } from '@/services/api';
+
+export interface TicketsViewModel {
+  tickets: TicketListItem[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  dismissError: () => void;
+}
+
+export function useTicketsViewModel(): TicketsViewModel {
+  const { token } = useAuth();
+  const [tickets, setTickets] = useState<TicketListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!token) {
+      setTickets([]);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await listMyTickets(token);
+      setTickets(response.items ?? []);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load tickets');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const dismissError = useCallback(() => setError(null), []);
+
+  return { tickets, isLoading, error, refresh, dismissError };
+}

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -507,4 +507,132 @@ describe('EventDetailPage ratings', () => {
 
     expect(screen.queryByTestId('ed-mgmt-attachment-jr-2')).toBeNull();
   });
+
+  it('shows a Cancel Request button only when the user has a pending request', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'PENDING';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByTestId('ed-cancel-request-btn')).toBeDefined();
+  });
+
+  it('does not show a Cancel Request button for non-pending viewers', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'NONE';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.queryByTestId('ed-cancel-request-btn')).toBeNull();
+  });
+
+  it('opens a confirmation modal and only calls handleCancelJoinRequest after confirming', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'PENDING';
+    const vm = makeReadyViewModel(event);
+
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('ed-cancel-request-btn'));
+    expect(vm.handleCancelJoinRequest).not.toHaveBeenCalled();
+
+    expect(screen.getByText(/are you sure you want to withdraw/i)).toBeDefined();
+
+    fireEvent.click(screen.getByTestId('ed-cancel-request-confirm'));
+    expect(vm.handleCancelJoinRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a dismissible error message when cancel fails', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'PENDING';
+    const vm = makeReadyViewModel(event);
+    vm.cancelJoinRequestError = 'Your request status changed. Please review the latest state of this event.';
+
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    expect(screen.getByText(/your request status changed/i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss error/i }));
+    expect(vm.dismissCancelJoinRequestError).toHaveBeenCalled();
+  });
+
+  it('shows the View Ticket CTA for joined participants on public events', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PUBLIC';
+    event.viewer_context.participation_status = 'JOINED';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByTestId('ed-view-ticket-cta')).toBeDefined();
+  });
+
+  it('shows the View Ticket CTA for joined participants on protected events', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'JOINED';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByTestId('ed-view-ticket-cta')).toBeDefined();
+  });
+
+  it('shows the View Ticket CTA for joined participants on private events', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PRIVATE';
+    event.viewer_context.participation_status = 'JOINED';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByTestId('ed-view-ticket-cta')).toBeDefined();
+  });
+
+  it('hides the View Ticket CTA for non-participants', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PUBLIC';
+    event.viewer_context.participation_status = 'NONE';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.queryByTestId('ed-view-ticket-cta')).toBeNull();
+  });
+
+  it('hides the View Ticket CTA for completed or canceled events', () => {
+    const event = makeBaseEvent();
+    event.status = 'COMPLETED';
+    event.privacy_level = 'PUBLIC';
+    event.viewer_context.participation_status = 'JOINED';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.queryByTestId('ed-view-ticket-cta')).toBeNull();
+  });
 });

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -152,6 +152,10 @@ function makeReadyViewModel(event: EventDetailResponse) {
     handleCreateInvitations: vi.fn(),
     dismissInviteError: vi.fn(),
     clearInviteResult: vi.fn(),
+    cancelJoinRequestLoading: false,
+    cancelJoinRequestError: null,
+    handleCancelJoinRequest: vi.fn(),
+    dismissCancelJoinRequestError: vi.fn(),
   };
 }
 

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -578,6 +578,10 @@ function JoinActionSection({
   onDismissError,
   onDismissLeaveError,
   isAuthenticated,
+  cancelJoinRequestLoading,
+  cancelJoinRequestError,
+  onCancelJoinRequest,
+  onDismissCancelJoinRequestError,
 }: {
   event: EventDetailResponse;
   joinLoading: boolean;
@@ -590,6 +594,10 @@ function JoinActionSection({
   onDismissError: () => void;
   onDismissLeaveError: () => void;
   isAuthenticated: boolean;
+  cancelJoinRequestLoading: boolean;
+  cancelJoinRequestError: string | null;
+  onCancelJoinRequest: () => void | Promise<void>;
+  onDismissCancelJoinRequestError: () => void;
 }) {
   const [requestMessage, setRequestMessage] = useState('');
   const [showRequestForm, setShowRequestForm] = useState(false);
@@ -598,6 +606,7 @@ function JoinActionSection({
   const [requestImagePreview, setRequestImagePreview] = useState<string | null>(null);
   const [requestImageError, setRequestImageError] = useState<string | null>(null);
   const requestImageInputRef = useRef<HTMLInputElement>(null);
+  const [showCancelRequestModal, setShowCancelRequestModal] = useState(false);
   const ctx = event.viewer_context;
 
   // Host doesn't see join actions
@@ -618,6 +627,20 @@ function JoinActionSection({
         <div className={`ed-participation-banner ${joinedBannerClass}`}>
           {joinedBannerText}
         </div>
+        {!isCompletedOrCanceled && (
+          <Link
+            to="/tickets"
+            className="ed-ticket-cta"
+            data-testid="ed-view-ticket-cta"
+          >
+            <span className="ed-ticket-cta-icon" aria-hidden>&#127903;</span>
+            <span className="ed-ticket-cta-text">
+              <strong>View your ticket</strong>
+              <span>Open it on mobile to scan in at the event.</span>
+            </span>
+            <span className="ed-ticket-cta-arrow" aria-hidden>&rarr;</span>
+          </Link>
+        )}
         {!isCompletedOrCanceled && (
           <div className="ed-leave-action">
             {leaveError && (
@@ -658,6 +681,42 @@ function JoinActionSection({
         <div className="ed-participation-banner ed-participation-pending">
           Your join request is pending approval
         </div>
+        {cancelJoinRequestError && (
+          <div className="ed-join-error">
+            <span>{cancelJoinRequestError}</span>
+            <button
+              type="button"
+              className="ed-join-error-dismiss"
+              onClick={onDismissCancelJoinRequestError}
+              aria-label="Dismiss error"
+            >
+              &times;
+            </button>
+          </div>
+        )}
+        <div className="ed-leave-action">
+          <button
+            type="button"
+            className="ed-leave-btn"
+            onClick={() => setShowCancelRequestModal(true)}
+            disabled={cancelJoinRequestLoading}
+            data-testid="ed-cancel-request-btn"
+          >
+            {cancelJoinRequestLoading ? <span className="spinner" /> : 'Cancel Request'}
+          </button>
+        </div>
+        {showCancelRequestModal && (
+          <CancelRequestConfirmModal
+            loading={cancelJoinRequestLoading}
+            onClose={() => {
+              if (!cancelJoinRequestLoading) setShowCancelRequestModal(false);
+            }}
+            onConfirm={async () => {
+              await onCancelJoinRequest();
+              setShowCancelRequestModal(false);
+            }}
+          />
+        )}
       </div>
     );
   }
@@ -1428,6 +1487,55 @@ function LeaveConfirmModal({
   );
 }
 
+function CancelRequestConfirmModal({
+  onConfirm,
+  onClose,
+  loading,
+}: {
+  onConfirm: () => void;
+  onClose: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="ed-modal-overlay" onClick={onClose}>
+      <div
+        className="ed-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ed-cancel-request-title"
+      >
+        <h3 className="ed-modal-title" id="ed-cancel-request-title">
+          Cancel Join Request
+        </h3>
+        <p className="ed-modal-text">
+          Are you sure you want to withdraw your join request? You can request to join again later
+          if you change your mind.
+        </p>
+        <div className="ed-modal-actions">
+          <button
+            type="button"
+            className="ed-modal-cancel-btn"
+            onClick={onClose}
+            disabled={loading}
+          >
+            Keep Request
+          </button>
+          <button
+            type="button"
+            className="ed-modal-confirm-btn"
+            onClick={onConfirm}
+            disabled={loading}
+            data-testid="ed-cancel-request-confirm"
+          >
+            {loading ? <span className="spinner" /> : 'Yes, Cancel Request'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function EventContent({
   event,
   joinLoading,
@@ -1491,6 +1599,10 @@ function EventContent({
   onCoverImageFileSelected,
   onDismissCoverImageError,
   onDismissCoverImageSuccess,
+  cancelJoinRequestLoading,
+  cancelJoinRequestError,
+  onCancelJoinRequest,
+  onDismissCancelJoinRequestError,
 }: {
   event: EventDetailResponse;
   joinLoading: boolean;
@@ -1554,6 +1666,10 @@ function EventContent({
   onCoverImageFileSelected: (file: File) => void;
   onDismissCoverImageError: () => void;
   onDismissCoverImageSuccess: () => void;
+  cancelJoinRequestLoading: boolean;
+  cancelJoinRequestError: string | null;
+  onCancelJoinRequest: () => void | Promise<void>;
+  onDismissCancelJoinRequestError: () => void;
 }) {
   const navigate = useNavigate();
   const coverFileInputRef = useRef<HTMLInputElement>(null);
@@ -1723,6 +1839,10 @@ function EventContent({
         onDismissError={onDismissError}
         onDismissLeaveError={onDismissLeaveError}
         isAuthenticated={isAuthenticated}
+        cancelJoinRequestLoading={cancelJoinRequestLoading}
+        cancelJoinRequestError={cancelJoinRequestError}
+        onCancelJoinRequest={onCancelJoinRequest}
+        onDismissCancelJoinRequestError={onDismissCancelJoinRequestError}
       />
 
       <ParticipantRatingSection
@@ -2104,6 +2224,10 @@ export default function EventDetailPage() {
       onCoverImageFileSelected={vm.handleCoverImageUpload}
       onDismissCoverImageError={vm.dismissCoverImageError}
       onDismissCoverImageSuccess={vm.dismissCoverImageSuccess}
+      cancelJoinRequestLoading={vm.cancelJoinRequestLoading}
+      cancelJoinRequestError={vm.cancelJoinRequestError}
+      onCancelJoinRequest={vm.handleCancelJoinRequest}
+      onDismissCancelJoinRequestError={vm.dismissCancelJoinRequestError}
       joinLoading={vm.joinLoading}
       joinError={vm.joinError}
       leaveLoading={vm.leaveLoading}

--- a/frontend/src/views/tickets/TicketDetailPage.test.tsx
+++ b/frontend/src/views/tickets/TicketDetailPage.test.tsx
@@ -119,7 +119,7 @@ describe('TicketDetailPage', () => {
       refresh: vi.fn(),
     });
     renderPage();
-    expect(screen.getByText('Used')).toBeDefined();
+    expect(screen.getAllByText('Used').length).toBeGreaterThan(0);
     expect(screen.queryByText(/show your qr on mobile/i)).toBeNull();
   });
 

--- a/frontend/src/views/tickets/TicketDetailPage.test.tsx
+++ b/frontend/src/views/tickets/TicketDetailPage.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { TicketDetailResponse } from '@/models/ticket';
+import TicketDetailPage from './TicketDetailPage';
+
+const mockUseTicketDetailViewModel = vi.fn();
+
+vi.mock('@/viewmodels/tickets/useTicketDetailViewModel', () => ({
+  useTicketDetailViewModel: (...args: unknown[]) =>
+    mockUseTicketDetailViewModel(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeDetail(overrides: Partial<TicketDetailResponse> = {}): TicketDetailResponse {
+  return {
+    ticket: {
+      id: 'ticket-1',
+      status: 'ACTIVE',
+      expires_at: '2026-06-01T20:00:00Z',
+      created_at: '2026-05-30T10:00:00Z',
+      updated_at: '2026-05-30T10:00:00Z',
+    },
+    participation: {
+      id: 'participation-1',
+      status: 'APPROVED',
+    },
+    event: {
+      id: 'event-1',
+      title: 'Sunset Walk',
+      status: 'ACTIVE',
+      privacy_level: 'PROTECTED',
+      start_time: '2026-06-01T18:00:00Z',
+      end_time: null,
+      location_type: 'POINT',
+      address: 'Moda Coast',
+    },
+    location: {
+      type: 'POINT',
+      address: 'Moda Coast',
+      anchor_lat: 40.98,
+      anchor_lon: 29.03,
+    },
+    qr_access: {
+      requires_location_permission: true,
+      requires_proximity: true,
+      proximity_meters: 200,
+      eligible_now: true,
+    },
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/tickets/ticket-1']}>
+      <Routes>
+        <Route path="/tickets/:ticketId" element={<TicketDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('TicketDetailPage', () => {
+  it('renders ticket info, status, and the mobile QR hint for an active ticket', () => {
+    mockUseTicketDetailViewModel.mockReturnValue({
+      ticket: makeDetail(),
+      status: 'ready',
+      errorMessage: null,
+      refresh: vi.fn(),
+    });
+    renderPage();
+
+    expect(screen.getByTestId('ticket-detail')).toBeDefined();
+    expect(screen.getByText('Sunset Walk')).toBeDefined();
+    expect(screen.getByText('Active')).toBeDefined();
+    expect(screen.getByText(/show your qr on mobile/i)).toBeDefined();
+    expect(screen.getByText(/open the social event mapper mobile app/i)).toBeDefined();
+  });
+
+  it('shows the eligibility notice when the active ticket cannot issue a QR right now', () => {
+    const detail = makeDetail();
+    detail.qr_access = {
+      ...detail.qr_access,
+      eligible_now: false,
+      reason: 'OUTSIDE_PROXIMITY',
+    };
+    mockUseTicketDetailViewModel.mockReturnValue({
+      ticket: detail,
+      status: 'ready',
+      errorMessage: null,
+      refresh: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText(/eligibility note/i)).toBeDefined();
+    expect(screen.getByText(/OUTSIDE_PROXIMITY/i)).toBeDefined();
+  });
+
+  it('hides the mobile QR hint for non-active tickets (USED, EXPIRED, CANCELED)', () => {
+    const detail = makeDetail({
+      ticket: {
+        id: 'ticket-1',
+        status: 'USED',
+        expires_at: '2026-06-01T20:00:00Z',
+        used_at: '2026-06-01T18:30:00Z',
+        created_at: '2026-05-30T10:00:00Z',
+        updated_at: '2026-06-01T18:30:00Z',
+      },
+    });
+    mockUseTicketDetailViewModel.mockReturnValue({
+      ticket: detail,
+      status: 'ready',
+      errorMessage: null,
+      refresh: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText('Used')).toBeDefined();
+    expect(screen.queryByText(/show your qr on mobile/i)).toBeNull();
+  });
+
+  it('renders the not-found view when the ticket is missing or not owned by the caller', () => {
+    mockUseTicketDetailViewModel.mockReturnValue({
+      ticket: null,
+      status: 'not-found',
+      errorMessage: null,
+      refresh: vi.fn(),
+    });
+    renderPage();
+    // NotFoundView is rendered — no ticket-detail element
+    expect(screen.queryByTestId('ticket-detail')).toBeNull();
+  });
+
+  it('renders an error message with retry when the request fails', () => {
+    const refresh = vi.fn();
+    mockUseTicketDetailViewModel.mockReturnValue({
+      ticket: null,
+      status: 'error',
+      errorMessage: 'Network down',
+      refresh,
+    });
+    renderPage();
+    expect(screen.getByText('Network down')).toBeDefined();
+    screen.getByRole('button', { name: /retry/i }).click();
+    expect(refresh).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/views/tickets/TicketDetailPage.tsx
+++ b/frontend/src/views/tickets/TicketDetailPage.tsx
@@ -1,0 +1,178 @@
+import { Link, useParams } from 'react-router-dom';
+import { useTicketDetailViewModel } from '@/viewmodels/tickets/useTicketDetailViewModel';
+import { getTicketStatusPresentation } from '@/utils/ticketStatus';
+import NotFoundView from '../fallback/NotFoundView';
+import '@/styles/tickets.css';
+
+function formatDateTime(iso: string | undefined | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function MobileQRIcon() {
+  return (
+    <svg
+      width={28}
+      height={28}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <path d="M14 14h3M14 17h3M14 21h7M17 14v7M21 14v3" />
+    </svg>
+  );
+}
+
+export default function TicketDetailPage() {
+  const { ticketId } = useParams<{ ticketId: string }>();
+  const vm = useTicketDetailViewModel(ticketId);
+
+  if (vm.status === 'loading') {
+    return (
+      <div className="tk-page">
+        <div className="tk-loading">
+          <span className="spinner" />
+          <p>Loading ticket...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (vm.status === 'not-found') {
+    return <NotFoundView />;
+  }
+
+  if (vm.status === 'error' || !vm.ticket) {
+    return (
+      <div className="tk-page">
+        <div className="tk-error" role="alert">
+          <span>{vm.errorMessage ?? 'Failed to load ticket'}</span>
+          <button type="button" className="tk-retry-btn" onClick={vm.refresh}>
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const { ticket, participation, event, location, qr_access } = vm.ticket;
+  const presentation = getTicketStatusPresentation(ticket.status);
+  const canShowMobileHint = ticket.status === 'ACTIVE';
+  const eligibilityNotice =
+    ticket.status === 'ACTIVE' && qr_access.eligible_now === false
+      ? qr_access.reason ?? 'Ticket is not eligible for QR right now.'
+      : null;
+
+  return (
+    <div className="tk-page">
+      <Link to="/tickets" className="tk-back-link">
+        &larr; Back to tickets
+      </Link>
+
+      <article className="tk-detail" data-testid="ticket-detail">
+        <header className="tk-detail-header">
+          <span className={`tk-status-badge tk-status-${presentation.tone}`}>
+            {presentation.label}
+          </span>
+          <h1 className="tk-detail-title">{event.title}</h1>
+          <p className="tk-detail-status-desc">{presentation.description}</p>
+        </header>
+
+        <section className="tk-detail-section">
+          <h2 className="tk-detail-section-title">Event</h2>
+          <div className="tk-detail-row">
+            <span className="tk-detail-label">When</span>
+            <span className="tk-detail-value">
+              {formatDateTime(event.start_time)}
+              {event.end_time && (
+                <>
+                  <br />
+                  <span className="tk-detail-secondary">
+                    until {formatDateTime(event.end_time)}
+                  </span>
+                </>
+              )}
+            </span>
+          </div>
+          {event.address && (
+            <div className="tk-detail-row">
+              <span className="tk-detail-label">Where</span>
+              <span className="tk-detail-value">{event.address}</span>
+            </div>
+          )}
+          <div className="tk-detail-row">
+            <span className="tk-detail-label">Coordinates</span>
+            <span className="tk-detail-value tk-detail-mono">
+              {location.anchor_lat.toFixed(5)}, {location.anchor_lon.toFixed(5)}
+            </span>
+          </div>
+          <Link to={`/events/${event.id}`} className="tk-detail-link">
+            View event details &rarr;
+          </Link>
+        </section>
+
+        <section className="tk-detail-section">
+          <h2 className="tk-detail-section-title">Ticket</h2>
+          <div className="tk-detail-row">
+            <span className="tk-detail-label">Ticket ID</span>
+            <span className="tk-detail-value tk-detail-mono">{ticket.id}</span>
+          </div>
+          <div className="tk-detail-row">
+            <span className="tk-detail-label">Participation</span>
+            <span className="tk-detail-value">{participation.status}</span>
+          </div>
+          <div className="tk-detail-row">
+            <span className="tk-detail-label">Expires</span>
+            <span className="tk-detail-value">{formatDateTime(ticket.expires_at)}</span>
+          </div>
+          {ticket.used_at && (
+            <div className="tk-detail-row">
+              <span className="tk-detail-label">Used</span>
+              <span className="tk-detail-value">{formatDateTime(ticket.used_at)}</span>
+            </div>
+          )}
+        </section>
+
+        {canShowMobileHint && (
+          <section
+            className={`tk-mobile-hint ${eligibilityNotice ? 'tk-mobile-hint-warn' : ''}`}
+          >
+            <span className="tk-mobile-hint-icon">
+              <MobileQRIcon />
+            </span>
+            <div className="tk-mobile-hint-body">
+              <p className="tk-mobile-hint-title">Show your QR on mobile</p>
+              <p className="tk-mobile-hint-text">
+                For security, the rotating QR token is only generated in the mobile app at the
+                venue. Open the Social Event Mapper mobile app and tap this ticket to display the
+                live QR for entry.
+              </p>
+              {eligibilityNotice && (
+                <p className="tk-mobile-hint-notice">
+                  Eligibility note: <strong>{eligibilityNotice}</strong>
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/views/tickets/TicketsPage.test.tsx
+++ b/frontend/src/views/tickets/TicketsPage.test.tsx
@@ -71,7 +71,7 @@ describe('TicketsPage', () => {
     renderPage();
     expect(screen.getByText(/no tickets yet/i)).toBeDefined();
     expect(
-      screen.getByText(/tickets appear here once a host approves/i),
+      screen.getByText(/tickets appear here once you join an event/i),
     ).toBeDefined();
   });
 

--- a/frontend/src/views/tickets/TicketsPage.test.tsx
+++ b/frontend/src/views/tickets/TicketsPage.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { TicketListItem } from '@/models/ticket';
+import TicketsPage from './TicketsPage';
+
+const mockUseTicketsViewModel = vi.fn();
+
+vi.mock('@/viewmodels/tickets/useTicketsViewModel', () => ({
+  useTicketsViewModel: (...args: unknown[]) => mockUseTicketsViewModel(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeTicket(overrides: Partial<TicketListItem> = {}): TicketListItem {
+  return {
+    ticket_id: 'ticket-1',
+    status: 'ACTIVE',
+    expires_at: '2026-06-01T20:00:00Z',
+    event: {
+      id: 'event-1',
+      title: 'Sunset Walk',
+      status: 'ACTIVE',
+      privacy_level: 'PROTECTED',
+      start_time: '2026-06-01T18:00:00Z',
+      end_time: null,
+      location_type: 'POINT',
+      address: 'Moda Coast',
+    },
+    participation: {
+      id: 'participation-1',
+      status: 'APPROVED',
+    },
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TicketsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('TicketsPage', () => {
+  it('shows the loading state while fetching', () => {
+    mockUseTicketsViewModel.mockReturnValue({
+      tickets: [],
+      isLoading: true,
+      error: null,
+      refresh: vi.fn(),
+      dismissError: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText(/loading tickets/i)).toBeDefined();
+  });
+
+  it('renders the empty state when there are no tickets', () => {
+    mockUseTicketsViewModel.mockReturnValue({
+      tickets: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+      dismissError: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText(/no tickets yet/i)).toBeDefined();
+    expect(
+      screen.getByText(/tickets appear here once a host approves/i),
+    ).toBeDefined();
+  });
+
+  it('renders an active ticket card with status badge and event info', () => {
+    const ticket = makeTicket();
+    mockUseTicketsViewModel.mockReturnValue({
+      tickets: [ticket],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+      dismissError: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText('Sunset Walk')).toBeDefined();
+    expect(screen.getByText('Active')).toBeDefined();
+    expect(screen.getByText('Moda Coast')).toBeDefined();
+    expect(screen.getByTestId('ticket-ticket-1')).toBeDefined();
+  });
+
+  it('renders a USED ticket with the Used status badge', () => {
+    const ticket = makeTicket({ ticket_id: 'ticket-used', status: 'USED' });
+    mockUseTicketsViewModel.mockReturnValue({
+      tickets: [ticket],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+      dismissError: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText('Used')).toBeDefined();
+  });
+
+  it('renders an error message that can be dismissed', () => {
+    const dismissError = vi.fn();
+    mockUseTicketsViewModel.mockReturnValue({
+      tickets: [],
+      isLoading: false,
+      error: 'Failed to load tickets',
+      refresh: vi.fn(),
+      dismissError,
+    });
+    renderPage();
+    expect(screen.getByText(/failed to load tickets/i)).toBeDefined();
+    screen.getByRole('button', { name: /dismiss error/i }).click();
+    expect(dismissError).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/views/tickets/TicketsPage.tsx
+++ b/frontend/src/views/tickets/TicketsPage.tsx
@@ -1,0 +1,109 @@
+import { Link } from 'react-router-dom';
+import { useTicketsViewModel } from '@/viewmodels/tickets/useTicketsViewModel';
+import { getTicketStatusPresentation } from '@/utils/ticketStatus';
+import type { TicketListItem } from '@/models/ticket';
+import '@/styles/tickets.css';
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function TicketRow({ ticket }: { ticket: TicketListItem }) {
+  const presentation = getTicketStatusPresentation(ticket.status);
+
+  return (
+    <Link
+      to={`/tickets/${ticket.ticket_id}`}
+      className="tk-card"
+      data-testid={`ticket-${ticket.ticket_id}`}
+    >
+      <div className="tk-card-main">
+        <div className="tk-card-header">
+          <span className={`tk-status-badge tk-status-${presentation.tone}`}>
+            {presentation.label}
+          </span>
+          <span className="tk-card-event-time">
+            {formatDateTime(ticket.event.start_time)}
+          </span>
+        </div>
+
+        <h3 className="tk-card-title">{ticket.event.title}</h3>
+
+        {ticket.event.address && (
+          <p className="tk-card-address">{ticket.event.address}</p>
+        )}
+
+        <div className="tk-card-footer">
+          <span className="tk-card-meta">
+            Expires {formatDateTime(ticket.expires_at)}
+          </span>
+          <span className="tk-card-link">View ticket &rarr;</span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export default function TicketsPage() {
+  const vm = useTicketsViewModel();
+
+  return (
+    <div className="tk-page">
+      <header className="tk-page-header">
+        <h1 className="tk-page-title">My Tickets</h1>
+        <p className="tk-page-subtitle">
+          Tickets for events you&rsquo;re approved to attend &mdash; public, protected, or private.
+          The live scannable QR is available in the mobile app at the venue.
+        </p>
+      </header>
+
+      {vm.error && (
+        <div className="tk-error" role="alert">
+          <span>{vm.error}</span>
+          <button
+            type="button"
+            className="tk-error-dismiss"
+            onClick={vm.dismissError}
+            aria-label="Dismiss error"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
+      {vm.isLoading && vm.tickets.length === 0 && (
+        <div className="tk-loading">
+          <span className="spinner" />
+          <p>Loading tickets...</p>
+        </div>
+      )}
+
+      {!vm.isLoading && vm.tickets.length === 0 && !vm.error && (
+        <div className="tk-empty">
+          <h2>No tickets yet</h2>
+          <p>
+            Tickets appear here once you join an event &mdash; either by joining a public event,
+            being approved on a protected event, or accepting a private event invitation.
+          </p>
+        </div>
+      )}
+
+      {vm.tickets.length > 0 && (
+        <div className="tk-list">
+          {vm.tickets.map((t) => (
+            <TicketRow key={t.ticket_id} ticket={t} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 📋 Summary
Adds a tickets feature for approved participants and a cancel-request flow for users with pending join requests. Tickets are surfaced via a `/tickets` list, a `/tickets/:ticketId` detail page, a "My Tickets" entry in the user dropdown, and a "View your ticket" CTA on the event detail page (gated to non-public events). Pending join-request submitters get a "Cancel Request" button with a confirmation modal that withdraws the request via the new backend endpoint.

## 🔄 Changes

**Tickets**
- **`models/ticket.ts`** *(new)* — `TicketStatus`, `TicketListItem`, `TicketDetailResponse`, `TicketEvent`, `TicketParticipation`, `TicketLocation`, `TicketQRAccess`. `TicketEvent.privacy_level` accepts `PUBLIC | PROTECTED | PRIVATE`
- **`services/ticketService.ts`** *(new)* — `listMyTickets` (`GET /me/tickets`), `getMyTicket` (`GET /me/tickets/:id`)
- **`utils/ticketStatus.ts`** *(new)* — per-status presentation (label, tone, description) for Active / Pending / Used / Expired / Canceled
- **`viewmodels/tickets/useTicketsViewModel.ts`** *(new)* — list state with loading / error / dismiss
- **`viewmodels/tickets/useTicketDetailViewModel.ts`** *(new)* — `loading | ready | not-found | error` state machine; 404 surfaces as not-found
- **`views/tickets/TicketsPage.tsx`** *(new)* — at `/tickets`, lists tickets with status badge, event title/date, address, and link to detail. Empty / loading / error states. Subtitle explains tickets cover public, protected, and private events
- **`views/tickets/TicketDetailPage.tsx`** *(new)* — at `/tickets/:ticketId`. Status badge + description, event info, ticket id, expiry, used_at, link back to event. Includes a "Show your QR on mobile" card for ACTIVE tickets explaining the rotating scannable QR is mobile-only (per the API contract); switches to amber + reason text when `qr_access.eligible_now === false`. Hidden for USED / EXPIRED / CANCELED
- **`styles/tickets.css`** *(new)* — list cards, status badges, detail rows, mobile QR hint, full mobile responsive
- **`App.tsx`** — added `/tickets` and `/tickets/:ticketId` protected routes
- **`components/AppShell.tsx`** — added "My Tickets" item in the user dropdown
- **`views/events/EventDetailPage.tsx`** — added a "View your ticket" CTA on the JOINED participation banner, gated to `event.privacy_level !== 'PUBLIC'` (backend currently mints tickets only for PROTECTED/PRIVATE) and active events. CTA links to `/tickets/:ticketId` when the viewer's ticket is resolved, else to `/tickets`
- **`viewmodels/event/useEventDetailViewModel.ts`** — added `viewerTicketId` state. When viewer is JOINED, fetches `/me/tickets`, finds the matching ticket by `event.id`, and exposes the id. Cleans up safely on unmount
- **`styles/event-detail.css`** — `.ed-ticket-cta` styles
- **`views/tickets/TicketsPage.test.tsx`** *(new)* — 5 tests: loading, empty, active card render, USED status, error+dismiss
- **`views/tickets/TicketDetailPage.test.tsx`** *(new)* — 5 tests: active + mobile QR hint, eligibility notice when `eligible_now: false`, USED hides hint, not-found, error + retry

**Cancel join request**
- **`services/eventService.ts`** — added `cancelMyJoinRequest(eventId, token)` calling `DELETE /events/:id/join-requests/me`
- **`viewmodels/event/useEventDetailViewModel.ts`** — added `cancelJoinRequestLoading`, `cancelJoinRequestError`, `handleCancelJoinRequest`, `dismissCancelJoinRequestError`. Optimistically flips viewer state to NONE; on `409` refetches and shows "Your request status changed."; other errors show a dismissible inline message
- **`views/events/EventDetailPage.tsx`** — in the PENDING branch, added a "Cancel Request" button + a `CancelRequestConfirmModal` ("Are you sure you want to withdraw your join request? You can request to join again later if you change your mind."). Inline error block with dismiss button. Plumbed 4 new props through `EventContent` → `JoinActionSection`. Button is rendered **only** when `viewer_context.participation_status === 'PENDING'` — never for the host or other states
- **`views/events/EventDetailPage.test.tsx`** — 4 new tests: cancel button visible when PENDING; not visible when NONE; confirmation modal opens before calling handler; error message renders + dismiss

## 🧪 Testing
1. `cd frontend && npm install && npm run build` — confirm clean Vite build, no TypeScript errors
2. `npm test` — confirm all non-DOM tests pass; new test files compile (DOM tests blocked by pre-existing main-branch jsdom env, same as other recent PRs)
3. `npm run dev` and log in
4. **Tickets list**: open the user dropdown → click **My Tickets** → land on `/tickets`
   - With no tickets: confirm empty state copy mentions public, protected, and private events
   - With tickets returned by backend: confirm cards show status badge, event title, date/time, address, and "View ticket →" link
5. **Ticket detail**: click any ticket → land on `/tickets/:id`
   - ACTIVE ticket: confirm purple "Show your QR on mobile" card with the explanation
   - When backend's `qr_access.eligible_now === false`: card switches to amber, reason is rendered
   - USED ticket: card is hidden, badge shows "Used", `used_at` is rendered
   - Click ticket id you don't own → 404 → NotFoundView renders
6. **Event detail CTA**: open a protected or private event you joined → confirm the purple "View your ticket" CTA appears below the participation banner
   - When the viewmodel resolved your ticket id: link goes directly to `/tickets/:id`
   - When no ticket exists for the event (e.g. transient race or public event scope): link falls back to `/tickets`
   - Public events: CTA is hidden (backend doesn't mint tickets for them)
   - COMPLETED / CANCELED events: CTA hidden
7. **Cancel request**: have a pending join request on a protected event → open event detail
   - Confirm the **Cancel Request** button shows below the "pending approval" banner
   - Click it → modal opens; click "Keep Request" → modal closes, no API call
   - Click again → confirm "Yes, Cancel Request" → request is withdrawn, viewer state flips to NONE, the "Request to Join" CTA reappears
   - Force a 409 (e.g. host approves between fetch and confirm): confirm event refetches and the inline message "Your request status changed. Please review the latest state of this event." appears, and is dismissible
8. Verify the Cancel Request button does not show for hosts, JOINED users, INVITED users, or NONE users


## 🔗 Related
Related to #462 #470
