### PR TITLE
feat(frontend): add event reporting controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import NotFoundView from './views/fallback/NotFoundView';
 import BackofficeLayout from './views/backoffice/BackofficeLayout';
 import UsersAdminPage from './views/backoffice/UsersAdminPage';
 import EventsAdminPage from './views/backoffice/EventsAdminPage';
+import EventReportsAdminPage from './views/backoffice/EventReportsAdminPage';
 import ParticipationsAdminPage from './views/backoffice/ParticipationsAdminPage';
 import TicketsAdminPage from './views/backoffice/TicketsAdminPage';
 import NotificationsAdminPage from './views/backoffice/NotificationsAdminPage';
@@ -54,6 +55,7 @@ export default function App() {
           <Route index element={<Navigate to="/backoffice/users" replace />} />
           <Route path="users" element={<UsersAdminPage />} />
           <Route path="events" element={<EventsAdminPage />} />
+          <Route path="event-reports" element={<EventReportsAdminPage />} />
           <Route path="participations" element={<ParticipationsAdminPage />} />
           <Route path="tickets" element={<TicketsAdminPage />} />
           <Route path="notifications" element={<NotificationsAdminPage />} />

--- a/frontend/src/models/admin.ts
+++ b/frontend/src/models/admin.ts
@@ -63,6 +63,23 @@ export interface AdminNotificationFilters {
   created_to?: string;
 }
 
+export interface AdminEventReportFilters {
+  q?: string;
+  status?: 'PENDING' | 'REVIEWED' | 'DISMISSED';
+  report_category?:
+    | 'SAFETY'
+    | 'HARASSMENT'
+    | 'SPAM_OR_SCAM'
+    | 'INAPPROPRIATE_CONTENT'
+    | 'EVENT_NOT_AS_DESCRIBED'
+    | 'ILLEGAL_OR_DANGEROUS'
+    | 'OTHER';
+  event_id?: string;
+  reporter_user_id?: string;
+  created_from?: string;
+  created_to?: string;
+}
+
 export interface AdminUser {
   id: string;
   username: string;
@@ -141,6 +158,28 @@ export interface AdminNotification {
   sse_sent_count: number;
   push_sent_count: number;
   push_failed_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminEventReport {
+  id: string;
+  event_id: string;
+  event_title: string | null;
+  reporter_user_id: string;
+  reporter_username: string | null;
+  reporter_email: string | null;
+  report_category:
+    | 'SAFETY'
+    | 'HARASSMENT'
+    | 'SPAM_OR_SCAM'
+    | 'INAPPROPRIATE_CONTENT'
+    | 'EVENT_NOT_AS_DESCRIBED'
+    | 'ILLEGAL_OR_DANGEROUS'
+    | 'OTHER';
+  message: string;
+  image_url: string | null;
+  status: 'PENDING' | 'REVIEWED' | 'DISMISSED';
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,6 +1,10 @@
 export type PrivacyLevel = 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
 export type LocationType = 'POINT' | 'ROUTE';
 export type PreferredGender = 'MALE' | 'FEMALE' | 'OTHER';
+export type EventReportCategory =
+  | 'SPAM_OR_SCAM'
+  | 'INAPPROPRIATE_CONTENT'
+  | 'HARASSMENT';
 
 export interface EventConstraint {
   type: string;
@@ -389,4 +393,23 @@ export interface UpsertReviewCommentRequest {
   message: string;
   rating: number;
   image_confirm_token?: string | null;
+}
+
+/* ── Event Reports ── */
+
+export interface CreateEventReportRequest {
+  report_category: EventReportCategory;
+  message: string;
+  image_confirm_token?: string | null;
+}
+
+export interface EventReportResponse {
+  id: string;
+  event_id: string;
+  reporter_user_id: string;
+  report_category: EventReportCategory;
+  message: string;
+  image_url: string | null;
+  status: 'PENDING' | 'REVIEWED' | 'DISMISSED';
+  created_at: string;
 }

--- a/frontend/src/services/adminService.test.ts
+++ b/frontend/src/services/adminService.test.ts
@@ -4,6 +4,7 @@ import {
   cancelAdminParticipation,
   createAdminNotification,
   createAdminParticipation,
+  listAdminEventReports,
 } from './adminService';
 
 vi.mock('@/config/api', () => ({
@@ -102,5 +103,37 @@ describe('admin mutation services', () => {
       method: 'POST',
       body: JSON.stringify({}),
     }));
+  });
+});
+
+describe('admin event report services', () => {
+  it('fetches event reports with filters', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      items: [],
+      limit: 25,
+      offset: 0,
+      total_count: 0,
+      has_next: false,
+    }), { status: 200 }));
+
+    await listAdminEventReports('token', {
+      limit: 25,
+      offset: 0,
+      status: 'PENDING',
+      report_category: 'HARASSMENT',
+      event_id: 'event-1',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://api.test/admin/event-reports?limit=25&offset=0&status=PENDING&report_category=HARASSMENT&event_id=event-1',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+        }),
+        cache: 'no-store',
+      }),
+    );
   });
 });

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -8,6 +8,8 @@ import type {
   AdminCreateParticipationResponse,
   AdminEvent,
   AdminEventFilters,
+  AdminEventReport,
+  AdminEventReportFilters,
   AdminListResponse,
   AdminNotification,
   AdminNotificationFilters,
@@ -85,6 +87,16 @@ export function listAdminNotifications(
   params: AdminPageParams & AdminNotificationFilters,
 ): Promise<AdminListResponse<AdminNotification>> {
   return apiGetAuth<AdminListResponse<AdminNotification>>(buildAdminListPath('/admin/notifications', params), token);
+}
+
+export function listAdminEventReports(
+  token: string,
+  params: AdminPageParams & AdminEventReportFilters,
+): Promise<AdminListResponse<AdminEventReport>> {
+  return apiGetAuth<AdminListResponse<AdminEventReport>>(
+    buildAdminListPath('/admin/event-reports', params),
+    token,
+  );
 }
 
 export function createAdminNotification(

--- a/frontend/src/services/eventService.test.ts
+++ b/frontend/src/services/eventService.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { reverseGeocode, searchLocation } from './eventService';
+import { reverseGeocode, searchLocation, createEventReport } from './eventService';
 
 vi.mock('@/config/api', () => ({
   API_BASE_URL: 'http://api.test',
@@ -259,5 +259,46 @@ describe('reverseGeocode', () => {
     );
 
     expect(await reverseGeocode(41, 29)).toBeNull();
+  });
+});
+
+describe('eventService.createEventReport', () => {
+  it('posts an authenticated event report request', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'report-1',
+          event_id: 'event-1',
+          reporter_user_id: 'user-1',
+          report_category: 'SPAM_OR_SCAM',
+          message: 'This looks suspicious.',
+          image_url: null,
+          status: 'PENDING',
+          created_at: '2026-05-09T10:00:00Z',
+        }),
+        { status: 201 },
+      ),
+    );
+
+    await createEventReport(
+      'event-1',
+      {
+        report_category: 'SPAM_OR_SCAM',
+        message: 'This looks suspicious.',
+      },
+      'access-token',
+    );
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/events/event-1/reports', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        report_category: 'SPAM_OR_SCAM',
+        message: 'This looks suspicious.',
+      }),
+    }));
   });
 });

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -32,6 +32,8 @@ import {
   ListEventCommentRepliesParams,
   CreateDiscussionCommentRequest,
   UpsertReviewCommentRequest,
+  CreateEventReportRequest,
+  EventReportResponse,
 } from '@/models/event';
 
 const PHOTON_BASE = 'https://photon.komoot.io';
@@ -377,6 +379,14 @@ export function getReviewCommentImageUploadUrl(
     {},
     token,
   );
+}
+
+export function createEventReport(
+  eventId: string,
+  request: CreateEventReportRequest,
+  token: string,
+): Promise<EventReportResponse> {
+  return apiPostAuth<EventReportResponse>(`/events/${eventId}/reports`, request, token);
 }
 
 export async function searchLocation(

--- a/frontend/src/styles/backoffice.css
+++ b/frontend/src/styles/backoffice.css
@@ -257,6 +257,64 @@
   border-bottom: 0;
 }
 
+.bo-status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 78px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #374151;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.bo-status-pending {
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.bo-status-reviewed {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.bo-status-dismissed {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.bo-report-table td {
+  white-space: normal;
+}
+
+.bo-report-linked-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 180px;
+}
+
+.bo-report-linked-cell a,
+.bo-report-linked-cell strong {
+  color: #111827;
+  font-weight: 700;
+}
+
+.bo-report-linked-cell span {
+  color: #6b7280;
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.bo-report-message {
+  min-width: 260px;
+  max-width: 440px;
+  color: #374151;
+  line-height: 1.45;
+}
+
 .bo-state {
   padding: 14px 16px;
   border: 1px solid #e5e7eb;

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -257,60 +257,25 @@
   cursor: not-allowed;
 }
 
-.ed-title-menu-wrap {
-  position: relative;
-  flex-shrink: 0;
-}
-
-.ed-title-menu-btn {
+.ed-report-flag-btn {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   width: 40px;
   height: 40px;
   border-radius: 50%;
   border: 1px solid #e5e7eb;
   background-color: #ffffff;
-  color: #374151;
-  font-size: 24px;
-  line-height: 1;
+  color: #9ca3af;
   cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
-.ed-title-menu-btn:hover {
-  background-color: #f9fafb;
-  border-color: #9ca3af;
-}
-
-.ed-title-menu {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  z-index: 20;
-  min-width: 168px;
-  padding: 6px;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
-  background: #ffffff;
-  box-shadow: 0 14px 32px rgba(17, 24, 39, 0.14);
-}
-
-.ed-title-menu-item {
-  width: 100%;
-  padding: 9px 10px;
-  border: none;
-  border-radius: 8px;
-  background: transparent;
-  color: #b91c1c;
-  font-size: 0.9rem;
-  font-weight: 700;
-  text-align: left;
-  cursor: pointer;
-}
-
-.ed-title-menu-item:hover {
-  background: #fef2f2;
+.ed-report-flag-btn:hover {
+  background-color: #fef2f2;
+  border-color: #fca5a5;
+  color: #dc2626;
 }
 
 .ed-category {
@@ -1701,11 +1666,6 @@
   .ed-title-actions {
     justify-content: flex-start;
     flex-wrap: wrap;
-  }
-
-  .ed-title-menu {
-    left: 0;
-    right: auto;
   }
 
   .ed-metrics {

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -257,6 +257,62 @@
   cursor: not-allowed;
 }
 
+.ed-title-menu-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.ed-title-menu-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+  color: #374151;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.ed-title-menu-btn:hover {
+  background-color: #f9fafb;
+  border-color: #9ca3af;
+}
+
+.ed-title-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 20;
+  min-width: 168px;
+  padding: 6px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 14px 32px rgba(17, 24, 39, 0.14);
+}
+
+.ed-title-menu-item {
+  width: 100%;
+  padding: 9px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #b91c1c;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ed-title-menu-item:hover {
+  background: #fef2f2;
+}
+
 .ed-category {
   display: inline-block;
   padding: 4px 12px;
@@ -1158,6 +1214,143 @@
   cursor: not-allowed;
 }
 
+.ed-report-modal {
+  max-width: 520px;
+}
+
+.ed-report-reasons {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.ed-report-reason {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #ffffff;
+  cursor: pointer;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.ed-report-reason:hover,
+.ed-report-reason.selected {
+  border-color: #111827;
+  background: #f9fafb;
+}
+
+.ed-report-reason input {
+  margin-top: 3px;
+  accent-color: #111827;
+}
+
+.ed-report-reason-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.ed-report-reason-label {
+  color: #111827;
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.ed-report-reason-hint {
+  color: #6b7280;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.ed-report-message-label {
+  display: block;
+  margin-bottom: 6px;
+  color: #374151;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.ed-report-message-label span {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.ed-report-message {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #111827;
+  font-family: inherit;
+  font-size: 0.92rem;
+  resize: vertical;
+}
+
+.ed-report-message:focus {
+  outline: none;
+  border-color: #111827;
+}
+
+.ed-report-message.has-error {
+  border-color: #dc2626;
+}
+
+.ed-report-char-count {
+  margin: 5px 0 16px;
+  color: #6b7280;
+  font-size: 0.78rem;
+  text-align: right;
+}
+
+.ed-report-char-count.is-error {
+  color: #dc2626;
+  font-weight: 700;
+}
+
+.ed-report-submit-btn {
+  background-color: #111827;
+  border-color: #111827;
+}
+
+.ed-report-submit-btn:hover:not(:disabled) {
+  background-color: #000000;
+  border-color: #000000;
+}
+
+.ed-report-success {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background-color: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #15803d;
+  font-size: 14px;
+  margin-bottom: 14px;
+}
+
+.ed-report-success span:first-child {
+  flex: 1;
+}
+
+.ed-report-success-dismiss {
+  background: none;
+  border: none;
+  color: #15803d;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
 /* Invitation status */
 .ed-invitation-status {
   padding: 3px 10px;
@@ -1500,6 +1693,21 @@
     font-size: 22px;
   }
 
+  .ed-title-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ed-title-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .ed-title-menu {
+    left: 0;
+    right: auto;
+  }
+
   .ed-metrics {
     gap: 16px;
     flex-wrap: wrap;
@@ -1561,6 +1769,10 @@
   .ed-modal {
     padding: 20px;
     margin: 12px;
+  }
+
+  .ed-modal-actions {
+    flex-direction: column;
   }
 
   .ed-modal-overlay {

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
@@ -9,6 +9,7 @@ const mockGetEventHostContextSummary = vi.fn();
 const mockAddFavorite = vi.fn();
 const mockRemoveFavorite = vi.fn();
 const mockRequestJoinEvent = vi.fn();
+const mockCreateEventReport = vi.fn();
 
 vi.mock('@/services/eventService', () => ({
   getEventDetail: (...args: unknown[]) => mockGetEventDetail(...args),
@@ -28,6 +29,7 @@ vi.mock('@/services/eventService', () => ({
   removeFavorite: (...args: unknown[]) => mockRemoveFavorite(...args),
   upsertEventRating: vi.fn(),
   upsertParticipantRating: vi.fn(),
+  createEventReport: (...args: unknown[]) => mockCreateEventReport(...args),
 }));
 
 vi.mock('@/utils/imageResize', () => ({
@@ -100,6 +102,16 @@ describe('useEventDetailViewModel favorites', () => {
     mockRequestJoinEvent.mockResolvedValue({
       join_request_id: 'join-request-1',
       event_id: 'event-1',
+      status: 'PENDING',
+      created_at: '2026-04-02T10:00:00Z',
+    });
+    mockCreateEventReport.mockResolvedValue({
+      id: 'report-1',
+      event_id: 'event-1',
+      reporter_user_id: 'user-1',
+      report_category: 'SPAM_OR_SCAM',
+      message: 'No additional details provided.',
+      image_url: null,
       status: 'PENDING',
       created_at: '2026-04-02T10:00:00Z',
     });

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -19,8 +19,10 @@ import {
   upsertEventRating,
   upsertParticipantRating,
   leaveEvent,
+  createEventReport,
 } from '@/services/eventService';
 import type {
+  EventReportCategory,
   EventDetailApprovedParticipant,
   EventDetailInvitation,
   EventDetailPendingJoinRequest,
@@ -70,6 +72,9 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   const [inviteLoading, setInviteLoading] = useState(false);
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteResult, setInviteResult] = useState<CreateEventInvitationsResponse | null>(null);
+  const [reportLoading, setReportLoading] = useState(false);
+  const [reportError, setReportError] = useState<string | null>(null);
+  const [reportSuccessMessage, setReportSuccessMessage] = useState<string | null>(null);
 
   useEffect(
     () => () => {
@@ -582,6 +587,49 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     }
   }, [eventId, token, refreshEventDetail, dismissCoverImageSuccess]);
 
+  const handleReportEvent = useCallback(async (
+    reportCategory: EventReportCategory,
+    message?: string,
+  ): Promise<boolean> => {
+    if (!eventId || !token) return false;
+    setReportLoading(true);
+    setReportError(null);
+    setReportSuccessMessage(null);
+
+    try {
+      await createEventReport(
+        eventId,
+        {
+          report_category: reportCategory,
+          message: message?.trim() || 'No additional details provided.',
+        },
+        token,
+      );
+      setReportSuccessMessage('Thanks. Your report has been submitted for review.');
+      return true;
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const errorMap: Record<string, string> = {
+          event_report_not_allowed: 'This event cannot be reported right now.',
+          already_reported: 'You have already reported this event.',
+          duplicate_report: 'You have already reported this event.',
+          event_report_duplicate: 'You have already reported this event.',
+          validation_error: err.details?.message ?? err.message,
+        };
+        if (err.status === 409) {
+          setReportError(errorMap[err.code] ?? 'You have already reported this event.');
+        } else {
+          setReportError(errorMap[err.code] ?? err.message);
+        }
+      } else {
+        setReportError('Failed to submit report. Please try again.');
+      }
+      return false;
+    } finally {
+      setReportLoading(false);
+    }
+  }, [eventId, token]);
+
   const loadMoreApprovedParticipants = useCallback(async () => {
     if (!approvedParticipantsHasNext || !approvedParticipantsNextCursor || approvedParticipantsLoading) return;
     await refreshApprovedParticipants(approvedParticipantsNextCursor, true);
@@ -640,6 +688,8 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
 
   const dismissInviteError = useCallback(() => setInviteError(null), []);
   const clearInviteResult = useCallback(() => setInviteResult(null), []);
+  const dismissReportError = useCallback(() => setReportError(null), []);
+  const dismissReportSuccess = useCallback(() => setReportSuccessMessage(null), []);
 
   return {
     event,
@@ -675,7 +725,11 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     cancelLoading,
     cancelError,
     favoriteLoading,
+    reportLoading,
+    reportError,
+    reportSuccessMessage,
     handleFavoriteToggle,
+    handleReportEvent,
     retry: fetchDetail,
     handleJoin,
     handleLeave,
@@ -697,6 +751,8 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     handleCoverImageUpload,
     dismissCoverImageError,
     dismissCoverImageSuccess,
+    dismissReportError,
+    dismissReportSuccess,
     loadMoreApprovedParticipants,
     loadMorePendingJoinRequests,
     loadMoreInvitations,

--- a/frontend/src/views/backoffice/BackofficeLayout.tsx
+++ b/frontend/src/views/backoffice/BackofficeLayout.tsx
@@ -4,6 +4,7 @@ import '@/styles/backoffice.css';
 const SIDEBAR_ITEMS = [
   { to: '/backoffice/users', label: 'Users' },
   { to: '/backoffice/events', label: 'Events' },
+  { to: '/backoffice/event-reports', label: 'Event Reports' },
   { to: '/backoffice/participations', label: 'Participations' },
   { to: '/backoffice/tickets', label: 'Tickets' },
   { to: '/backoffice/notifications', label: 'Notifications' },

--- a/frontend/src/views/backoffice/EventReportsAdminPage.tsx
+++ b/frontend/src/views/backoffice/EventReportsAdminPage.tsx
@@ -1,0 +1,118 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminEventReportFilters } from '@/models/admin';
+import { listAdminEventReports } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminEventReportFilters = {
+  q: '',
+  status: 'PENDING',
+  report_category: undefined,
+  event_id: '',
+  reporter_user_id: '',
+  created_from: '',
+  created_to: '',
+};
+
+const REPORT_CATEGORY_LABELS: Record<NonNullable<AdminEventReportFilters['report_category']>, string> = {
+  SAFETY: 'Safety',
+  HARASSMENT: 'Harassment',
+  SPAM_OR_SCAM: 'Spam or scam',
+  INAPPROPRIATE_CONTENT: 'Inappropriate',
+  EVENT_NOT_AS_DESCRIBED: 'Not as described',
+  ILLEGAL_OR_DANGEROUS: 'Illegal or dangerous',
+  OTHER: 'Other',
+};
+
+export default function EventReportsAdminPage() {
+  const { token } = useAuth();
+  const initialFilters = useMemo(() => INITIAL_FILTERS, []);
+  const vm = useAdminListViewModel({ token, initialFilters, fetchPage: listAdminEventReports });
+
+  return (
+    <BackofficePageShell
+      title="Event Reports"
+      subtitle="Review user-submitted flags for inappropriate, harassing, or spam event content."
+      filters={(
+        <>
+          <input aria-label="Search reports" placeholder="Search event, reporter, or message" value={vm.filters.q ?? ''} onChange={(event) => vm.setFilter('q', event.target.value)} />
+          <select aria-label="Report status" value={vm.filters.status ?? ''} onChange={(event) => vm.setFilter('status', event.target.value === '' ? undefined : event.target.value as AdminEventReportFilters['status'])}>
+            <option value="">Any status</option>
+            <option value="PENDING">PENDING</option>
+            <option value="REVIEWED">REVIEWED</option>
+            <option value="DISMISSED">DISMISSED</option>
+          </select>
+          <select aria-label="Report category" value={vm.filters.report_category ?? ''} onChange={(event) => vm.setFilter('report_category', event.target.value === '' ? undefined : event.target.value as AdminEventReportFilters['report_category'])}>
+            <option value="">Any reason</option>
+            {Object.entries(REPORT_CATEGORY_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+          <input aria-label="Event ID" placeholder="Event ID" value={vm.filters.event_id ?? ''} onChange={(event) => vm.setFilter('event_id', event.target.value)} />
+          <input aria-label="Reporter user ID" placeholder="Reporter user ID" value={vm.filters.reporter_user_id ?? ''} onChange={(event) => vm.setFilter('reporter_user_id', event.target.value)} />
+          <input aria-label="Created from" type="datetime-local" value={vm.filters.created_from ?? ''} onChange={(event) => vm.setFilter('created_from', event.target.value)} />
+          <input aria-label="Created to" type="datetime-local" value={vm.filters.created_to ?? ''} onChange={(event) => vm.setFilter('created_to', event.target.value)} />
+          <button type="button" onClick={vm.applyFilters}>Apply</button>
+          <button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+        </>
+      )}
+    >
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap">
+        <table className="bo-table bo-report-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Status</th>
+              <th>Reason</th>
+              <th>Event</th>
+              <th>Reporter</th>
+              <th>Message</th>
+              <th>Image</th>
+              <th>Created</th>
+              <th>Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {vm.items.map((report) => (
+              <tr key={report.id}>
+                <td><BackofficeIdCell id={report.id} /></td>
+                <td>
+                  <span className={`bo-status-pill bo-status-${report.status.toLowerCase()}`}>
+                    {report.status}
+                  </span>
+                </td>
+                <td>{REPORT_CATEGORY_LABELS[report.report_category] ?? report.report_category}</td>
+                <td>
+                  <div className="bo-report-linked-cell">
+                    <Link to={`/events/${report.event_id}`}>{report.event_title ?? 'Open event'}</Link>
+                    <span>{report.event_id}</span>
+                  </div>
+                </td>
+                <td>
+                  <div className="bo-report-linked-cell">
+                    <strong>{report.reporter_username ?? 'Unknown user'}</strong>
+                    <span>{report.reporter_email ?? report.reporter_user_id}</span>
+                  </div>
+                </td>
+                <td className="bo-report-message">{report.message}</td>
+                <td>
+                  {report.image_url ? (
+                    <a href={report.image_url} target="_blank" rel="noopener noreferrer">View</a>
+                  ) : (
+                    '-'
+                  )}
+                </td>
+                <td>{formatAdminDate(report.created_at)}</td>
+                <td>{formatAdminDate(report.updated_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -156,7 +156,7 @@ function makeReadyViewModel(event: EventDetailResponse) {
 }
 
 describe('EventDetailPage ratings', () => {
-  it('opens the report modal from the title action menu and submits the selected reason', async () => {
+  it('opens the report modal from the flag button and submits the selected reason', async () => {
     const event = makeBaseEvent();
     const vm = makeReadyViewModel(event);
     vm.handleReportEvent.mockResolvedValue(true);
@@ -164,8 +164,7 @@ describe('EventDetailPage ratings', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: /more event actions/i }));
-    fireEvent.click(screen.getByRole('menuitem', { name: /report event/i }));
+    fireEvent.click(screen.getByRole('button', { name: /report event/i }));
     fireEvent.click(screen.getByLabelText(/harassment/i));
     fireEvent.change(screen.getByLabelText(/additional details/i), {
       target: { value: 'The event description targets a user group.' },

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type {
   EventDetailPendingJoinRequest,
@@ -104,6 +104,8 @@ function makeReadyViewModel(event: EventDetailResponse) {
     invitationsHasNext: false,
     joinLoading: false,
     joinError: null,
+    leaveLoading: false,
+    leaveError: null,
     viewerRatingLoading: false,
     viewerRatingError: null,
     participantRatingLoadingId: null,
@@ -112,19 +114,29 @@ function makeReadyViewModel(event: EventDetailResponse) {
     moderateError: null,
     cancelLoading: false,
     cancelError: null,
+    favoriteLoading: false,
+    reportLoading: false,
+    reportError: null,
+    reportSuccessMessage: null,
     retry: vi.fn(),
     handleJoin: vi.fn(),
+    handleLeave: vi.fn(),
     handleRequestJoin: vi.fn(),
     handleViewerRatingSubmit: vi.fn(),
     handleParticipantRatingSubmit: vi.fn(),
     handleApprove: vi.fn(),
     handleReject: vi.fn(),
     handleCancel: vi.fn(),
+    handleFavoriteToggle: vi.fn(),
+    handleReportEvent: vi.fn(),
     dismissJoinError: vi.fn(),
+    dismissLeaveError: vi.fn(),
     dismissViewerRatingError: vi.fn(),
     dismissParticipantRatingError: vi.fn(),
     dismissModerateError: vi.fn(),
     dismissCancelError: vi.fn(),
+    dismissReportError: vi.fn(),
+    dismissReportSuccess: vi.fn(),
     coverImageUploading: false,
     coverImageError: null,
     coverImageSuccessMessage: null,
@@ -144,6 +156,41 @@ function makeReadyViewModel(event: EventDetailResponse) {
 }
 
 describe('EventDetailPage ratings', () => {
+  it('opens the report modal from the title action menu and submits the selected reason', async () => {
+    const event = makeBaseEvent();
+    const vm = makeReadyViewModel(event);
+    vm.handleReportEvent.mockResolvedValue(true);
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /more event actions/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /report event/i }));
+    fireEvent.click(screen.getByLabelText(/harassment/i));
+    fireEvent.change(screen.getByLabelText(/additional details/i), {
+      target: { value: 'The event description targets a user group.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /submit report/i }));
+
+    await waitFor(() => {
+      expect(vm.handleReportEvent).toHaveBeenCalledWith(
+        'HARASSMENT',
+        'The event description targets a user group.',
+      );
+    });
+  });
+
+  it('shows report success state from the view model', () => {
+    const event = makeBaseEvent();
+    const vm = makeReadyViewModel(event);
+    vm.reportSuccessMessage = 'Thanks. Your report has been submitted for review.';
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    expect(screen.getByText(/submitted for review/i)).toBeDefined();
+  });
+
   it('shows existing participant rating in summary mode until edit is requested', () => {
     const event = makeBaseEvent();
     event.viewer_event_rating = {

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -4,6 +4,7 @@ import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useEventDetailViewModel } from '@/viewmodels/event/useEventDetailViewModel';
 import type {
+  EventReportCategory,
   EventDetailApprovedParticipant,
   EventDetailInvitation,
   EventDetailPendingJoinRequest,
@@ -35,6 +36,25 @@ export function buildDirectionsUrl(lat: number, lon: number): string {
 
 const FEEDBACK_MIN_LENGTH = 10;
 const FEEDBACK_MAX_LENGTH = 100;
+const REPORT_MESSAGE_MAX_LENGTH = 1000;
+
+const REPORT_REASONS: Array<{ value: EventReportCategory; label: string; hint: string }> = [
+  {
+    value: 'SPAM_OR_SCAM',
+    label: 'Spam',
+    hint: 'Promotional, misleading, or scam-like event content.',
+  },
+  {
+    value: 'INAPPROPRIATE_CONTENT',
+    label: 'Inappropriate',
+    hint: 'Offensive, explicit, or otherwise inappropriate event content.',
+  },
+  {
+    value: 'HARASSMENT',
+    label: 'Harassment',
+    hint: 'Targeted abuse, threats, or harassing behavior.',
+  },
+];
 
 function formatDateTime(iso: string): string {
   const d = new Date(iso);
@@ -1267,6 +1287,108 @@ function CancelConfirmModal({
   );
 }
 
+function ReportEventModal({
+  loading,
+  error,
+  onSubmit,
+  onDismissError,
+  onClose,
+}: {
+  loading: boolean;
+  error: string | null;
+  onSubmit: (category: EventReportCategory, message?: string) => Promise<boolean>;
+  onDismissError: () => void;
+  onClose: () => void;
+}) {
+  const [category, setCategory] = useState<EventReportCategory>('SPAM_OR_SCAM');
+  const [message, setMessage] = useState('');
+  const isMessageTooLong = message.length > REPORT_MESSAGE_MAX_LENGTH;
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (isMessageTooLong || loading) return;
+    const success = await onSubmit(category, message);
+    if (success) onClose();
+  };
+
+  return (
+    <div className="ed-modal-overlay" onClick={onClose}>
+      <form className="ed-modal ed-report-modal" onSubmit={handleSubmit} onClick={(e) => e.stopPropagation()}>
+        <h3 className="ed-modal-title">Report Event</h3>
+        <p className="ed-modal-text">
+          Choose the closest reason. Reports are sent to moderators for review.
+        </p>
+
+        {error && (
+          <div className="ed-join-error" role="alert">
+            <span>{error}</span>
+            <button type="button" className="ed-join-error-dismiss" onClick={onDismissError}>
+              &times;
+            </button>
+          </div>
+        )}
+
+        <div className="ed-report-reasons" role="radiogroup" aria-label="Report reason">
+          {REPORT_REASONS.map((reason) => (
+            <label
+              key={reason.value}
+              className={`ed-report-reason ${category === reason.value ? 'selected' : ''}`}
+            >
+              <input
+                type="radio"
+                name="report-category"
+                value={reason.value}
+                checked={category === reason.value}
+                onChange={() => setCategory(reason.value)}
+                disabled={loading}
+              />
+              <span className="ed-report-reason-copy">
+                <span className="ed-report-reason-label">{reason.label}</span>
+                <span className="ed-report-reason-hint">{reason.hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+
+        <label className="ed-report-message-label" htmlFor="ed-report-message">
+          Additional details <span>(optional)</span>
+        </label>
+        <textarea
+          id="ed-report-message"
+          className={`ed-report-message ${isMessageTooLong ? 'has-error' : ''}`}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          maxLength={REPORT_MESSAGE_MAX_LENGTH + 1}
+          rows={4}
+          placeholder="Add context that would help moderators understand the issue."
+          disabled={loading}
+        />
+        <div className={`ed-report-char-count ${isMessageTooLong ? 'is-error' : ''}`}>
+          {message.length}/{REPORT_MESSAGE_MAX_LENGTH}
+        </div>
+
+        <div className="ed-modal-actions">
+          <button
+            type="button"
+            className="ed-modal-cancel-btn"
+            onClick={onClose}
+            disabled={loading}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="ed-modal-confirm-btn ed-report-submit-btn"
+            disabled={loading || isMessageTooLong}
+          >
+            {loading ? <span className="spinner" /> : 'Submit Report'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
 function LeaveConfirmModal({
   onConfirm,
   onClose,
@@ -1336,6 +1458,12 @@ function EventContent({
   onDismissCancelError,
   favoriteLoading,
   onFavoriteToggle,
+  reportLoading,
+  reportError,
+  reportSuccessMessage,
+  onReportEvent,
+  onDismissReportError,
+  onDismissReportSuccess,
   isAuthenticated,
   token,
   hostContextSummary,
@@ -1393,6 +1521,12 @@ function EventContent({
   onDismissCancelError: () => void;
   favoriteLoading: boolean;
   onFavoriteToggle: () => void;
+  reportLoading: boolean;
+  reportError: string | null;
+  reportSuccessMessage: string | null;
+  onReportEvent: (category: EventReportCategory, message?: string) => Promise<boolean>;
+  onDismissReportError: () => void;
+  onDismissReportSuccess: () => void;
   isAuthenticated: boolean;
   token: string | null;
   hostContextSummary: EventHostContextSummary | null;
@@ -1424,6 +1558,8 @@ function EventContent({
   const navigate = useNavigate();
   const coverFileInputRef = useRef<HTMLInputElement>(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [showTitleMenu, setShowTitleMenu] = useState(false);
+  const [showReportModal, setShowReportModal] = useState(false);
   const [activeParticipantEditorId, setActiveParticipantEditorId] = useState<string | null>(null);
   const hostCanRateParticipants = (
     event.viewer_context.is_host
@@ -1490,6 +1626,13 @@ function EventContent({
         </div>
       )}
 
+      {reportSuccessMessage && (
+        <div className="ed-report-success" role="status">
+          <span>{reportSuccessMessage}</span>
+          <button type="button" className="ed-report-success-dismiss" onClick={onDismissReportSuccess}>&times;</button>
+        </div>
+      )}
+
       {/* Title & category */}
       <div className="ed-header">
         <div className="ed-title-row">
@@ -1505,6 +1648,38 @@ function EventContent({
             >
               {event.viewer_context.is_favorited ? '★' : '☆'}
             </button>
+            <div className="ed-title-menu-wrap">
+              <button
+                type="button"
+                className="ed-title-menu-btn"
+                onClick={() => setShowTitleMenu((open) => !open)}
+                aria-label="More event actions"
+                aria-haspopup="menu"
+                aria-expanded={showTitleMenu}
+              >
+                ⋯
+              </button>
+              {showTitleMenu && (
+                <div className="ed-title-menu" role="menu">
+                  <button
+                    type="button"
+                    className="ed-title-menu-item"
+                    role="menuitem"
+                    onClick={() => {
+                      setShowTitleMenu(false);
+                      if (!isAuthenticated) {
+                        navigate('/login');
+                        return;
+                      }
+                      onDismissReportError();
+                      setShowReportModal(true);
+                    }}
+                  >
+                    Report Event
+                  </button>
+                </div>
+              )}
+            </div>
             <StatusBadge status={event.status} />
           </div>
         </div>
@@ -1864,6 +2039,16 @@ function EventContent({
           onClose={() => setShowCancelModal(false)}
         />
       )}
+
+      {showReportModal && (
+        <ReportEventModal
+          loading={reportLoading}
+          error={reportError}
+          onSubmit={onReportEvent}
+          onDismissError={onDismissReportError}
+          onClose={() => setShowReportModal(false)}
+        />
+      )}
     </div>
   );
 }
@@ -1952,6 +2137,12 @@ export default function EventDetailPage() {
       onDismissCancelError={vm.dismissCancelError}
       favoriteLoading={vm.favoriteLoading}
       onFavoriteToggle={vm.handleFavoriteToggle}
+      reportLoading={vm.reportLoading}
+      reportError={vm.reportError}
+      reportSuccessMessage={vm.reportSuccessMessage}
+      onReportEvent={vm.handleReportEvent}
+      onDismissReportError={vm.dismissReportError}
+      onDismissReportSuccess={vm.dismissReportSuccess}
       hostContextSummary={vm.hostContextSummary}
       approvedParticipants={vm.approvedParticipants}
       approvedParticipantsLoading={vm.approvedParticipantsLoading}

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -1558,7 +1558,6 @@ function EventContent({
   const navigate = useNavigate();
   const coverFileInputRef = useRef<HTMLInputElement>(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
-  const [showTitleMenu, setShowTitleMenu] = useState(false);
   const [showReportModal, setShowReportModal] = useState(false);
   const [activeParticipantEditorId, setActiveParticipantEditorId] = useState<string | null>(null);
   const hostCanRateParticipants = (
@@ -1648,38 +1647,34 @@ function EventContent({
             >
               {event.viewer_context.is_favorited ? '★' : '☆'}
             </button>
-            <div className="ed-title-menu-wrap">
-              <button
-                type="button"
-                className="ed-title-menu-btn"
-                onClick={() => setShowTitleMenu((open) => !open)}
-                aria-label="More event actions"
-                aria-haspopup="menu"
-                aria-expanded={showTitleMenu}
+            <button
+              type="button"
+              className="ed-report-flag-btn"
+              aria-label="Report event"
+              onClick={() => {
+                if (!isAuthenticated) {
+                  navigate('/login');
+                  return;
+                }
+                onDismissReportError();
+                setShowReportModal(true);
+              }}
+            >
+              <svg
+                width={18}
+                height={18}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
               >
-                ⋯
-              </button>
-              {showTitleMenu && (
-                <div className="ed-title-menu" role="menu">
-                  <button
-                    type="button"
-                    className="ed-title-menu-item"
-                    role="menuitem"
-                    onClick={() => {
-                      setShowTitleMenu(false);
-                      if (!isAuthenticated) {
-                        navigate('/login');
-                        return;
-                      }
-                      onDismissReportError();
-                      setShowReportModal(true);
-                    }}
-                  >
-                    Report Event
-                  </button>
-                </div>
-              )}
-            </div>
+                <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+                <line x1="4" y1="22" x2="4" y2="15" />
+              </svg>
+            </button>
             <StatusBadge status={event.status} />
           </div>
         </div>


### PR DESCRIPTION
## 📋 Summary
Adds the web event reporting flow and an admin backoffice view for reviewing submitted event reports.

## 🔄 Changes
- Added `Report Event` action to the event detail three-dot menu.
- Added reporting modal with Spam, Inappropriate, and Harassment reasons.
- Connected report submission to `POST /events/:id/reports`.
- Added success and error handling, including duplicate/conflict-friendly messaging.
- Added admin `Event Reports` backoffice page and sidebar route.
- Added report filters for status, category, event ID, reporter ID, search, and created date range.
- Added event/admin report models and service methods.
- Added service tests for event reporting and admin event report listing.

## 🧪 Testing
- `npm run build` ✅
- `npm test -- adminService.test.ts eventService.test.ts` ✅

## 🔗 Related
Related to #479
