### PR TITLE
feat(frontend): indicate approximate event locations

### DIFF
--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -93,6 +93,7 @@ export interface DiscoverEventItem {
   location_address: string | null;
   location_lat?: number;
   location_lon?: number;
+  is_location_approximate: boolean;
   privacy_level: 'PUBLIC' | 'PROTECTED';
   approved_participant_count: number;
   is_favorited: boolean;
@@ -126,6 +127,7 @@ export interface EventDetailLocation {
   address: string | null;
   point: EventDetailPoint | null;
   route_points: EventDetailPoint[];
+  is_location_approximate: boolean;
 }
 
 export interface EventDetailUserSummary {

--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -1014,6 +1014,36 @@
   text-overflow: ellipsis;
 }
 
+.dc-approx-location-badge {
+  width: max-content;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border: 1px solid #bfdbfe;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.dc-approx-location-badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.16);
+  flex-shrink: 0;
+}
+
+.dc-map-approx-location-badge {
+  margin-top: 2px;
+}
+
 .dc-card-footer {
   display: flex;
   align-items: center;

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -1415,6 +1415,25 @@
   font-size: 0.9rem;
 }
 
+.ed-approx-location-warning {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 0 12px;
+  padding: 11px 13px;
+  border-radius: 10px;
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.ed-approx-location-warning strong {
+  color: #1e40af;
+  font-size: 0.92rem;
+}
+
 .ed-directions-btn {
   position: absolute;
   bottom: 12px;
@@ -1442,6 +1461,22 @@
 
 .ed-directions-btn:active {
   transform: scale(0.97);
+}
+
+.ed-approx-location-note {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 500;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(239, 246, 255, 0.95);
+  border: 1px solid #bfdbfe;
+  color: #1d4ed8;
+  font-size: 0.84rem;
+  font-weight: 700;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.14);
 }
 
 .ed-map-fallback {

--- a/frontend/src/utils/locationApproximation.test.ts
+++ b/frontend/src/utils/locationApproximation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowApproximateLocationIndicator } from './locationApproximation';
+
+describe('shouldShowApproximateLocationIndicator', () => {
+  it.each([
+    {
+      name: 'public non-participant with exact backend location',
+      privacyLevel: 'PUBLIC' as const,
+      isLocationApproximate: false,
+      isHost: false,
+      participationStatus: 'NONE',
+      expected: false,
+    },
+    {
+      name: 'public non-participant with unexpected approximate flag',
+      privacyLevel: 'PUBLIC' as const,
+      isLocationApproximate: true,
+      isHost: false,
+      participationStatus: 'NONE',
+      expected: false,
+    },
+    {
+      name: 'protected non-participant with approximate backend location',
+      privacyLevel: 'PROTECTED' as const,
+      isLocationApproximate: true,
+      isHost: false,
+      participationStatus: 'NONE',
+      expected: true,
+    },
+    {
+      name: 'protected approved participant with exact backend location',
+      privacyLevel: 'PROTECTED' as const,
+      isLocationApproximate: false,
+      isHost: false,
+      participationStatus: 'JOINED',
+      expected: false,
+    },
+    {
+      name: 'protected host with exact backend location',
+      privacyLevel: 'PROTECTED' as const,
+      isLocationApproximate: false,
+      isHost: true,
+      participationStatus: 'NONE',
+      expected: false,
+    },
+    {
+      name: 'private invited viewer with exact backend location',
+      privacyLevel: 'PRIVATE' as const,
+      isLocationApproximate: false,
+      isHost: false,
+      participationStatus: 'INVITED',
+      expected: false,
+    },
+  ])('$name', ({ expected, ...context }) => {
+    expect(shouldShowApproximateLocationIndicator(context)).toBe(expected);
+  });
+});

--- a/frontend/src/utils/locationApproximation.ts
+++ b/frontend/src/utils/locationApproximation.ts
@@ -1,0 +1,28 @@
+import type { PrivacyLevel } from '@/models/event';
+
+interface ApproximateLocationContext {
+  privacyLevel: PrivacyLevel;
+  isLocationApproximate: boolean;
+  isHost: boolean;
+  participationStatus: string;
+}
+
+export const APPROXIMATE_LOCATION_RADIUS_METERS = 250;
+
+export function shouldShowApproximateLocationIndicator({
+  privacyLevel,
+  isLocationApproximate,
+  isHost,
+  participationStatus,
+}: ApproximateLocationContext): boolean {
+  if (!isLocationApproximate) return false;
+  if (privacyLevel !== 'PROTECTED') return false;
+  if (isHost) return false;
+  return participationStatus !== 'JOINED';
+}
+
+export function getApproximateLocationText(hasAddress: boolean): string {
+  return hasAddress
+    ? 'Approximate location'
+    : 'Approximate area shown. Exact address is visible after approval.';
+}

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
@@ -67,6 +67,7 @@ function makeEvent(overrides: Partial<EventDetailResponse> = {}): EventDetailRes
       address: 'Moda Coast',
       point: { lat: 40.98, lon: 29.03 },
       route_points: [],
+      is_location_approximate: false,
     },
     tags: ['walk'],
     constraints: [],

--- a/frontend/src/views/discover/DiscoverMapView.tsx
+++ b/frontend/src/views/discover/DiscoverMapView.tsx
@@ -5,6 +5,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { EventCoverImage } from '@/components/EventCoverImage';
 import type { DiscoverEventItem } from '@/models/event';
+import { getApproximateLocationText } from '@/utils/locationApproximation';
 
 interface DiscoverMapViewProps {
   events: DiscoverEventItem[];
@@ -140,6 +141,11 @@ function EventOverlayCard({
 
         {event.location_address && (
           <p className="dc-map-card-address">{event.location_address}</p>
+        )}
+        {event.is_location_approximate && (
+          <span className="dc-approx-location-badge dc-map-approx-location-badge">
+            {getApproximateLocationText(Boolean(event.location_address))}
+          </span>
         )}
 
         <div className="dc-map-card-footer">

--- a/frontend/src/views/discover/DiscoverPage.tsx
+++ b/frontend/src/views/discover/DiscoverPage.tsx
@@ -10,6 +10,7 @@ import type { DiscoverEventItem, DiscoverSortBy } from '@/models/event';
 import { EventCoverImage } from '@/components/EventCoverImage';
 import { getEventLifecyclePresentation } from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
+import { getApproximateLocationText } from '@/utils/locationApproximation';
 import DiscoverMapView from './DiscoverMapView';
 import '@/styles/discover.css';
 
@@ -247,6 +248,11 @@ function EventCard({ event }: { event: DiscoverEventItem }) {
 
         {event.location_address && (
           <p className="dc-card-location">{event.location_address}</p>
+        )}
+        {event.is_location_approximate && (
+          <span className="dc-approx-location-badge">
+            {getApproximateLocationText(Boolean(event.location_address))}
+          </span>
         )}
 
         <div className="dc-card-footer">

--- a/frontend/src/views/events/EventDetailMiniMap.tsx
+++ b/frontend/src/views/events/EventDetailMiniMap.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
-import { MapContainer, Marker, Polyline, TileLayer } from 'react-leaflet';
+import { Circle, MapContainer, Marker, Polyline, TileLayer } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { EventDetailLocation } from '@/models/event';
+import { APPROXIMATE_LOCATION_RADIUS_METERS } from '@/utils/locationApproximation';
 
 interface EventDetailMiniMapProps {
   location: EventDetailLocation;
@@ -50,8 +51,21 @@ export default function EventDetailMiniMap({ location }: EventDetailMiniMapProps
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-      <Marker position={[anchor.lat, anchor.lon]} icon={markerIcon} />
-      {polylinePositions.length > 1 && (
+      {location.is_location_approximate ? (
+        <Circle
+          center={[anchor.lat, anchor.lon]}
+          radius={APPROXIMATE_LOCATION_RADIUS_METERS}
+          pathOptions={{
+            color: '#2563eb',
+            fillColor: '#60a5fa',
+            fillOpacity: 0.22,
+            weight: 2,
+          }}
+        />
+      ) : (
+        <Marker position={[anchor.lat, anchor.lon]} icon={markerIcon} />
+      )}
+      {!location.is_location_approximate && polylinePositions.length > 1 && (
         <Polyline positions={polylinePositions} pathOptions={{ color: '#7c3aed', weight: 4 }} />
       )}
     </MapContainer>

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -252,7 +252,7 @@ describe('EventDetailPage ratings', () => {
 
     renderPage();
 
-    expect(screen.getByText(/approximate area/i)).toBeDefined();
+    expect(screen.getByText(/^approximate area$/i)).toBeDefined();
     expect(screen.getByText(/approximate location shown/i)).toBeDefined();
     expect(screen.getByText(/hides its exact address until your participation is approved/i)).toBeDefined();
     expect(screen.getByText(/exact address is visible after approval/i)).toBeDefined();

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -54,6 +54,7 @@ function makeBaseEvent(): EventDetailResponse {
       address: 'Moda Coast',
       point: { lat: 40.98, lon: 29.03 },
       route_points: [],
+      is_location_approximate: false,
     },
     tags: ['walk'],
     constraints: [],
@@ -235,6 +236,29 @@ describe('EventDetailPage ratings', () => {
     expect(link.rel).toContain('noopener');
   });
 
+  it('shows approximate area copy and hides directions for approximate protected locations', () => {
+    const event = makeBaseEvent();
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'NONE';
+    event.location = {
+      type: 'POINT',
+      address: null,
+      point: { lat: 40.981, lon: 29.032 },
+      route_points: [],
+      is_location_approximate: true,
+    };
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByText(/approximate area/i)).toBeDefined();
+    expect(screen.getByText(/approximate location shown/i)).toBeDefined();
+    expect(screen.getByText(/hides its exact address until your participation is approved/i)).toBeDefined();
+    expect(screen.getByText(/exact address is visible after approval/i)).toBeDefined();
+    expect(screen.queryByTestId('ed-directions-link')).toBeNull();
+  });
+
   it('shows the map fallback and hides the directions link when coordinates are missing', () => {
     const event = makeBaseEvent();
     event.location = {
@@ -242,6 +266,7 @@ describe('EventDetailPage ratings', () => {
       address: 'No coordinates here',
       point: null,
       route_points: [],
+      is_location_approximate: false,
     };
 
     mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -18,6 +18,7 @@ import type {
 import { EventCoverImage } from '@/components/EventCoverImage';
 import { UserAvatar } from '@/components/UserAvatar';
 import { getEventLifecyclePresentation, getEventStatusPresentation } from '@/utils/eventStatus';
+import { getApproximateLocationText } from '@/utils/locationApproximation';
 import NotFoundView from '../fallback/NotFoundView';
 import AccessDeniedView from '../fallback/AccessDeniedView';
 import '@/styles/event-detail.css';
@@ -183,21 +184,36 @@ function LocationSection({ location }: { location: EventDetailResponse['location
   }, [location]);
 
   const hasMap = anchor !== null;
+  const isApproximate = location.is_location_approximate;
 
   return (
     <div className="ed-section">
       <h2 className="ed-section-title">Location</h2>
+      {isApproximate && (
+        <div className="ed-approx-location-warning" role="status">
+          <strong>Approximate location shown</strong>
+          <span>
+            This protected event hides its exact address until your participation is approved.
+          </span>
+        </div>
+      )}
       <div className="ed-info-row">
         <span className="ed-info-icon">&#128205;</span>
         <div>
-          {location.address ? (
+          {location.address && !isApproximate ? (
             <p className="ed-info-primary">{location.address}</p>
+          ) : isApproximate ? (
+            <p className="ed-info-primary">Approximate area</p>
           ) : (
             <p className="ed-info-secondary">No address provided</p>
           )}
           <p className="ed-info-secondary">
-            {location.type === 'ROUTE' ? 'Route-based event' : 'Point location'}
-            {location.point && (
+            {isApproximate
+              ? getApproximateLocationText(Boolean(location.address))
+              : location.type === 'ROUTE'
+                ? 'Route-based event'
+                : 'Point location'}
+            {!isApproximate && location.point && (
               <> &middot; {location.point.lat.toFixed(4)}, {location.point.lon.toFixed(4)}</>
             )}
           </p>
@@ -216,28 +232,34 @@ function LocationSection({ location }: { location: EventDetailResponse['location
           >
             <EventDetailMiniMap location={location} />
           </Suspense>
-          <a
-            className="ed-directions-btn"
-            href={buildDirectionsUrl(anchor.lat, anchor.lon)}
-            target="_blank"
-            rel="noopener noreferrer"
-            data-testid="ed-directions-link"
-          >
-            <svg
-              width={16}
-              height={16}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden
+          {isApproximate ? (
+            <div className="ed-approx-location-note" role="note">
+              Exact directions become available after your participation is approved.
+            </div>
+          ) : (
+            <a
+              className="ed-directions-btn"
+              href={buildDirectionsUrl(anchor.lat, anchor.lon)}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="ed-directions-link"
             >
-              <polygon points="3 11 22 2 13 21 11 13 3 11" />
-            </svg>
-            Get directions
-          </a>
+              <svg
+                width={16}
+                height={16}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <polygon points="3 11 22 2 13 21 11 13 3 11" />
+              </svg>
+              Get directions
+            </a>
+          )}
         </div>
       ) : (
         <p className="ed-map-fallback">Map unavailable for this event.</p>


### PR DESCRIPTION
## 📋 Summary
Surfaces backend-provided approximate location state on web discovery and event detail pages, so protected event viewers understand when the shown location is intentionally not exact.

## 🔄 Changes
- Added `is_location_approximate` to frontend discovery and event detail location models.
- Added an “Approximate location” badge to Discover cards when the backend flag is true.
- Added the same approximate-location indicator to Discover map event previews.
- Updated event detail location copy to show “Approximate area” instead of exact address/coordinates when approximate.
- Added an event detail warning explaining that exact address is hidden until participation is approved.
- Updated the event detail mini map to render a 250m approximation circle instead of a pinpoint marker.
- Hid exact directions while the location is approximate.
- Added utility logic and tests for viewer/privacy approximate-location visibility combinations.

## 🧪 Testing
- `npm run build` ✅
- `npm test -- locationApproximation.test.ts` ✅

## 🔗 Related
Related to #490 
