### PR TITLE
feat(backend): split received invitations response into pending and past buckets & create invitation   detail endpoint (#581)

### DIFF
--- a/backend/internal/adapter/in/postgres/invitation_repo.go
+++ b/backend/internal/adapter/in/postgres/invitation_repo.go
@@ -251,6 +251,62 @@ func (r *InvitationRepository) ListReceivedPastInvitations(
 	return records, nil
 }
 
+// GetReceivedInvitation returns a single invitation owned by the recipient
+// regardless of status, used by the modal-fetch flow that opens from a
+// notification. Filters: invitation id, invited_user_id, PRIVATE event.
+// Returns domain.ErrNotFound when no row matches all three filters so the
+// API can respond with a 404 that does not leak the row's existence.
+func (r *InvitationRepository) GetReceivedInvitation(
+	ctx context.Context,
+	userID, invitationID uuid.UUID,
+) (*invitationapp.ReceivedInvitationRecord, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT
+			inv.id,
+			inv.status,
+			inv.message,
+			inv.expires_at,
+			inv.created_at,
+			inv.updated_at,
+			e.id,
+			e.title,
+			e.image_url,
+			e.start_time,
+			e.end_time,
+			e.status,
+			e.privacy_level,
+			e.approved_participant_count,
+			host.id,
+			host.username,
+			hp.display_name,
+			hp.avatar_url
+		FROM invitation inv
+		JOIN event e ON e.id = inv.event_id
+		JOIN app_user host ON host.id = inv.host_id
+		LEFT JOIN profile hp ON hp.user_id = host.id
+		WHERE inv.id = $1
+		  AND inv.invited_user_id = $2
+		  AND e.privacy_level = $3
+		LIMIT 1
+	`, invitationID, userID, domain.PrivacyPrivate)
+	if err != nil {
+		return nil, fmt.Errorf("get received invitation: %w", err)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("get received invitation: %w", err)
+		}
+		return nil, domain.ErrNotFound
+	}
+	record, err := scanReceivedInvitation(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan received invitation: %w", err)
+	}
+	return record, nil
+}
+
 func (r *InvitationRepository) AcceptInvitation(
 	ctx context.Context,
 	userID, invitationID uuid.UUID,

--- a/backend/internal/adapter/in/postgres/invitation_repo.go
+++ b/backend/internal/adapter/in/postgres/invitation_repo.go
@@ -175,6 +175,82 @@ func (r *InvitationRepository) ListReceivedPendingInvitations(
 	return records, nil
 }
 
+// ListReceivedPastInvitations returns DECLINED+EXPIRED invitations for the
+// given user against PRIVATE events. The query intentionally omits an
+// event-status filter (the past bucket should still surface invitations
+// for events that have since ended). Pagination is keyset on
+// (updated_at, id) DESC; (FetchLimit) is set to (limit + 1) so callers can
+// detect whether another page exists without a count query.
+func (r *InvitationRepository) ListReceivedPastInvitations(
+	ctx context.Context,
+	userID uuid.UUID,
+	params invitationapp.ListPastInvitationsParams,
+) ([]invitationapp.ReceivedInvitationRecord, error) {
+	const baseSelect = `
+		SELECT
+			inv.id,
+			inv.status,
+			inv.message,
+			inv.expires_at,
+			inv.created_at,
+			inv.updated_at,
+			e.id,
+			e.title,
+			e.image_url,
+			e.start_time,
+			e.end_time,
+			e.status,
+			e.privacy_level,
+			e.approved_participant_count,
+			host.id,
+			host.username,
+			hp.display_name,
+			hp.avatar_url
+		FROM invitation inv
+		JOIN event e ON e.id = inv.event_id
+		JOIN app_user host ON host.id = inv.host_id
+		LEFT JOIN profile hp ON hp.user_id = host.id
+		WHERE inv.invited_user_id = $1
+		  AND inv.status = ANY($2::text[])
+		  AND e.privacy_level = $3
+	`
+
+	args := []any{
+		userID,
+		[]string{string(domain.InvitationStatusDeclined), string(domain.InvitationStatusExpired)},
+		domain.PrivacyPrivate,
+	}
+	query := baseSelect
+	if params.Cursor != nil {
+		// Strict-less-than tuple comparison preserves DESC ordering and
+		// ensures the cursor row itself is excluded from the next page.
+		query += " AND (inv.updated_at, inv.id) < ($4, $5)"
+		args = append(args, params.Cursor.UpdatedAt, params.Cursor.InvitationID)
+	}
+	query += " ORDER BY inv.updated_at DESC, inv.id DESC"
+	query += fmt.Sprintf(" LIMIT $%d", len(args)+1)
+	args = append(args, params.FetchLimit)
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list past received invitations: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]invitationapp.ReceivedInvitationRecord, 0)
+	for rows.Next() {
+		record, err := scanReceivedInvitation(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, *record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate past received invitations: %w", err)
+	}
+	return records, nil
+}
+
 func (r *InvitationRepository) AcceptInvitation(
 	ctx context.Context,
 	userID, invitationID uuid.UUID,

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -1341,7 +1341,7 @@ func (f *fakeInvitationService) CreateInvitations(_ context.Context, _, _ uuid.U
 	return &invitation.CreateInvitationsResult{}, nil
 }
 
-func (f *fakeInvitationService) ListReceivedInvitations(_ context.Context, _ uuid.UUID) (*invitation.ReceivedInvitationsResult, error) {
+func (f *fakeInvitationService) ListReceivedInvitations(_ context.Context, _ invitation.ListReceivedInvitationsInput) (*invitation.ReceivedInvitationsResult, error) {
 	return nil, nil
 }
 

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -1345,6 +1345,10 @@ func (f *fakeInvitationService) ListReceivedInvitations(_ context.Context, _ inv
 	return nil, nil
 }
 
+func (f *fakeInvitationService) GetReceivedInvitation(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*invitation.ReceivedInvitation, error) {
+	return nil, nil
+}
+
 func (f *fakeInvitationService) AcceptInvitation(_ context.Context, _, _ uuid.UUID) (*invitation.AcceptInvitationResult, error) {
 	return nil, nil
 }

--- a/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
+++ b/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
@@ -2,6 +2,7 @@ package profile_handler
 
 import (
 	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/adapter/out/httpapi"
@@ -205,13 +206,31 @@ func (h *ProfileHandler) ListFavoriteEvents(c *fiber.Ctx) error {
 	return c.JSON(result)
 }
 
-// ListReceivedInvitations handles GET /me/invitations.
+// ListReceivedInvitations handles GET /me/invitations and returns the
+// authenticated user's invitations split into pending and past buckets.
+// Past is paginated via past_cursor / past_limit query params; pending is
+// always returned in full because it is small and clients render it eagerly.
 func (h *ProfileHandler) ListReceivedInvitations(c *fiber.Ctx) error {
 	if h.invitationService == nil {
 		return httpapi.WriteError(c, domain.ConflictError(domain.ErrorCodeInvitationNotAllowed, "Invitations are not available."))
 	}
 	claims := httpapi.UserClaims(c)
-	result, err := h.invitationService.ListReceivedInvitations(c.UserContext(), claims.UserID)
+
+	input := invitation.ListReceivedInvitationsInput{UserID: claims.UserID}
+	if raw := strings.TrimSpace(c.Query("past_cursor")); raw != "" {
+		input.PastCursor = &raw
+	}
+	if raw := strings.TrimSpace(c.Query("past_limit")); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil {
+			return httpapi.WriteError(c, domain.ValidationError(map[string]string{
+				"past_limit": "must be an integer",
+			}))
+		}
+		input.PastLimit = &v
+	}
+
+	result, err := h.invitationService.ListReceivedInvitations(c.UserContext(), input)
 	if err != nil {
 		return httpapi.WriteError(c, err)
 	}
@@ -221,7 +240,9 @@ func (h *ProfileHandler) ListReceivedInvitations(c *fiber.Ctx) error {
 		"my invitations fetched",
 		httpapi.OperationAttr("profile.invitations.list"),
 		httpapi.UserIDAttr(claims.UserID),
-		slog.Int("result_count", len(result.Items)),
+		slog.Int("pending_count", len(result.Pending)),
+		slog.Int("past_count", len(result.Past.Items)),
+		slog.Bool("past_has_next", result.Past.PageInfo.HasNext),
 	)
 	return c.JSON(result)
 }

--- a/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
+++ b/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
@@ -42,6 +42,7 @@ func RegisterProfileRoutes(router fiber.Router, handler *ProfileHandler, auth fi
 	me.Get("/events/canceled", handler.GetMyCanceledEvents)
 	me.Get("/favorites", handler.ListFavoriteEvents)
 	me.Get("/invitations", handler.ListReceivedInvitations)
+	me.Get("/invitations/:invitationId", handler.GetReceivedInvitation)
 	me.Post("/invitations/:invitationId/accept", handler.AcceptInvitation)
 	me.Post("/invitations/:invitationId/decline", handler.DeclineInvitation)
 }
@@ -243,6 +244,36 @@ func (h *ProfileHandler) ListReceivedInvitations(c *fiber.Ctx) error {
 		slog.Int("pending_count", len(result.Pending)),
 		slog.Int("past_count", len(result.Past.Items)),
 		slog.Bool("past_has_next", result.Past.PageInfo.HasNext),
+	)
+	return c.JSON(result)
+}
+
+// GetReceivedInvitation handles GET /me/invitations/:invitationId. It
+// returns the latest state of an invitation addressed to the authenticated
+// user, regardless of status. Clients use this to refresh modal content
+// opened from a (possibly stale) notification — e.g. to render a "host
+// canceled" banner when the underlying invitation is no longer actionable.
+func (h *ProfileHandler) GetReceivedInvitation(c *fiber.Ctx) error {
+	if h.invitationService == nil {
+		return httpapi.WriteError(c, domain.ConflictError(domain.ErrorCodeInvitationNotAllowed, "Invitations are not available."))
+	}
+	invitationID, err := parseInvitationIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	claims := httpapi.UserClaims(c)
+	result, err := h.invitationService.GetReceivedInvitation(c.UserContext(), claims.UserID, invitationID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my invitation fetched",
+		httpapi.OperationAttr("profile.invitations.get"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("invitation_id", invitationID.String()),
+		slog.String("status", result.Status),
 	)
 	return c.JSON(result)
 }

--- a/backend/internal/application/invitation/cursor.go
+++ b/backend/internal/application/invitation/cursor.go
@@ -1,0 +1,60 @@
+package invitation
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+func encodePastInvitationCursor(cursor PastInvitationCursor) (string, error) {
+	raw, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("marshal past invitation cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+// decodePastInvitationCursor parses an opaque token. It enforces both
+// fields are populated so callers cannot smuggle a partial cursor that
+// would skip pages or scan from the start of the index.
+func decodePastInvitationCursor(token string) (*PastInvitationCursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return nil, fmt.Errorf("decode past invitation cursor: %w", err)
+	}
+
+	var cursor PastInvitationCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil {
+		return nil, fmt.Errorf("unmarshal past invitation cursor: %w", err)
+	}
+	if cursor.UpdatedAt.IsZero() {
+		return nil, fmt.Errorf("cursor is missing updated_at")
+	}
+	if cursor.InvitationID == uuid.Nil {
+		return nil, fmt.Errorf("cursor is missing invitation_id")
+	}
+	return &cursor, nil
+}
+
+// buildNextPastInvitationCursor returns nil when there is no next page,
+// avoiding unnecessary cursors in the response.
+func buildNextPastInvitationCursor(items []ReceivedInvitation, hasNext bool) (*string, error) {
+	if !hasNext || len(items) == 0 {
+		return nil, nil
+	}
+	last := items[len(items)-1]
+	id, err := uuid.Parse(last.InvitationID)
+	if err != nil {
+		return nil, fmt.Errorf("parse last invitation id: %w", err)
+	}
+	encoded, err := encodePastInvitationCursor(PastInvitationCursor{
+		UpdatedAt:    last.UpdatedAt,
+		InvitationID: id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &encoded, nil
+}

--- a/backend/internal/application/invitation/cursor_test.go
+++ b/backend/internal/application/invitation/cursor_test.go
@@ -1,0 +1,112 @@
+package invitation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestPastInvitationCursorRoundTrip(t *testing.T) {
+	original := PastInvitationCursor{
+		UpdatedAt:    time.Date(2026, 5, 8, 10, 30, 45, 0, time.UTC),
+		InvitationID: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+	}
+
+	token, err := encodePastInvitationCursor(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	decoded, err := decodePastInvitationCursor(token)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !decoded.UpdatedAt.Equal(original.UpdatedAt) {
+		t.Fatalf("updated_at mismatch: got %v, want %v", decoded.UpdatedAt, original.UpdatedAt)
+	}
+	if decoded.InvitationID != original.InvitationID {
+		t.Fatalf("invitation_id mismatch: got %v, want %v", decoded.InvitationID, original.InvitationID)
+	}
+}
+
+func TestDecodePastInvitationCursorRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"empty token", ""},
+		{"non-base64", "!!!not-base64!!!"},
+		{"valid base64 of garbage json", "Z2FyYmFnZQ"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := decodePastInvitationCursor(tc.token); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestDecodePastInvitationCursorRejectsZeroFields(t *testing.T) {
+	zeroTime, err := encodePastInvitationCursor(PastInvitationCursor{
+		InvitationID: uuid.New(),
+	})
+	if err != nil {
+		t.Fatalf("encode zero-time: %v", err)
+	}
+	if _, err := decodePastInvitationCursor(zeroTime); err == nil {
+		t.Fatal("expected error for zero updated_at, got nil")
+	}
+
+	zeroID, err := encodePastInvitationCursor(PastInvitationCursor{
+		UpdatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("encode zero-id: %v", err)
+	}
+	if _, err := decodePastInvitationCursor(zeroID); err == nil {
+		t.Fatal("expected error for nil invitation_id, got nil")
+	}
+}
+
+func TestBuildNextPastInvitationCursor(t *testing.T) {
+	items := []ReceivedInvitation{
+		{InvitationID: "11111111-1111-1111-1111-111111111111", UpdatedAt: time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)},
+		{InvitationID: "22222222-2222-2222-2222-222222222222", UpdatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC)},
+	}
+
+	got, err := buildNextPastInvitationCursor(items, true)
+	if err != nil {
+		t.Fatalf("buildNext hasNext=true: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil cursor when hasNext=true")
+	}
+	decoded, err := decodePastInvitationCursor(*got)
+	if err != nil {
+		t.Fatalf("decode round-trip: %v", err)
+	}
+	if decoded.InvitationID.String() != items[1].InvitationID {
+		t.Fatalf("cursor encodes wrong tail: got %v, want %v", decoded.InvitationID, items[1].InvitationID)
+	}
+
+	none, err := buildNextPastInvitationCursor(items, false)
+	if err != nil {
+		t.Fatalf("buildNext hasNext=false: %v", err)
+	}
+	if none != nil {
+		t.Fatal("expected nil cursor when hasNext=false")
+	}
+
+	empty, err := buildNextPastInvitationCursor(nil, true)
+	if err != nil {
+		t.Fatalf("buildNext empty: %v", err)
+	}
+	if empty != nil {
+		t.Fatal("expected nil cursor for empty items even when hasNext=true")
+	}
+}

--- a/backend/internal/application/invitation/repository.go
+++ b/backend/internal/application/invitation/repository.go
@@ -10,6 +10,11 @@ import (
 type Repository interface {
 	CreateInvitations(ctx context.Context, params CreateInvitationsParams) (*CreateInvitationsRecord, error)
 	ListReceivedPendingInvitations(ctx context.Context, userID uuid.UUID) ([]ReceivedInvitationRecord, error)
+	// ListReceivedPastInvitations returns the recipient's DECLINED+EXPIRED
+	// invitations for PRIVATE events, ordered (updated_at DESC, id DESC) for
+	// keyset pagination. Event status is intentionally not filtered so a
+	// declined invitation for an event that has since ended remains visible.
+	ListReceivedPastInvitations(ctx context.Context, userID uuid.UUID, params ListPastInvitationsParams) ([]ReceivedInvitationRecord, error)
 	AcceptInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*AcceptInvitationRecord, error)
 	DeclineInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*domain.Invitation, error)
 	GetInvitationNotificationContext(ctx context.Context, invitationID uuid.UUID) (*InvitationNotificationContext, error)

--- a/backend/internal/application/invitation/repository.go
+++ b/backend/internal/application/invitation/repository.go
@@ -15,6 +15,12 @@ type Repository interface {
 	// keyset pagination. Event status is intentionally not filtered so a
 	// declined invitation for an event that has since ended remains visible.
 	ListReceivedPastInvitations(ctx context.Context, userID uuid.UUID, params ListPastInvitationsParams) ([]ReceivedInvitationRecord, error)
+	// GetReceivedInvitation returns the recipient's view of a single
+	// invitation regardless of status (PENDING/ACCEPTED/DECLINED/EXPIRED/
+	// CANCELED) and event state. Returns domain.ErrNotFound when the row
+	// does not exist, the caller is not the invited user, or the event is
+	// not PRIVATE — never leak existence by status code.
+	GetReceivedInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*ReceivedInvitationRecord, error)
 	AcceptInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*AcceptInvitationRecord, error)
 	DeclineInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*domain.Invitation, error)
 	GetInvitationNotificationContext(ctx context.Context, invitationID uuid.UUID) (*InvitationNotificationContext, error)

--- a/backend/internal/application/invitation/repository_dto.go
+++ b/backend/internal/application/invitation/repository_dto.go
@@ -54,6 +54,14 @@ type InvitationNotificationContext struct {
 	InvitedDisplayName *string
 }
 
+// ListPastInvitationsParams carries the keyset cursor and fetch budget for
+// the past bucket. FetchLimit is normally Limit+1 so the service can
+// detect whether another page exists without an extra query.
+type ListPastInvitationsParams struct {
+	Cursor     *PastInvitationCursor
+	FetchLimit int
+}
+
 type ReceivedInvitationRecord struct {
 	InvitationID uuid.UUID
 	Status       domain.InvitationStatus

--- a/backend/internal/application/invitation/service.go
+++ b/backend/internal/application/invitation/service.go
@@ -2,6 +2,7 @@ package invitation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -118,6 +119,25 @@ func (s *Service) ListReceivedInvitations(ctx context.Context, input ListReceive
 			},
 		},
 	}, nil
+}
+
+// GetReceivedInvitation fetches the latest state of one invitation owned
+// by the caller. It deliberately returns no event-status or invitation-
+// status filter so the modal flow can render warnings for CANCELED,
+// EXPIRED, or already-actioned invitations. domain.ErrNotFound from the
+// repo (missing row, wrong recipient, non-PRIVATE event) maps to a 404
+// with the standard invitation_not_found code; the caller's identity is
+// never leaked via a 403.
+func (s *Service) GetReceivedInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*ReceivedInvitation, error) {
+	record, err := s.repo.GetReceivedInvitation(ctx, userID, invitationID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeInvitationNotFound, "The requested invitation does not exist.")
+		}
+		return nil, fmt.Errorf("get received invitation: %w", err)
+	}
+	dto := toReceivedInvitation(*record)
+	return &dto, nil
 }
 
 // normalizeListReceivedInvitationsInput resolves the past-bucket page size

--- a/backend/internal/application/invitation/service.go
+++ b/backend/internal/application/invitation/service.go
@@ -73,17 +73,83 @@ func (s *Service) CreateInvitations(
 	return toCreateInvitationsResult(record), nil
 }
 
-func (s *Service) ListReceivedInvitations(ctx context.Context, userID uuid.UUID) (*ReceivedInvitationsResult, error) {
-	records, err := s.repo.ListReceivedPendingInvitations(ctx, userID)
+func (s *Service) ListReceivedInvitations(ctx context.Context, input ListReceivedInvitationsInput) (*ReceivedInvitationsResult, error) {
+	limit, cursor, appErr := normalizeListReceivedInvitationsInput(input)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	pendingRecords, err := s.repo.ListReceivedPendingInvitations(ctx, input.UserID)
+	if err != nil {
+		return nil, err
+	}
+	pending := make([]ReceivedInvitation, len(pendingRecords))
+	for i, record := range pendingRecords {
+		pending[i] = toReceivedInvitation(record)
+	}
+
+	pastRecords, err := s.repo.ListReceivedPastInvitations(ctx, input.UserID, ListPastInvitationsParams{
+		Cursor:     cursor,
+		FetchLimit: limit + 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	hasNext := len(pastRecords) > limit
+	if hasNext {
+		pastRecords = pastRecords[:limit]
+	}
+	pastItems := make([]ReceivedInvitation, len(pastRecords))
+	for i, record := range pastRecords {
+		pastItems[i] = toReceivedInvitation(record)
+	}
+	nextCursor, err := buildNextPastInvitationCursor(pastItems, hasNext)
 	if err != nil {
 		return nil, err
 	}
 
-	items := make([]ReceivedInvitation, len(records))
-	for i, record := range records {
-		items[i] = toReceivedInvitation(record)
+	return &ReceivedInvitationsResult{
+		Pending: pending,
+		Past: ReceivedInvitationsPastResult{
+			Items: pastItems,
+			PageInfo: InvitationPageInfo{
+				NextCursor: nextCursor,
+				HasNext:    hasNext,
+			},
+		},
+	}, nil
+}
+
+// normalizeListReceivedInvitationsInput resolves the past-bucket page size
+// and decodes the cursor token. A bad cursor produces a 400 with code
+// `validation_error` so clients can react predictably; a missing cursor or
+// limit falls back to safe defaults.
+func normalizeListReceivedInvitationsInput(input ListReceivedInvitationsInput) (int, *PastInvitationCursor, *domain.AppError) {
+	limit := DefaultPastInvitationLimit
+	if input.PastLimit != nil {
+		v := *input.PastLimit
+		if v < 1 || v > MaxPastInvitationLimit {
+			return 0, nil, domain.ValidationError(map[string]string{
+				"past_limit": fmt.Sprintf("must be between 1 and %d", MaxPastInvitationLimit),
+			})
+		}
+		limit = v
 	}
-	return &ReceivedInvitationsResult{Items: items}, nil
+
+	var cursor *PastInvitationCursor
+	if input.PastCursor != nil {
+		token := strings.TrimSpace(*input.PastCursor)
+		if token != "" {
+			decoded, err := decodePastInvitationCursor(token)
+			if err != nil {
+				return 0, nil, domain.ValidationError(map[string]string{
+					"past_cursor": "cursor is invalid",
+				})
+			}
+			cursor = decoded
+		}
+	}
+	return limit, cursor, nil
 }
 
 func (s *Service) AcceptInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*AcceptInvitationResult, error) {

--- a/backend/internal/application/invitation/service_dto.go
+++ b/backend/internal/application/invitation/service_dto.go
@@ -1,10 +1,39 @@
 package invitation
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// DefaultPastInvitationLimit is the page size used when callers do not
+	// specify past_limit. Matches the team default for paginated endpoints.
+	DefaultPastInvitationLimit = 25
+	// MaxPastInvitationLimit caps client-supplied past_limit to keep request
+	// cost predictable; matches NotificationCenter's MaxNotificationLimit.
+	MaxPastInvitationLimit = 50
+)
 
 type CreateInvitationsInput struct {
 	Usernames []string
 	Message   *string
+}
+
+// ListReceivedInvitationsInput drives GET /me/invitations. Only the past
+// bucket is paginated; pending always returns the full active set.
+type ListReceivedInvitationsInput struct {
+	UserID     uuid.UUID
+	PastCursor *string
+	PastLimit  *int
+}
+
+// PastInvitationCursor is the keyset used to paginate the past bucket.
+// (UpdatedAt, InvitationID) is a stable, unique tuple under the bucket's
+// (updated_at DESC, id DESC) ordering.
+type PastInvitationCursor struct {
+	UpdatedAt    time.Time `json:"updated_at"`
+	InvitationID uuid.UUID `json:"invitation_id"`
 }
 
 type CreatedInvitation struct {
@@ -30,8 +59,28 @@ type CreateInvitationsResult struct {
 	Failed                []InvitationFailure `json:"failed"`
 }
 
+// ReceivedInvitationsResult is the response from GET /me/invitations,
+// split into a pending bucket (all currently actionable invitations) and a
+// past bucket (DECLINED + EXPIRED — actionable history excluding ACCEPTED
+// and CANCELED, which would either duplicate participation views or
+// surface host-side decisions awkwardly).
 type ReceivedInvitationsResult struct {
-	Items []ReceivedInvitation `json:"items"`
+	Pending []ReceivedInvitation          `json:"pending"`
+	Past    ReceivedInvitationsPastResult `json:"past"`
+}
+
+// ReceivedInvitationsPastResult holds the paginated past bucket plus its
+// cursor metadata. Only this bucket is paginated.
+type ReceivedInvitationsPastResult struct {
+	Items    []ReceivedInvitation `json:"items"`
+	PageInfo InvitationPageInfo   `json:"page_info"`
+}
+
+// InvitationPageInfo mirrors the project's existing PageInfo shape (e.g.
+// NotificationPageInfo) so clients can reuse pagination components.
+type InvitationPageInfo struct {
+	NextCursor *string `json:"next_cursor"`
+	HasNext    bool    `json:"has_next"`
 }
 
 type ReceivedInvitation struct {

--- a/backend/internal/application/invitation/service_test.go
+++ b/backend/internal/application/invitation/service_test.go
@@ -35,6 +35,8 @@ type fakeRepo struct {
 	lastPastParams      ListPastInvitationsParams
 	pastErr             error
 	pendingErr          error
+	getReceivedResult   *ReceivedInvitationRecord
+	getReceivedErr      error
 }
 
 func (r *fakeRepo) CreateInvitations(_ context.Context, params CreateInvitationsParams) (*CreateInvitationsRecord, error) {
@@ -82,6 +84,13 @@ func (r *fakeRepo) AcceptInvitation(context.Context, uuid.UUID, uuid.UUID) (*Acc
 
 func (r *fakeRepo) DeclineInvitation(context.Context, uuid.UUID, uuid.UUID) (*domain.Invitation, error) {
 	return r.declineResult, nil
+}
+
+func (r *fakeRepo) GetReceivedInvitation(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*ReceivedInvitationRecord, error) {
+	if r.getReceivedErr != nil {
+		return nil, r.getReceivedErr
+	}
+	return r.getReceivedResult, nil
 }
 
 func (r *fakeRepo) GetInvitationNotificationContext(_ context.Context, invitationID uuid.UUID) (*InvitationNotificationContext, error) {
@@ -323,6 +332,95 @@ func TestListReceivedInvitationsBucketsAndPagination(t *testing.T) {
 		// then
 		if !errors.Is(err, expected) {
 			t.Errorf("expected wrapped %v, got %v", expected, err)
+		}
+	})
+}
+
+func TestGetReceivedInvitation(t *testing.T) {
+	t.Run("happy path returns translated DTO", func(t *testing.T) {
+		// given
+		invID := uuid.New()
+		eventID := uuid.New()
+		hostID := uuid.New()
+		repo := &fakeRepo{
+			getReceivedResult: &ReceivedInvitationRecord{
+				InvitationID: invID,
+				Status:       domain.InvitationStatusCanceled,
+				CreatedAt:    time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC),
+				UpdatedAt:    time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC),
+				Event: ReceivedInvitationEventRecord{
+					ID:           eventID,
+					Title:        "Yoga",
+					StartTime:    time.Date(2026, 5, 10, 9, 0, 0, 0, time.UTC),
+					Status:       domain.EventStatusActive,
+					PrivacyLevel: domain.PrivacyPrivate,
+				},
+				Host: ReceivedInvitationUserRecord{ID: hostID, Username: "ada"},
+			},
+		}
+		service := NewService(repo, fakeUnitOfWork{})
+
+		// when
+		result, err := service.GetReceivedInvitation(context.Background(), uuid.New(), invID)
+
+		// then
+		if err != nil {
+			t.Fatalf("GetReceivedInvitation: %v", err)
+		}
+		if result.InvitationID != invID.String() {
+			t.Errorf("invitation_id = %s, want %s", result.InvitationID, invID)
+		}
+		// Detail endpoint must surface CANCELED so the client modal can warn.
+		if result.Status != string(domain.InvitationStatusCanceled) {
+			t.Errorf("status = %s, want CANCELED", result.Status)
+		}
+		if result.Host.Username != "ada" {
+			t.Errorf("host.username = %s, want ada", result.Host.Username)
+		}
+	})
+
+	t.Run("ErrNotFound from repo maps to invitation_not_found 404", func(t *testing.T) {
+		// given
+		repo := &fakeRepo{getReceivedErr: domain.ErrNotFound}
+		service := NewService(repo, fakeUnitOfWork{})
+
+		// when
+		_, err := service.GetReceivedInvitation(context.Background(), uuid.New(), uuid.New())
+
+		// then
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var appErr *domain.AppError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected *domain.AppError, got %T", err)
+		}
+		if appErr.Code != domain.ErrorCodeInvitationNotFound {
+			t.Errorf("Code = %s, want %s", appErr.Code, domain.ErrorCodeInvitationNotFound)
+		}
+		if appErr.Status != domain.StatusNotFound {
+			t.Errorf("Status = %d, want %d", appErr.Status, domain.StatusNotFound)
+		}
+	})
+
+	t.Run("unexpected repo error propagates wrapped", func(t *testing.T) {
+		// given
+		expected := errors.New("db down")
+		repo := &fakeRepo{getReceivedErr: expected}
+		service := NewService(repo, fakeUnitOfWork{})
+
+		// when
+		_, err := service.GetReceivedInvitation(context.Background(), uuid.New(), uuid.New())
+
+		// then
+		if !errors.Is(err, expected) {
+			t.Errorf("expected wrapped %v, got %v", expected, err)
+		}
+		// Must NOT be an *AppError — that would silently downgrade to 404/500
+		// and lose the wrap chain for upstream observability.
+		var appErr *domain.AppError
+		if errors.As(err, &appErr) {
+			t.Errorf("expected raw error, got *domain.AppError = %v", appErr)
 		}
 	})
 }

--- a/backend/internal/application/invitation/service_test.go
+++ b/backend/internal/application/invitation/service_test.go
@@ -30,13 +30,13 @@ type fakeRepo struct {
 	// past returns up to FetchLimit rows, optionally honoring the cursor's
 	// strict-less-than (updated_at, id) DESC predicate so tests can drive
 	// pagination behavior without spinning up Postgres.
-	pending             []ReceivedInvitationRecord
-	past                []ReceivedInvitationRecord
-	lastPastParams      ListPastInvitationsParams
-	pastErr             error
-	pendingErr          error
-	getReceivedResult   *ReceivedInvitationRecord
-	getReceivedErr      error
+	pending           []ReceivedInvitationRecord
+	past              []ReceivedInvitationRecord
+	lastPastParams    ListPastInvitationsParams
+	pastErr           error
+	pendingErr        error
+	getReceivedResult *ReceivedInvitationRecord
+	getReceivedErr    error
 }
 
 func (r *fakeRepo) CreateInvitations(_ context.Context, params CreateInvitationsParams) (*CreateInvitationsRecord, error) {

--- a/backend/internal/application/invitation/service_test.go
+++ b/backend/internal/application/invitation/service_test.go
@@ -26,6 +26,15 @@ type fakeRepo struct {
 	revokeCallCount  int
 	lastRevokeParams RevokeInvitationParams
 	revokeErr        error
+	// pending and past hold canned responses for the receive-list paths.
+	// past returns up to FetchLimit rows, optionally honoring the cursor's
+	// strict-less-than (updated_at, id) DESC predicate so tests can drive
+	// pagination behavior without spinning up Postgres.
+	pending             []ReceivedInvitationRecord
+	past                []ReceivedInvitationRecord
+	lastPastParams      ListPastInvitationsParams
+	pastErr             error
+	pendingErr          error
 }
 
 func (r *fakeRepo) CreateInvitations(_ context.Context, params CreateInvitationsParams) (*CreateInvitationsRecord, error) {
@@ -37,11 +46,34 @@ func (r *fakeRepo) CreateInvitations(_ context.Context, params CreateInvitations
 }
 
 func (r *fakeRepo) ListReceivedPendingInvitations(context.Context, uuid.UUID) ([]ReceivedInvitationRecord, error) {
-	return nil, nil
+	if r.pendingErr != nil {
+		return nil, r.pendingErr
+	}
+	return r.pending, nil
 }
 
-func (r *fakeRepo) ListReceivedPastInvitations(context.Context, uuid.UUID, ListPastInvitationsParams) ([]ReceivedInvitationRecord, error) {
-	return nil, nil
+func (r *fakeRepo) ListReceivedPastInvitations(_ context.Context, _ uuid.UUID, params ListPastInvitationsParams) ([]ReceivedInvitationRecord, error) {
+	r.lastPastParams = params
+	if r.pastErr != nil {
+		return nil, r.pastErr
+	}
+	// Apply the cursor predicate so pagination tests can rely on
+	// (updated_at, id) DESC strict-less-than semantics without a real DB.
+	rows := r.past
+	if params.Cursor != nil {
+		filtered := rows[:0:0]
+		for _, row := range rows {
+			if row.UpdatedAt.Before(params.Cursor.UpdatedAt) ||
+				(row.UpdatedAt.Equal(params.Cursor.UpdatedAt) && row.InvitationID.String() < params.Cursor.InvitationID.String()) {
+				filtered = append(filtered, row)
+			}
+		}
+		rows = filtered
+	}
+	if params.FetchLimit > 0 && len(rows) > params.FetchLimit {
+		rows = rows[:params.FetchLimit]
+	}
+	return rows, nil
 }
 
 func (r *fakeRepo) AcceptInvitation(context.Context, uuid.UUID, uuid.UUID) (*AcceptInvitationRecord, error) {
@@ -74,6 +106,225 @@ func (r *fakeRepo) RevokeInvitation(_ context.Context, params RevokeInvitationPa
 		CreatedAt: now.Add(-time.Hour),
 		UpdatedAt: now,
 	}, nil
+}
+
+func TestListReceivedInvitationsBucketsAndPagination(t *testing.T) {
+	t1 := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	t2 := t1.Add(-1 * time.Hour) // older — appears second under updated_at DESC
+	pendingID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	pastID1 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	pastID2 := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+	pendingRec := ReceivedInvitationRecord{InvitationID: pendingID, Status: domain.InvitationStatusPending, UpdatedAt: t1}
+	pastRec1 := ReceivedInvitationRecord{InvitationID: pastID1, Status: domain.InvitationStatusDeclined, UpdatedAt: t1}
+	pastRec2 := ReceivedInvitationRecord{InvitationID: pastID2, Status: domain.InvitationStatusExpired, UpdatedAt: t2}
+
+	t.Run("empty result returns empty buckets and no cursor", func(t *testing.T) {
+		// given
+		repo := &fakeRepo{}
+		service := NewService(repo, fakeUnitOfWork{})
+
+		// when
+		result, err := service.ListReceivedInvitations(context.Background(), ListReceivedInvitationsInput{
+			UserID: uuid.New(),
+		})
+
+		// then
+		if err != nil {
+			t.Fatalf("ListReceivedInvitations() error = %v", err)
+		}
+		if len(result.Pending) != 0 {
+			t.Errorf("expected empty pending, got %d", len(result.Pending))
+		}
+		if len(result.Past.Items) != 0 {
+			t.Errorf("expected empty past items, got %d", len(result.Past.Items))
+		}
+		if result.Past.PageInfo.HasNext {
+			t.Errorf("expected has_next=false on empty result")
+		}
+		if result.Past.PageInfo.NextCursor != nil {
+			t.Errorf("expected nil next_cursor on empty result")
+		}
+	})
+
+	t.Run("populated buckets with implicit limit do not produce a cursor", func(t *testing.T) {
+		// given
+		repo := &fakeRepo{
+			pending: []ReceivedInvitationRecord{pendingRec},
+			past:    []ReceivedInvitationRecord{pastRec1, pastRec2},
+		}
+		service := NewService(repo, fakeUnitOfWork{})
+
+		// when
+		result, err := service.ListReceivedInvitations(context.Background(), ListReceivedInvitationsInput{
+			UserID: uuid.New(),
+		})
+
+		// then
+		if err != nil {
+			t.Fatalf("ListReceivedInvitations() error = %v", err)
+		}
+		if got, want := len(result.Pending), 1; got != want {
+			t.Errorf("pending = %d, want %d", got, want)
+		}
+		if got, want := len(result.Past.Items), 2; got != want {
+			t.Errorf("past items = %d, want %d", got, want)
+		}
+		if result.Past.PageInfo.HasNext {
+			t.Errorf("has_next = true, want false (only 2 items, default limit 25)")
+		}
+		// FetchLimit asked the repo for limit+1 = 26 to detect overflow.
+		if got, want := repo.lastPastParams.FetchLimit, DefaultPastInvitationLimit+1; got != want {
+			t.Errorf("FetchLimit = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("explicit limit produces a next_cursor when more rows exist", func(t *testing.T) {
+		// given — past has 2 rows, limit = 1, so first page should be 1 item + has_next=true
+		repo := &fakeRepo{
+			past: []ReceivedInvitationRecord{pastRec1, pastRec2},
+		}
+		service := NewService(repo, fakeUnitOfWork{})
+		limit := 1
+
+		// when
+		result, err := service.ListReceivedInvitations(context.Background(), ListReceivedInvitationsInput{
+			UserID:    uuid.New(),
+			PastLimit: &limit,
+		})
+
+		// then
+		if err != nil {
+			t.Fatalf("ListReceivedInvitations() error = %v", err)
+		}
+		if got, want := len(result.Past.Items), 1; got != want {
+			t.Fatalf("page1 items = %d, want %d", got, want)
+		}
+		if !result.Past.PageInfo.HasNext {
+			t.Errorf("page1 has_next = false, want true")
+		}
+		if result.Past.PageInfo.NextCursor == nil {
+			t.Fatalf("page1 next_cursor is nil, want non-nil")
+		}
+
+		// and — the cursor decodes back to the page tail's (updated_at, id)
+		decoded, err := decodePastInvitationCursor(*result.Past.PageInfo.NextCursor)
+		if err != nil {
+			t.Fatalf("decode round-trip: %v", err)
+		}
+		if decoded.InvitationID != pastID1 {
+			t.Errorf("cursor invitation_id = %s, want %s (newest declined)", decoded.InvitationID, pastID1)
+		}
+	})
+
+	t.Run("invalid cursor returns validation_error", func(t *testing.T) {
+		// given
+		repo := &fakeRepo{}
+		service := NewService(repo, fakeUnitOfWork{})
+		bad := "!!!not-a-cursor!!!"
+
+		// when
+		_, err := service.ListReceivedInvitations(context.Background(), ListReceivedInvitationsInput{
+			UserID:     uuid.New(),
+			PastCursor: &bad,
+		})
+
+		// then
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var appErr *domain.AppError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected *domain.AppError, got %T", err)
+		}
+		if appErr.Code != domain.ErrorCodeValidation {
+			t.Errorf("Code = %s, want %s", appErr.Code, domain.ErrorCodeValidation)
+		}
+		if _, ok := appErr.Details["past_cursor"]; !ok {
+			t.Errorf("expected past_cursor detail, got %v", appErr.Details)
+		}
+	})
+
+	t.Run("out-of-range past_limit returns validation_error", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			limit int
+		}{
+			{"zero", 0},
+			{"negative", -5},
+			{"above max", MaxPastInvitationLimit + 1},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				// given
+				repo := &fakeRepo{}
+				service := NewService(repo, fakeUnitOfWork{})
+
+				// when
+				_, err := service.ListReceivedInvitations(context.Background(), ListReceivedInvitationsInput{
+					UserID:    uuid.New(),
+					PastLimit: &tc.limit,
+				})
+
+				// then
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				var appErr *domain.AppError
+				if !errors.As(err, &appErr) {
+					t.Fatalf("expected *domain.AppError, got %T", err)
+				}
+				if appErr.Code != domain.ErrorCodeValidation {
+					t.Errorf("Code = %s, want %s", appErr.Code, domain.ErrorCodeValidation)
+				}
+				if _, ok := appErr.Details["past_limit"]; !ok {
+					t.Errorf("expected past_limit detail, got %v", appErr.Details)
+				}
+			})
+		}
+	})
+
+	t.Run("empty cursor string is ignored (treated as no cursor)", func(t *testing.T) {
+		// given — empty string after trim should not trip the decoder
+		repo := &fakeRepo{
+			past: []ReceivedInvitationRecord{pastRec1},
+		}
+		service := NewService(repo, fakeUnitOfWork{})
+		emptyCursor := "   "
+
+		// when
+		result, err := service.ListReceivedInvitations(context.Background(), ListReceivedInvitationsInput{
+			UserID:     uuid.New(),
+			PastCursor: &emptyCursor,
+		})
+
+		// then
+		if err != nil {
+			t.Fatalf("expected empty cursor to be ignored, got error: %v", err)
+		}
+		if got, want := len(result.Past.Items), 1; got != want {
+			t.Errorf("past items = %d, want %d", got, want)
+		}
+		if repo.lastPastParams.Cursor != nil {
+			t.Errorf("expected nil Cursor passed to repo, got %v", repo.lastPastParams.Cursor)
+		}
+	})
+
+	t.Run("repository error on past bucket propagates", func(t *testing.T) {
+		// given
+		expected := errors.New("db down")
+		repo := &fakeRepo{pastErr: expected}
+		service := NewService(repo, fakeUnitOfWork{})
+
+		// when
+		_, err := service.ListReceivedInvitations(context.Background(), ListReceivedInvitationsInput{
+			UserID: uuid.New(),
+		})
+
+		// then
+		if !errors.Is(err, expected) {
+			t.Errorf("expected wrapped %v, got %v", expected, err)
+		}
+	})
 }
 
 func TestRevokeInvitationDelegatesToRepo(t *testing.T) {

--- a/backend/internal/application/invitation/service_test.go
+++ b/backend/internal/application/invitation/service_test.go
@@ -40,6 +40,10 @@ func (r *fakeRepo) ListReceivedPendingInvitations(context.Context, uuid.UUID) ([
 	return nil, nil
 }
 
+func (r *fakeRepo) ListReceivedPastInvitations(context.Context, uuid.UUID, ListPastInvitationsParams) ([]ReceivedInvitationRecord, error) {
+	return nil, nil
+}
+
 func (r *fakeRepo) AcceptInvitation(context.Context, uuid.UUID, uuid.UUID) (*AcceptInvitationRecord, error) {
 	return r.acceptResult, nil
 }

--- a/backend/internal/application/invitation/usecase.go
+++ b/backend/internal/application/invitation/usecase.go
@@ -9,6 +9,10 @@ import (
 type UseCase interface {
 	CreateInvitations(ctx context.Context, hostID, eventID uuid.UUID, input CreateInvitationsInput) (*CreateInvitationsResult, error)
 	ListReceivedInvitations(ctx context.Context, input ListReceivedInvitationsInput) (*ReceivedInvitationsResult, error)
+	// GetReceivedInvitation returns the latest state of a single invitation
+	// addressed to the caller, regardless of status — clients use it to
+	// refresh modal content opened from a stale notification.
+	GetReceivedInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*ReceivedInvitation, error)
 	AcceptInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*AcceptInvitationResult, error)
 	DeclineInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*DeclineInvitationResult, error)
 	RevokeInvitation(ctx context.Context, hostID, eventID, invitationID uuid.UUID) error

--- a/backend/internal/application/invitation/usecase.go
+++ b/backend/internal/application/invitation/usecase.go
@@ -8,7 +8,7 @@ import (
 
 type UseCase interface {
 	CreateInvitations(ctx context.Context, hostID, eventID uuid.UUID, input CreateInvitationsInput) (*CreateInvitationsResult, error)
-	ListReceivedInvitations(ctx context.Context, userID uuid.UUID) (*ReceivedInvitationsResult, error)
+	ListReceivedInvitations(ctx context.Context, input ListReceivedInvitationsInput) (*ReceivedInvitationsResult, error)
 	AcceptInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*AcceptInvitationResult, error)
 	DeclineInvitation(ctx context.Context, userID, invitationID uuid.UUID) (*DeclineInvitationResult, error)
 	RevokeInvitation(ctx context.Context, hostID, eventID, invitationID uuid.UUID) error

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -1711,17 +1711,26 @@ func TestListReceivedInvitationsReturnsCurrentPendingOnly(t *testing.T) {
 	insertInvitation(t, declinedEventID, host.ID, invitee.ID, domain.InvitationStatusDeclined, nil, nil)
 
 	// when
-	result, err := harness.InvitationService.ListReceivedInvitations(context.Background(), invitee.ID)
+	result, err := harness.InvitationService.ListReceivedInvitations(context.Background(), invitationapp.ListReceivedInvitationsInput{
+		UserID: invitee.ID,
+	})
 
 	// then
 	if err != nil {
 		t.Fatalf("ListReceivedInvitations() error = %v", err)
 	}
-	if len(result.Items) != 1 {
-		t.Fatalf("expected 1 current invitation, got %d", len(result.Items))
+	if len(result.Pending) != 1 {
+		t.Fatalf("expected 1 pending invitation, got %d", len(result.Pending))
 	}
-	if result.Items[0].Event.ID != pendingEventID.String() {
-		t.Fatalf("expected pending event %s, got %s", pendingEventID, result.Items[0].Event.ID)
+	if result.Pending[0].Event.ID != pendingEventID.String() {
+		t.Fatalf("expected pending event %s, got %s", pendingEventID, result.Pending[0].Event.ID)
+	}
+	// DECLINED now belongs to the past bucket, not pending.
+	if len(result.Past.Items) != 1 {
+		t.Fatalf("expected 1 past invitation, got %d", len(result.Past.Items))
+	}
+	if result.Past.Items[0].Event.ID != declinedEventID.String() {
+		t.Fatalf("expected past event %s, got %s", declinedEventID, result.Past.Items[0].Event.ID)
 	}
 }
 

--- a/backend/tests_integration/invitation_test.go
+++ b/backend/tests_integration/invitation_test.go
@@ -4,6 +4,7 @@ package tests_integration
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -171,6 +172,127 @@ func TestListReceivedInvitationsPastPagination(t *testing.T) {
 	}
 	if page2.Past.PageInfo.NextCursor != nil {
 		t.Errorf("page2 next_cursor non-nil, want nil")
+	}
+}
+
+// TestGetReceivedInvitationReturnsAllStatuses asserts that the detail
+// endpoint surfaces the latest invitation state regardless of status —
+// including CANCELED and ACCEPTED, which the list endpoint deliberately
+// hides. The modal flow that opens from a stale notification depends on
+// this, so all five InvitationStatus values are exercised.
+func TestGetReceivedInvitationReturnsAllStatuses(t *testing.T) {
+	// given
+	h := common.NewEventHarness(t)
+	host := common.GivenUser(t, h.AuthRepo)
+	invitee := common.GivenUser(t, h.AuthRepo)
+	ctx := context.Background()
+
+	// One event per status — invitation rows are unique per (event, user).
+	pendingEvent := givenPrivateEvent(t, h.Service, host.ID)
+	acceptedEvent := givenPrivateEvent(t, h.Service, host.ID)
+	declinedEvent := givenPrivateEvent(t, h.Service, host.ID)
+	expiredEvent := givenPrivateEvent(t, h.Service, host.ID)
+	canceledEvent := givenPrivateEvent(t, h.Service, host.ID)
+
+	pendingID := givenInvitation(t, h.InvitationService, host.ID, pendingEvent, invitee.Username)
+	acceptedID := givenInvitation(t, h.InvitationService, host.ID, acceptedEvent, invitee.Username)
+	declinedID := givenInvitation(t, h.InvitationService, host.ID, declinedEvent, invitee.Username)
+	expiredID := givenInvitation(t, h.InvitationService, host.ID, expiredEvent, invitee.Username)
+	canceledID := givenInvitation(t, h.InvitationService, host.ID, canceledEvent, invitee.Username)
+
+	if _, err := h.InvitationService.AcceptInvitation(ctx, invitee.ID, acceptedID); err != nil {
+		t.Fatalf("AcceptInvitation: %v", err)
+	}
+	if _, err := h.InvitationService.DeclineInvitation(ctx, invitee.ID, declinedID); err != nil {
+		t.Fatalf("DeclineInvitation: %v", err)
+	}
+	if err := h.InvitationService.RevokeInvitation(ctx, host.ID, canceledEvent, canceledID); err != nil {
+		t.Fatalf("RevokeInvitation: %v", err)
+	}
+	expireInvitation(t, expiredID)
+
+	// when / then — fetch each by id and assert the round-tripped status
+	cases := []struct {
+		name         string
+		invitationID uuid.UUID
+		wantStatus   string
+	}{
+		{"PENDING", pendingID, string(domain.InvitationStatusPending)},
+		{"ACCEPTED", acceptedID, string(domain.InvitationStatusAccepted)},
+		{"DECLINED", declinedID, string(domain.InvitationStatusDeclined)},
+		{"EXPIRED", expiredID, string(domain.InvitationStatusExpired)},
+		{"CANCELED", canceledID, string(domain.InvitationStatusCanceled)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := h.InvitationService.GetReceivedInvitation(ctx, invitee.ID, tc.invitationID)
+			if err != nil {
+				t.Fatalf("GetReceivedInvitation: %v", err)
+			}
+			if got.InvitationID != tc.invitationID.String() {
+				t.Errorf("invitation_id = %s, want %s", got.InvitationID, tc.invitationID)
+			}
+			if got.Status != tc.wantStatus {
+				t.Errorf("status = %s, want %s", got.Status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestGetReceivedInvitationDoesNotLeakOtherUsersRows asserts that asking
+// for someone else's invitation returns 404 — never 403 — so the server
+// does not signal that the row exists at all.
+func TestGetReceivedInvitationDoesNotLeakOtherUsersRows(t *testing.T) {
+	// given
+	h := common.NewEventHarness(t)
+	host := common.GivenUser(t, h.AuthRepo)
+	invitee := common.GivenUser(t, h.AuthRepo)
+	stranger := common.GivenUser(t, h.AuthRepo)
+	ctx := context.Background()
+
+	event := givenPrivateEvent(t, h.Service, host.ID)
+	invitationID := givenInvitation(t, h.InvitationService, host.ID, event, invitee.Username)
+
+	// when — stranger asks for invitee's invitation
+	_, err := h.InvitationService.GetReceivedInvitation(ctx, stranger.ID, invitationID)
+
+	// then — must be a 404 invitation_not_found, indistinguishable from a
+	// genuinely missing row.
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T", err)
+	}
+	if appErr.Code != domain.ErrorCodeInvitationNotFound {
+		t.Errorf("Code = %s, want %s", appErr.Code, domain.ErrorCodeInvitationNotFound)
+	}
+	if appErr.Status != domain.StatusNotFound {
+		t.Errorf("Status = %d, want %d", appErr.Status, domain.StatusNotFound)
+	}
+}
+
+// TestGetReceivedInvitationReturns404ForMissingID covers the genuine
+// missing-row case.
+func TestGetReceivedInvitationReturns404ForMissingID(t *testing.T) {
+	// given
+	h := common.NewEventHarness(t)
+	user := common.GivenUser(t, h.AuthRepo)
+
+	// when
+	_, err := h.InvitationService.GetReceivedInvitation(context.Background(), user.ID, uuid.New())
+
+	// then
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var appErr *domain.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *domain.AppError, got %T", err)
+	}
+	if appErr.Code != domain.ErrorCodeInvitationNotFound {
+		t.Errorf("Code = %s, want %s", appErr.Code, domain.ErrorCodeInvitationNotFound)
 	}
 }
 

--- a/backend/tests_integration/invitation_test.go
+++ b/backend/tests_integration/invitation_test.go
@@ -1,0 +1,240 @@
+//go:build integration
+
+package tests_integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
+	invitationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/invitation"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
+	"github.com/google/uuid"
+)
+
+// TestListReceivedInvitationsBuckets exercises GET /me/invitations end-to-end
+// against a real Postgres. It seeds invitations across every status and
+// asserts the bucketing rules from issue #581:
+//   - pending bucket: PENDING for ACTIVE/IN_PROGRESS PRIVATE events only
+//   - past bucket: DECLINED + EXPIRED only
+//   - ACCEPTED is absent (already shows in My Events)
+//   - CANCELED is absent (host-side decision should not surface here)
+func TestListReceivedInvitationsBuckets(t *testing.T) {
+	// given
+	h := common.NewEventHarness(t)
+	host := common.GivenUser(t, h.AuthRepo)
+	invitee := common.GivenUser(t, h.AuthRepo)
+	ctx := context.Background()
+
+	pendingEvent := givenPrivateEvent(t, h.Service, host.ID)
+	declinedEvent := givenPrivateEvent(t, h.Service, host.ID)
+	expiredEvent := givenPrivateEvent(t, h.Service, host.ID)
+	acceptedEvent := givenPrivateEvent(t, h.Service, host.ID)
+	canceledEvent := givenPrivateEvent(t, h.Service, host.ID)
+
+	pendingID := givenInvitation(t, h.InvitationService, host.ID, pendingEvent, invitee.Username)
+	declinedID := givenInvitation(t, h.InvitationService, host.ID, declinedEvent, invitee.Username)
+	expiredID := givenInvitation(t, h.InvitationService, host.ID, expiredEvent, invitee.Username)
+	acceptedID := givenInvitation(t, h.InvitationService, host.ID, acceptedEvent, invitee.Username)
+	canceledID := givenInvitation(t, h.InvitationService, host.ID, canceledEvent, invitee.Username)
+
+	if _, err := h.InvitationService.DeclineInvitation(ctx, invitee.ID, declinedID); err != nil {
+		t.Fatalf("DeclineInvitation: %v", err)
+	}
+	if _, err := h.InvitationService.AcceptInvitation(ctx, invitee.ID, acceptedID); err != nil {
+		t.Fatalf("AcceptInvitation: %v", err)
+	}
+	if err := h.InvitationService.RevokeInvitation(ctx, host.ID, canceledEvent, canceledID); err != nil {
+		t.Fatalf("RevokeInvitation: %v", err)
+	}
+	// EXPIRED has no public-API path; flip status directly to mimic the
+	// scheduled job that sweeps overdue invitations in production.
+	expireInvitation(t, expiredID)
+
+	// when
+	result, err := h.InvitationService.ListReceivedInvitations(ctx, invitationapp.ListReceivedInvitationsInput{
+		UserID: invitee.ID,
+	})
+	if err != nil {
+		t.Fatalf("ListReceivedInvitations: %v", err)
+	}
+
+	// then — pending bucket
+	if got, want := len(result.Pending), 1; got != want {
+		t.Fatalf("pending count = %d, want %d", got, want)
+	}
+	if result.Pending[0].InvitationID != pendingID.String() {
+		t.Fatalf("pending[0] = %s, want %s", result.Pending[0].InvitationID, pendingID)
+	}
+	if result.Pending[0].Status != string(domain.InvitationStatusPending) {
+		t.Fatalf("pending[0].status = %s, want PENDING", result.Pending[0].Status)
+	}
+
+	// then — past bucket: DECLINED + EXPIRED only
+	if got, want := len(result.Past.Items), 2; got != want {
+		t.Fatalf("past count = %d, want %d (items=%+v)", got, want, result.Past.Items)
+	}
+	pastIDs := map[string]string{
+		result.Past.Items[0].InvitationID: result.Past.Items[0].Status,
+		result.Past.Items[1].InvitationID: result.Past.Items[1].Status,
+	}
+	if pastIDs[declinedID.String()] != string(domain.InvitationStatusDeclined) {
+		t.Errorf("DECLINED invitation %s missing or wrong status: %v", declinedID, pastIDs)
+	}
+	if pastIDs[expiredID.String()] != string(domain.InvitationStatusExpired) {
+		t.Errorf("EXPIRED invitation %s missing or wrong status: %v", expiredID, pastIDs)
+	}
+	if _, found := pastIDs[acceptedID.String()]; found {
+		t.Errorf("ACCEPTED invitation should NOT be in past, but found: %s", acceptedID)
+	}
+	if _, found := pastIDs[canceledID.String()]; found {
+		t.Errorf("CANCELED invitation should NOT be in past, but found: %s", canceledID)
+	}
+	if result.Past.PageInfo.HasNext {
+		t.Errorf("past.has_next = true, want false (only 2 items)")
+	}
+	if result.Past.PageInfo.NextCursor != nil {
+		t.Errorf("past.next_cursor = %v, want nil", *result.Past.PageInfo.NextCursor)
+	}
+}
+
+// TestListReceivedInvitationsPastPagination verifies cursor paging works:
+// limit=1 returns one item with has_next=true and a non-nil cursor; the
+// cursor request returns the second item with has_next=false.
+func TestListReceivedInvitationsPastPagination(t *testing.T) {
+	// given
+	h := common.NewEventHarness(t)
+	host := common.GivenUser(t, h.AuthRepo)
+	invitee := common.GivenUser(t, h.AuthRepo)
+	ctx := context.Background()
+
+	firstEvent := givenPrivateEvent(t, h.Service, host.ID)
+	secondEvent := givenPrivateEvent(t, h.Service, host.ID)
+	first := givenInvitation(t, h.InvitationService, host.ID, firstEvent, invitee.Username)
+	second := givenInvitation(t, h.InvitationService, host.ID, secondEvent, invitee.Username)
+
+	// Decline first, then second — so by updated_at DESC, second appears first.
+	if _, err := h.InvitationService.DeclineInvitation(ctx, invitee.ID, first); err != nil {
+		t.Fatalf("DeclineInvitation first: %v", err)
+	}
+	// Force a discernible time delta so updated_at ordering is deterministic.
+	time.Sleep(10 * time.Millisecond)
+	if _, err := h.InvitationService.DeclineInvitation(ctx, invitee.ID, second); err != nil {
+		t.Fatalf("DeclineInvitation second: %v", err)
+	}
+
+	// when — first page
+	limit := 1
+	page1, err := h.InvitationService.ListReceivedInvitations(ctx, invitationapp.ListReceivedInvitationsInput{
+		UserID:    invitee.ID,
+		PastLimit: &limit,
+	})
+	if err != nil {
+		t.Fatalf("ListReceivedInvitations page1: %v", err)
+	}
+
+	// then — first page returns the most recently declined invitation
+	if got, want := len(page1.Past.Items), 1; got != want {
+		t.Fatalf("page1 past count = %d, want %d", got, want)
+	}
+	if page1.Past.Items[0].InvitationID != second.String() {
+		t.Fatalf("page1[0] = %s, want %s (most recent decline)", page1.Past.Items[0].InvitationID, second)
+	}
+	if !page1.Past.PageInfo.HasNext {
+		t.Fatalf("page1 has_next = false, want true")
+	}
+	if page1.Past.PageInfo.NextCursor == nil {
+		t.Fatalf("page1 next_cursor is nil, want non-nil")
+	}
+
+	// when — second page using the cursor
+	page2, err := h.InvitationService.ListReceivedInvitations(ctx, invitationapp.ListReceivedInvitationsInput{
+		UserID:     invitee.ID,
+		PastLimit:  &limit,
+		PastCursor: page1.Past.PageInfo.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("ListReceivedInvitations page2: %v", err)
+	}
+
+	// then — second page returns the older invitation, no next page
+	if got, want := len(page2.Past.Items), 1; got != want {
+		t.Fatalf("page2 past count = %d, want %d", got, want)
+	}
+	if page2.Past.Items[0].InvitationID != first.String() {
+		t.Fatalf("page2[0] = %s, want %s", page2.Past.Items[0].InvitationID, first)
+	}
+	if page2.Past.PageInfo.HasNext {
+		t.Errorf("page2 has_next = true, want false")
+	}
+	if page2.Past.PageInfo.NextCursor != nil {
+		t.Errorf("page2 next_cursor non-nil, want nil")
+	}
+}
+
+// givenPrivateEvent inserts a PRIVATE event owned by hostID using the live
+// service so all invariants (location, category, etc.) are consistent with
+// production behavior. Returns the event ID.
+func givenPrivateEvent(t *testing.T, svc eventapp.UseCase, hostID uuid.UUID) uuid.UUID {
+	t.Helper()
+	categoryID := common.GivenEventCategory(t)
+	startTime := time.Now().UTC().Add(24 * time.Hour)
+	result, err := svc.CreateEvent(context.Background(), hostID, eventapp.CreateEventInput{
+		Title:        "private_invitation_event_" + uuid.NewString()[:8],
+		Description:  common.StringPtr("Integration fixture"),
+		CategoryID:   &categoryID,
+		LocationType: domain.LocationPoint,
+		Lat:          common.Float64Ptr(41.0),
+		Lon:          common.Float64Ptr(29.0),
+		StartTime:    startTime,
+		PrivacyLevel: domain.PrivacyPrivate,
+	})
+	if err != nil {
+		t.Fatalf("givenPrivateEvent CreateEvent: %v", err)
+	}
+	id, err := uuid.Parse(result.ID)
+	if err != nil {
+		t.Fatalf("givenPrivateEvent uuid.Parse: %v", err)
+	}
+	return id
+}
+
+// givenInvitation creates a single PENDING invitation from host to the
+// given invitee for the given event and returns the new invitation ID.
+func givenInvitation(t *testing.T, svc invitationapp.UseCase, hostID, eventID uuid.UUID, inviteeUsername string) uuid.UUID {
+	t.Helper()
+	result, err := svc.CreateInvitations(context.Background(), hostID, eventID, invitationapp.CreateInvitationsInput{
+		Usernames: []string{inviteeUsername},
+	})
+	if err != nil {
+		t.Fatalf("givenInvitation CreateInvitations: %v", err)
+	}
+	if len(result.SuccessfulInvitations) != 1 {
+		t.Fatalf("givenInvitation expected 1 successful invitation, got %d (failures=%v)", len(result.SuccessfulInvitations), result.Failed)
+	}
+	id, err := uuid.Parse(result.SuccessfulInvitations[0].InvitationID)
+	if err != nil {
+		t.Fatalf("givenInvitation uuid.Parse: %v", err)
+	}
+	return id
+}
+
+// expireInvitation flips an invitation to EXPIRED via raw SQL so we can
+// exercise the past-bucket EXPIRED path without standing up the scheduled
+// expiry job. The production sweeper performs the equivalent UPDATE.
+func expireInvitation(t *testing.T, invitationID uuid.UUID) {
+	t.Helper()
+	pool := common.RequirePool(t)
+	tag, err := pool.Exec(context.Background(),
+		`UPDATE invitation SET status = $1, updated_at = now() WHERE id = $2`,
+		domain.InvitationStatusExpired, invitationID,
+	)
+	if err != nil {
+		t.Fatalf("expireInvitation: %v", err)
+	}
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("expireInvitation: expected 1 row affected, got %d", tag.RowsAffected())
+	}
+}

--- a/docs/openapi/profile.yaml
+++ b/docs/openapi/profile.yaml
@@ -138,12 +138,34 @@ paths:
 
   /me/invitations:
     get:
-      summary: Get current private-event invitations
-      description: Returns the authenticated user's current `PENDING` invitations for active private events.
+      summary: Get the authenticated user's invitations
+      description: |
+        Returns the authenticated user's invitations split into two buckets:
+
+        - `pending`: actionable invitations — `status = PENDING`, `event.privacy_level = PRIVATE`, event status in `ACTIVE` or `IN_PROGRESS`. Ordered `created_at ASC, id ASC`. Always returned in full (unpaginated).
+        - `past`: history of `DECLINED` and `EXPIRED` invitations for `PRIVATE` events, regardless of event status (so a declined invitation for a now-ended event is still visible). Ordered `updated_at DESC, id DESC`. Paginated via `past_cursor` / `past_limit`.
+
+        `ACCEPTED` invitations are intentionally absent from `past` because the resulting participation is already visible via `GET /me/events/upcoming` and `/me/events/completed`. `CANCELED` invitations (host-revoked) are also absent so the recipient is not confronted with host-side decisions.
       tags:
         - Profile
       security:
         - bearerAuth: []
+      parameters:
+        - in: query
+          name: past_cursor
+          required: false
+          schema:
+            type: string
+          description: Opaque pagination cursor for the past bucket. Echo back the `past.page_info.next_cursor` value from the previous response. Omit on the first page. Returns `validation_error` (400) when the cursor is malformed.
+        - in: query
+          name: past_limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 25
+          description: Page size for the past bucket. Pending bucket ignores this parameter.
       responses:
         "200":
           description: Invitations retrieved successfully.
@@ -151,6 +173,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReceivedInvitationsResponse"
+        "400":
+          description: Validation error (invalid `past_cursor` or `past_limit` out of range).
         "401":
           description: Missing or invalid access token.
 
@@ -499,12 +523,41 @@ components:
     ReceivedInvitationsResponse:
       type: object
       additionalProperties: false
-      required: [items]
+      required: [pending, past]
+      properties:
+        pending:
+          type: array
+          description: Actionable invitations (`status = PENDING`) for `PRIVATE` events whose status is `ACTIVE` or `IN_PROGRESS`. Unpaginated.
+          items:
+            $ref: "#/components/schemas/ReceivedInvitation"
+        past:
+          $ref: "#/components/schemas/ReceivedInvitationsPast"
+
+    ReceivedInvitationsPast:
+      type: object
+      additionalProperties: false
+      required: [items, page_info]
       properties:
         items:
           type: array
+          description: Page of past invitations (`status` ∈ {`DECLINED`, `EXPIRED`}) ordered by `updated_at` descending.
           items:
             $ref: "#/components/schemas/ReceivedInvitation"
+        page_info:
+          $ref: "#/components/schemas/InvitationPageInfo"
+
+    InvitationPageInfo:
+      type: object
+      additionalProperties: false
+      required: [next_cursor, has_next]
+      properties:
+        next_cursor:
+          type:
+            - string
+            - "null"
+          description: Token to pass as `past_cursor` on the next request. `null` when `has_next` is `false`.
+        has_next:
+          type: boolean
 
     ReceivedInvitation:
       type: object
@@ -516,7 +569,7 @@ components:
           format: uuid
         status:
           type: string
-          enum: [PENDING]
+          enum: [PENDING, DECLINED, EXPIRED]
         message:
           type:
             - string

--- a/docs/openapi/profile.yaml
+++ b/docs/openapi/profile.yaml
@@ -178,6 +178,33 @@ paths:
         "401":
           description: Missing or invalid access token.
 
+  /me/invitations/{invitation_id}:
+    get:
+      summary: Get the latest state of a single received invitation
+      description: |
+        Returns the latest state of one invitation addressed to the authenticated user. Used by clients to refresh modal content opened from a (possibly stale) notification — the response can carry any status (`PENDING`, `ACCEPTED`, `DECLINED`, `EXPIRED`, `CANCELED`) so the client can render an appropriate banner before letting the user act.
+
+        Returns `404` (`invitation_not_found`) when the invitation does not exist, when it is addressed to a different user, or when its event is not `PRIVATE` — the response shape is identical for all three so the API does not leak the existence of rows belonging to other users.
+      tags:
+        - Profile
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/InvitationIdParam"
+      responses:
+        "200":
+          description: Invitation found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReceivedInvitation"
+        "400":
+          description: Invalid invitation id.
+        "401":
+          description: Missing or invalid access token.
+        "404":
+          description: Invitation not found, not yours, or not for a `PRIVATE` event.
+
   /me/invitations/{invitation_id}/accept:
     post:
       summary: Accept a private-event invitation
@@ -569,7 +596,9 @@ components:
           format: uuid
         status:
           type: string
-          enum: [PENDING, DECLINED, EXPIRED]
+          enum: [PENDING, ACCEPTED, DECLINED, EXPIRED, CANCELED]
+          description: |
+            Invitation lifecycle status. The list endpoint (`GET /me/invitations`) only returns `PENDING` (in `pending`) or `DECLINED`/`EXPIRED` (in `past.items`); the detail endpoint (`GET /me/invitations/{id}`) can return any of the five values so clients can surface CANCELED and ACCEPTED states.
         message:
           type:
             - string


### PR DESCRIPTION
Closes #581

  ## Summary

  Splits `GET /me/invitations` into two buckets — `pending` (unchanged behavior) and `past` (DECLINED +
   EXPIRED) — and adds `GET /me/invitations/{invitation_id}` so a client modal opened from a
  notification can fetch the latest invitation status before rendering.

  ## Acceptance Criteria

  - [x] `GET /me/invitations` returns `{ pending: [...], past: { items: [...], page_info: {...} } }`
  - [x] `pending` bucket keeps current filtering (PENDING + PRIVATE + ACTIVE/IN_PROGRESS event)
  - [x] `past` bucket contains only DECLINED and EXPIRED invitations for PRIVATE events, regardless of
  event status
  - [x] ACCEPTED and CANCELED invitations are absent from both buckets
  - [x] `past_cursor` and `past_limit` query parameters paginate the past bucket; pending is
  unpaginated
  - [x] `past` is ordered by `updated_at DESC, id DESC`; `pending` keeps `created_at ASC, id ASC`
  - [x] A new invitation detail endpoint is created and backed by integration tests
  - [x] OpenAPI spec at `docs/openapi/profile.yaml` reflects the new shape and parameters
  - [x] Unit tests cover empty, mixed-status, pagination, and sort order
  - [x] Integration test verifies bucketing against real Postgres

  ## Breaking change

  `GET /me/invitations` no longer returns `{ items: [...] }`. Clients must switch to:

  ```json
  {
    "pending": [ "ReceivedInvitation", "..." ],
    "past": {
      "items": [ "ReceivedInvitation", "..." ],
      "page_info": { "next_cursor": "...", "has_next": true }
    }
  }
  ```

  Frontend invitations page (PR #564) and any mobile consumers need a coordinated follow-up.

  ## New endpoint

  `GET /me/invitations/{invitation_id}` returns a single invitation in any of the five statuses
  (PENDING / ACCEPTED / DECLINED / EXPIRED / CANCELED). Used by the notification → modal flow so
  clients can warn the user when the host has cancelled, or when the invitation has already been
  actioned. Returns 404 (`invitation_not_found`) when the row is missing, owned by another user, or for
   a non-PRIVATE event — never 403, to avoid leaking row existence.

  ## Notable design decisions

  - **Past scope = DECLINED + EXPIRED only.** ACCEPTED is absent because the resulting participation is
   already visible via `GET /me/events/upcoming` / `completed`. CANCELED is absent because surfacing
  host-revoked invitations in the recipient's history is awkward UX.
  - **Past pagination is keyset (`updated_at DESC, id DESC`)**, opaque base64 cursor — mirrors
  `internal/application/notification/cursor.go`.
  - **Pending is unpaginated** — small set, clients render eagerly.
  - **`ReceivedInvitation.status` enum widened** at the schema level to all five values; the list
  endpoint's narrower subset is documented at the operation level.

  ## Test plan

  - [x] `go test ./internal/...` (all packages green; invitation package coverage 83.5%)
  - [x] `go test -race -count=1 ./internal/...` (30 packages, no races)
  - [x] `go test -tags=integration ./tests_integration/...` (testcontainers Postgres, 58s, all green)
  - [x] `go vet`, `staticcheck`, `golangci-lint`, `gosec` — clean
  - [x] `go build ./cmd/server`

  ## Out of scope

  - Frontend / mobile clients adapting to the new response shape — separate PRs after this lands.
  - Showing ACCEPTED or CANCELED invitations in the past bucket — explicitly rejected during product
  evaluation.
  - Surfacing outbound invitations to hosts — handled by `/events/{id}/invitations`.