### PR TITLE
feat(frontend): show profile badges

### DIFF
--- a/frontend/src/models/profile.ts
+++ b/frontend/src/models/profile.ts
@@ -92,3 +92,30 @@ export interface ImageUploadInitResponse {
 export interface ImageUploadConfirmRequest {
   confirm_token: string;
 }
+
+export type BadgeCategory = 'HOSTING' | 'PARTICIPATION' | 'SOCIAL';
+
+export interface BadgeBase {
+  slug: string;
+  name: string;
+  description: string;
+  icon_url: string | null;
+  category: BadgeCategory;
+}
+
+export interface EarnedBadge extends BadgeBase {
+  earned_at: string;
+}
+
+export interface CatalogBadge extends BadgeBase {
+  earned: boolean;
+  earned_at: string | null;
+}
+
+export interface UserBadgesResponse {
+  items: EarnedBadge[];
+}
+
+export interface BadgeCatalogResponse {
+  items: CatalogBadge[];
+}

--- a/frontend/src/services/profileService.test.ts
+++ b/frontend/src/services/profileService.test.ts
@@ -31,3 +31,50 @@ describe('profileService.changePassword', () => {
     }));
   });
 });
+
+describe('profileService badges', () => {
+  it('fetches the authenticated user badges endpoint', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+
+    await profileService.getMyBadges('access-token');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/me/badges', expect.objectContaining({
+      method: 'GET',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      cache: 'no-store',
+    }));
+  });
+
+  it('fetches another user badges endpoint', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+
+    await profileService.getUserBadges('user-123', 'access-token');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/users/user-123/badges', expect.objectContaining({
+      method: 'GET',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      cache: 'no-store',
+    }));
+  });
+
+  it('fetches the badge catalog endpoint', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+
+    await profileService.getBadgeCatalog('access-token');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/badges', expect.objectContaining({
+      method: 'GET',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      cache: 'no-store',
+    }));
+  });
+});

--- a/frontend/src/services/profileService.ts
+++ b/frontend/src/services/profileService.ts
@@ -10,6 +10,8 @@ import {
   FavoriteLocationsResponse,
   CreateFavoriteLocationRequest,
   UpdateFavoriteLocationRequest,
+  UserBadgesResponse,
+  BadgeCatalogResponse,
 } from '../models/profile';
 
 interface EventListResponse {
@@ -75,5 +77,17 @@ export const profileService = {
 
   async deleteFavoriteLocation(id: string, token: string): Promise<void> {
     return apiDeleteAuth<void>(`/me/favorite-locations/${id}`, token);
+  },
+
+  async getMyBadges(token: string): Promise<UserBadgesResponse> {
+    return apiGetAuth<UserBadgesResponse>('/me/badges', token);
+  },
+
+  async getUserBadges(userId: string, token: string): Promise<UserBadgesResponse> {
+    return apiGetAuth<UserBadgesResponse>(`/users/${userId}/badges`, token);
+  },
+
+  async getBadgeCatalog(token: string): Promise<BadgeCatalogResponse> {
+    return apiGetAuth<BadgeCatalogResponse>('/badges', token);
   },
 };

--- a/frontend/src/styles/profile.css
+++ b/frontend/src/styles/profile.css
@@ -357,6 +357,357 @@
   background: #f3f4f6;
 }
 
+/* Badges */
+
+.profile-badges {
+  margin-top: 2.25rem;
+  padding-top: 2rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.profile-badges-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.profile-badges-title,
+.profile-badge-modal-title {
+  margin: 0;
+  color: #111827;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.profile-badges-subtitle {
+  margin: 0.35rem 0 0;
+  color: #6b7280;
+  font-size: 0.92rem;
+}
+
+.profile-badges-view-all {
+  flex-shrink: 0;
+  padding: 0.55rem 0.95rem;
+  border-radius: 6px;
+  border: 1px solid #111827;
+  background: #ffffff;
+  color: #111827;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, opacity 0.15s;
+}
+
+.profile-badges-view-all:hover:not(:disabled) {
+  background: #111827;
+  color: #ffffff;
+}
+
+.profile-badges-view-all:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.profile-badges-row {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(132px, 152px);
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding: 0.25rem 0 0.8rem;
+  scroll-snap-type: x proximity;
+}
+
+.profile-badge-card {
+  min-height: 158px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #111827;
+  padding: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.55rem;
+  text-align: center;
+  cursor: pointer;
+  scroll-snap-align: start;
+  transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s, opacity 0.15s;
+}
+
+.profile-badge-card.compact {
+  min-height: 146px;
+}
+
+.profile-badge-card:hover {
+  transform: translateY(-1px);
+  border-color: #111827;
+  box-shadow: 0 8px 22px rgba(17, 24, 39, 0.08);
+}
+
+.profile-badge-card.locked {
+  background: #f9fafb;
+  color: #6b7280;
+}
+
+.profile-badge-card.locked .profile-badge-icon-wrap,
+.profile-badge-card.locked .profile-badge-name {
+  filter: grayscale(1);
+  opacity: 0.62;
+}
+
+.profile-badge-icon-wrap {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  background: #f3f4f6;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.profile-badge-icon-img {
+  width: 44px;
+  height: 44px;
+  object-fit: contain;
+}
+
+.profile-badge-icon-emoji {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.profile-badge-lock {
+  position: absolute;
+  right: -7px;
+  bottom: -7px;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: #111827;
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  box-shadow: 0 2px 8px rgba(17, 24, 39, 0.18);
+}
+
+.profile-badge-name {
+  color: inherit;
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.profile-badge-date {
+  margin-top: auto;
+  color: #6b7280;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.profile-badges-state,
+.profile-badges-empty {
+  padding: 1.25rem 1rem;
+  border: 1px dashed #d1d5db;
+  border-radius: 10px;
+  background: #f9fafb;
+  color: #6b7280;
+  text-align: center;
+  font-size: 0.92rem;
+}
+
+.profile-badges-state.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  color: #dc2626;
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
+.profile-badges-state.error button {
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #991b1b;
+  padding: 0.35rem 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.profile-badge-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  background: rgba(17, 24, 39, 0.45);
+}
+
+.profile-badge-modal-card {
+  width: min(100%, 440px);
+  max-height: min(86vh, 760px);
+  overflow-y: auto;
+  border-radius: 14px;
+  background: #ffffff;
+  box-shadow: 0 24px 70px rgba(17, 24, 39, 0.24);
+  padding: 1rem;
+}
+
+.profile-badge-modal-card.wide {
+  width: min(100%, 760px);
+}
+
+.profile-badge-modal-header {
+  display: grid;
+  grid-template-columns: 72px 1fr 72px;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.profile-badge-modal-title {
+  text-align: center;
+}
+
+.profile-badge-modal-close,
+.profile-badge-modal-text-btn {
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111827;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.profile-badge-modal-close {
+  justify-self: end;
+  width: 36px;
+  height: 36px;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.profile-badge-modal-text-btn {
+  justify-self: start;
+  padding: 0.45rem 0.7rem;
+}
+
+.profile-badge-modal-close:hover,
+.profile-badge-modal-text-btn:hover {
+  background: #f3f4f6;
+}
+
+.profile-badge-detail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.65rem;
+  padding: 0.75rem 0.5rem 0.5rem;
+}
+
+.profile-badge-detail.locked {
+  color: #6b7280;
+}
+
+.profile-badge-detail-icon {
+  position: relative;
+  width: 86px;
+  height: 86px;
+  border-radius: 22px;
+  background: #f3f4f6;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-badge-detail-icon .profile-badge-icon-img {
+  width: 64px;
+  height: 64px;
+}
+
+.profile-badge-detail-icon .profile-badge-icon-emoji {
+  font-size: 3rem;
+}
+
+.profile-badge-lock.detail {
+  right: -8px;
+  bottom: -8px;
+}
+
+.profile-badge-detail h3 {
+  margin: 0.4rem 0 0;
+  color: #111827;
+  font-size: 1.35rem;
+}
+
+.profile-badge-detail-category {
+  margin: 0;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #374151;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.profile-badge-detail-description,
+.profile-badge-detail-status {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.profile-badge-detail-status {
+  font-weight: 700;
+}
+
+.profile-badge-tabs {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.75rem;
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.profile-badge-tab {
+  flex-shrink: 0;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #374151;
+  padding: 0.45rem 0.8rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.profile-badge-tab.active {
+  background: #111827;
+  border-color: #111827;
+  color: #ffffff;
+}
+
+.profile-badge-catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
 /* ── Change Password ── */
 
 .change-password-section {
@@ -518,6 +869,36 @@
 
   .profile-history-grid {
     grid-template-columns: 1fr;
+  }
+
+  .profile-badges-header,
+  .profile-badges-state.error {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .profile-badges-view-all {
+    width: 100%;
+  }
+
+  .profile-badges-row {
+    grid-auto-columns: minmax(124px, 142px);
+  }
+
+  .profile-badge-modal-overlay {
+    align-items: flex-end;
+    padding: 0.75rem;
+  }
+
+  .profile-badge-modal-card,
+  .profile-badge-modal-card.wide {
+    width: 100%;
+    max-height: 88vh;
+    border-radius: 14px;
+  }
+
+  .profile-badge-catalog-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .form-actions {

--- a/frontend/src/viewmodels/profile/useProfileViewModel.ts
+++ b/frontend/src/viewmodels/profile/useProfileViewModel.ts
@@ -1,7 +1,13 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { ApiError } from '@/services/api';
-import { EventSummary, UserProfile, UpdateProfileRequest } from '../../models/profile';
+import {
+  CatalogBadge,
+  EarnedBadge,
+  EventSummary,
+  UserProfile,
+  UpdateProfileRequest,
+} from '../../models/profile';
 import { profileService } from '../../services/profileService';
 import { prepareAvatarBlobs } from '../../utils/imageResize';
 import { searchLocation } from '@/services/eventService';
@@ -28,12 +34,16 @@ export function useProfileViewModel(token: string | null) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [hostedEvents, setHostedEvents] = useState<EventSummary[]>([]);
   const [attendedEvents, setAttendedEvents] = useState<EventSummary[]>([]);
+  const [earnedBadges, setEarnedBadges] = useState<EarnedBadge[]>([]);
+  const [badgeCatalog, setBadgeCatalog] = useState<CatalogBadge[]>([]);
 
   // UI states
   const [isLoading, setIsLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [badgeError, setBadgeError] = useState<string | null>(null);
+  const [badgesLoading, setBadgesLoading] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -105,9 +115,30 @@ export function useProfileViewModel(token: string | null) {
     }
   }, [token, setProfileSummary]);
 
+  const fetchBadges = useCallback(async () => {
+    if (!token) return;
+    setBadgesLoading(true);
+    setBadgeError(null);
+    try {
+      const [earned, catalog] = await Promise.all([
+        profileService.getMyBadges(token),
+        profileService.getBadgeCatalog(token),
+      ]);
+      setEarnedBadges(earned.items ?? []);
+      setBadgeCatalog(catalog.items ?? []);
+    } catch (err: unknown) {
+      setEarnedBadges([]);
+      setBadgeCatalog([]);
+      setBadgeError(err instanceof Error ? err.message : 'Failed to load badges');
+    } finally {
+      setBadgesLoading(false);
+    }
+  }, [token]);
+
   useEffect(() => {
     fetchProfile();
-  }, [fetchProfile]);
+    fetchBadges();
+  }, [fetchBadges, fetchProfile]);
 
   useEffect(
     () => () => {
@@ -346,6 +377,11 @@ export function useProfileViewModel(token: string | null) {
     profile,
     hostedEvents,
     attendedEvents,
+    earnedBadges,
+    badgeCatalog,
+    badgesLoading,
+    badgeError,
+    refreshBadges: fetchBadges,
     isLoading,
     isEditing,
     isSaving,

--- a/frontend/src/views/profile/ProfilePage.tsx
+++ b/frontend/src/views/profile/ProfilePage.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { EventCoverImage } from '@/components/EventCoverImage';
 import { useProfileViewModel } from '../../viewmodels/profile/useProfileViewModel';
-import type { EventSummary } from '../../models/profile';
+import type { BadgeCategory, CatalogBadge, EarnedBadge, EventSummary } from '../../models/profile';
 import { getEventLifecyclePresentation } from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
 
@@ -14,6 +14,267 @@ const MAX_SIZE_MB = 10;
 
 type ProfileHistoryTab = 'hosted' | 'attended';
 type PasswordFieldKey = 'current' | 'new' | 'confirm';
+
+const BADGE_CATEGORY_LABELS: Record<BadgeCategory, string> = {
+  HOSTING: 'Hosting',
+  PARTICIPATION: 'Participation',
+  SOCIAL: 'Social',
+};
+
+function formatBadgeDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function getBadgeIcon(badge: Pick<CatalogBadge, 'slug' | 'category' | 'icon_url'>): string {
+  if (badge.icon_url) return badge.icon_url;
+  const bySlug: Record<string, string> = {
+    FIRST_STEPS: '👣',
+    REGULAR: '🎟️',
+    VETERAN: '🏅',
+    EXPLORER: '🧭',
+    HOST_DEBUT: '🎤',
+    SUPER_HOST: '🌟',
+    TOP_RATED: '⭐',
+    FAVORITE_FINDER: '📍',
+  };
+  if (bySlug[badge.slug]) return bySlug[badge.slug];
+  if (badge.category === 'HOSTING') return '🎤';
+  if (badge.category === 'SOCIAL') return '🤝';
+  return '🏅';
+}
+
+function earnedToCatalogBadge(badge: EarnedBadge): CatalogBadge {
+  return {
+    ...badge,
+    earned: true,
+    earned_at: badge.earned_at,
+  };
+}
+
+function BadgeIcon({ badge }: { badge: CatalogBadge }) {
+  if (badge.icon_url) {
+    return <img src={badge.icon_url} alt="" className="profile-badge-icon-img" />;
+  }
+  return <span className="profile-badge-icon-emoji" aria-hidden>{getBadgeIcon(badge)}</span>;
+}
+
+function BadgeCard({
+  badge,
+  compact = false,
+  onClick,
+}: {
+  badge: CatalogBadge;
+  compact?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`profile-badge-card ${compact ? 'compact' : ''} ${badge.earned ? 'earned' : 'locked'}`}
+      onClick={onClick}
+    >
+      <span className="profile-badge-icon-wrap">
+        <BadgeIcon badge={badge} />
+        {!badge.earned && <span className="profile-badge-lock" aria-label="Locked">🔒</span>}
+      </span>
+      <span className="profile-badge-name">{badge.name}</span>
+      <span className="profile-badge-date">
+        {badge.earned_at ? formatBadgeDate(badge.earned_at) : 'Not earned'}
+      </span>
+    </button>
+  );
+}
+
+function BadgeDetail({
+  badge,
+  onBack,
+  onClose,
+}: {
+  badge: CatalogBadge;
+  onBack: (() => void) | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="profile-badge-modal-card" role="dialog" aria-modal="true" aria-labelledby="profile-badge-detail-title">
+      <div className="profile-badge-modal-header">
+        {onBack ? (
+          <button type="button" className="profile-badge-modal-text-btn" onClick={onBack}>
+            Back
+          </button>
+        ) : (
+          <span className="profile-badge-modal-spacer" aria-hidden />
+        )}
+        <h2 id="profile-badge-detail-title" className="profile-badge-modal-title">Badge details</h2>
+        <button type="button" className="profile-badge-modal-close" onClick={onClose} aria-label="Close">
+          ×
+        </button>
+      </div>
+      <div className={`profile-badge-detail ${badge.earned ? 'earned' : 'locked'}`}>
+        <span className="profile-badge-detail-icon">
+          <BadgeIcon badge={badge} />
+          {!badge.earned && <span className="profile-badge-lock detail" aria-label="Locked">🔒</span>}
+        </span>
+        <h3>{badge.name}</h3>
+        <p className="profile-badge-detail-category">{BADGE_CATEGORY_LABELS[badge.category] ?? badge.category}</p>
+        <p className="profile-badge-detail-description">{badge.description}</p>
+        <p className="profile-badge-detail-status">
+          {badge.earned_at
+            ? `Earned ${formatBadgeDate(badge.earned_at)}`
+            : `Not yet earned. ${badge.description}`}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function BadgeCatalogModal({
+  badges,
+  activeCategory,
+  onCategoryChange,
+  onSelectBadge,
+  onClose,
+}: {
+  badges: CatalogBadge[];
+  activeCategory: BadgeCategory | 'ALL';
+  onCategoryChange: (category: BadgeCategory | 'ALL') => void;
+  onSelectBadge: (badge: CatalogBadge) => void;
+  onClose: () => void;
+}) {
+  const categories: Array<BadgeCategory | 'ALL'> = ['ALL', 'HOSTING', 'PARTICIPATION', 'SOCIAL'];
+  const visibleBadges = activeCategory === 'ALL'
+    ? badges
+    : badges.filter((badge) => badge.category === activeCategory);
+
+  return (
+    <div className="profile-badge-modal-card wide" role="dialog" aria-modal="true" aria-labelledby="profile-badge-catalog-title">
+      <div className="profile-badge-modal-header">
+        <span className="profile-badge-modal-spacer" aria-hidden />
+        <h2 id="profile-badge-catalog-title" className="profile-badge-modal-title">All Badges</h2>
+        <button type="button" className="profile-badge-modal-close" onClick={onClose} aria-label="Close">
+          ×
+        </button>
+      </div>
+      <div className="profile-badge-tabs" role="tablist" aria-label="Badge categories">
+        {categories.map((category) => (
+          <button
+            key={category}
+            type="button"
+            className={`profile-badge-tab ${activeCategory === category ? 'active' : ''}`}
+            onClick={() => onCategoryChange(category)}
+          >
+            {category === 'ALL' ? 'All' : BADGE_CATEGORY_LABELS[category]}
+          </button>
+        ))}
+      </div>
+      {visibleBadges.length > 0 ? (
+        <div className="profile-badge-catalog-grid">
+          {visibleBadges.map((badge) => (
+            <BadgeCard key={badge.slug} badge={badge} onClick={() => onSelectBadge(badge)} />
+          ))}
+        </div>
+      ) : (
+        <div className="profile-badges-empty">No badges in this category yet.</div>
+      )}
+    </div>
+  );
+}
+
+function ProfileBadgesSection({
+  earnedBadges,
+  badgeCatalog,
+  badgesLoading,
+  badgeError,
+  onRetry,
+}: {
+  earnedBadges: EarnedBadge[];
+  badgeCatalog: CatalogBadge[];
+  badgesLoading: boolean;
+  badgeError: string | null;
+  onRetry: () => void;
+}) {
+  const [selectedBadge, setSelectedBadge] = useState<CatalogBadge | null>(null);
+  const [catalogOpen, setCatalogOpen] = useState(false);
+  const [activeCategory, setActiveCategory] = useState<BadgeCategory | 'ALL'>('ALL');
+  const badgesForPreview = badgeCatalog.length > 0
+    ? badgeCatalog
+    : earnedBadges.map(earnedToCatalogBadge);
+
+  const closeModal = () => {
+    setSelectedBadge(null);
+    setCatalogOpen(false);
+  };
+
+  return (
+    <section className="profile-badges">
+      <div className="profile-badges-header">
+        <div>
+          <h2 className="profile-badges-title">Badges</h2>
+          <p className="profile-badges-subtitle">Achievements earned through hosting, participation, and social activity</p>
+        </div>
+        <button
+          type="button"
+          className="profile-badges-view-all"
+          onClick={() => {
+            setCatalogOpen(true);
+            setSelectedBadge(null);
+          }}
+          disabled={badgesLoading || badgesForPreview.length === 0}
+        >
+          View All Badges
+        </button>
+      </div>
+
+      {badgesLoading ? (
+        <div className="profile-badges-state">Loading badges...</div>
+      ) : badgeError ? (
+        <div className="profile-badges-state error">
+          <span>{badgeError}</span>
+          <button type="button" onClick={onRetry}>Retry</button>
+        </div>
+      ) : badgesForPreview.length > 0 ? (
+        <div className="profile-badges-row" aria-label="Profile badges">
+          {badgesForPreview.map((badge) => (
+            <BadgeCard
+              key={badge.slug}
+              badge={badge}
+              compact
+              onClick={() => setSelectedBadge(badge)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="profile-badges-empty">No badges available yet.</div>
+      )}
+
+      {(selectedBadge || catalogOpen) && (
+        <div className="profile-badge-modal-overlay" role="presentation" onClick={closeModal}>
+          <div onClick={(e) => e.stopPropagation()}>
+            {selectedBadge ? (
+              <BadgeDetail
+                badge={selectedBadge}
+                onBack={catalogOpen ? () => setSelectedBadge(null) : null}
+                onClose={closeModal}
+              />
+            ) : (
+              <BadgeCatalogModal
+                badges={badgesForPreview}
+                activeCategory={activeCategory}
+                onCategoryChange={setActiveCategory}
+                onSelectBadge={setSelectedBadge}
+                onClose={closeModal}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
 
 function formatDate(iso: string): string {
   const d = new Date(iso);
@@ -271,6 +532,11 @@ export default function ProfilePage() {
     profile,
     hostedEvents,
     attendedEvents,
+    earnedBadges,
+    badgeCatalog,
+    badgesLoading,
+    badgeError,
+    refreshBadges,
     isLoading,
     isEditing,
     isSaving,
@@ -430,6 +696,14 @@ export default function ProfilePage() {
             )}
           </div>
         </div>
+
+        <ProfileBadgesSection
+          earnedBadges={earnedBadges}
+          badgeCatalog={badgeCatalog}
+          badgesLoading={badgesLoading}
+          badgeError={badgeError}
+          onRetry={refreshBadges}
+        />
 
         {changePasswordSection}
 


### PR DESCRIPTION
## 📋 Summary
Adds badge visibility to the profile page, including earned badges, locked catalog badges, and detail views so users can inspect achievement progress.

## 🔄 Changes
- Added frontend badge models for earned badges and catalog badges.
- Added profile service calls for `/me/badges`, `/users/:id/badges`, and `/badges`.
- Fetches the current user’s earned badges and full badge catalog on profile load.
- Added a responsive “Badges” section to the profile page.
- Shows earned badges with icon, name, and earned date.
- Shows unearned badges grayed out with a lock indicator.
- Added badge detail modal with name, description, category, earned date, and progress hint.
- Added “View All Badges” modal with category tabs.
- Added service tests for badge API endpoints.

## 🧪 Testing
- `npm run build` ✅
- `npm test -- profileService.test.ts` ✅

## 🔗 Related
Related to #436 
