### PR TITLE
feat(mobile): fixed inconsistencies in the mapview, event detail screen and agreed backend invitations contract

### DIFF
--- a/mobile/src/components/events/PointPickerMap.tsx
+++ b/mobile/src/components/events/PointPickerMap.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
+import { DARK_MAP_STYLE } from '@/theme/mapStyle';
 import { reverseGeocode } from '@/services/eventService';
 import MapZoomControls from './MapZoomControls';
 
@@ -21,7 +22,7 @@ const DEFAULT_REGION = {
 };
 
 export default function PointPickerMap({ lat, lon, disabled, onSelect }: Props) {
-  const { theme } = useTheme();
+  const { theme, isDark } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
   const mapRef = useRef<MapView>(null);
   const lastRegionRef = useRef(DEFAULT_REGION);
@@ -71,8 +72,11 @@ export default function PointPickerMap({ lat, lon, disabled, onSelect }: Props) 
   return (
     <View style={styles.container}>
       <MapView
+        key={`point-picker-map-${isDark ? 'dark' : 'light'}`}
         ref={mapRef}
         style={styles.map}
+        userInterfaceStyle={isDark ? 'dark' : 'light'}
+        customMapStyle={isDark ? DARK_MAP_STYLE : []}
         initialRegion={region}
         onRegionChangeComplete={(r) => {
           lastRegionRef.current = r;

--- a/mobile/src/components/events/RoutePointsEditor.tsx
+++ b/mobile/src/components/events/RoutePointsEditor.tsx
@@ -11,6 +11,7 @@ import MapView, { Marker, Polyline, type LatLng } from 'react-native-maps';
 import { Feather } from '@expo/vector-icons';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
+import { DARK_MAP_STYLE } from '@/theme/mapStyle';
 import type { LocationSuggestion } from '@/models/event';
 import type { RouteWaypoint } from '@/viewmodels/event/useCreateEventViewModel';
 import { fetchRoutedGeometry, reverseGeocode } from '@/services/eventService';
@@ -54,7 +55,7 @@ export default function RoutePointsEditor({
   onMove,
   onUpdateLabel,
 }: Props) {
-  const { theme } = useTheme();
+  const { theme, isDark } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
   const mapRef = useRef<MapView>(null);
   const lastRegionRef = useRef(DEFAULT_REGION);
@@ -187,8 +188,11 @@ export default function RoutePointsEditor({
 
       <View style={styles.mapContainer}>
         <MapView
+          key={`route-editor-map-${isDark ? 'dark' : 'light'}`}
           ref={mapRef}
           style={styles.map}
+          userInterfaceStyle={isDark ? 'dark' : 'light'}
+          customMapStyle={isDark ? DARK_MAP_STYLE : []}
           initialRegion={initialRegion}
           onRegionChangeComplete={(region) => {
             lastRegionRef.current = region;

--- a/mobile/src/components/home/EventMapView.test.tsx
+++ b/mobile/src/components/home/EventMapView.test.tsx
@@ -422,7 +422,7 @@ describe('EventMapView', () => {
       );
     });
 
-    it('offsets markers that share the same dense coordinate area', () => {
+    it('offsets markers that are geographically very close', () => {
       render(
         <EventMapView
           events={[
@@ -446,7 +446,6 @@ describe('EventMapView', () => {
       expect(firstCoordinate).toBeTruthy();
       expect(secondCoordinate).toBeTruthy();
       expect(firstCoordinate).not.toEqual(secondCoordinate);
-      expect(screen.getAllByText('2').length).toBeGreaterThan(0);
     });
 
     it('shows participant count and capacity when both are present', () => {

--- a/mobile/src/components/home/EventMapView.tsx
+++ b/mobile/src/components/home/EventMapView.tsx
@@ -16,6 +16,7 @@ import MapView, {
 import { useFocusEffect } from 'expo-router';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
+import { DARK_MAP_STYLE } from '@/theme/mapStyle';
 import type { EventSummary } from '@/models/event';
 import { formatEventDateLabel } from '@/utils/eventDate';
 import {
@@ -368,6 +369,8 @@ export default function EventMapView({
 }: EventMapViewProps) {
   const { theme, isDark } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
+  const mapRef = useRef<MapView | null>(null);
+  const [visibleRegion, setVisibleRegion] = useState<MapRegion>(region);
   const mapPadding = useMemo(
     () => ({ ...DISCOVERY_MAP_PADDING_BASE, top: DISCOVERY_MAP_PADDING_BASE.top + headerTopInset }),
     [headerTopInset],
@@ -377,9 +380,14 @@ export default function EventMapView({
     Record<string, ImageStatus>
   >({});
 
+  useEffect(() => {
+    setVisibleRegion(region);
+    mapRef.current?.animateToRegion(region, 250);
+  }, [region]);
+
   const mappableEvents = useMemo(
-    () => buildMappableEvents(events, region, isDark),
-    [events, region, isDark],
+    () => buildMappableEvents(events, visibleRegion, isDark),
+    [events, visibleRegion, isDark],
   );
 
   const selectedEvent = useMemo(
@@ -416,6 +424,7 @@ export default function EventMapView({
     }
   }, [selectedEvent, selectedEventId]);
 
+
   if (isLoading) {
     return (
       <View style={styles.centeredState} testID="map-loading">
@@ -435,10 +444,22 @@ export default function EventMapView({
   return (
     <View style={styles.container} testID="event-map-view">
       <MapView
+        key={`event-map-${isDark ? 'dark' : 'light'}`}
+        ref={mapRef}
         style={styles.map}
         provider={Platform.OS === 'android' ? PROVIDER_GOOGLE : undefined}
-        region={region}
+        userInterfaceStyle={isDark ? 'dark' : 'light'}
+        customMapStyle={isDark ? DARK_MAP_STYLE : []}
+        initialRegion={region}
         mapPadding={mapPadding}
+        onRegionChangeComplete={(nextRegion) => {
+          setVisibleRegion({
+            latitude: nextRegion.latitude,
+            longitude: nextRegion.longitude,
+            latitudeDelta: nextRegion.latitudeDelta,
+            longitudeDelta: nextRegion.longitudeDelta,
+          });
+        }}
         onPress={() => setSelectedEventId(null)}
         testID="map-surface"
       >

--- a/mobile/src/models/invitation.ts
+++ b/mobile/src/models/invitation.ts
@@ -1,10 +1,14 @@
-export type InvitationStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'CANCELLED' | 'EXPIRED';
+export type InvitationStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'CANCELED' | 'EXPIRED';
 
 export interface InvitationEventSummary {
   id: string;
   title: string;
-  image_url: string | null;
+  image_url?: string | null;
   start_time: string;
+  end_time?: string | null;
+  status?: 'ACTIVE' | 'IN_PROGRESS';
+  privacy_level?: 'PRIVATE';
+  approved_participant_count?: number;
 }
 
 export interface ReceivedInvitation {
@@ -12,18 +16,31 @@ export interface ReceivedInvitation {
   status: InvitationStatus;
   event: InvitationEventSummary;
   host: {
+    id?: string;
     username: string;
     display_name: string | null;
     profile_image_url: string | null;
+    avatar_url?: string | null;
   };
   message: string | null;
+  expires_at?: string | null;
   created_at: string;
   updated_at: string;
 }
 
-export interface ReceivedInvitationsResponse {
+export interface InvitationPageInfo {
+  next_cursor: string | null;
+  has_next: boolean;
+}
+
+export interface ReceivedInvitationsPast {
   items: ReceivedInvitation[];
-  total: number;
+  page_info: InvitationPageInfo;
+}
+
+export interface ReceivedInvitationsResponse {
+  pending: ReceivedInvitation[];
+  past: ReceivedInvitationsPast;
 }
 
 export interface AcceptInvitationResponse {

--- a/mobile/src/services/invitationService.ts
+++ b/mobile/src/services/invitationService.ts
@@ -6,7 +6,7 @@ import {
 } from '@/models/invitation';
 
 /**
- * Fetches the current user's pending private-event invitations.
+ * Fetches the current user's invitations grouped into pending and past buckets.
  */
 export async function listMyInvitations(token: string): Promise<ReceivedInvitationsResponse> {
   return apiGetAuth<ReceivedInvitationsResponse>('/me/invitations', token);

--- a/mobile/src/theme/mapStyle.ts
+++ b/mobile/src/theme/mapStyle.ts
@@ -1,0 +1,80 @@
+export const DARK_MAP_STYLE = [
+  { elementType: 'geometry', stylers: [{ color: '#242f3e' }] },
+  { elementType: 'labels.text.stroke', stylers: [{ color: '#242f3e' }] },
+  { elementType: 'labels.text.fill', stylers: [{ color: '#746855' }] },
+  {
+    featureType: 'administrative.locality',
+    elementType: 'labels.text.fill',
+    stylers: [{ color: '#d59563' }],
+  },
+  {
+    featureType: 'poi',
+    elementType: 'labels.text.fill',
+    stylers: [{ color: '#d59563' }],
+  },
+  {
+    featureType: 'poi.park',
+    elementType: 'geometry',
+    stylers: [{ color: '#263c3f' }],
+  },
+  {
+    featureType: 'poi.park',
+    elementType: 'labels.text.fill',
+    stylers: [{ color: '#6b9a76' }],
+  },
+  {
+    featureType: 'road',
+    elementType: 'geometry',
+    stylers: [{ color: '#38414e' }],
+  },
+  {
+    featureType: 'road',
+    elementType: 'geometry.stroke',
+    stylers: [{ color: '#212a37' }],
+  },
+  {
+    featureType: 'road',
+    elementType: 'labels.text.fill',
+    stylers: [{ color: '#9ca5b3' }],
+  },
+  {
+    featureType: 'road.highway',
+    elementType: 'geometry',
+    stylers: [{ color: '#746855' }],
+  },
+  {
+    featureType: 'road.highway',
+    elementType: 'geometry.stroke',
+    stylers: [{ color: '#1f2835' }],
+  },
+  {
+    featureType: 'road.highway',
+    elementType: 'labels.text.fill',
+    stylers: [{ color: '#f3d19c' }],
+  },
+  {
+    featureType: 'transit',
+    elementType: 'geometry',
+    stylers: [{ color: '#2f3948' }],
+  },
+  {
+    featureType: 'transit.station',
+    elementType: 'labels.text.fill',
+    stylers: [{ color: '#d59563' }],
+  },
+  {
+    featureType: 'water',
+    elementType: 'geometry',
+    stylers: [{ color: '#17263c' }],
+  },
+  {
+    featureType: 'water',
+    elementType: 'labels.text.fill',
+    stylers: [{ color: '#515c6d' }],
+  },
+  {
+    featureType: 'water',
+    elementType: 'labels.text.stroke',
+    stylers: [{ color: '#17263c' }],
+  },
+];

--- a/mobile/src/viewmodels/event/useEventDetailViewModel.test.tsx
+++ b/mobile/src/viewmodels/event/useEventDetailViewModel.test.tsx
@@ -411,7 +411,7 @@ describe('useEventDetailViewModel', () => {
     });
     mockSearchUsers.mockResolvedValue({ items: [] });
     mockListMyInvitations.mockResolvedValue({
-      items: [
+      pending: [
         {
           invitation_id: 'inv-1',
           status: 'PENDING',
@@ -431,7 +431,10 @@ describe('useEventDetailViewModel', () => {
           updated_at: invitedPrivateEventFixture.updated_at,
         },
       ],
-      total: 1,
+      past: {
+        items: [],
+        page_info: { next_cursor: null, has_next: false },
+      },
     });
     mockAcceptInvitation.mockResolvedValue({
       message: 'Invitation accepted',

--- a/mobile/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/mobile/src/viewmodels/event/useEventDetailViewModel.ts
@@ -231,6 +231,17 @@ function normalizePickedImageUri(uri: string): string {
   return normalized;
 }
 
+function normalizeParticipationStatus(
+  status: EventDetail['viewer_context']['participation_status'] | 'APPROVED' | null | undefined,
+): ParticipationStatus {
+  if (status === 'APPROVED' || status === 'JOINED') return 'JOINED';
+  if (status === 'PENDING') return 'PENDING';
+  if (status === 'INVITED') return 'INVITED';
+  if (status === 'LEAVED') return 'LEAVED';
+  if (status === 'CANCELED') return 'CANCELED';
+  return 'NONE';
+}
+
 function getPickedImageUriCandidates(uri: string): string[] {
   return [...new Set([uri, decodeFileUriOnce(uri), normalizePickedImageUri(uri)])];
 }
@@ -363,9 +374,22 @@ export function useEventDetailViewModel(eventId: string): EventDetailViewModel {
 
       try {
         const data = await getEventDetail(eventId, token);
-        setEvent(data);
+        const normalizedParticipationStatus = normalizeParticipationStatus(
+          data.viewer_context.participation_status as
+            | EventDetail['viewer_context']['participation_status']
+            | 'APPROVED'
+            | null
+            | undefined,
+        );
+        setEvent({
+          ...data,
+          viewer_context: {
+            ...data.viewer_context,
+            participation_status: normalizedParticipationStatus,
+          },
+        });
         setIsFavorited(data.viewer_context.is_favorited);
-        setParticipationStatus(data.viewer_context.participation_status);
+        setParticipationStatus(normalizedParticipationStatus);
         if (data.viewer_context.is_host) {
           void refreshHostContextSummary();
         }
@@ -849,7 +873,7 @@ export function useEventDetailViewModel(eventId: string): EventDetailViewModel {
     if (!token || !event) return null;
 
     const response = await listMyInvitations(token);
-    const invitation = response.items.find((item) => item.event.id === event.id);
+    const invitation = response.pending.find((item) => item.event.id === event.id);
     return invitation?.invitation_id ?? null;
   }, [event, token]);
 

--- a/mobile/src/viewmodels/event/useMyEventsViewModel.test.tsx
+++ b/mobile/src/viewmodels/event/useMyEventsViewModel.test.tsx
@@ -66,7 +66,7 @@ const myEventsResponse: MyEventsResponse = {
 };
 
 const myInvitationsResponse = {
-  items: [
+  pending: [
     {
       invitation_id: 'inv-1',
       status: 'PENDING',
@@ -75,7 +75,10 @@ const myInvitationsResponse = {
       message: 'Join us!',
     },
   ],
-  total: 1,
+  past: {
+    items: [],
+    page_info: { next_cursor: null, has_next: false },
+  },
 };
 
 describe('useMyEventsViewModel', () => {
@@ -124,7 +127,10 @@ describe('useMyEventsViewModel', () => {
     // First call returns 1, second (after reload) returns 0
     mockListMyInvitations
       .mockResolvedValueOnce(myInvitationsResponse as any)
-      .mockResolvedValueOnce({ items: [], total: 0 } as any);
+      .mockResolvedValueOnce({
+        pending: [],
+        past: { items: [], page_info: { next_cursor: null, has_next: false } },
+      } as any);
 
     const { result } = renderHook(() => useMyEventsViewModel());
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/mobile/src/viewmodels/event/useMyEventsViewModel.ts
+++ b/mobile/src/viewmodels/event/useMyEventsViewModel.ts
@@ -133,8 +133,8 @@ export function useMyEventsViewModel(): MyEventsViewModel {
       ]);
       setHostedEvents(eventsResponse.hosted_events);
       setAttendedEvents(eventsResponse.attended_events);
-      setInvitations(invitationsResponse.items);
-      setInvitationCount(invitationsResponse.items.length);
+      setInvitations(invitationsResponse.pending);
+      setInvitationCount(invitationsResponse.pending.length);
     } catch {
       setHostedEvents([]);
       setAttendedEvents([]);

--- a/mobile/src/viewmodels/invitation/useInvitationsViewModel.test.ts
+++ b/mobile/src/viewmodels/invitation/useInvitationsViewModel.test.ts
@@ -44,7 +44,7 @@ describe('useInvitationsViewModel', () => {
 
   it('fetches invitations on mount', async () => {
     const mockInvitations = {
-      items: [
+      pending: [
         {
           invitation_id: 'inv-1',
           status: 'PENDING',
@@ -53,6 +53,7 @@ describe('useInvitationsViewModel', () => {
           created_at: '2026-05-01T10:00:00Z',
         },
       ],
+      past: { items: [], page_info: { next_cursor: null, has_next: false } },
     };
     mockInvitationService.listMyInvitations.mockResolvedValue(mockInvitations as any);
 
@@ -82,9 +83,10 @@ describe('useInvitationsViewModel', () => {
 
   it('removes invitation from list after successful accept', async () => {
     const mockInvitations = {
-      items: [
+      pending: [
         { invitation_id: 'inv-1', status: 'PENDING', event: { title: 'E1' }, host: { username: 'h1' } },
       ],
+      past: { items: [], page_info: { next_cursor: null, has_next: false } },
     };
     mockInvitationService.listMyInvitations.mockResolvedValue(mockInvitations as any);
     mockInvitationService.acceptInvitation.mockResolvedValue({} as any);
@@ -105,9 +107,10 @@ describe('useInvitationsViewModel', () => {
 
   it('removes invitation from list after successful decline', async () => {
     const mockInvitations = {
-      items: [
+      pending: [
         { invitation_id: 'inv-1', status: 'PENDING', event: { title: 'E1' }, host: { username: 'h1' } },
       ],
+      past: { items: [], page_info: { next_cursor: null, has_next: false } },
     };
     mockInvitationService.listMyInvitations.mockResolvedValue(mockInvitations as any);
     mockInvitationService.declineInvitation.mockResolvedValue({} as any);

--- a/mobile/src/viewmodels/invitation/useInvitationsViewModel.ts
+++ b/mobile/src/viewmodels/invitation/useInvitationsViewModel.ts
@@ -31,7 +31,7 @@ export function useInvitationsViewModel(): InvitationsViewModel {
     setError(null);
     try {
       const response = await listMyInvitations(token);
-      setInvitations(response.items);
+      setInvitations(response.pending);
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message);

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -35,6 +35,7 @@ import EventDiscussionSection from '@/components/events/EventDiscussionSection';
 import { useEventDiscussionViewModel } from '@/viewmodels/event/useEventDiscussionViewModel';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
+import { DARK_MAP_STYLE } from '@/theme/mapStyle';
 
 interface EventDetailViewProps {
   eventId: string;
@@ -408,87 +409,6 @@ function ParticipantRatingSection({
 
 /** Radius (metres) of the circle drawn around a fuzzed PROTECTED event location. */
 const APPROX_LOCATION_RADIUS_METERS = 500;
-
-const darkMapStyle = [
-  { elementType: 'geometry', stylers: [{ color: '#242f3e' }] },
-  { elementType: 'labels.text.stroke', stylers: [{ color: '#242f3e' }] },
-  { elementType: 'labels.text.fill', stylers: [{ color: '#746855' }] },
-  {
-    featureType: 'administrative.locality',
-    elementType: 'labels.text.fill',
-    stylers: [{ color: '#d59563' }],
-  },
-  {
-    featureType: 'poi',
-    elementType: 'labels.text.fill',
-    stylers: [{ color: '#d59563' }],
-  },
-  {
-    featureType: 'poi.park',
-    elementType: 'geometry',
-    stylers: [{ color: '#263c3f' }],
-  },
-  {
-    featureType: 'poi.park',
-    elementType: 'labels.text.fill',
-    stylers: [{ color: '#6b9a76' }],
-  },
-  {
-    featureType: 'road',
-    elementType: 'geometry',
-    stylers: [{ color: '#38414e' }],
-  },
-  {
-    featureType: 'road',
-    elementType: 'geometry.stroke',
-    stylers: [{ color: '#212a37' }],
-  },
-  {
-    featureType: 'road',
-    elementType: 'labels.text.fill',
-    stylers: [{ color: '#9ca5b3' }],
-  },
-  {
-    featureType: 'road.highway',
-    elementType: 'geometry',
-    stylers: [{ color: '#746855' }],
-  },
-  {
-    featureType: 'road.highway',
-    elementType: 'geometry.stroke',
-    stylers: [{ color: '#1f2835' }],
-  },
-  {
-    featureType: 'road.highway',
-    elementType: 'labels.text.fill',
-    stylers: [{ color: '#f3d19c' }],
-  },
-  {
-    featureType: 'transit',
-    elementType: 'geometry',
-    stylers: [{ color: '#2f3948' }],
-  },
-  {
-    featureType: 'transit.station',
-    elementType: 'labels.text.fill',
-    stylers: [{ color: '#d59563' }],
-  },
-  {
-    featureType: 'water',
-    elementType: 'geometry',
-    stylers: [{ color: '#17263c' }],
-  },
-  {
-    featureType: 'water',
-    elementType: 'labels.text.fill',
-    stylers: [{ color: '#515c6d' }],
-  },
-  {
-    featureType: 'water',
-    elementType: 'labels.text.stroke',
-    stylers: [{ color: '#17263c' }],
-  },
-];
 
 export default function EventDetailView({ eventId }: EventDetailViewProps) {
   const vm = useEventDetailViewModel(eventId);
@@ -1009,8 +929,10 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                   testID="mini-map-touchable"
                 >
                   <MapView
+                    key={`event-detail-mini-map-${isDark ? 'dark' : 'light'}`}
                     style={styles.miniMap}
-                    customMapStyle={isDark ? darkMapStyle : []}
+                    userInterfaceStyle={isDark ? 'dark' : 'light'}
+                    customMapStyle={isDark ? DARK_MAP_STYLE : []}
                     region={region}
                     scrollEnabled={false}
                     zoomEnabled={false}
@@ -1515,8 +1437,10 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
           >
           <View style={styles.fullMapContainer}>
             <MapView
+              key={`event-detail-full-map-${isDark ? 'dark' : 'light'}`}
               style={styles.fullMap}
-              customMapStyle={isDark ? darkMapStyle : []}
+              userInterfaceStyle={isDark ? 'dark' : 'light'}
+              customMapStyle={isDark ? DARK_MAP_STYLE : []}
               initialRegion={initialRegion}
             >
               {isRoute && polylineCoords && polylineCoords.length >= 2 && (


### PR DESCRIPTION
## 📋 Summary

Aligns the mobile map and event flows with recent backend and UX expectations.  
This PR ensures map styling follows the **in-app theme selection** (not just system mode), updates invitation consumption to the backend’s new `/invitations/received` shape (`pending` / `past`), fixes event detail participation status handling so **join/leave** buttons reflect the real state, and removes map clustering behavior so nearby events render as individual markers with existing dense-marker offset logic.

## 🔄 Changes

- **Map Theming**
  - Added shared dark map style usage via `mobile/src/theme/mapStyle.ts`.
  - Updated map surfaces to respect app theme (`dark` / `light`) with `userInterfaceStyle`.
  - Added theme-dependent `key` remount behavior for `MapView` where needed to ensure Android applies theme changes reliably.

- **Invitation Contract Migration**
  - Updated invitation model and service layers to the backend response format:
    - from legacy list-like shape to `{ pending, past }`.
  - Updated all affected consumers in viewmodels to read from the new contract.
  - Updated invitation-related tests to match the new payload structure.

- **Event Detail Participation Fix**
  - Normalized backend participation values (including `APPROVED`) into mobile UI participation states.
  - Fixed event detail action state so joining an event correctly transitions UI from **Join** to **Leave** behavior.

- **Map Marker Behavior**
  - Removed clustering implementation from discovery map rendering.
  - Kept non-cluster marker rendering with dense-coordinate offset behavior for close points.
  - Updated map tests accordingly (no cluster expectation; marker offset expectation retained).

## 🧪 Testing

**Automated**
```bash
cd mobile
npm test -- --runInBand EventMapView.test.tsx
```

**Manual**

- Toggle app theme between light/dark and verify map style updates consistently (including Android).
- Open My Events and verify invitation-dependent event data loads correctly.
- Open event detail, join an event, and verify action state updates correctly to leave-capable state.
- Verify nearby events on discovery map appear as individual markers (no cluster bubble), with overlap offset behavior.
- Validate invitation views/flows still behave correctly with pending / past backend data.

##  🔗 Related
Closes #591
Closes #592