### PR TITLE
feat(frontend): add discussion and review interaction panel on event detail

### DIFF
--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -317,3 +317,67 @@ export interface FavoriteEventItem {
 export interface FavoriteEventsResponse {
   items: FavoriteEventItem[];
 }
+
+/* ── Comments (Discussion + Review) ── */
+
+export type CommentType = 'DISCUSSION' | 'REVIEW';
+
+export interface EventCommentAuthor {
+  id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+}
+
+export interface EventComment {
+  id: string;
+  event_id: string;
+  user: EventCommentAuthor;
+  comment_type: CommentType;
+  message: string;
+  parent_id: string | null;
+  rating: number | null;
+  image_url: string | null;
+  likes_count: number;
+  reply_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EventCommentPageInfo {
+  next_cursor: string | null;
+  has_next: boolean;
+}
+
+export interface EventCommentCollection {
+  items: EventComment[];
+  page_info: EventCommentPageInfo;
+}
+
+export interface EventCommentsResponse {
+  discussion_comments: EventCommentCollection;
+  review_comments: EventCommentCollection;
+}
+
+export interface ListEventCommentsParams {
+  discussion_limit?: number;
+  discussion_cursor?: string | null;
+  review_limit?: number;
+  review_cursor?: string | null;
+}
+
+export interface ListEventCommentRepliesParams {
+  limit?: number;
+  cursor?: string | null;
+}
+
+export interface CreateDiscussionCommentRequest {
+  message: string;
+  parent_id?: string | null;
+}
+
+export interface UpsertReviewCommentRequest {
+  message: string;
+  rating: number;
+  image_confirm_token?: string | null;
+}

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -24,6 +24,13 @@ import {
   EventInvitationsResponse,
   RatingWriteRequest,
   RatingResponse,
+  EventCommentsResponse,
+  EventCommentCollection,
+  EventComment,
+  ListEventCommentsParams,
+  ListEventCommentRepliesParams,
+  CreateDiscussionCommentRequest,
+  UpsertReviewCommentRequest,
 } from '@/models/event';
 
 const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
@@ -253,6 +260,72 @@ export function removeFavorite(eventId: string, token: string): Promise<void> {
 export async function getFavoriteEvents(token: string): Promise<FavoriteEventItem[]> {
   const res = await apiGetAuth<FavoriteEventsResponse>('/me/favorites', token);
   return res.items ?? [];
+}
+
+export function listEventComments(
+  eventId: string,
+  token: string | null,
+  params: ListEventCommentsParams = {},
+): Promise<EventCommentsResponse> {
+  const qs = new URLSearchParams();
+  if (params.discussion_limit != null) qs.set('discussion_limit', String(params.discussion_limit));
+  if (params.discussion_cursor) qs.set('discussion_cursor', params.discussion_cursor);
+  if (params.review_limit != null) qs.set('review_limit', String(params.review_limit));
+  if (params.review_cursor) qs.set('review_cursor', params.review_cursor);
+  const query = qs.toString();
+  const path = query === ''
+    ? `/events/${eventId}/comments`
+    : `/events/${eventId}/comments?${query}`;
+  if (token) {
+    return apiGetAuth<EventCommentsResponse>(path, token);
+  }
+  return apiGet<EventCommentsResponse>(path);
+}
+
+export function listEventCommentReplies(
+  eventId: string,
+  commentId: string,
+  token: string | null,
+  params: ListEventCommentRepliesParams = {},
+): Promise<EventCommentCollection> {
+  const qs = new URLSearchParams();
+  if (params.limit != null) qs.set('limit', String(params.limit));
+  if (params.cursor) qs.set('cursor', params.cursor);
+  const query = qs.toString();
+  const path = query === ''
+    ? `/events/${eventId}/comments/${commentId}/replies`
+    : `/events/${eventId}/comments/${commentId}/replies?${query}`;
+  if (token) {
+    return apiGetAuth<EventCommentCollection>(path, token);
+  }
+  return apiGet<EventCommentCollection>(path);
+}
+
+export function createDiscussionComment(
+  eventId: string,
+  body: CreateDiscussionCommentRequest,
+  token: string,
+): Promise<EventComment> {
+  return apiPostAuth<EventComment>(`/events/${eventId}/comments`, body, token);
+}
+
+export function upsertReviewComment(
+  eventId: string,
+  body: UpsertReviewCommentRequest,
+  token: string,
+): Promise<EventComment> {
+  return apiPostAuth<EventComment>(`/events/${eventId}/review-comments`, body, token);
+}
+
+export function getReviewCommentImageUploadUrl(
+  eventId: string,
+  token: string,
+): Promise<ImageUploadInitResponse> {
+  return apiPostAuth<ImageUploadInitResponse>(
+    `/events/${eventId}/review-comments/image/upload-url`,
+    {},
+    token,
+  );
 }
 
 export async function searchLocation(

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -1808,3 +1808,622 @@
     width: 100%;
   }
 }
+
+/* ──────────────────────────────────────────────
+   Event interaction panel (Discussion + Review)
+   ────────────────────────────────────────────── */
+
+.ed-comments-section {
+  gap: 16px;
+  border-top: 1px solid #e5e7eb;
+  padding-top: 24px;
+}
+
+.ed-comments-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ed-comments-title {
+  margin: 0;
+}
+
+.ed-comments-tabs {
+  display: inline-flex;
+  border: 1px solid #e5e7eb;
+  background-color: #f9fafb;
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+  width: fit-content;
+}
+
+.ed-comments-tab {
+  border: none;
+  background: transparent;
+  color: #4b5563;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.ed-comments-tab:hover {
+  color: #111827;
+}
+
+.ed-comments-tab.is-active {
+  background-color: #ffffff;
+  color: #111827;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.ed-comments-single-tab-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ed-comments-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 4px;
+}
+
+.ed-comments-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+}
+
+.ed-comments-composer-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 2px;
+}
+
+.ed-comments-textarea {
+  width: 100%;
+  min-height: 72px;
+  padding: 10px 12px;
+  font-size: 14px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  color: #111827;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.ed-comments-textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.ed-comments-textarea:disabled {
+  background-color: #f3f4f6;
+  color: #6b7280;
+  cursor: not-allowed;
+}
+
+.ed-comments-form-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.ed-comments-form-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.ed-comments-char-count {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.ed-comments-primary-btn,
+.ed-comments-secondary-btn {
+  font-size: 14px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ed-comments-primary-btn {
+  border: 1px solid transparent;
+  background-color: #111827;
+  color: #ffffff;
+}
+
+.ed-comments-primary-btn:hover:not(:disabled) {
+  background-color: #1f2937;
+}
+
+.ed-comments-primary-btn:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.ed-comments-secondary-btn {
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  color: #374151;
+}
+
+.ed-comments-secondary-btn:hover:not(:disabled) {
+  border-color: #111827;
+  color: #111827;
+}
+
+.ed-comments-secondary-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.ed-comments-load-more {
+  align-self: center;
+  width: fit-content;
+  padding: 8px 24px;
+}
+
+.ed-comments-callout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background-color: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #1d4ed8;
+  font-size: 14px;
+}
+
+.ed-comments-callout-muted {
+  background-color: #f9fafb;
+  border-color: #e5e7eb;
+  color: #4b5563;
+}
+
+.ed-comments-link {
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ed-comments-link:hover {
+  text-decoration: underline;
+}
+
+.ed-comments-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ed-comments-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+}
+
+.ed-comments-item-reply {
+  border-color: #f1f5f9;
+  background-color: #f9fafb;
+}
+
+.ed-comments-item-review {
+  border-color: #fde68a;
+  background-color: #fffbeb;
+}
+
+.ed-comments-item-header {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.ed-comments-item-author {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ed-comments-item-author-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ed-comments-item-name {
+  font-weight: 600;
+  color: #111827;
+  font-size: 14px;
+}
+
+.ed-comments-item-meta {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.ed-comments-host-badge {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.ed-comments-item-message {
+  margin: 0;
+  font-size: 14px;
+  color: #1f2937;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.ed-comments-item-actions {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.ed-comments-link-btn {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: #1d4ed8;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ed-comments-link-btn:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.ed-comments-link-btn:disabled {
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.ed-comments-replies {
+  list-style: none;
+  margin: 4px 0 0 36px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-left: 2px solid #e5e7eb;
+  padding-left: 14px;
+}
+
+.ed-comments-empty-inline {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.ed-comments-reply-form {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ed-comments-empty {
+  padding: 28px 14px;
+  text-align: center;
+  border: 1px dashed #e5e7eb;
+  border-radius: 12px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.ed-comments-state {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  padding: 24px 14px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.ed-comments-state-error {
+  color: #b91c1c;
+}
+
+.ed-comments-error,
+.ed-comments-success {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.ed-comments-error {
+  background-color: #fee2e2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+
+.ed-comments-success {
+  background-color: #dcfce7;
+  border: 1px solid #bbf7d0;
+  color: #166534;
+}
+
+.ed-comments-error-dismiss {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+/* Review specific */
+.ed-comments-review-composer {
+  background-color: #fffbeb;
+  border-color: #fde68a;
+}
+
+.ed-comments-review-rating-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.ed-comments-stars-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.ed-comments-star-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: transparent;
+  color: #cbd5e1;
+  cursor: pointer;
+  font-size: 28px;
+  line-height: 1;
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+
+.ed-comments-star-btn span {
+  font-size: 28px;
+  line-height: 1;
+}
+
+.ed-comments-star-btn.is-active {
+  color: #f59e0b;
+}
+
+.ed-comments-star-btn:hover:not(:disabled),
+.ed-comments-star-btn:focus-visible:not(:disabled) {
+  transform: translateY(-1px) scale(1.05);
+}
+
+.ed-comments-star-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.ed-comments-review-rating-summary {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background-color: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: #64748b;
+}
+
+.ed-comments-review-rating-summary.is-selected {
+  color: #92400e;
+  border-color: rgba(245, 158, 11, 0.45);
+  background-color: #fff7ed;
+}
+
+.ed-comments-review-rating {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ed-comments-review-stars {
+  font-size: 16px;
+  color: #f59e0b;
+  letter-spacing: 1px;
+}
+
+.ed-comments-review-rating-text {
+  font-size: 13px;
+  color: #92400e;
+  font-weight: 600;
+}
+
+.ed-comments-review-image-link {
+  display: block;
+  align-self: flex-start;
+  border-radius: 10px;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+.ed-comments-review-image {
+  display: block;
+  max-width: 100%;
+  max-height: 320px;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+.ed-comments-image-drop {
+  position: relative;
+  border: 2px dashed #d1d5db;
+  border-radius: 12px;
+  padding: 16px;
+  background-color: #ffffff;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.ed-comments-image-drop.is-dragging {
+  border-color: #2563eb;
+  background-color: #eff6ff;
+}
+
+.ed-comments-image-drop.has-image {
+  padding: 12px;
+}
+
+.ed-comments-image-input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ed-comments-image-drop-trigger {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  text-align: left;
+  color: #374151;
+}
+
+.ed-comments-image-drop-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.ed-comments-image-drop-icon {
+  font-size: 24px;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  background-color: #f3f4f6;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ed-comments-image-drop-text {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  color: #374151;
+}
+
+.ed-comments-image-drop-text strong {
+  font-weight: 700;
+  color: #111827;
+}
+
+.ed-comments-image-drop-text span {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.ed-comments-image-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ed-comments-image-preview-img {
+  width: 100%;
+  max-height: 240px;
+  object-fit: cover;
+  border-radius: 10px;
+  background-color: #f3f4f6;
+}
+
+.ed-comments-image-preview-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.ed-comments-image-remove {
+  color: #b91c1c;
+  border-color: #fecaca;
+}
+
+.ed-comments-image-remove:hover:not(:disabled) {
+  border-color: #b91c1c;
+  color: #991b1b;
+}
+
+@media (max-width: 600px) {
+  .ed-comments-replies {
+    margin-left: 18px;
+    padding-left: 10px;
+  }
+
+  .ed-comments-image-drop-trigger {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .ed-comments-tabs {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .ed-comments-tab {
+    flex: 1;
+    text-align: center;
+  }
+}

--- a/frontend/src/viewmodels/event/useEventCommentsViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventCommentsViewModel.ts
@@ -1,0 +1,455 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  listEventComments,
+  listEventCommentReplies,
+  createDiscussionComment,
+  upsertReviewComment,
+  getReviewCommentImageUploadUrl,
+} from '@/services/eventService';
+import type {
+  EventComment,
+  EventCommentCollection,
+} from '@/models/event';
+import { ApiError } from '@/services/api';
+import { prepareAvatarBlobs } from '@/utils/imageResize';
+
+const PAGE_LIMIT = 25;
+
+export type CommentsStatus = 'idle' | 'loading' | 'ready' | 'error' | 'unavailable';
+
+export interface RepliesState {
+  items: EventComment[];
+  loading: boolean;
+  error: string | null;
+  nextCursor: string | null;
+  hasNext: boolean;
+  expanded: boolean;
+}
+
+interface CursorState {
+  next: string | null;
+  hasNext: boolean;
+}
+
+const EMPTY_CURSOR: CursorState = { next: null, hasNext: false };
+
+function defaultRepliesState(): RepliesState {
+  return {
+    items: [],
+    loading: false,
+    error: null,
+    nextCursor: null,
+    hasNext: false,
+    expanded: false,
+  };
+}
+
+function mapCommentApiError(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) {
+    const codeMap: Record<string, string> = {
+      comments_not_allowed: 'Comments are not available for this event.',
+      review_not_allowed: 'You are not eligible to review this event.',
+      review_window_closed: 'The review window for this event has closed.',
+      discussion_window_closed: 'Discussion is closed for this event.',
+      validation_error: err.details?.message ?? err.message,
+      not_found: 'Event or comment not found.',
+    };
+    return codeMap[err.code] ?? err.message ?? fallback;
+  }
+  return fallback;
+}
+
+export function useEventCommentsViewModel(
+  eventId: string | undefined,
+  token: string | null,
+) {
+  const [status, setStatus] = useState<CommentsStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const [discussionComments, setDiscussionComments] = useState<EventComment[]>([]);
+  const [discussionCursor, setDiscussionCursor] = useState<CursorState>(EMPTY_CURSOR);
+  const [discussionLoadingMore, setDiscussionLoadingMore] = useState(false);
+
+  const [reviewComments, setReviewComments] = useState<EventComment[]>([]);
+  const [reviewCursor, setReviewCursor] = useState<CursorState>(EMPTY_CURSOR);
+  const [reviewLoadingMore, setReviewLoadingMore] = useState(false);
+
+  const [repliesByCommentId, setRepliesByCommentId] = useState<Record<string, RepliesState>>({});
+
+  const [discussionSubmitLoading, setDiscussionSubmitLoading] = useState(false);
+  const [discussionSubmitError, setDiscussionSubmitError] = useState<string | null>(null);
+
+  const [replySubmitState, setReplySubmitState] = useState<{
+    parentId: string | null;
+    loading: boolean;
+    error: string | null;
+  }>({ parentId: null, loading: false, error: null });
+
+  const [reviewSubmitLoading, setReviewSubmitLoading] = useState(false);
+  const [reviewSubmitError, setReviewSubmitError] = useState<string | null>(null);
+  const [reviewSubmitSuccess, setReviewSubmitSuccess] = useState<string | null>(null);
+  const reviewSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (reviewSuccessTimerRef.current) clearTimeout(reviewSuccessTimerRef.current);
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    setStatus('idle');
+    setErrorMessage(null);
+    setDiscussionComments([]);
+    setDiscussionCursor(EMPTY_CURSOR);
+    setReviewComments([]);
+    setReviewCursor(EMPTY_CURSOR);
+    setRepliesByCommentId({});
+    setDiscussionSubmitError(null);
+    setReplySubmitState({ parentId: null, loading: false, error: null });
+    setReviewSubmitError(null);
+    setReviewSubmitSuccess(null);
+  }, []);
+
+  const applyResponseCollection = useCallback(
+    (
+      collection: EventCommentCollection,
+      setItems: (items: EventComment[]) => void,
+      setCursor: (cursor: CursorState) => void,
+    ) => {
+      setItems(collection.items);
+      setCursor({ next: collection.page_info.next_cursor, hasNext: collection.page_info.has_next });
+    },
+    [],
+  );
+
+  const loadInitial = useCallback(async () => {
+    if (!eventId) return;
+    setStatus('loading');
+    setErrorMessage(null);
+    try {
+      const data = await listEventComments(eventId, token, {
+        discussion_limit: PAGE_LIMIT,
+        review_limit: PAGE_LIMIT,
+      });
+      applyResponseCollection(data.discussion_comments, setDiscussionComments, setDiscussionCursor);
+      applyResponseCollection(data.review_comments, setReviewComments, setReviewCursor);
+      setStatus('ready');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 409 && err.code === 'comments_not_allowed') {
+          setStatus('unavailable');
+          return;
+        }
+        if (err.status === 404) {
+          setStatus('unavailable');
+          return;
+        }
+      }
+      setStatus('error');
+      setErrorMessage(mapCommentApiError(err, 'Failed to load comments. Please try again.'));
+    }
+  }, [eventId, token, applyResponseCollection]);
+
+  useEffect(() => {
+    if (!eventId) {
+      reset();
+      return;
+    }
+    void loadInitial();
+  }, [eventId, token, loadInitial, reset]);
+
+  const loadMoreDiscussion = useCallback(async () => {
+    if (!eventId || !discussionCursor.hasNext || !discussionCursor.next || discussionLoadingMore) {
+      return;
+    }
+    setDiscussionLoadingMore(true);
+    try {
+      const data = await listEventComments(eventId, token, {
+        discussion_limit: PAGE_LIMIT,
+        discussion_cursor: discussionCursor.next,
+        review_limit: 1,
+      });
+      setDiscussionComments((prev) => [...prev, ...data.discussion_comments.items]);
+      setDiscussionCursor({
+        next: data.discussion_comments.page_info.next_cursor,
+        hasNext: data.discussion_comments.page_info.has_next,
+      });
+    } catch (err) {
+      setErrorMessage(mapCommentApiError(err, 'Failed to load more discussion comments.'));
+    } finally {
+      setDiscussionLoadingMore(false);
+    }
+  }, [eventId, token, discussionCursor, discussionLoadingMore]);
+
+  const loadMoreReviews = useCallback(async () => {
+    if (!eventId || !reviewCursor.hasNext || !reviewCursor.next || reviewLoadingMore) {
+      return;
+    }
+    setReviewLoadingMore(true);
+    try {
+      const data = await listEventComments(eventId, token, {
+        discussion_limit: 1,
+        review_limit: PAGE_LIMIT,
+        review_cursor: reviewCursor.next,
+      });
+      setReviewComments((prev) => [...prev, ...data.review_comments.items]);
+      setReviewCursor({
+        next: data.review_comments.page_info.next_cursor,
+        hasNext: data.review_comments.page_info.has_next,
+      });
+    } catch (err) {
+      setErrorMessage(mapCommentApiError(err, 'Failed to load more reviews.'));
+    } finally {
+      setReviewLoadingMore(false);
+    }
+  }, [eventId, token, reviewCursor, reviewLoadingMore]);
+
+  const updateReplyState = useCallback(
+    (commentId: string, updater: (prev: RepliesState) => RepliesState) => {
+      setRepliesByCommentId((prev) => {
+        const current = prev[commentId] ?? defaultRepliesState();
+        return { ...prev, [commentId]: updater(current) };
+      });
+    },
+    [],
+  );
+
+  const loadReplies = useCallback(
+    async (commentId: string, cursor?: string | null, append = false) => {
+      if (!eventId) return;
+      updateReplyState(commentId, (prev) => ({ ...prev, loading: true, error: null }));
+      try {
+        const data = await listEventCommentReplies(eventId, commentId, token, {
+          limit: PAGE_LIMIT,
+          cursor: cursor ?? undefined,
+        });
+        updateReplyState(commentId, (prev) => ({
+          ...prev,
+          items: append ? [...prev.items, ...data.items] : data.items,
+          loading: false,
+          error: null,
+          nextCursor: data.page_info.next_cursor,
+          hasNext: data.page_info.has_next,
+          expanded: true,
+        }));
+      } catch (err) {
+        updateReplyState(commentId, (prev) => ({
+          ...prev,
+          loading: false,
+          error: mapCommentApiError(err, 'Failed to load replies.'),
+        }));
+      }
+    },
+    [eventId, token, updateReplyState],
+  );
+
+  const toggleReplies = useCallback(
+    async (comment: EventComment) => {
+      const existing = repliesByCommentId[comment.id];
+      if (existing && existing.expanded) {
+        updateReplyState(comment.id, (prev) => ({ ...prev, expanded: false }));
+        return;
+      }
+      if (existing && existing.items.length > 0) {
+        updateReplyState(comment.id, (prev) => ({ ...prev, expanded: true }));
+        return;
+      }
+      if (comment.reply_count === 0) {
+        updateReplyState(comment.id, (prev) => ({ ...prev, expanded: true }));
+        return;
+      }
+      await loadReplies(comment.id);
+    },
+    [repliesByCommentId, updateReplyState, loadReplies],
+  );
+
+  const loadMoreReplies = useCallback(
+    async (commentId: string) => {
+      const current = repliesByCommentId[commentId];
+      if (!current || current.loading || !current.hasNext || !current.nextCursor) return;
+      await loadReplies(commentId, current.nextCursor, true);
+    },
+    [repliesByCommentId, loadReplies],
+  );
+
+  const submitDiscussion = useCallback(
+    async (message: string): Promise<boolean> => {
+      if (!eventId || !token) return false;
+      const trimmed = message.trim();
+      if (trimmed.length === 0) {
+        setDiscussionSubmitError('Please write a message before posting.');
+        return false;
+      }
+      setDiscussionSubmitLoading(true);
+      setDiscussionSubmitError(null);
+      try {
+        const created = await createDiscussionComment(eventId, { message: trimmed }, token);
+        setDiscussionComments((prev) => [created, ...prev]);
+        return true;
+      } catch (err) {
+        setDiscussionSubmitError(mapCommentApiError(err, 'Failed to post comment. Please try again.'));
+        return false;
+      } finally {
+        setDiscussionSubmitLoading(false);
+      }
+    },
+    [eventId, token],
+  );
+
+  const submitReply = useCallback(
+    async (parentId: string, message: string): Promise<boolean> => {
+      if (!eventId || !token) return false;
+      const trimmed = message.trim();
+      if (trimmed.length === 0) {
+        setReplySubmitState({ parentId, loading: false, error: 'Please write a reply before posting.' });
+        return false;
+      }
+      setReplySubmitState({ parentId, loading: true, error: null });
+      try {
+        const created = await createDiscussionComment(
+          eventId,
+          { message: trimmed, parent_id: parentId },
+          token,
+        );
+        setDiscussionComments((prev) =>
+          prev.map((c) =>
+            c.id === parentId ? { ...c, reply_count: c.reply_count + 1 } : c,
+          ),
+        );
+        updateReplyState(parentId, (prev) => ({
+          ...prev,
+          items: [...prev.items, created],
+          expanded: true,
+        }));
+        setReplySubmitState({ parentId: null, loading: false, error: null });
+        return true;
+      } catch (err) {
+        setReplySubmitState({
+          parentId,
+          loading: false,
+          error: mapCommentApiError(err, 'Failed to post reply. Please try again.'),
+        });
+        return false;
+      }
+    },
+    [eventId, token, updateReplyState],
+  );
+
+  const submitReview = useCallback(
+    async (rating: number, message: string, imageFile: File | null): Promise<boolean> => {
+      if (!eventId || !token) return false;
+      const trimmed = message.trim();
+      if (rating < 1 || rating > 5) {
+        setReviewSubmitError('Select a rating from 1 to 5 stars.');
+        return false;
+      }
+      if (trimmed.length === 0) {
+        setReviewSubmitError('Please write a review message.');
+        return false;
+      }
+      setReviewSubmitLoading(true);
+      setReviewSubmitError(null);
+      setReviewSubmitSuccess(null);
+      try {
+        let imageConfirmToken: string | undefined;
+        if (imageFile) {
+          const { original, small } = await prepareAvatarBlobs(imageFile);
+          const uploadInit = await getReviewCommentImageUploadUrl(eventId, token);
+          for (const instruction of uploadInit.uploads) {
+            const blob = instruction.variant === 'ORIGINAL' ? original : small;
+            const res = await fetch(instruction.url, {
+              method: instruction.method,
+              headers: instruction.headers,
+              body: blob,
+            });
+            if (!res.ok) {
+              throw new Error(`Image upload failed (${instruction.variant}).`);
+            }
+          }
+          imageConfirmToken = uploadInit.confirm_token;
+        }
+
+        const upserted = await upsertReviewComment(
+          eventId,
+          {
+            message: trimmed,
+            rating,
+            image_confirm_token: imageConfirmToken ?? null,
+          },
+          token,
+        );
+
+        setReviewComments((prev) => {
+          const filtered = prev.filter((c) => c.id !== upserted.id);
+          return [upserted, ...filtered];
+        });
+
+        if (reviewSuccessTimerRef.current) clearTimeout(reviewSuccessTimerRef.current);
+        setReviewSubmitSuccess('Review submitted. Thanks for sharing your experience.');
+        reviewSuccessTimerRef.current = setTimeout(() => {
+          setReviewSubmitSuccess(null);
+          reviewSuccessTimerRef.current = null;
+        }, 5000);
+        return true;
+      } catch (err) {
+        setReviewSubmitError(mapCommentApiError(err, 'Failed to submit review. Please try again.'));
+        return false;
+      } finally {
+        setReviewSubmitLoading(false);
+      }
+    },
+    [eventId, token],
+  );
+
+  const dismissDiscussionSubmitError = useCallback(() => setDiscussionSubmitError(null), []);
+  const dismissReplySubmitError = useCallback(
+    () => setReplySubmitState((prev) => ({ ...prev, error: null, parentId: prev.loading ? prev.parentId : null })),
+    [],
+  );
+  const dismissReviewSubmitError = useCallback(() => setReviewSubmitError(null), []);
+  const dismissReviewSubmitSuccess = useCallback(() => {
+    if (reviewSuccessTimerRef.current) {
+      clearTimeout(reviewSuccessTimerRef.current);
+      reviewSuccessTimerRef.current = null;
+    }
+    setReviewSubmitSuccess(null);
+  }, []);
+
+  return {
+    status,
+    errorMessage,
+
+    discussionComments,
+    discussionHasNext: discussionCursor.hasNext,
+    discussionLoadingMore,
+
+    reviewComments,
+    reviewHasNext: reviewCursor.hasNext,
+    reviewLoadingMore,
+
+    repliesByCommentId,
+
+    discussionSubmitLoading,
+    discussionSubmitError,
+    replySubmitState,
+    reviewSubmitLoading,
+    reviewSubmitError,
+    reviewSubmitSuccess,
+
+    retry: loadInitial,
+    loadMoreDiscussion,
+    loadMoreReviews,
+    toggleReplies,
+    loadMoreReplies,
+    submitDiscussion,
+    submitReply,
+    submitReview,
+    dismissDiscussionSubmitError,
+    dismissReplySubmitError,
+    dismissReviewSubmitError,
+    dismissReviewSubmitSuccess,
+  };
+}
+
+export type EventCommentsViewModel = ReturnType<typeof useEventCommentsViewModel>;

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -20,6 +20,7 @@ import { UserAvatar } from '@/components/UserAvatar';
 import { getEventLifecyclePresentation, getEventStatusPresentation } from '@/utils/eventStatus';
 import NotFoundView from '../fallback/NotFoundView';
 import AccessDeniedView from '../fallback/AccessDeniedView';
+import EventInteractionPanel from './EventInteractionPanel';
 import '@/styles/event-detail.css';
 
 const EventDetailMiniMap = lazy(() => import('./EventDetailMiniMap'));
@@ -1227,6 +1228,7 @@ function EventContent({
   favoriteLoading,
   onFavoriteToggle,
   isAuthenticated,
+  token,
   hostContextSummary,
   approvedParticipants,
   approvedParticipantsLoading,
@@ -1283,6 +1285,7 @@ function EventContent({
   favoriteLoading: boolean;
   onFavoriteToggle: () => void;
   isAuthenticated: boolean;
+  token: string | null;
   hostContextSummary: EventHostContextSummary | null;
   approvedParticipants: EventDetailApprovedParticipant[];
   approvedParticipantsLoading: boolean;
@@ -1721,6 +1724,12 @@ function EventContent({
             )}
           </div>
         )}
+
+        <EventInteractionPanel
+          event={event}
+          token={token}
+          isAuthenticated={isAuthenticated}
+        />
       </div>
 
       {/* Cancel confirmation modal */}
@@ -1787,6 +1796,7 @@ export default function EventDetailPage() {
     <EventContent
       event={vm.event}
       isAuthenticated={Boolean(token)}
+      token={token}
       coverImageUploading={vm.coverImageUploading}
       coverImageError={vm.coverImageError}
       coverImageSuccessMessage={vm.coverImageSuccessMessage}

--- a/frontend/src/views/events/EventInteractionPanel.tsx
+++ b/frontend/src/views/events/EventInteractionPanel.tsx
@@ -1,0 +1,816 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { Link } from 'react-router-dom';
+import { UserAvatar } from '@/components/UserAvatar';
+import type { EventComment, EventDetailResponse } from '@/models/event';
+import { useEventCommentsViewModel } from '@/viewmodels/event/useEventCommentsViewModel';
+
+const COMMENT_MAX_LENGTH = 1000;
+const REVIEW_MIN_LENGTH = 1;
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+
+type InteractionTab = 'DISCUSSION' | 'REVIEW';
+
+export interface EventInteractionPanelProps {
+  event: EventDetailResponse;
+  token: string | null;
+  isAuthenticated: boolean;
+}
+
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const seconds = Math.max(1, Math.floor((now - then) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function getDisplayName(user: { display_name: string | null; username: string }): string {
+  return user.display_name ?? user.username;
+}
+
+function renderStarsInline(rating: number): string {
+  const full = Math.max(0, Math.min(5, rating));
+  return `${'★'.repeat(full)}${'☆'.repeat(5 - full)}`;
+}
+
+interface ReviewStarsInputProps {
+  value: number;
+  onChange: (value: number) => void;
+  disabled?: boolean;
+}
+
+function ReviewStarsInput({ value, onChange, disabled }: ReviewStarsInputProps) {
+  const [hovered, setHovered] = useState<number | null>(null);
+  const active = hovered ?? value;
+  return (
+    <div className="ed-comments-stars-input" role="radiogroup" aria-label="Select a star rating">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <button
+          key={star}
+          type="button"
+          role="radio"
+          aria-checked={value === star}
+          aria-label={`${star} star${star === 1 ? '' : 's'}`}
+          className={`ed-comments-star-btn ${active >= star ? 'is-active' : ''}`}
+          onClick={() => onChange(star)}
+          onMouseEnter={() => setHovered(star)}
+          onMouseLeave={() => setHovered(null)}
+          onFocus={() => setHovered(star)}
+          onBlur={() => setHovered(null)}
+          disabled={disabled}
+        >
+          <span aria-hidden="true">★</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface CommentItemProps {
+  comment: EventComment;
+  hostUserId: string;
+  variant: 'top-level' | 'reply';
+}
+
+function CommentAuthorBlock({ comment, hostUserId, variant }: CommentItemProps) {
+  const isHost = comment.user.id === hostUserId;
+  return (
+    <div className="ed-comments-item-header">
+      <UserAvatar
+        username={comment.user.username}
+        displayName={comment.user.display_name}
+        avatarUrl={comment.user.avatar_url}
+        size={variant === 'reply' ? 'sm' : 'sm'}
+        variant={isHost ? 'accent' : 'muted'}
+      />
+      <div className="ed-comments-item-author">
+        <div className="ed-comments-item-author-line">
+          <span className="ed-comments-item-name">{getDisplayName(comment.user)}</span>
+          {isHost && <span className="ed-comments-host-badge">Host</span>}
+        </div>
+        <span className="ed-comments-item-meta">
+          @{comment.user.username} · {timeAgo(comment.created_at)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+interface DiscussionCommentNodeProps {
+  comment: EventComment;
+  hostUserId: string;
+  vm: ReturnType<typeof useEventCommentsViewModel>;
+  canReply: boolean;
+  onRequireSignIn: () => void;
+}
+
+function DiscussionCommentNode({
+  comment,
+  hostUserId,
+  vm,
+  canReply,
+  onRequireSignIn,
+}: DiscussionCommentNodeProps) {
+  const repliesState = vm.repliesByCommentId[comment.id];
+  const [showReplyForm, setShowReplyForm] = useState(false);
+  const [replyText, setReplyText] = useState('');
+
+  const submittingThisReply =
+    vm.replySubmitState.parentId === comment.id && vm.replySubmitState.loading;
+  const replyError =
+    vm.replySubmitState.parentId === comment.id ? vm.replySubmitState.error : null;
+
+  const replies = repliesState?.items ?? [];
+  const expanded = repliesState?.expanded ?? false;
+  const replyCount = comment.reply_count;
+
+  const handleReplyClick = () => {
+    if (!canReply) {
+      onRequireSignIn();
+      return;
+    }
+    setShowReplyForm((prev) => !prev);
+  };
+
+  const handleReplySubmit = async () => {
+    const success = await vm.submitReply(comment.id, replyText);
+    if (success) {
+      setReplyText('');
+      setShowReplyForm(false);
+    }
+  };
+
+  const repliesToggleLabel = expanded
+    ? 'Hide replies'
+    : replyCount === 0
+      ? 'Show replies'
+      : `View ${replyCount} ${replyCount === 1 ? 'reply' : 'replies'}`;
+
+  return (
+    <li className="ed-comments-item ed-comments-item-top">
+      <CommentAuthorBlock comment={comment} hostUserId={hostUserId} variant="top-level" />
+      <p className="ed-comments-item-message">{comment.message}</p>
+
+      <div className="ed-comments-item-actions">
+        {(replyCount > 0 || expanded) && (
+          <button
+            type="button"
+            className="ed-comments-link-btn"
+            onClick={() => vm.toggleReplies(comment)}
+            disabled={repliesState?.loading}
+          >
+            {repliesState?.loading && !expanded ? 'Loading…' : repliesToggleLabel}
+          </button>
+        )}
+        <button
+          type="button"
+          className="ed-comments-link-btn"
+          onClick={handleReplyClick}
+          disabled={submittingThisReply}
+        >
+          {showReplyForm ? 'Cancel reply' : 'Reply'}
+        </button>
+      </div>
+
+      {expanded && (
+        <ul className="ed-comments-replies">
+          {replies.length === 0 && !repliesState?.loading && replyCount === 0 && (
+            <li className="ed-comments-empty-inline">No replies yet.</li>
+          )}
+          {replies.map((reply) => (
+            <li key={reply.id} className="ed-comments-item ed-comments-item-reply">
+              <CommentAuthorBlock comment={reply} hostUserId={hostUserId} variant="reply" />
+              <p className="ed-comments-item-message">{reply.message}</p>
+            </li>
+          ))}
+          {repliesState?.error && (
+            <li className="ed-comments-error" role="alert">
+              {repliesState.error}
+            </li>
+          )}
+          {repliesState?.hasNext && (
+            <li>
+              <button
+                type="button"
+                className="ed-comments-link-btn"
+                onClick={() => vm.loadMoreReplies(comment.id)}
+                disabled={repliesState.loading}
+              >
+                {repliesState.loading ? 'Loading…' : 'Load more replies'}
+              </button>
+            </li>
+          )}
+        </ul>
+      )}
+
+      {showReplyForm && canReply && (
+        <div className="ed-comments-reply-form">
+          <textarea
+            className="ed-comments-textarea"
+            value={replyText}
+            onChange={(e) => setReplyText(e.target.value)}
+            placeholder="Write a reply…"
+            rows={2}
+            maxLength={COMMENT_MAX_LENGTH}
+            disabled={submittingThisReply}
+          />
+          {replyError && (
+            <div className="ed-comments-error" role="alert">
+              <span>{replyError}</span>
+              <button
+                type="button"
+                className="ed-comments-error-dismiss"
+                onClick={() => vm.dismissReplySubmitError()}
+                aria-label="Dismiss error"
+              >
+                ×
+              </button>
+            </div>
+          )}
+          <div className="ed-comments-form-actions">
+            <span className="ed-comments-char-count">
+              {replyText.trim().length}/{COMMENT_MAX_LENGTH}
+            </span>
+            <div className="ed-comments-form-buttons">
+              <button
+                type="button"
+                className="ed-comments-secondary-btn"
+                onClick={() => {
+                  setReplyText('');
+                  setShowReplyForm(false);
+                }}
+                disabled={submittingThisReply}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="ed-comments-primary-btn"
+                onClick={handleReplySubmit}
+                disabled={submittingThisReply || replyText.trim().length === 0}
+              >
+                {submittingThisReply ? <span className="spinner" /> : 'Post reply'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+interface ReviewItemProps {
+  comment: EventComment;
+  hostUserId: string;
+}
+
+function ReviewItem({ comment, hostUserId }: ReviewItemProps) {
+  return (
+    <li className="ed-comments-item ed-comments-item-review">
+      <CommentAuthorBlock comment={comment} hostUserId={hostUserId} variant="top-level" />
+      {comment.rating != null && (
+        <div className="ed-comments-review-rating">
+          <span className="ed-comments-review-stars" aria-hidden="true">
+            {renderStarsInline(comment.rating)}
+          </span>
+          <span className="ed-comments-review-rating-text">
+            {comment.rating}/5
+          </span>
+        </div>
+      )}
+      <p className="ed-comments-item-message">{comment.message}</p>
+      {comment.image_url && (
+        <a
+          href={comment.image_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ed-comments-review-image-link"
+        >
+          <img
+            src={comment.image_url}
+            alt={`Memory shared by ${getDisplayName(comment.user)}`}
+            className="ed-comments-review-image"
+            loading="lazy"
+          />
+        </a>
+      )}
+    </li>
+  );
+}
+
+interface DiscussionSectionProps {
+  event: EventDetailResponse;
+  vm: ReturnType<typeof useEventCommentsViewModel>;
+  isAuthenticated: boolean;
+}
+
+function DiscussionSection({ event, vm, isAuthenticated }: DiscussionSectionProps) {
+  const [composerText, setComposerText] = useState('');
+
+  const writesAllowed = (() => {
+    if (!isAuthenticated) return false;
+    if (event.privacy_level === 'PRIVATE') return false;
+    if (event.status === 'ACTIVE') return true;
+    if (event.status === 'IN_PROGRESS') {
+      return event.viewer_context.is_host || event.viewer_context.participation_status === 'JOINED';
+    }
+    return false;
+  })();
+
+  const composerDisabledReason = (() => {
+    if (event.privacy_level === 'PRIVATE') return 'Discussion is unavailable for private events.';
+    if (event.status === 'COMPLETED')
+      return 'This event has ended. Past discussion is read-only — share your experience in the Review tab.';
+    if (event.status === 'CANCELED') return 'This event was canceled. Discussion is closed.';
+    if (event.status === 'IN_PROGRESS' && !writesAllowed)
+      return 'Only the host and joined participants can post during the event.';
+    if (!isAuthenticated) return null;
+    return null;
+  })();
+
+  const handleSubmit = async () => {
+    const success = await vm.submitDiscussion(composerText);
+    if (success) setComposerText('');
+  };
+
+  const composerCount = composerText.trim().length;
+
+  return (
+    <div className="ed-comments-tab-content" data-testid="ed-discussion-section">
+      {/* Composer */}
+      {writesAllowed ? (
+        <div className="ed-comments-composer">
+          <textarea
+            className="ed-comments-textarea"
+            value={composerText}
+            onChange={(e) => setComposerText(e.target.value)}
+            placeholder={
+              event.status === 'IN_PROGRESS'
+                ? 'Share an update from the event…'
+                : 'Ask a question or share something with attendees…'
+            }
+            rows={3}
+            maxLength={COMMENT_MAX_LENGTH}
+            disabled={vm.discussionSubmitLoading}
+            data-testid="ed-discussion-composer"
+          />
+          {vm.discussionSubmitError && (
+            <div className="ed-comments-error" role="alert">
+              <span>{vm.discussionSubmitError}</span>
+              <button
+                type="button"
+                className="ed-comments-error-dismiss"
+                onClick={vm.dismissDiscussionSubmitError}
+                aria-label="Dismiss error"
+              >
+                ×
+              </button>
+            </div>
+          )}
+          <div className="ed-comments-form-actions">
+            <span className="ed-comments-char-count">
+              {composerCount}/{COMMENT_MAX_LENGTH}
+            </span>
+            <button
+              type="button"
+              className="ed-comments-primary-btn"
+              onClick={handleSubmit}
+              disabled={vm.discussionSubmitLoading || composerCount === 0}
+              data-testid="ed-discussion-submit"
+            >
+              {vm.discussionSubmitLoading ? <span className="spinner" /> : 'Post'}
+            </button>
+          </div>
+        </div>
+      ) : !isAuthenticated ? (
+        <div className="ed-comments-callout">
+          <span>Sign in to join the discussion.</span>
+          <Link to="/login" className="ed-comments-link">
+            Sign in
+          </Link>
+        </div>
+      ) : composerDisabledReason ? (
+        <div className="ed-comments-callout ed-comments-callout-muted">
+          <span>{composerDisabledReason}</span>
+        </div>
+      ) : null}
+
+      {/* List */}
+      {vm.status === 'loading' ? (
+        <div className="ed-comments-state">
+          <span className="spinner" />
+          <p>Loading discussion…</p>
+        </div>
+      ) : vm.status === 'error' ? (
+        <div className="ed-comments-state ed-comments-state-error">
+          <p>{vm.errorMessage ?? 'Failed to load discussion.'}</p>
+          <button type="button" className="ed-comments-secondary-btn" onClick={vm.retry}>
+            Try again
+          </button>
+        </div>
+      ) : vm.discussionComments.length === 0 ? (
+        <div className="ed-comments-empty">
+          <p>No comments yet. Start the conversation!</p>
+        </div>
+      ) : (
+        <>
+          <ul className="ed-comments-list">
+            {vm.discussionComments.map((comment) => (
+              <DiscussionCommentNode
+                key={comment.id}
+                comment={comment}
+                hostUserId={event.host.id}
+                vm={vm}
+                canReply={writesAllowed}
+                onRequireSignIn={() => {
+                  // The composer above already nudges sign-in; nothing to do here.
+                }}
+              />
+            ))}
+          </ul>
+          {vm.discussionHasNext && (
+            <button
+              type="button"
+              className="ed-comments-secondary-btn ed-comments-load-more"
+              onClick={vm.loadMoreDiscussion}
+              disabled={vm.discussionLoadingMore}
+            >
+              {vm.discussionLoadingMore ? 'Loading…' : 'Load more comments'}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+interface ReviewSectionProps {
+  event: EventDetailResponse;
+  vm: ReturnType<typeof useEventCommentsViewModel>;
+  isAuthenticated: boolean;
+}
+
+function ReviewSection({ event, vm, isAuthenticated }: ReviewSectionProps) {
+  const [rating, setRating] = useState(0);
+  const [message, setMessage] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!imageFile) {
+      setImagePreviewUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return null;
+      });
+      return;
+    }
+    const url = URL.createObjectURL(imageFile);
+    setImagePreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [imageFile]);
+
+  const isVerifiedAttendee =
+    !event.viewer_context.is_host
+    && event.viewer_context.participation_status === 'JOINED'
+    && event.status === 'COMPLETED'
+    && event.privacy_level !== 'PRIVATE';
+
+  const validateAndSetImage = (file: File | null) => {
+    setImageError(null);
+    if (!file) {
+      setImageFile(null);
+      return;
+    }
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      setImageError('Please choose a JPEG, PNG, or WebP image.');
+      return;
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+      setImageError('Image must be 8MB or smaller.');
+      return;
+    }
+    setImageFile(file);
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    validateAndSetImage(file);
+    event.target.value = '';
+  };
+
+  const handleSubmit = async () => {
+    const success = await vm.submitReview(rating, message, imageFile);
+    if (success) {
+      setMessage('');
+      setRating(0);
+      setImageFile(null);
+    }
+  };
+
+  const composerCount = message.trim().length;
+  const submitDisabled =
+    vm.reviewSubmitLoading || rating < 1 || composerCount < REVIEW_MIN_LENGTH;
+
+  return (
+    <div className="ed-comments-tab-content" data-testid="ed-review-section">
+      {!isAuthenticated ? (
+        <div className="ed-comments-callout">
+          <span>Sign in to leave a review for this event.</span>
+          <Link to="/login" className="ed-comments-link">
+            Sign in
+          </Link>
+        </div>
+      ) : !isVerifiedAttendee ? (
+        <div className="ed-comments-callout ed-comments-callout-muted">
+          <span>
+            Only verified attendees of this event can leave a review and share memories.
+          </span>
+        </div>
+      ) : (
+        <div className="ed-comments-composer ed-comments-review-composer">
+          <h3 className="ed-comments-composer-title">Share your experience</h3>
+          <div className="ed-comments-review-rating-row">
+            <ReviewStarsInput
+              value={rating}
+              onChange={setRating}
+              disabled={vm.reviewSubmitLoading}
+            />
+            <span
+              className={`ed-comments-review-rating-summary ${rating > 0 ? 'is-selected' : ''}`}
+            >
+              {rating > 0 ? `${rating}/5` : 'Tap to rate'}
+            </span>
+          </div>
+          <textarea
+            className="ed-comments-textarea"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="What was memorable about this event?"
+            rows={4}
+            maxLength={COMMENT_MAX_LENGTH}
+            disabled={vm.reviewSubmitLoading}
+            data-testid="ed-review-message"
+          />
+
+          {/* Image upload area */}
+          <div
+            className={`ed-comments-image-drop ${isDragging ? 'is-dragging' : ''} ${imagePreviewUrl ? 'has-image' : ''}`}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={(e) => {
+              e.preventDefault();
+              setIsDragging(false);
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              setIsDragging(false);
+              const file = e.dataTransfer.files?.[0] ?? null;
+              validateAndSetImage(file);
+            }}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ALLOWED_IMAGE_TYPES.join(',')}
+              className="ed-comments-image-input"
+              onChange={handleFileChange}
+              disabled={vm.reviewSubmitLoading}
+            />
+            {imagePreviewUrl ? (
+              <div className="ed-comments-image-preview">
+                <img
+                  src={imagePreviewUrl}
+                  alt="Selected memory preview"
+                  className="ed-comments-image-preview-img"
+                />
+                <div className="ed-comments-image-preview-actions">
+                  <button
+                    type="button"
+                    className="ed-comments-secondary-btn"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={vm.reviewSubmitLoading}
+                  >
+                    Replace image
+                  </button>
+                  <button
+                    type="button"
+                    className="ed-comments-secondary-btn ed-comments-image-remove"
+                    onClick={() => {
+                      setImageFile(null);
+                      setImageError(null);
+                    }}
+                    disabled={vm.reviewSubmitLoading}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="ed-comments-image-drop-trigger"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={vm.reviewSubmitLoading}
+              >
+                <span className="ed-comments-image-drop-icon" aria-hidden="true">
+                  📷
+                </span>
+                <span className="ed-comments-image-drop-text">
+                  <strong>Add a memory</strong>
+                  <span>Click to upload or drag &amp; drop a photo (optional)</span>
+                </span>
+              </button>
+            )}
+          </div>
+
+          {imageError && (
+            <div className="ed-comments-error" role="alert">
+              <span>{imageError}</span>
+              <button
+                type="button"
+                className="ed-comments-error-dismiss"
+                onClick={() => setImageError(null)}
+                aria-label="Dismiss error"
+              >
+                ×
+              </button>
+            </div>
+          )}
+
+          {vm.reviewSubmitError && (
+            <div className="ed-comments-error" role="alert">
+              <span>{vm.reviewSubmitError}</span>
+              <button
+                type="button"
+                className="ed-comments-error-dismiss"
+                onClick={vm.dismissReviewSubmitError}
+                aria-label="Dismiss error"
+              >
+                ×
+              </button>
+            </div>
+          )}
+
+          {vm.reviewSubmitSuccess && (
+            <div className="ed-comments-success" role="status">
+              <span>{vm.reviewSubmitSuccess}</span>
+              <button
+                type="button"
+                className="ed-comments-error-dismiss"
+                onClick={vm.dismissReviewSubmitSuccess}
+                aria-label="Dismiss"
+              >
+                ×
+              </button>
+            </div>
+          )}
+
+          <div className="ed-comments-form-actions">
+            <span className="ed-comments-char-count">
+              {composerCount}/{COMMENT_MAX_LENGTH}
+            </span>
+            <button
+              type="button"
+              className="ed-comments-primary-btn"
+              onClick={handleSubmit}
+              disabled={submitDisabled}
+              data-testid="ed-review-submit"
+            >
+              {vm.reviewSubmitLoading ? <span className="spinner" /> : 'Submit review'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {vm.status === 'loading' ? (
+        <div className="ed-comments-state">
+          <span className="spinner" />
+          <p>Loading reviews…</p>
+        </div>
+      ) : vm.status === 'error' ? (
+        <div className="ed-comments-state ed-comments-state-error">
+          <p>{vm.errorMessage ?? 'Failed to load reviews.'}</p>
+          <button type="button" className="ed-comments-secondary-btn" onClick={vm.retry}>
+            Try again
+          </button>
+        </div>
+      ) : vm.reviewComments.length === 0 ? (
+        <div className="ed-comments-empty">
+          <p>No reviews yet. Be the first to share your experience.</p>
+        </div>
+      ) : (
+        <>
+          <ul className="ed-comments-list">
+            {vm.reviewComments.map((comment) => (
+              <ReviewItem key={comment.id} comment={comment} hostUserId={event.host.id} />
+            ))}
+          </ul>
+          {vm.reviewHasNext && (
+            <button
+              type="button"
+              className="ed-comments-secondary-btn ed-comments-load-more"
+              onClick={vm.loadMoreReviews}
+              disabled={vm.reviewLoadingMore}
+            >
+              {vm.reviewLoadingMore ? 'Loading…' : 'Load more reviews'}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function EventInteractionPanel({
+  event,
+  token,
+  isAuthenticated,
+}: EventInteractionPanelProps) {
+  const vm = useEventCommentsViewModel(event.id, token);
+
+  // Discussion appears for ACTIVE/IN_PROGRESS/COMPLETED. Hide entire panel for CANCELED or PRIVATE.
+  const panelHidden = event.privacy_level === 'PRIVATE' || event.status === 'CANCELED';
+
+  const reviewVisible = event.status === 'COMPLETED';
+  const discussionVisible = event.status !== 'CANCELED';
+
+  const defaultTab: InteractionTab = useMemo(() => {
+    if (reviewVisible) return 'REVIEW';
+    return 'DISCUSSION';
+  }, [reviewVisible]);
+
+  const [activeTab, setActiveTab] = useState<InteractionTab>(defaultTab);
+
+  // If status changes (rare in this view), align selected tab with new default.
+  useEffect(() => {
+    setActiveTab(defaultTab);
+  }, [defaultTab]);
+
+  if (panelHidden) return null;
+  if (vm.status === 'unavailable') return null;
+
+  const showTabs = discussionVisible && reviewVisible;
+
+  return (
+    <section className="ed-section ed-comments-section" aria-label="Event interaction">
+      <div className="ed-comments-header">
+        <h2 className="ed-section-title ed-comments-title">Community</h2>
+        {showTabs ? (
+          <div className="ed-comments-tabs" role="tablist" aria-label="Discussion or review">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'DISCUSSION'}
+              className={`ed-comments-tab ${activeTab === 'DISCUSSION' ? 'is-active' : ''}`}
+              onClick={() => setActiveTab('DISCUSSION')}
+              data-testid="ed-tab-discussion"
+            >
+              Discussion
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'REVIEW'}
+              className={`ed-comments-tab ${activeTab === 'REVIEW' ? 'is-active' : ''}`}
+              onClick={() => setActiveTab('REVIEW')}
+              data-testid="ed-tab-review"
+            >
+              Reviews
+            </button>
+          </div>
+        ) : (
+          <span className="ed-comments-single-tab-label">
+            {discussionVisible ? 'Discussion' : 'Reviews'}
+          </span>
+        )}
+      </div>
+
+      {showTabs ? (
+        activeTab === 'REVIEW' ? (
+          <ReviewSection event={event} vm={vm} isAuthenticated={isAuthenticated} />
+        ) : (
+          <DiscussionSection event={event} vm={vm} isAuthenticated={isAuthenticated} />
+        )
+      ) : discussionVisible ? (
+        <DiscussionSection event={event} vm={vm} isAuthenticated={isAuthenticated} />
+      ) : (
+        <ReviewSection event={event} vm={vm} isAuthenticated={isAuthenticated} />
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## 📋 Summary
Adds a new tabbed Community section to the event detail page so users can interact with each event before, during, and after it happens. Discussion is available while the event is upcoming or in progress, and Review (with star rating + memory image) is available only once the event is completed and is the default tab when shown.

## 🔄 Changes
- **New view:** `frontend/src/views/events/EventInteractionPanel.tsx` renders the tabbed Community section, with composer, reply trees, host badge, and image drag-and-drop support.
- **New view-model:** `frontend/src/viewmodels/event/useEventCommentsViewModel.ts` manages discussion + review pagination, per-comment replies, submissions, image upload flow, and error/success state.
- **Service layer:** `frontend/src/services/eventService.ts` now exposes `listEventComments`, `listEventCommentReplies`, `createDiscussionComment`, `upsertReviewComment`, and `getReviewCommentImageUploadUrl`.
- **Models:** `frontend/src/models/event.ts` adds `EventComment`, `EventCommentAuthor`, `EventCommentCollection`, `EventCommentsResponse`, `CommentType`, and the matching request/params types.
- **Page wiring:** `frontend/src/views/events/EventDetailPage.tsx` threads the auth `token` down to `EventContent` and renders `<EventInteractionPanel />` at the bottom of the sections column.
- **Styles:** `frontend/src/styles/event-detail.css` adds the `ed-comments-*` design — tabs, list items, replies, composers, image drop-zone, host badge, and error/success banners.
- **Visibility rules**
  - Hidden entirely for `PRIVATE` and `CANCELED` events, and when the backend reports `comments_not_allowed`.
  - Discussion tab visible for `ACTIVE` (UPCOMING) and `IN_PROGRESS`; composer follows backend rules (any signed-in user during `ACTIVE`; only host or joined participants during `IN_PROGRESS`).
  - Review tab visible only for `COMPLETED`; composer is gated to verified attendees (`participation_status === 'JOINED'` && `!is_host`); selected by default when the event is completed.
  - Replies are limited to one level (parent always points to a top-level comment); host messages get a "Host" badge.
- **Image upload:** review images are pre-resized to ORIGINAL/SMALL JPEG variants, uploaded via `/review-comments/image/upload-url`, then committed via the `image_confirm_token` on the upsert call.

## 🧪 Testing
- `cd frontend && npx tsc --noEmit` — type check passes.
- `cd frontend && npx vite build` — production build succeeds.
- Manual smoke checklist (run `npm run dev` and open an event):
  - Open an `ACTIVE` event → only **Discussion** tab is shown; signed-in users can post a top-level comment and reply once.
  - Open an `IN_PROGRESS` event → composer is enabled only for the host or a joined participant; everyone else sees the read-only callout.
  - Open a `COMPLETED` public event as a non-attendee → both tabs visible, **Reviews** is selected by default, review composer is gated behind a "verified attendees only" callout.
  - Open a `COMPLETED` event as a joined attendee → submit a review with a star rating, message, and an image (try both file picker and drag-and-drop). Confirm the new review appears at the top of the list with the image rendered.
  - Open a `PRIVATE` or `CANCELED` event → the Community section is hidden entirely.
  - Sign out → composer rows replace themselves with a "Sign in" callout linking to `/login`.

## 🔗 Related
Related to #448 
