### PR TITLE
feat(frontend): improve map view for discover page

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Copy to `.env.local` (git-ignored) and fill in real values for local dev.
+# Public Google Maps JS API key — restricted via HTTP referrer in the GCP console.
+VITE_GOOGLE_MAPS_API_KEY=
+# Optional: a Map ID enables Cloud-styled vector maps + AdvancedMarker.
+VITE_GOOGLE_MAPS_MAP_ID=

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 dist
 tsconfig.tsbuildinfo
+.env
+.env.local
+.env.*.local

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -5,7 +5,10 @@ Read `/AGENTS.md` first, then use this file for frontend work.
 ## Stack
 
 - **UI:** React.
-- **Map:** [MapLibre GL JS](https://maplibre.org/) for the web map (vector tiles, camera, layers).
+- **Map:** Google Maps via [`@vis.gl/react-google-maps`](https://visgl.github.io/react-google-maps/) (Vector maps, AdvancedMarker, light/dark `colorScheme`).
+  - The API key is read from `VITE_GOOGLE_MAPS_API_KEY` (and an optional Map ID from `VITE_GOOGLE_MAPS_MAP_ID`). See `.env.example`. When the key is missing, map components render a graceful fallback so the rest of the UI still works in dev.
+  - The provider is mounted once near the route tree in `src/components/GoogleMapsProvider.tsx`; do not instantiate `<APIProvider>` again in feature code.
+  - Discover view-mode (list vs. map) is shared between the global header toggle and the Discover page through `src/contexts/DiscoverViewModeContext.tsx`.
 
 ## Development rules
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,9 @@
       "name": "social-event-mapper-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@types/leaflet": "^1.9.21",
-        "leaflet": "^1.9.4",
+        "@vis.gl/react-google-maps": "^1.8.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.1.0"
       },
       "devDependencies": {
@@ -30,77 +28,68 @@
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "resolved": "https://registry.npmmirror.com/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.5.tgz",
-      "integrity": "sha512-8cMAA1bE66Mb/tfmkhcfJLjEPgyT7SSy6lW6id5XL113ai1ky76d/1L27sGnXCMsLfq66DInAU3OzuahB4lu9Q==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.7"
+        "@csstools/css-tokenizer": "^4.0.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.6.tgz",
-      "integrity": "sha512-Tgmk6EQM0nc9xvp7sEHRVavbknhb/vGKht+04yAT3t5KQwZ02CSobCtcFgaHH04ZrjD1BhEKNA8tRhzFV20gkA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7"
+        "is-potential-custom-element-name": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -111,19 +100,21 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmmirror.com/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -151,9 +142,10 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -167,9 +159,10 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -183,18 +176,20 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -205,9 +200,10 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -222,45 +218,50 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.29.0"
@@ -270,10 +271,11 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmmirror.com/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
       },
@@ -286,9 +288,10 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
       "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -301,9 +304,10 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
       "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -316,7 +320,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
@@ -326,9 +330,10 @@
     },
     "node_modules/@babel/template": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -340,9 +345,10 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -358,9 +364,10 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -371,7 +378,7 @@
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
       "license": "MIT",
@@ -384,7 +391,7 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
       "dev": true,
       "funding": [
@@ -403,9 +410,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "dev": true,
       "funding": [
         {
@@ -427,9 +434,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
       "dev": true,
       "funding": [
         {
@@ -444,7 +451,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
+        "@csstools/css-calc": "^3.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -456,7 +463,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
@@ -478,9 +485,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
       "dev": true,
       "funding": [
         {
@@ -504,7 +511,7 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
@@ -524,12 +531,13 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
       "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -540,12 +548,13 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
       "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -556,12 +565,13 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
       "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -572,12 +582,13 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
       "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -588,12 +599,13 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
       "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -604,12 +616,13 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
       "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -620,12 +633,13 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
       "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -636,12 +650,13 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
       "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -652,12 +667,13 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
       "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -668,12 +684,13 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
       "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -684,12 +701,13 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
       "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -700,12 +718,13 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
       "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -716,12 +735,13 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
       "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -732,12 +752,13 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
       "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -748,12 +769,13 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
       "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -764,12 +786,13 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
       "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -780,12 +803,13 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
       "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -796,12 +820,13 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -812,12 +837,13 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
       "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -828,12 +854,13 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -844,12 +871,13 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
       "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -860,12 +888,13 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
       "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -876,12 +905,13 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
       "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -892,12 +922,13 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
       "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -908,12 +939,13 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
       "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -924,12 +956,13 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
       "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -940,7 +973,7 @@
     },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true,
       "license": "MIT",
@@ -956,11 +989,21 @@
         }
       }
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz",
+      "integrity": "sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -968,9 +1011,10 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -978,365 +1022,384 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@react-leaflet/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1344,9 +1407,10 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -1364,7 +1428,7 @@
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
@@ -1384,14 +1448,14 @@
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@testing-library/react/-/react-16.3.2.tgz",
       "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "license": "MIT",
@@ -1419,7 +1483,7 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT",
@@ -1427,9 +1491,10 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -1440,18 +1505,20 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -1459,9 +1526,10 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
@@ -1486,55 +1554,68 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
-    },
-    "node_modules/@types/leaflet": {
-      "version": "1.9.21",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
-      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
+    "node_modules/@types/google.maps": {
+      "version": "3.64.0",
+      "resolved": "https://registry.npmmirror.com/@types/google.maps/-/google.maps-3.64.0.tgz",
+      "integrity": "sha512-dN0H6tB4lgLQLovcbPXFYYOEV41TpyyJghzb5jrzjB96FZmjeOghevVdC+BMGd6YqyCqXaggyEtqRXLRjzCBZA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmmirror.com/@vis.gl/react-google-maps/-/react-google-maps-1.8.3.tgz",
+      "integrity": "sha512-DW7nEuvOJ299DmdBnvGiUARrgS/+sTEO1iJgG9J8YaErZqLoq7S4TJ22f3EjJvR4dti4L4gft43JEK77nnKXDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "^2.0.2",
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
@@ -1667,7 +1748,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -1678,7 +1759,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
@@ -1692,7 +1773,7 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1711,10 +1792,11 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -1724,7 +1806,7 @@
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
       "license": "MIT",
@@ -1733,9 +1815,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmmirror.com/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -1751,12 +1833,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1776,9 +1859,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {
@@ -1793,7 +1876,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -1824,14 +1908,16 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1842,7 +1928,7 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
@@ -1856,20 +1942,21 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
@@ -1883,9 +1970,10 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1900,7 +1988,7 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
@@ -1917,7 +2005,7 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
@@ -1927,26 +2015,27 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "resolved": "https://registry.npmmirror.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
-      "dev": true
+      "version": "1.5.353",
+      "resolved": "https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -1961,10 +2050,11 @@
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2002,9 +2092,10 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2029,11 +2120,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -2048,10 +2146,11 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2062,16 +2161,17 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://registry.npmmirror.com/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
@@ -2084,7 +2184,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
       "license": "MIT",
@@ -2094,40 +2194,41 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "29.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
-      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmmirror.com/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
         "@exodus/bytes": "^1.15.0",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7",
-        "parse5": "^8.0.0",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^6.0.1",
-        "undici": "^7.24.5",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
@@ -2147,9 +2248,9 @@
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2158,9 +2259,10 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -2170,20 +2272,16 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/leaflet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2194,16 +2292,17 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
@@ -2224,14 +2323,14 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "resolved": "https://registry.npmmirror.com/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "license": "MIT",
@@ -2241,14 +2340,15 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2256,6 +2356,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2264,19 +2365,20 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
-      "dev": true
+      "version": "2.0.38",
+      "resolved": "https://registry.npmmirror.com/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -2301,15 +2403,17 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2318,9 +2422,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2336,6 +2440,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2347,7 +2452,7 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
@@ -2363,7 +2468,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
@@ -2372,58 +2477,49 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmmirror.com/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
-    "node_modules/react-leaflet": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
-      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
-      "dependencies": {
-        "@react-leaflet/core": "^3.0.0"
-      },
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "resolved": "https://registry.npmmirror.com/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+      "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -2442,11 +2538,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
-      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmmirror.com/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
+      "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.15.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2458,7 +2555,7 @@
     },
     "node_modules/redent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dev": true,
       "license": "MIT",
@@ -2472,7 +2569,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
@@ -2481,10 +2578,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -2496,37 +2594,37 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
@@ -2539,22 +2637,25 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
+      "resolved": "https://registry.npmmirror.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -2565,9 +2666,10 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2588,7 +2690,7 @@
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dev": true,
       "license": "MIT",
@@ -2621,7 +2723,7 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://registry.npmmirror.com/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
@@ -2641,13 +2743,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2687,28 +2790,28 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmmirror.com/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.30"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmmirror.com/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2721,7 +2824,7 @@
     },
     "node_modules/tr46": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
@@ -2734,9 +2837,10 @@
     },
     "node_modules/typescript": {
       "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2746,9 +2850,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2756,14 +2860,15 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true
+      "version": "7.19.2",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
@@ -2780,6 +2885,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -2792,10 +2898,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmmirror.com/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -2963,7 +3070,7 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
@@ -2976,7 +3083,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2986,7 +3093,7 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
@@ -2996,7 +3103,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
@@ -3028,7 +3135,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3038,16 +3145,17 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,11 +11,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@types/leaflet": "^1.9.21",
-    "leaflet": "^1.9.4",
+    "@vis.gl/react-google-maps": "^1.8.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from './contexts/AuthContext';
+import { GoogleMapsProvider } from './components/GoogleMapsProvider';
+import { DiscoverViewModeProvider } from './contexts/DiscoverViewModeContext';
 import LandingPage from './views/auth/LandingPage';
 import LoginView from './views/auth/LoginView';
 import RegisterView from './views/auth/RegisterView';
@@ -34,47 +36,51 @@ export default function App() {
   }
 
   return (
-    <Routes>
-      {/* Landing page */}
-      <Route path="/" element={token ? <Navigate to="/discover" replace /> : <LandingPage />} />
+    <GoogleMapsProvider>
+      <DiscoverViewModeProvider>
+        <Routes>
+          {/* Landing page */}
+          <Route path="/" element={token ? <Navigate to="/discover" replace /> : <LandingPage />} />
 
-      {/* App shell wraps all main pages (public + protected) */}
-      <Route element={<AppShell />}>
-        <Route path="/discover" element={<DiscoverPage />} />
+          {/* App shell wraps all main pages (public + protected) */}
+          <Route element={<AppShell />}>
+            <Route path="/discover" element={<DiscoverPage />} />
 
-        {/* Protected routes — require auth */}
-        <Route path="/events/create" element={<ProtectedRoute><CreateEventPage /></ProtectedRoute>} />
-        <Route path="/events/:id" element={<EventDetailPage />} />
-        <Route path="/my-events" element={<ProtectedRoute><MyEventsPage /></ProtectedRoute>} />
-        <Route path="/invitations" element={<ProtectedRoute><InvitationsPage /></ProtectedRoute>} />
-        <Route path="/notifications" element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>} />
-        <Route path="/tickets" element={<ProtectedRoute><TicketsPage /></ProtectedRoute>} />
-        <Route path="/tickets/:ticketId" element={<ProtectedRoute><TicketDetailPage /></ProtectedRoute>} />
-        <Route path="/favorites" element={<ProtectedRoute><FavoritesPage /></ProtectedRoute>} />
-        <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
-        <Route
-          path="/backoffice"
-          element={<AdminRoute><BackofficeLayout /></AdminRoute>}
-        >
-          <Route index element={<Navigate to="/backoffice/users" replace />} />
-          <Route path="users" element={<UsersAdminPage />} />
-          <Route path="events" element={<EventsAdminPage />} />
-          <Route path="event-reports" element={<EventReportsAdminPage />} />
-          <Route path="participations" element={<ParticipationsAdminPage />} />
-          <Route path="tickets" element={<TicketsAdminPage />} />
-          <Route path="notifications" element={<NotificationsAdminPage />} />
-        </Route>
-        <Route path="/admin-panel" element={<Navigate to="/backoffice" replace />} />
-        <Route path="/admin-panel/*" element={<Navigate to="/backoffice" replace />} />
-      </Route>
+            {/* Protected routes — require auth */}
+            <Route path="/events/create" element={<ProtectedRoute><CreateEventPage /></ProtectedRoute>} />
+            <Route path="/events/:id" element={<EventDetailPage />} />
+            <Route path="/my-events" element={<ProtectedRoute><MyEventsPage /></ProtectedRoute>} />
+            <Route path="/invitations" element={<ProtectedRoute><InvitationsPage /></ProtectedRoute>} />
+            <Route path="/notifications" element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>} />
+            <Route path="/tickets" element={<ProtectedRoute><TicketsPage /></ProtectedRoute>} />
+            <Route path="/tickets/:ticketId" element={<ProtectedRoute><TicketDetailPage /></ProtectedRoute>} />
+            <Route path="/favorites" element={<ProtectedRoute><FavoritesPage /></ProtectedRoute>} />
+            <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
+            <Route
+              path="/backoffice"
+              element={<AdminRoute><BackofficeLayout /></AdminRoute>}
+            >
+              <Route index element={<Navigate to="/backoffice/users" replace />} />
+              <Route path="users" element={<UsersAdminPage />} />
+              <Route path="events" element={<EventsAdminPage />} />
+              <Route path="event-reports" element={<EventReportsAdminPage />} />
+              <Route path="participations" element={<ParticipationsAdminPage />} />
+              <Route path="tickets" element={<TicketsAdminPage />} />
+              <Route path="notifications" element={<NotificationsAdminPage />} />
+            </Route>
+            <Route path="/admin-panel" element={<Navigate to="/backoffice" replace />} />
+            <Route path="/admin-panel/*" element={<Navigate to="/backoffice" replace />} />
+          </Route>
 
-      {/* Auth pages (no shell) */}
-      <Route path="/login" element={<LoginView />} />
-      <Route path="/register" element={<RegisterView />} />
-      <Route path="/forgot-password" element={<ForgotPasswordView />} />
+          {/* Auth pages (no shell) */}
+          <Route path="/login" element={<LoginView />} />
+          <Route path="/register" element={<RegisterView />} />
+          <Route path="/forgot-password" element={<ForgotPasswordView />} />
 
-      {/* Fallback */}
-      <Route path="*" element={<NotFoundView />} />
-    </Routes>
+          {/* Fallback */}
+          <Route path="*" element={<NotFoundView />} />
+        </Routes>
+      </DiscoverViewModeProvider>
+    </GoogleMapsProvider>
   );
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useDiscoverViewMode } from '@/contexts/DiscoverViewModeContext';
 import { UserAvatar } from '@/components/UserAvatar';
 import { logout } from '@/services/authService';
 import SemLogo from '@/components/SemLogo';
@@ -27,8 +28,10 @@ export default function AppShell() {
   const isLoggedIn = !!token;
   const navItems = isLoggedIn ? AUTH_NAV : [];
   const isAdminPanel = location.pathname.startsWith('/backoffice') || location.pathname.startsWith('/admin-panel');
+  const isDiscoverRoute = location.pathname === '/discover';
   const isDarkMode = theme === 'dark';
   const { unreadCount } = useUnreadCountViewModel();
+  const { viewMode, setViewMode } = useDiscoverViewMode();
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -59,7 +62,7 @@ export default function AppShell() {
       <header className="shell-header">
         <div className="shell-header-inner">
           <NavLink to="/discover" className="shell-logo" onClick={closeMobileMenu}>
-            <SemLogo height={48} color={isDarkMode ? '#f9fafb' : '#111827'} />
+            <SemLogo height={56} color={isDarkMode ? '#f9fafb' : '#111827'} />
           </NavLink>
 
           {navItems.length > 0 && (
@@ -80,6 +83,59 @@ export default function AppShell() {
           )}
 
           <div className="shell-header-right">
+            {isDiscoverRoute && (
+              <div className="shell-view-toggle" role="group" aria-label="Discover view mode">
+                <button
+                  type="button"
+                  className={`shell-view-toggle-btn ${viewMode === 'list' ? 'active' : ''}`}
+                  onClick={() => setViewMode('list')}
+                  aria-pressed={viewMode === 'list'}
+                  title="List view"
+                >
+                  <svg
+                    className="shell-view-toggle-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden
+                  >
+                    <line x1="8" y1="6" x2="21" y2="6" />
+                    <line x1="8" y1="12" x2="21" y2="12" />
+                    <line x1="8" y1="18" x2="21" y2="18" />
+                    <line x1="3" y1="6" x2="3.01" y2="6" />
+                    <line x1="3" y1="12" x2="3.01" y2="12" />
+                    <line x1="3" y1="18" x2="3.01" y2="18" />
+                  </svg>
+                  <span className="shell-view-toggle-label">List</span>
+                </button>
+                <button
+                  type="button"
+                  className={`shell-view-toggle-btn ${viewMode === 'map' ? 'active' : ''}`}
+                  onClick={() => setViewMode('map')}
+                  aria-pressed={viewMode === 'map'}
+                  title="Map view"
+                >
+                  <svg
+                    className="shell-view-toggle-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden
+                  >
+                    <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6" />
+                    <line x1="8" y1="2" x2="8" y2="18" />
+                    <line x1="16" y1="6" x2="16" y2="22" />
+                  </svg>
+                  <span className="shell-view-toggle-label">Map</span>
+                </button>
+              </div>
+            )}
             <button
               type="button"
               className="shell-theme-btn"
@@ -229,7 +285,11 @@ export default function AppShell() {
         />
       )}
 
-      <main className={`shell-main ${isAdminPanel ? 'admin-panel-main' : ''}`}>
+      <main
+        className={`shell-main ${isAdminPanel ? 'admin-panel-main' : ''} ${
+          isDiscoverRoute && viewMode === 'map' ? 'discover-map-main' : ''
+        }`}
+      >
         <Outlet />
       </main>
 

--- a/frontend/src/components/GoogleMapsProvider.tsx
+++ b/frontend/src/components/GoogleMapsProvider.tsx
@@ -1,0 +1,21 @@
+import { type ReactNode } from 'react';
+import { APIProvider } from '@vis.gl/react-google-maps';
+
+const API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
+export const GOOGLE_MAPS_MAP_ID =
+  import.meta.env.VITE_GOOGLE_MAPS_MAP_ID || 'sem_discover_map';
+
+export const isGoogleMapsConfigured = (): boolean =>
+  typeof API_KEY === 'string' && API_KEY.trim().length > 0;
+
+export function GoogleMapsProvider({ children }: { children: ReactNode }) {
+  if (!isGoogleMapsConfigured()) {
+    return <>{children}</>;
+  }
+  return (
+    <APIProvider apiKey={API_KEY as string} libraries={['marker']}>
+      {children}
+    </APIProvider>
+  );
+}

--- a/frontend/src/contexts/DiscoverViewModeContext.tsx
+++ b/frontend/src/contexts/DiscoverViewModeContext.tsx
@@ -1,0 +1,72 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type DiscoverViewMode = 'list' | 'map';
+
+interface DiscoverViewModeContextValue {
+  viewMode: DiscoverViewMode;
+  setViewMode: (mode: DiscoverViewMode) => void;
+  toggleViewMode: () => void;
+}
+
+const STORAGE_KEY = 'sem_discover_view_mode';
+const DEFAULT_VIEW_MODE: DiscoverViewMode = 'map';
+
+function readInitialViewMode(): DiscoverViewMode {
+  if (typeof window === 'undefined') return DEFAULT_VIEW_MODE;
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === 'list' || stored === 'map') return stored;
+  } catch {
+    /* ignore */
+  }
+  return DEFAULT_VIEW_MODE;
+}
+
+const DiscoverViewModeContext = createContext<DiscoverViewModeContextValue>({
+  viewMode: DEFAULT_VIEW_MODE,
+  setViewMode: () => undefined,
+  toggleViewMode: () => undefined,
+});
+
+export function DiscoverViewModeProvider({ children }: { children: ReactNode }) {
+  const [viewMode, setViewModeState] = useState<DiscoverViewMode>(readInitialViewMode);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, viewMode);
+    } catch {
+      /* ignore */
+    }
+  }, [viewMode]);
+
+  const setViewMode = useCallback((mode: DiscoverViewMode) => {
+    setViewModeState(mode);
+  }, []);
+
+  const toggleViewMode = useCallback(() => {
+    setViewModeState((prev) => (prev === 'map' ? 'list' : 'map'));
+  }, []);
+
+  const value = useMemo(
+    () => ({ viewMode, setViewMode, toggleViewMode }),
+    [viewMode, setViewMode, toggleViewMode],
+  );
+
+  return (
+    <DiscoverViewModeContext.Provider value={value}>
+      {children}
+    </DiscoverViewModeContext.Provider>
+  );
+}
+
+export function useDiscoverViewMode(): DiscoverViewModeContextValue {
+  return useContext(DiscoverViewModeContext);
+}

--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -264,7 +264,7 @@
 }
 
 .dc-loc-modal-section {
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 .dc-loc-modal-section-label {
@@ -274,6 +274,17 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: #6b7280;
+}
+
+.dc-loc-modal-permission {
+  margin: 0;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: #fef3c7;
+  border: 1px solid #fde68a;
+  color: #92400e;
+  font-size: 13px;
+  line-height: 1.4;
 }
 
 .dc-loc-modal-pill {
@@ -357,10 +368,10 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 52px;
+  height: 48px;
   padding: 0 14px;
-  margin-bottom: 12px;
-  border-radius: 16px;
+  margin-bottom: 8px;
+  border-radius: 14px;
   border: 1px solid #e5e7eb;
   background: #f9fafb;
 }
@@ -380,10 +391,9 @@
 }
 
 .dc-loc-modal-list-wrap {
-  min-height: 80px;
   max-height: 220px;
   overflow-y: auto;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .dc-loc-modal-hint {
@@ -449,6 +459,9 @@
 .dc-search {
   flex: 1;
   min-width: 0;
+  height: 40px;
+  padding: 0 18px;
+  border-radius: 999px;
 }
 
 .dc-filter-toggle {
@@ -457,7 +470,7 @@
   justify-content: center;
   gap: 8px;
   padding: 8px 16px;
-  border-radius: 10px;
+  border-radius: 999px;
   border: 1px solid #d1d5db;
   background-color: #ffffff;
   font-size: 14px;
@@ -465,6 +478,35 @@
   cursor: pointer;
   white-space: nowrap;
   transition: all 0.15s;
+}
+
+/* Collapse/expand button next to the Filters pill in map mode */
+.dc-overlay-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  color: #374151;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+
+.dc-overlay-collapse-btn:hover {
+  border-color: #111827;
+  color: #111827;
+}
+
+.dc-overlay-collapse-icon {
+  transition: transform 0.2s ease;
+}
+
+.dc-overlay-collapse-icon--up {
+  transform: rotate(180deg);
 }
 
 .dc-filter-toggle-icon {
@@ -685,31 +727,18 @@
   margin-bottom: 12px;
 }
 
-.dc-category-label {
-  margin-bottom: 8px;
-}
-
-.dc-category-row-with-expand {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  align-items: flex-start;
-  gap: 8px;
-}
-
 .dc-category-chips {
-  flex: 1;
-  min-width: 0;
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
   /* Collapsed max-height uses em so it tracks .dc-category-chip font size */
   font-size: 12px;
 }
 
-/* Collapsed: exactly one row; 40px was taller than one chip row, so the next row peeked through */
+/* Collapsed: keep up to 2 rows so show-more (inline last child) stays visible */
 .dc-category-chips--collapsed {
-  max-height: calc(1.25em + 10px + 8px);
+  max-height: calc(2 * (1.25em + 10px) + 8px);
   overflow: hidden;
 }
 
@@ -1014,36 +1043,6 @@
   text-overflow: ellipsis;
 }
 
-.dc-approx-location-badge {
-  width: max-content;
-  max-width: 100%;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 8px;
-  border-radius: 999px;
-  background: #eff6ff;
-  color: #1d4ed8;
-  border: 1px solid #bfdbfe;
-  font-size: 11px;
-  font-weight: 800;
-  line-height: 1.2;
-}
-
-.dc-approx-location-badge::before {
-  content: "";
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #3b82f6;
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.16);
-  flex-shrink: 0;
-}
-
-.dc-map-approx-location-badge {
-  margin-top: 2px;
-}
-
 .dc-card-footer {
   display: flex;
   align-items: center;
@@ -1159,75 +1158,213 @@
   }
 }
 
-/* ── List/Map view toggle ── */
+/* ── Discover map mode (full-bleed) ── */
 
-.dc-view-toggle {
-  display: inline-flex;
-  align-items: stretch;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 4px;
-  flex-shrink: 0;
-  gap: 2px;
+.dc-page--map {
+  position: relative;
+  width: 100%;
+  height: calc(100dvh - var(--shell-header-height, 64px));
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background: #f1f5f9;
 }
-
-.dc-view-toggle-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0.5rem 0.9rem;
-  background: none;
-  border: none;
-  border-radius: 7px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #64748b;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
-  line-height: 1;
-}
-
-.dc-view-toggle-icon {
-  flex-shrink: 0;
-}
-
-.dc-view-toggle-btn:hover:not(.active) {
-  color: #111827;
-  background: rgba(255, 255, 255, 0.6);
-}
-
-.dc-view-toggle-btn.active {
-  background: #ffffff;
-  color: #111827;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(15, 23, 42, 0.04);
-}
-
-/* ── Map surface ── */
 
 .dc-map-wrapper {
-  position: relative;
-  margin-top: 1.5rem;
-  border-radius: 16px;
+  position: absolute;
+  inset: 0;
+  border-radius: 0;
   overflow: hidden;
-  border: 1px solid #e2e8f0;
   background: #f1f5f9;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-}
-
-.dc-map-surface {
-  height: calc(100vh - 280px);
-  min-height: 560px;
-  width: 100%;
   z-index: 0;
 }
 
-/* Hide leaflet's default white background around divIcon markers */
-.leaflet-div-icon.dc-map-cat-marker {
-  background: transparent;
-  border: none;
+.dc-map-surface {
+  width: 100%;
+  height: 100%;
 }
 
+/* Reset list-mode wrapper styling when not in map mode */
+.dc-page:not(.dc-page--map) .dc-map-wrapper {
+  position: relative;
+  margin-top: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.dc-page:not(.dc-page--map) .dc-map-surface {
+  height: calc(100vh - 280px);
+  min-height: 560px;
+}
+
+/* Floating overlays */
+.dc-overlay {
+  position: absolute;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.dc-overlay > * {
+  pointer-events: auto;
+}
+
+.dc-overlay-top-left {
+  top: 16px;
+  left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: min(360px, calc(100% - 32px));
+}
+
+.dc-overlay-top-center {
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(640px, calc(100% - 480px));
+}
+
+.dc-overlay-top-right {
+  top: 16px;
+  right: 16px;
+  z-index: 25;
+}
+
+/* Title card (top-left, above search) */
+.dc-title-card {
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 14px;
+  padding: 12px 16px;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+.dc-title-card .dc-title {
+  font-size: 20px;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.dc-title-card .dc-subtitle {
+  font-size: 13px;
+  color: #475569;
+  margin: 2px 0 0;
+}
+
+/* Map-mode search/filter toolbar inherits .dc-search-toolbar but sits in a card */
+.dc-page--map .dc-search-toolbar {
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 14px;
+  padding: 8px;
+  margin: 0;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+.dc-page--map .dc-filter-panel {
+  margin: 0;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  max-height: calc(100dvh - 320px);
+  overflow-y: auto;
+}
+
+.dc-page--map .dc-location-prompt {
+  margin: 0;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.dc-page--map .dc-category-block {
+  margin: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  box-shadow: none;
+}
+
+/* On the map, chips get an individual translucent backdrop so they stay
+   readable without a parent panel. */
+.dc-page--map .dc-category-chip {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+}
+
+.dc-page--map .dc-category-chip.selected {
+  background: #111827;
+  border-color: #111827;
+  color: #ffffff;
+}
+
+.dc-page--map .dc-category-expand {
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.18);
+}
+
+/* Wider top-right location button */
+.dc-location-bar-btn--wide {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 280px;
+  padding: 12px 18px;
+  border-radius: 999px;
+  border: none;
+  background: #111827;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.22);
+  transition: background-color 0.15s, box-shadow 0.15s, transform 0.1s;
+}
+
+.dc-location-bar-btn--wide:hover {
+  background: #1f2937;
+  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.28);
+}
+
+.dc-location-bar-btn--wide:active {
+  transform: scale(0.98);
+}
+
+.dc-location-bar-btn--wide .dc-location-bar-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.dc-location-bar-btn--wide .dc-location-bar-value {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  letter-spacing: 0.01em;
+  font-style: italic;
+}
+
+.dc-location-bar-btn--wide .dc-location-bar-chevron {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+/* Map status overlays */
 .dc-map-overlay {
   position: absolute;
   left: 50%;
@@ -1242,9 +1379,9 @@
   align-items: center;
   gap: 0.5rem;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-  z-index: 500;
+  z-index: 15;
   text-align: center;
-  max-width: 340px;
+  max-width: 360px;
 }
 
 .dc-map-overlay p,
@@ -1268,194 +1405,910 @@
   background: rgba(255, 255, 255, 0.96);
 }
 
-/* ── Event side card overlay (left corner of map) ── */
-
-.dc-map-card {
-  position: absolute;
-  top: 16px;
-  left: 16px;
-  width: 320px;
-  max-width: calc(100% - 32px);
-  background: #ffffff;
-  border-radius: 16px;
-  overflow: hidden;
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18), 0 0 0 1px rgba(15, 23, 42, 0.04);
-  z-index: 600;
-  animation: dc-map-card-enter 0.2s ease-out;
+/* Marker bubble */
+.dc-map-marker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transform: translateY(-2px);
 }
 
-@keyframes dc-map-card-enter {
-  from {
-    opacity: 0;
-    transform: translateY(-4px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.dc-map-card-close {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 30px;
-  height: 30px;
+.dc-map-marker-bubble {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 3px solid #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(15, 23, 42, 0.55);
-  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.28);
+  transition: transform 0.12s ease;
+}
+
+.dc-map-marker--selected .dc-map-marker-bubble {
+  width: 46px;
+  height: 46px;
+  border-width: 4px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.36);
+  transform: scale(1.05);
+}
+
+.dc-map-marker-emoji {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.dc-map-marker-count {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 10px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  color: #111827;
+  font-size: 11px;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dc-map-marker-tail {
+  width: 0;
+  height: 0;
+  margin-top: -3px;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 10px solid currentColor;
+}
+
+/* Right-side event details panel — floats with a gap from the viewport edges */
+.dc-side-panel {
+  position: absolute;
+  right: 16px;
+  top: 86px;
+  bottom: 16px;
+  width: clamp(300px, 23vw, 360px);
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 18px;
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.18), 0 0 0 1px rgba(15, 23, 42, 0.04);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: dc-side-panel-enter 0.22s ease-out;
+}
+
+@keyframes dc-side-panel-enter {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.dc-side-panel-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
   border: none;
   border-radius: 50%;
-  font-size: 1.2rem;
-  font-weight: 600;
+  background: rgba(15, 23, 42, 0.55);
+  color: #ffffff;
+  font-size: 22px;
   line-height: 1;
   cursor: pointer;
   z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background 0.15s;
 }
 
-.dc-map-card-close:hover {
+.dc-side-panel-close:hover {
   background: rgba(15, 23, 42, 0.85);
 }
 
-.dc-map-card-image {
+.dc-side-panel-image {
   position: relative;
   width: 100%;
-  height: 160px;
+  height: 150px;
   background: #f1f5f9;
+  flex-shrink: 0;
 }
 
-.dc-map-card-image-img,
-.dc-map-card-image > div {
+.dc-side-panel-image-badges {
+  position: absolute;
+  bottom: 10px;
+  left: 12px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.dc-side-panel-image-img,
+.dc-side-panel-image > div {
   width: 100%;
   height: 100%;
   display: block;
 }
 
-.dc-map-card-image img {
+.dc-side-panel-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.dc-map-card-category {
-  position: absolute;
-  bottom: 10px;
-  left: 12px;
+.dc-side-panel-category {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   padding: 4px 10px;
-  font-size: 0.7rem;
-  font-weight: 700;
-  color: #ffffff;
-  background: #7c3aed;
   border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  max-width: 70%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
-.dc-map-card-body {
+.dc-side-panel-body {
   padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  flex: 1;
 }
 
-.dc-map-card-title {
-  margin: 0 0 6px;
+.dc-side-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.dc-side-panel-title {
+  margin: 0;
   font-size: 1.05rem;
   font-weight: 700;
   color: #0f172a;
-  line-height: 1.3;
+  line-height: 1.25;
+  flex: 1;
+  min-width: 0;
 }
 
-.dc-map-card-meta-row {
+.dc-side-panel-facts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.dc-map-card-meta {
+.dc-side-panel-fact {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
   font-size: 0.82rem;
   color: #475569;
-  font-weight: 500;
+  line-height: 1.4;
 }
 
-.dc-map-card-address {
-  margin: 0 0 10px;
+.dc-side-panel-fact-icon {
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.dc-side-panel-fact-note {
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.dc-side-panel-host-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: #f8fafc;
+  border-radius: 12px;
+}
+
+.dc-side-panel-host-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.dc-side-panel-cta {
+  margin-top: auto;
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  background: #111827;
+  color: #ffffff !important;
+  border-radius: 12px;
+  text-align: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background 0.15s, transform 0.05s;
+}
+
+.dc-side-panel-cta:hover {
+  background: #000000;
+}
+
+.dc-side-panel-cta:active {
+  transform: scale(0.98);
+}
+
+.dc-side-panel-lifecycle {
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  flex-shrink: 0;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.dc-side-panel-lifecycle-upcoming {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+}
+
+.dc-side-panel-lifecycle-in-progress {
+  background-color: #fef9c3;
+  color: #a16207;
+}
+
+.dc-side-panel-host-name {
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: #0f172a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dc-side-panel-host-score {
+  font-size: 0.78rem;
+  color: #ca8a04;
+  font-weight: 700;
+}
+
+.dc-side-panel-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #334155;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.dc-side-panel-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.dc-side-panel-tag {
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #475569;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.dc-side-panel-privacy {
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.dc-side-panel-privacy-public {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+.dc-side-panel-privacy-protected {
+  background-color: #fef3c7;
+  color: #d97706;
+}
+
+.dc-side-panel-privacy-private {
+  background-color: #fee2e2;
+  color: #dc2626;
+}
+
+.dc-side-panel-status {
+  margin: 4px 0 0;
   font-size: 0.82rem;
   color: #64748b;
-  line-height: 1.4;
+}
+
+.dc-side-panel-status--error {
+  color: #b91c1c;
+}
+
+/* Filter modal (centered popup) */
+.dc-filter-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 250;
+  background-color: rgba(15, 23, 42, 0.32);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+  overflow-y: auto;
+}
+
+.dc-filter-modal {
+  width: 100%;
+  max-width: 460px;
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  max-height: min(80vh, 720px);
+}
+
+.dc-filter-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.dc-filter-modal-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 800;
+  color: #111827;
+}
+
+.dc-filter-modal-close {
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: none;
+  font-size: 24px;
+  color: #111827;
+  cursor: pointer;
+  border-radius: 10px;
+  line-height: 1;
+}
+
+.dc-filter-modal-close:hover {
+  background: #f3f4f6;
+}
+
+.dc-filter-modal-body {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+}
+
+.dc-filter-modal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  border-top: 1px solid #f1f5f9;
+}
+
+.dc-filter-modal-clear {
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid #dc2626;
+  background: none;
+  color: #dc2626;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.dc-filter-modal-clear:hover {
+  background: #fef2f2;
+}
+
+.dc-filter-modal-apply {
+  margin-left: auto;
+  padding: 10px 24px;
+  border: none;
+  border-radius: 999px;
+  background: #111827;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.dc-filter-modal-apply:hover {
+  background: #1f2937;
+}
+
+/* Events list under search bar (map mode) */
+.dc-overlay-events {
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 14px;
+  padding: 6px;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  max-height: calc(100dvh - 280px);
+  overflow-y: auto;
+}
+
+.dc-overlay-events-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dc-overlay-events-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 18px 14px;
+  font-size: 13px;
+  color: #64748b;
+  text-align: center;
+}
+
+.dc-overlay-events-status--error {
+  color: #b91c1c;
+  flex-direction: column;
+}
+
+.dc-overlay-events-retry {
+  padding: 4px 14px;
+  border-radius: 8px;
+  border: 1px solid #dc2626;
+  background: none;
+  color: #dc2626;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dc-overlay-events-more {
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-radius: 10px;
+  background: #f3f4f6;
+  color: #111827;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.dc-overlay-events-more:hover:not(:disabled) {
+  background: #e5e7eb;
+}
+
+.dc-overlay-events-more:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dc-list-item {
+  display: flex;
+  width: 100%;
+  gap: 10px;
+  padding: 8px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.dc-list-item:hover {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.dc-list-item.selected {
+  background: rgba(17, 24, 39, 0.06);
+  border-color: rgba(17, 24, 39, 0.3);
+}
+
+.dc-list-item-image {
+  width: 64px;
+  height: 64px;
+  border-radius: 10px;
+  overflow: hidden;
+  flex-shrink: 0;
+  background: #f1f5f9;
+}
+
+.dc-list-item-image-img,
+.dc-list-item-image > div {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.dc-list-item-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.dc-list-item-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dc-list-item-category {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.dc-list-item-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.25;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
-.dc-map-card-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 0;
-  border-top: 1px solid #f1f5f9;
-  margin-bottom: 10px;
-}
-
-.dc-map-card-participants {
-  font-size: 0.8rem;
+.dc-list-item-meta {
+  font-size: 11px;
   color: #64748b;
-  font-weight: 500;
-}
-
-.dc-map-card-score {
-  font-size: 0.82rem;
-  color: #ca8a04;
   font-weight: 600;
 }
 
-.dc-map-card-cta {
-  display: block;
-  width: 100%;
-  padding: 10px 14px;
-  background: #111827;
-  color: #ffffff !important;
-  border-radius: 10px;
+.dc-list-item-address {
+  font-size: 11px;
+  color: #94a3b8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Collapsed top-left overlay: only the search row stays visible */
+.dc-overlay-top-left--collapsed {
+  gap: 0;
+}
+
+/* Dark theme overrides for the new map UI */
+:root[data-theme='dark'] .dc-page--map,
+:root[data-theme='dark'] .dc-map-wrapper {
+  background: #050505;
+}
+
+:root[data-theme='dark'] .dc-title-card,
+:root[data-theme='dark'] .dc-page--map .dc-search-toolbar,
+:root[data-theme='dark'] .dc-page--map .dc-filter-panel,
+:root[data-theme='dark'] .dc-page--map .dc-location-prompt {
+  background: rgba(8, 8, 8, 0.86);
+  border-color: rgba(255, 255, 255, 0.06);
+  color: #e5e7eb;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5);
+}
+
+:root[data-theme='dark'] .dc-page--map .dc-category-chip {
+  background: rgba(8, 8, 8, 0.86);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #e5e7eb;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+:root[data-theme='dark'] .dc-page--map .dc-category-chip.selected {
+  background: #f9fafb;
+  border-color: #f9fafb;
+  color: #111827;
+}
+
+:root[data-theme='dark'] .dc-title-card .dc-title {
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-title-card .dc-subtitle {
+  color: #94a3b8;
+}
+
+:root[data-theme='dark'] .dc-location-bar-btn--wide {
+  background: #f9fafb;
+  color: #111827;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.55);
+}
+
+:root[data-theme='dark'] .dc-location-bar-btn--wide:hover {
+  background: #ffffff;
+}
+
+:root[data-theme='dark'] .dc-side-panel {
+  background: #0a0a0a;
+  border-color: #2a2a2a;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.55);
+}
+
+:root[data-theme='dark'] .dc-side-panel-title {
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-side-panel-meta {
+  color: #cbd5e1;
+}
+
+:root[data-theme='dark'] .dc-side-panel-address {
+  color: #94a3b8;
+}
+
+:root[data-theme='dark'] .dc-side-panel-footer {
+  border-color: #1f2937;
+}
+
+:root[data-theme='dark'] .dc-side-panel-cta {
+  background: #f9fafb;
+  color: #111827 !important;
+}
+
+:root[data-theme='dark'] .dc-side-panel-cta:hover {
+  background: #ffffff;
+}
+
+:root[data-theme='dark'] .dc-side-panel-host-row {
+  background: #111111;
+}
+
+:root[data-theme='dark'] .dc-side-panel-host-name {
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-side-panel-fact {
+  color: #cbd5e1;
+}
+
+:root[data-theme='dark'] .dc-side-panel-fact-note {
+  color: #6b7280;
+}
+
+:root[data-theme='dark'] .dc-side-panel-description {
+  color: #cbd5e1;
+}
+
+:root[data-theme='dark'] .dc-side-panel-tag {
+  background: #1f2937;
+  color: #cbd5e1;
+}
+
+:root[data-theme='dark'] .dc-side-panel-status {
+  color: #94a3b8;
+}
+
+:root[data-theme='dark'] .dc-side-panel-status--error {
+  color: #fca5a5;
+}
+
+:root[data-theme='dark'] .dc-filter-modal {
+  background: #0a0a0a;
+  border-color: #2a2a2a;
+  color: #e5e7eb;
+}
+
+:root[data-theme='dark'] .dc-filter-modal-title {
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-filter-modal-header,
+:root[data-theme='dark'] .dc-filter-modal-footer {
+  border-color: #1f2937;
+}
+
+:root[data-theme='dark'] .dc-filter-modal-close {
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-filter-modal-close:hover {
+  background: #111111;
+}
+
+:root[data-theme='dark'] .dc-filter-modal-apply {
+  background: #f9fafb;
+  color: #111827;
+}
+
+:root[data-theme='dark'] .dc-overlay-events {
+  background: rgba(8, 8, 8, 0.86);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+:root[data-theme='dark'] .dc-overlay-events-status {
+  color: #94a3b8;
+}
+
+:root[data-theme='dark'] .dc-overlay-events-more {
+  background: #111111;
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-overlay-events-more:hover:not(:disabled) {
+  background: #1f1f1f;
+}
+
+:root[data-theme='dark'] .dc-list-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+:root[data-theme='dark'] .dc-list-item.selected {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+:root[data-theme='dark'] .dc-list-item-category {
+  color: #94a3b8;
+}
+
+:root[data-theme='dark'] .dc-list-item-title {
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-list-item-meta,
+:root[data-theme='dark'] .dc-list-item-address {
+  color: #94a3b8;
+}
+
+:root[data-theme='dark'] .dc-overlay-collapse-btn {
+  background: rgba(8, 8, 8, 0.86);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #e5e7eb;
+}
+
+:root[data-theme='dark'] .dc-overlay-collapse-btn:hover {
+  border-color: #f9fafb;
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-loc-modal-permission {
+  background: rgba(245, 158, 11, 0.18);
+  border-color: rgba(251, 191, 36, 0.35);
+  color: #fde68a;
+}
+
+:root[data-theme='dark'] .dc-map-marker-count {
+  background: #0a0a0a;
+  border-color: #2a2a2a;
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .dc-map-overlay {
+  background: #0a0a0a;
+  border-color: #2a2a2a;
+  color: #e5e7eb;
+}
+
+:root[data-theme='dark'] .dc-map-overlay p {
+  color: #cbd5e1;
+}
+
+:root[data-theme='dark'] .dc-map-overlay h3 {
+  color: #f9fafb;
+}
+
+/* Event detail mini-map placeholder when API key missing */
+.ed-map-surface--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  font-size: 0.88rem;
-  font-weight: 600;
-  text-decoration: none;
-  transition: background 0.15s, transform 0.05s;
+  padding: 24px;
+  color: #64748b;
+  background: #f1f5f9;
+  border-radius: 12px;
 }
 
-.dc-map-card-cta:hover {
-  background: #000000;
+:root[data-theme='dark'] .ed-map-surface--placeholder {
+  background: #0a0a0a;
+  color: #94a3b8;
 }
 
-.dc-map-card-cta:active {
-  transform: scale(0.98);
+@media (max-width: 900px) {
+  .dc-overlay-top-center {
+    width: min(420px, calc(100% - 64px));
+  }
+  .dc-side-panel {
+    width: clamp(300px, 38vw, 380px);
+  }
 }
 
-@media (max-width: 600px) {
-  .dc-map-surface {
-    height: calc(100vh - 240px);
-    min-height: 420px;
+@media (max-width: 720px) {
+  .dc-overlay-top-left {
+    width: calc(100% - 32px);
   }
-
-  .dc-map-card {
-    top: 12px;
-    left: 12px;
-    width: calc(100% - 24px);
+  .dc-overlay-top-center {
+    position: static;
+    transform: none;
+    margin: 0 16px;
+    width: calc(100% - 32px);
   }
-
-  .dc-map-card-image {
-    height: 140px;
+  .dc-overlay-top-right {
+    top: auto;
+    bottom: 16px;
+    right: 16px;
+    left: 16px;
   }
-
-  .dc-view-toggle-btn {
-    padding: 0.4rem 0.7rem;
-    font-size: 0.8rem;
+  .dc-location-bar-btn--wide {
+    width: 100%;
+    min-width: 0;
+    justify-content: space-between;
   }
-
-  .dc-view-toggle-label {
-    display: none;
+  .dc-side-panel {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    max-height: 70vh;
+    border-left: none;
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 18px 18px 0 0;
+    animation-name: dc-side-panel-enter-mobile;
+  }
+  @keyframes dc-side-panel-enter-mobile {
+    from {
+      transform: translateY(100%);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
   }
 }

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -49,7 +49,11 @@
 }
 
 .shell-nav-link {
-  padding: 8px 14px;
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  box-sizing: border-box;
+  padding: 0 14px;
   border-radius: 8px;
   font-size: 14px;
   font-weight: 500;
@@ -163,7 +167,11 @@
 
 /* Create Event button */
 .shell-create-btn {
-  padding: 8px 16px;
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  box-sizing: border-box;
+  padding: 0 16px;
   font-size: 14px;
   font-weight: 600;
   color: #ffffff;
@@ -182,7 +190,9 @@
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  padding: 7px 14px;
+  height: 40px;
+  box-sizing: border-box;
+  padding: 0 14px;
   font-size: 14px;
   font-weight: 600;
   color: #111827;
@@ -221,10 +231,12 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  height: 40px;
+  box-sizing: border-box;
   background: none;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
-  padding: 6px 12px;
+  padding: 0 12px;
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -244,8 +256,18 @@
 
 .shell-username {
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 700;
   color: #374151;
+}
+
+/* Shrink the avatar inside the profile button so it doesn't touch the edges */
+.shell-user-btn .user-avatar--sm {
+  width: 28px;
+  height: 28px;
+}
+
+.shell-user-btn .user-avatar--sm .user-avatar-fallback {
+  font-size: 12px;
 }
 
 /* Dropdown */
@@ -381,6 +403,61 @@
   max-width: none;
   margin: 0;
   padding: 0;
+}
+
+/* Discover map mode: let the page take the full viewport below the header */
+.shell-main.discover-map-main {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+/* List/Map view toggle in the global header */
+.shell-view-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  height: 40px;
+  box-sizing: border-box;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.shell-view-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #64748b;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+  line-height: 1;
+}
+
+.shell-view-toggle-icon {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.shell-view-toggle-btn:hover:not(.active) {
+  color: #111827;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.shell-view-toggle-btn.active {
+  background: #ffffff;
+  color: #111827;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(15, 23, 42, 0.04);
 }
 
 /* Responsive */
@@ -618,6 +695,35 @@
 
 :root[data-theme='dark'] .hamburger-line {
   background-color: #e5e7eb;
+}
+
+:root[data-theme='dark'] .shell-view-toggle {
+  background: #111111;
+  border-color: #2a2a2a;
+}
+
+:root[data-theme='dark'] .shell-view-toggle-btn {
+  color: #94a3b8;
+}
+
+:root[data-theme='dark'] .shell-view-toggle-btn:hover:not(.active) {
+  color: #f3f4f6;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+:root[data-theme='dark'] .shell-view-toggle-btn.active {
+  background: #202020;
+  color: #f9fafb;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+@media (max-width: 600px) {
+  .shell-view-toggle-label {
+    display: none;
+  }
+  .shell-view-toggle-btn {
+    padding: 5px 8px;
+  }
 }
 
 :root[data-theme='dark'] .shell-fab {

--- a/frontend/src/utils/eventCategoryPresentation.ts
+++ b/frontend/src/utils/eventCategoryPresentation.ts
@@ -1,0 +1,88 @@
+export interface EventCategoryPresentation {
+  label: string;
+  emoji: string;
+  color: string;
+  tintColor: string;
+  textColor: string;
+}
+
+interface EventCategoryPresentationConfig {
+  emoji: string;
+  lightColor: string;
+  darkColor: string;
+}
+
+const CATEGORY_PRESENTATION_BY_NAME: Record<string, EventCategoryPresentationConfig> = {
+  sports: { emoji: '🏃', lightColor: '#2563EB', darkColor: '#60A5FA' },
+  music: { emoji: '🎵', lightColor: '#DB2777', darkColor: '#F472B6' },
+  education: { emoji: '🎓', lightColor: '#7C3AED', darkColor: '#A78BFA' },
+  technology: { emoji: '💻', lightColor: '#0891B2', darkColor: '#22D3EE' },
+  art: { emoji: '🎨', lightColor: '#EA580C', darkColor: '#FB923C' },
+  fooddrink: { emoji: '🍽️', lightColor: '#C2410C', darkColor: '#FDBA74' },
+  outdoors: { emoji: '🌲', lightColor: '#059669', darkColor: '#34D399' },
+  fitness: { emoji: '💪', lightColor: '#DC2626', darkColor: '#F87171' },
+  networking: { emoji: '🤝', lightColor: '#4F46E5', darkColor: '#818CF8' },
+  gaming: { emoji: '🎮', lightColor: '#9333EA', darkColor: '#C084FC' },
+  charity: { emoji: '💛', lightColor: '#B45309', darkColor: '#FBBF24' },
+  photography: { emoji: '📷', lightColor: '#0284C7', darkColor: '#38BDF8' },
+  travel: { emoji: '✈️', lightColor: '#0D9488', darkColor: '#2DD4BF' },
+  workshops: { emoji: '🛠️', lightColor: '#475569', darkColor: '#CBD5E1' },
+  conferences: { emoji: '🎤', lightColor: '#4338CA', darkColor: '#A5B4FC' },
+  moviescinema: { emoji: '🎬', lightColor: '#B91C1C', darkColor: '#FCA5A5' },
+  theatre: { emoji: '🎭', lightColor: '#C026D3', darkColor: '#E879F9' },
+  booksliterature: { emoji: '📚', lightColor: '#D97706', darkColor: '#FCD34D' },
+  wellness: { emoji: '🧘', lightColor: '#65A30D', darkColor: '#A3E635' },
+  volunteering: { emoji: '🙌', lightColor: '#BE123C', darkColor: '#FB7185' },
+  social: { emoji: '🤗', lightColor: '#0D9488', darkColor: '#5EEAD4' },
+  culture: { emoji: '🏛️', lightColor: '#7C2D12', darkColor: '#FDBA74' },
+  entertainment: { emoji: '🎉', lightColor: '#C026D3', darkColor: '#E879F9' },
+};
+
+const FALLBACK_CATEGORY_PRESENTATIONS: EventCategoryPresentationConfig[] = [
+  { emoji: '📍', lightColor: '#2563EB', darkColor: '#60A5FA' },
+  { emoji: '✨', lightColor: '#7C3AED', darkColor: '#A78BFA' },
+  { emoji: '📌', lightColor: '#0D9488', darkColor: '#2DD4BF' },
+  { emoji: '🎟️', lightColor: '#B45309', darkColor: '#FBBF24' },
+];
+
+function normalizeCategoryName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function hashString(value: string): number {
+  return value.split('').reduce((hash, char) => {
+    return (hash * 31 + char.charCodeAt(0)) >>> 0;
+  }, 0);
+}
+
+function getReadableTextColor(backgroundColor: string): string {
+  const normalized = backgroundColor.replace('#', '');
+  const red = parseInt(normalized.slice(0, 2), 16);
+  const green = parseInt(normalized.slice(2, 4), 16);
+  const blue = parseInt(normalized.slice(4, 6), 16);
+  const luminance = (0.299 * red + 0.587 * green + 0.114 * blue) / 255;
+
+  return luminance > 0.62 ? '#0F172A' : '#FFFFFF';
+}
+
+export function getEventCategoryPresentation(
+  categoryName: string,
+  isDark: boolean,
+): EventCategoryPresentation {
+  const label = categoryName.trim() || 'Event';
+  const normalizedName = normalizeCategoryName(label);
+  const config =
+    CATEGORY_PRESENTATION_BY_NAME[normalizedName] ??
+    FALLBACK_CATEGORY_PRESENTATIONS[
+      hashString(normalizedName) % FALLBACK_CATEGORY_PRESENTATIONS.length
+    ];
+  const color = isDark ? config.darkColor : config.lightColor;
+
+  return {
+    label,
+    emoji: config.emoji,
+    color,
+    tintColor: `${color}${isDark ? '30' : '18'}`,
+    textColor: getReadableTextColor(color),
+  };
+}

--- a/frontend/src/viewmodels/discover/useDiscoverViewModel.ts
+++ b/frontend/src/viewmodels/discover/useDiscoverViewModel.ts
@@ -580,6 +580,14 @@ export function useDiscoverViewModel(token: string | null) {
     setModalLocationResults([]);
   }, [defaultProfileLocation]);
 
+  const selectBrowserLocationInModal = useCallback(() => {
+    const current = browserLocation.current;
+    if (!current) return;
+    setPendingLocation(current);
+    setModalLocationQuery('');
+    setModalLocationResults([]);
+  }, []);
+
   const applyModalLocation = useCallback(() => {
     setSelectedLocation(pendingLocation ?? defaultProfileLocation ?? null);
     setModalLocationQuery('');
@@ -636,9 +644,12 @@ export function useDiscoverViewModel(token: string | null) {
     selectModalSuggestion,
     selectFavoriteInModal,
     selectDefaultProfileInModal,
+    selectBrowserLocationInModal,
     applyModalLocation,
     resetModalLocationDraft,
     hasCustomLocationFilter,
+    hasBrowserLocation,
+    browserLocationPermissionDenied,
     updateSearch,
     updateFilter,
     updateCategory,

--- a/frontend/src/views/discover/DiscoverEventSidePanel.tsx
+++ b/frontend/src/views/discover/DiscoverEventSidePanel.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { EventCoverImage } from '@/components/EventCoverImage';
+import { UserAvatar } from '@/components/UserAvatar';
+import { useAuth } from '@/contexts/AuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import { getEventDetail } from '@/services/eventService';
+import { getEventCategoryPresentation } from '@/utils/eventCategoryPresentation';
+import { getEventLifecyclePresentation } from '@/utils/eventStatus';
+import { ApiError } from '@/services/api';
+import type { DiscoverEventItem, EventDetailResponse } from '@/models/event';
+
+interface DiscoverEventSidePanelProps {
+  event: DiscoverEventItem;
+  onClose: () => void;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function formatRange(startISO: string, endISO: string | null): string {
+  if (!endISO) return `${formatDate(startISO)} · ${formatTime(startISO)}`;
+  const start = new Date(startISO);
+  const end = new Date(endISO);
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+  if (sameDay) {
+    return `${formatDate(startISO)} · ${formatTime(startISO)} – ${formatTime(endISO)}`;
+  }
+  return `${formatDate(startISO)} ${formatTime(startISO)} → ${formatDate(endISO)} ${formatTime(endISO)}`;
+}
+
+function formatGender(g: string | null | undefined): string | null {
+  if (!g) return null;
+  const lower = g.toLowerCase();
+  if (lower === 'male' || lower === 'female' || lower === 'other') {
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
+  }
+  return g;
+}
+
+export default function DiscoverEventSidePanel({
+  event,
+  onClose,
+}: DiscoverEventSidePanelProps) {
+  const { token } = useAuth();
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  const [detail, setDetail] = useState<EventDetailResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDetail(null);
+    setError(null);
+    setLoading(true);
+    getEventDetail(event.id, token)
+      .then((res) => {
+        if (cancelled) return;
+        setDetail(res);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof ApiError ? err.message : 'Failed to load event details.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [event.id, token]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const title = detail?.title ?? event.title;
+  const description = detail?.description ?? null;
+  const imageUrl = detail?.image_url ?? event.image_url;
+  const startTime = detail?.start_time ?? event.start_time;
+  const endTime = detail?.end_time ?? null;
+  const address = detail?.location?.address ?? event.location_address ?? null;
+  const categoryName = detail?.category?.name ?? event.category_name ?? '';
+  const presentation = useMemo(
+    () => getEventCategoryPresentation(categoryName, isDark),
+    [categoryName, isDark],
+  );
+  const lifecycle = getEventLifecyclePresentation(detail?.status ?? event.status);
+  const approvedCount =
+    detail?.approved_participant_count ?? event.approved_participant_count;
+  const capacity = detail?.capacity ?? null;
+  const tags = detail?.tags ?? [];
+  const host = detail?.host ?? null;
+  const hostName = host ? host.display_name ?? host.username : null;
+  const hostScore = detail?.host_score?.final_score ?? event.host_score.final_score;
+  const minAge = detail?.minimum_age ?? null;
+  const preferredGender = formatGender(detail?.preferred_gender);
+  const favoriteCount = detail?.favorite_count ?? null;
+  const privacyLevel = detail?.privacy_level ?? event.privacy_level;
+  const isApprox = detail?.location?.is_location_approximate ?? false;
+
+  return (
+    <aside
+      className="dc-side-panel"
+      role="dialog"
+      aria-label={`Event: ${title}`}
+    >
+      <button
+        type="button"
+        className="dc-side-panel-close"
+        onClick={onClose}
+        aria-label="Close event preview"
+      >
+        ×
+      </button>
+
+      <div className="dc-side-panel-image">
+        <EventCoverImage
+          src={imageUrl}
+          alt={title}
+          imgClassName="dc-side-panel-image-img"
+          variant="card"
+        />
+        <div className="dc-side-panel-image-badges">
+          <span
+            className="dc-side-panel-category"
+            style={{ background: presentation.color, color: presentation.textColor }}
+          >
+            <span aria-hidden>{presentation.emoji}</span>
+            <span>{presentation.label}</span>
+          </span>
+          {lifecycle && (
+            <span
+              className={`dc-side-panel-lifecycle ${
+                lifecycle.variant === 'upcoming'
+                  ? 'dc-side-panel-lifecycle-upcoming'
+                  : 'dc-side-panel-lifecycle-in-progress'
+              }`}
+            >
+              {lifecycle.label}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="dc-side-panel-body">
+        <div className="dc-side-panel-head">
+          <h2 className="dc-side-panel-title">{title}</h2>
+          <span
+            className={`dc-side-panel-privacy dc-side-panel-privacy-${privacyLevel.toLowerCase()}`}
+          >
+            {privacyLevel === 'PUBLIC'
+              ? 'Public'
+              : privacyLevel === 'PROTECTED'
+              ? 'Protected'
+              : 'Private'}
+          </span>
+        </div>
+
+        <ul className="dc-side-panel-facts">
+          <li className="dc-side-panel-fact">
+            <span className="dc-side-panel-fact-icon" aria-hidden>📅</span>
+            <span>{formatRange(startTime, endTime)}</span>
+          </li>
+          {address && (
+            <li className="dc-side-panel-fact">
+              <span className="dc-side-panel-fact-icon" aria-hidden>📍</span>
+              <span>
+                {address}
+                {isApprox && (
+                  <span className="dc-side-panel-fact-note"> · approximate area</span>
+                )}
+              </span>
+            </li>
+          )}
+          <li className="dc-side-panel-fact">
+            <span className="dc-side-panel-fact-icon" aria-hidden>👥</span>
+            <span>
+              {approvedCount} going{capacity != null ? ` / ${capacity}` : ''}
+            </span>
+          </li>
+          {(minAge != null || preferredGender) && (
+            <li className="dc-side-panel-fact">
+              <span className="dc-side-panel-fact-icon" aria-hidden>🛡️</span>
+              <span>
+                {minAge != null && <>Age {minAge}+</>}
+                {minAge != null && preferredGender && ' · '}
+                {preferredGender && <>{preferredGender} preferred</>}
+              </span>
+            </li>
+          )}
+          {favoriteCount != null && favoriteCount > 0 && (
+            <li className="dc-side-panel-fact">
+              <span className="dc-side-panel-fact-icon" aria-hidden>♥</span>
+              <span>
+                {favoriteCount} {favoriteCount === 1 ? 'favorite' : 'favorites'}
+              </span>
+            </li>
+          )}
+        </ul>
+
+        {host && (
+          <div className="dc-side-panel-host-row">
+            <UserAvatar
+              username={host.username}
+              displayName={host.display_name}
+              avatarUrl={host.avatar_url}
+              size="sm"
+              variant="muted"
+            />
+            <div className="dc-side-panel-host-info">
+              <div className="dc-side-panel-host-name">{hostName}</div>
+              {hostScore != null && (
+                <div className="dc-side-panel-host-score">★ {hostScore.toFixed(1)} host score</div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {description && (
+          <p className="dc-side-panel-description">{description}</p>
+        )}
+
+        {tags.length > 0 && (
+          <div className="dc-side-panel-tags">
+            {tags.slice(0, 8).map((tag) => (
+              <span key={tag} className="dc-side-panel-tag">
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {loading && (
+          <p className="dc-side-panel-status" role="status">
+            Loading details…
+          </p>
+        )}
+        {error && (
+          <p className="dc-side-panel-status dc-side-panel-status--error" role="alert">
+            {error}
+          </p>
+        )}
+
+        <Link to={`/events/${event.id}`} className="dc-side-panel-cta">
+          Go to event page &rarr;
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/views/discover/DiscoverMapView.tsx
+++ b/frontend/src/views/discover/DiscoverMapView.tsx
@@ -1,172 +1,92 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { MapContainer, Marker, TileLayer, useMap } from 'react-leaflet';
-import L from 'leaflet';
-import 'leaflet/dist/leaflet.css';
-import { EventCoverImage } from '@/components/EventCoverImage';
+import { useEffect, useMemo } from 'react';
+import {
+  AdvancedMarker,
+  Map as GoogleMap,
+  useMap,
+  type MapCameraChangedEvent,
+} from '@vis.gl/react-google-maps';
+import { useTheme } from '@/contexts/ThemeContext';
+import { isGoogleMapsConfigured, GOOGLE_MAPS_MAP_ID } from '@/components/GoogleMapsProvider';
+import { getEventCategoryPresentation } from '@/utils/eventCategoryPresentation';
 import type { DiscoverEventItem } from '@/models/event';
-import { getApproximateLocationText } from '@/utils/locationApproximation';
 
 interface DiscoverMapViewProps {
   events: DiscoverEventItem[];
   isLoading: boolean;
   error: string | null;
   center: { lat: number; lon: number };
+  selectedEventId: string | null;
+  onSelectEvent: (eventId: string | null) => void;
   onRetry: () => void;
 }
 
-const MARKER_COLORS = [
-  '#7c3aed', // violet
-  '#2563eb', // blue
-  '#0891b2', // cyan
-  '#059669', // emerald
-  '#ca8a04', // amber
-  '#dc2626', // red
-  '#db2777', // pink
-  '#9333ea', // purple
-];
+interface MappableEvent {
+  event: DiscoverEventItem;
+  position: { lat: number; lng: number };
+  groupSize: number;
+}
 
-function colorForCategory(category: string): string {
-  let hash = 0;
-  for (let i = 0; i < category.length; i++) {
-    hash = (hash * 31 + category.charCodeAt(i)) | 0;
+function getDenseKey(event: DiscoverEventItem): string {
+  return `${(event.location_lat as number).toFixed(4)}:${(event.location_lon as number).toFixed(4)}`;
+}
+
+function buildMappableEvents(events: DiscoverEventItem[]): MappableEvent[] {
+  const eventsWithCoords = events.filter(
+    (e): e is DiscoverEventItem & { location_lat: number; location_lon: number } =>
+      typeof e.location_lat === 'number' &&
+      typeof e.location_lon === 'number' &&
+      Number.isFinite(e.location_lat) &&
+      Number.isFinite(e.location_lon),
+  );
+
+  const groups = new Map<string, number>();
+  for (const e of eventsWithCoords) {
+    const k = getDenseKey(e);
+    groups.set(k, (groups.get(k) ?? 0) + 1);
   }
-  return MARKER_COLORS[Math.abs(hash) % MARKER_COLORS.length];
-}
 
-function buildCategoryIcon(category: string, isSelected: boolean): L.DivIcon {
-  const letter = (category?.[0] ?? '?').toUpperCase();
-  const color = colorForCategory(category ?? '');
-  const size = isSelected ? 44 : 38;
-  const ring = isSelected ? '3px solid #ffffff' : '2px solid #ffffff';
-  const shadow = isSelected
-    ? '0 6px 16px rgba(0,0,0,0.35), 0 0 0 4px rgba(124,58,237,0.18)'
-    : '0 3px 8px rgba(0,0,0,0.25)';
-  const html = `
-    <div style="
-      width:${size}px;
-      height:${size}px;
-      border-radius:50%;
-      background:${color};
-      color:#ffffff;
-      border:${ring};
-      box-shadow:${shadow};
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
-      font-weight:700;
-      font-size:${isSelected ? 17 : 15}px;
-      line-height:1;
-      transition:transform 0.15s;
-    ">${letter}</div>
-  `;
-  return L.divIcon({
-    html,
-    className: 'dc-map-cat-marker',
-    iconSize: [size, size],
-    iconAnchor: [size / 2, size / 2],
+  return eventsWithCoords.map((event, idx) => {
+    const key = getDenseKey(event);
+    const groupSize = groups.get(key) ?? 1;
+    const offset =
+      groupSize > 1
+        ? denseOffset(idx, groupSize)
+        : { lat: 0, lng: 0 };
+    return {
+      event,
+      position: {
+        lat: (event.location_lat as number) + offset.lat,
+        lng: (event.location_lon as number) + offset.lng,
+      },
+      groupSize,
+    };
   });
 }
 
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleDateString(undefined, {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-  });
-}
-
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleTimeString(undefined, {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
+/** Spread overlapping markers in a small ring so they don't fully overlap. */
+function denseOffset(index: number, groupSize: number): { lat: number; lng: number } {
+  const markersPerRing = 8;
+  const ringPos = index % markersPerRing;
+  const visible = Math.min(groupSize, markersPerRing);
+  const angle = (Math.PI * 2 * ringPos) / visible - Math.PI / 2;
+  const radius = 0.00018;
+  return { lat: Math.sin(angle) * radius, lng: Math.cos(angle) * radius };
 }
 
 function MapRecenter({ center }: { center: { lat: number; lon: number } }) {
   const map = useMap();
   useEffect(() => {
-    map.setView([center.lat, center.lon], map.getZoom(), { animate: true });
+    if (!map) return;
+    map.panTo({ lat: center.lat, lng: center.lon });
   }, [center.lat, center.lon, map]);
   return null;
 }
 
-function EventOverlayCard({
-  event,
-  onClose,
-}: {
-  event: DiscoverEventItem;
-  onClose: () => void;
-}) {
-  const color = colorForCategory(event.category_name ?? '');
-
+function MapNotConfigured() {
   return (
-    <div className="dc-map-card" role="dialog" aria-label={`Event: ${event.title}`}>
-      <button
-        type="button"
-        className="dc-map-card-close"
-        onClick={onClose}
-        aria-label="Close event preview"
-      >
-        ×
-      </button>
-
-      <div className="dc-map-card-image">
-        <EventCoverImage
-          src={event.image_url}
-          alt={event.title}
-          imgClassName="dc-map-card-image-img"
-          variant="card"
-        />
-        <span
-          className="dc-map-card-category"
-          style={{ background: color }}
-        >
-          {event.category_name}
-        </span>
-      </div>
-
-      <div className="dc-map-card-body">
-        <h3 className="dc-map-card-title">{event.title}</h3>
-
-        <div className="dc-map-card-meta-row">
-          <span className="dc-map-card-meta">
-            {formatDate(event.start_time)} · {formatTime(event.start_time)}
-          </span>
-        </div>
-
-        {event.location_address && (
-          <p className="dc-map-card-address">{event.location_address}</p>
-        )}
-        {event.is_location_approximate && (
-          <span className="dc-approx-location-badge dc-map-approx-location-badge">
-            {getApproximateLocationText(Boolean(event.location_address))}
-          </span>
-        )}
-
-        <div className="dc-map-card-footer">
-          <span className="dc-map-card-participants">
-            {event.approved_participant_count} participant
-            {event.approved_participant_count !== 1 ? 's' : ''}
-          </span>
-          {event.host_score.final_score != null && (
-            <span className="dc-map-card-score">
-              ★ {event.host_score.final_score.toFixed(1)}
-            </span>
-          )}
-        </div>
-
-        <Link
-          to={`/events/${event.id}`}
-          className="dc-map-card-cta"
-        >
-          View Details &rarr;
-        </Link>
-      </div>
+    <div className="dc-map-overlay" role="status">
+      <h3>Map unavailable</h3>
+      <p>Set <code>VITE_GOOGLE_MAPS_API_KEY</code> in your local environment to enable the Google Maps view.</p>
     </div>
   );
 }
@@ -176,56 +96,81 @@ export default function DiscoverMapView({
   isLoading,
   error,
   center,
+  selectedEventId,
+  onSelectEvent,
   onRetry,
 }: DiscoverMapViewProps) {
-  const mapRef = useRef<L.Map | null>(null);
-  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+  const configured = isGoogleMapsConfigured();
 
-  const mappableEvents = useMemo(
-    () => events.filter((e) => e.location_lat != null && e.location_lon != null),
-    [events],
-  );
+  const mappable = useMemo(() => buildMappableEvents(events), [events]);
 
   useEffect(() => {
-    if (selectedEventId && !mappableEvents.find((e) => e.id === selectedEventId)) {
-      setSelectedEventId(null);
+    if (selectedEventId && !mappable.some((m) => m.event.id === selectedEventId)) {
+      onSelectEvent(null);
     }
-  }, [mappableEvents, selectedEventId]);
-
-  const selectedEvent = mappableEvents.find((e) => e.id === selectedEventId) ?? null;
+  }, [mappable, onSelectEvent, selectedEventId]);
 
   return (
     <div className="dc-map-wrapper" data-testid="discover-map">
-      <MapContainer
-        center={[center.lat, center.lon]}
-        zoom={12}
-        scrollWheelZoom
-        className="dc-map-surface"
-        ref={mapRef}
-      >
-        <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />
-        <MapRecenter center={center} />
-        {mappableEvents.map((event) => (
-          <Marker
-            key={event.id}
-            position={[event.location_lat as number, event.location_lon as number]}
-            icon={buildCategoryIcon(event.category_name ?? '', event.id === selectedEventId)}
-            eventHandlers={{
-              click: () => setSelectedEventId(event.id),
-            }}
-            zIndexOffset={event.id === selectedEventId ? 1000 : 0}
-          />
-        ))}
-      </MapContainer>
-
-      {selectedEvent && (
-        <EventOverlayCard
-          event={selectedEvent}
-          onClose={() => setSelectedEventId(null)}
-        />
+      {configured ? (
+        <GoogleMap
+          key={isDark ? 'dark' : 'light'}
+          mapId={GOOGLE_MAPS_MAP_ID}
+          defaultCenter={{ lat: center.lat, lng: center.lon }}
+          defaultZoom={12}
+          colorScheme={isDark ? 'DARK' : 'LIGHT'}
+          gestureHandling="greedy"
+          disableDefaultUI={false}
+          mapTypeControl={false}
+          streetViewControl={false}
+          fullscreenControl={false}
+          clickableIcons={false}
+          onClick={() => onSelectEvent(null)}
+          onCameraChanged={(_e: MapCameraChangedEvent) => {
+            /* keep camera in user control */
+          }}
+          className="dc-map-surface"
+        >
+          <MapRecenter center={center} />
+          {mappable.map((item) => {
+            const presentation = getEventCategoryPresentation(
+              item.event.category_name ?? '',
+              isDark,
+            );
+            const isSelected = item.event.id === selectedEventId;
+            return (
+              <AdvancedMarker
+                key={item.event.id}
+                position={item.position}
+                onClick={() => onSelectEvent(item.event.id)}
+                zIndex={isSelected ? 1000 : 1}
+              >
+                <div
+                  className={`dc-map-marker ${isSelected ? 'dc-map-marker--selected' : ''}`}
+                  data-testid={`marker-${item.event.id}`}
+                >
+                  <div
+                    className="dc-map-marker-bubble"
+                    style={{ background: presentation.color }}
+                  >
+                    <span className="dc-map-marker-emoji">{presentation.emoji}</span>
+                    {item.groupSize > 1 && (
+                      <span className="dc-map-marker-count">{item.groupSize}</span>
+                    )}
+                  </div>
+                  <div
+                    className="dc-map-marker-tail"
+                    style={{ borderTopColor: presentation.color }}
+                  />
+                </div>
+              </AdvancedMarker>
+            );
+          })}
+        </GoogleMap>
+      ) : (
+        <MapNotConfigured />
       )}
 
       {isLoading && (
@@ -244,7 +189,7 @@ export default function DiscoverMapView({
         </div>
       )}
 
-      {!isLoading && !error && mappableEvents.length === 0 && (
+      {configured && !isLoading && !error && mappable.length === 0 && (
         <div className="dc-map-overlay dc-map-overlay-empty" role="status">
           <h3>No events on the map</h3>
           <p>Try adjusting filters or expanding the radius.</p>

--- a/frontend/src/views/discover/DiscoverPage.tsx
+++ b/frontend/src/views/discover/DiscoverPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { useDiscoverViewMode } from '@/contexts/DiscoverViewModeContext';
 import {
   useDiscoverViewModel,
   RADIUS_OPTIONS,
@@ -10,11 +11,9 @@ import type { DiscoverEventItem, DiscoverSortBy } from '@/models/event';
 import { EventCoverImage } from '@/components/EventCoverImage';
 import { getEventLifecyclePresentation } from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
-import { getApproximateLocationText } from '@/utils/locationApproximation';
 import DiscoverMapView from './DiscoverMapView';
+import DiscoverEventSidePanel from './DiscoverEventSidePanel';
 import '@/styles/discover.css';
-
-type DiscoverViewMode = 'list' | 'map';
 
 const SORT_OPTIONS: { label: string; value: DiscoverSortBy; icon: 'time' | 'distance' }[] = [
   { label: 'Soonest', value: 'START_TIME', icon: 'time' },
@@ -60,6 +59,30 @@ function MapPinIcon({ className }: { className?: string }) {
   );
 }
 
+function CrosshairIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width={18}
+      height={18}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="8" />
+      <circle cx="12" cy="12" r="2" />
+      <line x1="12" y1="2" x2="12" y2="5" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+      <line x1="2" y1="12" x2="5" y2="12" />
+      <line x1="19" y1="12" x2="22" y2="12" />
+    </svg>
+  );
+}
+
 function ChevronDownIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -75,51 +98,6 @@ function ChevronDownIcon({ className }: { className?: string }) {
       aria-hidden
     >
       <path d="m6 9 6 6 6-6" />
-    </svg>
-  );
-}
-
-function ListIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      width={16}
-      height={16}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <line x1="8" y1="6" x2="21" y2="6" />
-      <line x1="8" y1="12" x2="21" y2="12" />
-      <line x1="8" y1="18" x2="21" y2="18" />
-      <line x1="3" y1="6" x2="3.01" y2="6" />
-      <line x1="3" y1="12" x2="3.01" y2="12" />
-      <line x1="3" y1="18" x2="3.01" y2="18" />
-    </svg>
-  );
-}
-
-function MapIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      width={16}
-      height={16}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6" />
-      <line x1="8" y1="2" x2="8" y2="18" />
-      <line x1="16" y1="6" x2="16" y2="22" />
     </svg>
   );
 }
@@ -249,11 +227,6 @@ function EventCard({ event }: { event: DiscoverEventItem }) {
         {event.location_address && (
           <p className="dc-card-location">{event.location_address}</p>
         )}
-        {event.is_location_approximate && (
-          <span className="dc-approx-location-badge">
-            {getApproximateLocationText(Boolean(event.location_address))}
-          </span>
-        )}
 
         <div className="dc-card-footer">
           <span className="dc-card-participants">
@@ -270,14 +243,55 @@ function EventCard({ event }: { event: DiscoverEventItem }) {
   );
 }
 
+function MapEventListItem({
+  event,
+  onSelect,
+  isSelected,
+}: {
+  event: DiscoverEventItem;
+  onSelect: (id: string) => void;
+  isSelected: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={`dc-list-item ${isSelected ? 'selected' : ''}`}
+      onClick={() => onSelect(event.id)}
+    >
+      <div className="dc-list-item-image">
+        <EventCoverImage
+          src={event.image_url}
+          alt={event.title}
+          imgClassName="dc-list-item-image-img"
+          variant="card"
+        />
+      </div>
+      <div className="dc-list-item-body">
+        <div className="dc-list-item-category">{event.category_name}</div>
+        <div className="dc-list-item-title">{event.title}</div>
+        <div className="dc-list-item-meta">
+          {formatDate(event.start_time)} · {formatTime(event.start_time)}
+        </div>
+        {event.location_address && (
+          <div className="dc-list-item-address">{event.location_address}</div>
+        )}
+      </div>
+    </button>
+  );
+}
+
 export default function DiscoverPage() {
   const { token } = useAuth();
   const vm = useDiscoverViewModel(token);
-  const [filtersOpen, setFiltersOpen] = useState(false);
-  const [viewMode, setViewMode] = useState<DiscoverViewMode>('list');
+  const { viewMode } = useDiscoverViewMode();
+  const [filterModalOpen, setFilterModalOpen] = useState(false);
+  const [overlayCollapsed, setOverlayCollapsed] = useState(false);
   const [categoriesExpanded, setCategoriesExpanded] = useState(false);
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const categoryChipsRef = useRef<HTMLDivElement>(null);
   const [categoryChipsNeedExpand, setCategoryChipsNeedExpand] = useState(false);
+
+  const isMapMode = viewMode === 'map';
 
   useLayoutEffect(() => {
     const el = categoryChipsRef.current;
@@ -301,14 +315,16 @@ export default function DiscoverPage() {
     }
   }, [categoryChipsNeedExpand, categoriesExpanded]);
 
+  // The filter button "*" / active highlight should reflect ONLY user-applied
+  // filter knobs — the location selection has its own dedicated UI affordance,
+  // so a default location should not paint the Filters button as "active".
   const hasActiveFilters =
     vm.filters.sortBy !== 'START_TIME' ||
     vm.filters.privacy !== 'ALL' ||
     vm.filters.startFrom !== '' ||
     vm.filters.startTo !== '' ||
     vm.filters.radiusMeters !== 50000 ||
-    vm.filters.categoryId !== null ||
-    vm.hasCustomLocationFilter;
+    vm.filters.categoryId !== null;
 
   useEffect(() => {
     if (!vm.isLocationModalOpen) return;
@@ -324,438 +340,605 @@ export default function DiscoverPage() {
     };
   }, [vm.isLocationModalOpen, vm.closeLocationModal]);
 
-  return (
-    <div className="dc-page">
-      <header className="dc-page-header">
-        <div className="dc-page-header-text">
-          <h1 className="dc-title">Discover Events</h1>
-          <p className="dc-subtitle">Find events happening near you</p>
-        </div>
-        <div className="dc-page-header-location">
+  useEffect(() => {
+    if (!filterModalOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setFilterModalOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      document.body.style.overflow = prev;
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [filterModalOpen]);
+
+  // Clear selection if the selected event is no longer in the loaded list
+  useEffect(() => {
+    if (!selectedEventId) return;
+    if (!vm.events.find((e) => e.id === selectedEventId)) {
+      setSelectedEventId(null);
+    }
+  }, [selectedEventId, vm.events]);
+
+  const selectedEvent =
+    selectedEventId != null
+      ? vm.events.find((e) => e.id === selectedEventId) ?? null
+      : null;
+
+  const titleBlock = (
+    <div className="dc-title-card">
+      <h1 className="dc-title">Discover Events</h1>
+      <p className="dc-subtitle">Find events happening near you</p>
+    </div>
+  );
+
+  const locationButton = (
+    <button
+      type="button"
+      className="dc-location-bar-btn dc-location-bar-btn--wide"
+      onClick={vm.handleLocationButtonClick}
+      aria-haspopup="dialog"
+      aria-expanded={vm.isLocationModalOpen}
+      aria-label={`Location: ${vm.locationShortLabel}. Open location picker.`}
+    >
+      <MapPinIcon className="dc-location-bar-icon" />
+      <span className="dc-location-bar-value">{vm.locationShortLabel}</span>
+      <ChevronDownIcon className="dc-location-bar-chevron" />
+    </button>
+  );
+
+  const searchToolbar = (
+    <div className="dc-search-toolbar">
+      <input
+        type="text"
+        className="field-input dc-search"
+        placeholder="Search events..."
+        value={vm.filters.q}
+        onChange={(e) => vm.updateSearch(e.target.value)}
+      />
+      <button
+        type="button"
+        className={`dc-filter-toggle ${hasActiveFilters ? 'has-filters' : ''}`}
+        onClick={() => setFilterModalOpen(true)}
+      >
+        <FilterIcon className="dc-filter-toggle-icon" />
+        <span>Filters</span>
+      </button>
+      {isMapMode && (
+        <button
+          type="button"
+          className="dc-overlay-collapse-btn"
+          onClick={() => setOverlayCollapsed((v) => !v)}
+          aria-pressed={overlayCollapsed}
+          aria-label={overlayCollapsed ? 'Expand panel' : 'Collapse panel'}
+          title={overlayCollapsed ? 'Expand panel' : 'Collapse panel'}
+        >
+          <ChevronDownIcon
+            className={`dc-overlay-collapse-icon ${
+              overlayCollapsed ? 'dc-overlay-collapse-icon--up' : ''
+            }`}
+          />
+        </button>
+      )}
+    </div>
+  );
+
+  const filterModal = filterModalOpen && (
+    <div
+      className="dc-filter-modal-overlay"
+      role="presentation"
+      onClick={() => setFilterModalOpen(false)}
+    >
+      <div
+        className="dc-filter-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dc-filter-modal-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="dc-filter-modal-header">
+          <h2 id="dc-filter-modal-title" className="dc-filter-modal-title">
+            Filters
+          </h2>
           <button
             type="button"
-            className="dc-location-bar-btn"
-            onClick={vm.handleLocationButtonClick}
-            aria-haspopup="dialog"
-            aria-expanded={vm.isLocationModalOpen}
-            aria-label={`Location: ${vm.locationShortLabel}. Open location picker.`}
+            className="dc-filter-modal-close"
+            onClick={() => setFilterModalOpen(false)}
+            aria-label="Close filters"
           >
-            <MapPinIcon className="dc-location-bar-icon" />
-            <span className="dc-location-bar-value">{vm.locationShortLabel}</span>
-            <ChevronDownIcon className="dc-location-bar-chevron" />
+            ×
           </button>
         </div>
-      </header>
 
-      {vm.showBrowserLocationPrompt && (
-        <div className="dc-location-prompt" role="status">
-          <p className="dc-location-prompt-text">
-            Use your device location for nearby results. Safari requires tapping the button below to allow
-            access.
-          </p>
-          {vm.browserLocationError && (
-            <p className="dc-location-prompt-error">{vm.browserLocationError}</p>
-          )}
-          <div className="dc-location-prompt-actions">
+        <div className="dc-filter-modal-body">
+          <div className="dc-filter-group">
+            <label className="dc-filter-label" id="dc-discover-sort-label">Sort by</label>
+            <div className="dc-sort-row" role="group" aria-labelledby="dc-discover-sort-label">
+              {SORT_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`dc-sort-chip ${vm.filters.sortBy === opt.value ? 'selected' : ''}`}
+                  onClick={() => vm.updateSort(opt.value)}
+                >
+                  <SortOptionIcon kind={opt.icon} className="dc-sort-chip-icon" />
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="dc-filter-group">
+            <label className="dc-filter-label">Radius</label>
+            <div className="dc-chip-row">
+              {RADIUS_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`dc-filter-chip ${vm.filters.radiusMeters === opt.value ? 'selected' : ''}`}
+                  onClick={() => vm.updateFilter('radiusMeters', opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="dc-filter-group">
+            <label className="dc-filter-label">Privacy</label>
+            <div className="dc-chip-row">
+              {PRIVACY_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`dc-filter-chip ${vm.filters.privacy === opt.value ? 'selected' : ''}`}
+                  onClick={() => vm.updateFilter('privacy', opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="dc-filter-group">
+            <label className="dc-filter-label">Date Range</label>
+            <div className="dc-date-row">
+              <input
+                type="date"
+                className="field-input dc-date-input"
+                value={vm.filters.startFrom}
+                onChange={(e) => vm.updateFilter('startFrom', e.target.value)}
+                placeholder="From"
+              />
+              <span className="dc-date-sep">to</span>
+              <input
+                type="date"
+                className="field-input dc-date-input"
+                value={vm.filters.startTo}
+                onChange={(e) => vm.updateFilter('startTo', e.target.value)}
+                placeholder="To"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="dc-filter-modal-footer">
+          {hasActiveFilters && (
             <button
               type="button"
-              className="dc-location-prompt-primary"
+              className="dc-filter-modal-clear"
+              onClick={() => {
+                vm.clearFilters();
+              }}
+            >
+              Clear all
+            </button>
+          )}
+          <button
+            type="button"
+            className="dc-filter-modal-apply"
+            onClick={() => setFilterModalOpen(false)}
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const categoriesBlock = vm.categories.length > 0 && (
+    <div className="dc-category-block">
+      <div
+        ref={categoryChipsRef}
+        className={`dc-category-chips ${
+          categoryChipsNeedExpand && !categoriesExpanded ? 'dc-category-chips--collapsed' : ''
+        }`}
+        role="group"
+        aria-label="Event categories"
+      >
+        {vm.categories.map((cat) => (
+          <button
+            key={cat.id}
+            type="button"
+            className={`dc-category-chip ${vm.filters.categoryId === cat.id ? 'selected' : ''}`}
+            onClick={() => vm.updateCategory(cat.id)}
+          >
+            {cat.name}
+          </button>
+        ))}
+        {categoryChipsNeedExpand && (
+          <button
+            type="button"
+            className="dc-category-expand"
+            onClick={() => setCategoriesExpanded((e) => !e)}
+            aria-expanded={categoriesExpanded}
+          >
+            <span>{categoriesExpanded ? 'Show less' : 'Show more'}</span>
+            <ChevronDownIcon
+              className={`dc-category-expand-chevron ${
+                categoriesExpanded ? 'dc-category-expand-chevron--open' : ''
+              }`}
+            />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  const browserLocationPrompt = vm.showBrowserLocationPrompt && (
+    <div className="dc-location-prompt" role="status">
+      <p className="dc-location-prompt-text">
+        Use your device location for nearby results. Safari requires tapping the button below to allow access.
+      </p>
+      {vm.browserLocationError && (
+        <p className="dc-location-prompt-error">{vm.browserLocationError}</p>
+      )}
+      <div className="dc-location-prompt-actions">
+        <button
+          type="button"
+          className="dc-location-prompt-primary"
+          onClick={vm.requestBrowserLocation}
+          disabled={vm.browserLocationRequestPending}
+        >
+          {vm.browserLocationRequestPending ? 'Requesting…' : 'Use my location'}
+        </button>
+        <button
+          type="button"
+          className="dc-location-prompt-dismiss"
+          onClick={vm.dismissBrowserLocationPrompt}
+        >
+          Not now
+        </button>
+      </div>
+    </div>
+  );
+
+  const eventsListUnderSearch = (
+    <div className="dc-overlay-events">
+      {vm.error && (
+        <div className="dc-overlay-events-status dc-overlay-events-status--error">
+          {vm.error}
+          <button type="button" className="dc-overlay-events-retry" onClick={vm.refresh}>
+            Retry
+          </button>
+        </div>
+      )}
+      {vm.isLoading ? (
+        <div className="dc-overlay-events-status">
+          <span className="spinner" /> Loading events…
+        </div>
+      ) : vm.events.length === 0 && !vm.error ? (
+        <div className="dc-overlay-events-status">
+          No events match your filters.
+        </div>
+      ) : (
+        <ul className="dc-overlay-events-list">
+          {vm.events.map((event) => (
+            <li key={event.id}>
+              <MapEventListItem
+                event={event}
+                onSelect={setSelectedEventId}
+                isSelected={selectedEventId === event.id}
+              />
+            </li>
+          ))}
+          {vm.hasNext && (
+            <li>
+              <button
+                type="button"
+                className="dc-overlay-events-more"
+                onClick={vm.loadMore}
+                disabled={vm.isLoadingMore}
+              >
+                {vm.isLoadingMore ? <span className="spinner" /> : 'Load more'}
+              </button>
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+
+  const browserLocCurrentlyApplied =
+    vm.hasBrowserLocation &&
+    vm.pendingLocation?.display_name?.endsWith('(your location)') === true;
+
+  const defaultLocCurrentlyApplied =
+    !!vm.defaultProfileLocation &&
+    !!vm.pendingLocation &&
+    vm.pendingLocation.lat === vm.defaultProfileLocation.lat &&
+    vm.pendingLocation.lon === vm.defaultProfileLocation.lon;
+
+  const locationModal = vm.isLocationModalOpen && (
+    <div
+      className="dc-loc-modal-overlay"
+      role="presentation"
+      onClick={vm.closeLocationModal}
+    >
+      <div
+        className="dc-loc-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dc-loc-modal-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="dc-loc-modal-header">
+          <button
+            type="button"
+            className="dc-loc-modal-icon-btn"
+            onClick={vm.closeLocationModal}
+            aria-label="Close"
+          >
+            ×
+          </button>
+          <h2 id="dc-loc-modal-title" className="dc-loc-modal-title">
+            Choose location
+          </h2>
+          {vm.defaultProfileLocation ? (
+            <button
+              type="button"
+              className="dc-loc-modal-reset"
+              onClick={vm.resetModalLocationDraft}
+            >
+              Reset
+            </button>
+          ) : (
+            <span className="dc-loc-modal-header-spacer" aria-hidden />
+          )}
+        </div>
+
+        <div className="dc-loc-modal-section">
+          <p className="dc-loc-modal-section-label">Current location</p>
+          {vm.hasBrowserLocation ? (
+            <button
+              type="button"
+              className={`dc-loc-modal-pill ${browserLocCurrentlyApplied ? 'selected' : ''}`}
+              onClick={vm.selectBrowserLocationInModal}
+            >
+              <CrosshairIcon className="dc-loc-modal-pill-icon" />
+              <span>Use my current location</span>
+            </button>
+          ) : vm.browserLocationPermissionDenied ? (
+            <p className="dc-loc-modal-permission">
+              Location permission denied. Allow location access in your browser settings to use your
+              current position.
+            </p>
+          ) : (
+            <button
+              type="button"
+              className="dc-loc-modal-pill"
               onClick={vm.requestBrowserLocation}
               disabled={vm.browserLocationRequestPending}
             >
-              {vm.browserLocationRequestPending ? 'Requesting…' : 'Use my location'}
+              <CrosshairIcon className="dc-loc-modal-pill-icon" />
+              <span>
+                {vm.browserLocationRequestPending
+                  ? 'Requesting permission…'
+                  : 'Need location permission'}
+              </span>
             </button>
-            <button type="button" className="dc-location-prompt-dismiss" onClick={vm.dismissBrowserLocationPrompt}>
-              Not now
+          )}
+        </div>
+
+        {vm.defaultProfileLocation && (
+          <div className="dc-loc-modal-section">
+            <p className="dc-loc-modal-section-label">Default</p>
+            <button
+              type="button"
+              className={`dc-loc-modal-pill ${defaultLocCurrentlyApplied ? 'selected' : ''}`}
+              onClick={vm.selectDefaultProfileInModal}
+            >
+              <MapPinIcon className="dc-loc-modal-pill-icon" />
+              <span>{formatEventLocation(vm.defaultProfileLocation.display_name)}</span>
             </button>
           </div>
-        </div>
-      )}
+        )}
 
-      <div className="dc-filters">
-        <div className="dc-search-toolbar">
+        {vm.favoriteLocations.length > 0 && (
+          <div className="dc-loc-modal-section dc-loc-modal-section--favorites">
+            <p className="dc-loc-modal-section-label">Favorite locations</p>
+            <ul className="dc-loc-modal-fav-list">
+              {vm.favoriteLocations.map((fav) => {
+                const selected =
+                  vm.pendingLocation != null &&
+                  Number(vm.pendingLocation.lat) === fav.lat &&
+                  Number(vm.pendingLocation.lon) === fav.lon;
+                return (
+                  <li key={fav.id}>
+                    <button
+                      type="button"
+                      className={`dc-loc-modal-fav-item ${selected ? 'selected' : ''}`}
+                      onClick={() => vm.selectFavoriteInModal(fav)}
+                    >
+                      <span className="dc-loc-modal-fav-name">{fav.name}</span>
+                      <span className="dc-loc-modal-fav-address">{fav.address}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        <div className="dc-loc-modal-search">
+          <SearchIcon className="dc-loc-modal-search-icon" />
           <input
             type="text"
-            className="field-input dc-search"
-            placeholder="Search events..."
-            value={vm.filters.q}
-            onChange={(e) => vm.updateSearch(e.target.value)}
+            className="dc-loc-modal-input field-input"
+            placeholder="Search for a location"
+            value={vm.modalLocationQuery}
+            onChange={(e) => vm.updateModalLocationQuery(e.target.value)}
+            autoComplete="off"
+            autoCorrect="off"
           />
-          <div
-            className="dc-view-toggle"
-            role="group"
-            aria-label="View mode"
-          >
-            <button
-              type="button"
-              className={`dc-view-toggle-btn ${viewMode === 'list' ? 'active' : ''}`}
-              onClick={() => setViewMode('list')}
-              aria-pressed={viewMode === 'list'}
-              title="List view"
-            >
-              <ListIcon className="dc-view-toggle-icon" />
-              <span className="dc-view-toggle-label">List</span>
-            </button>
-            <button
-              type="button"
-              className={`dc-view-toggle-btn ${viewMode === 'map' ? 'active' : ''}`}
-              onClick={() => setViewMode('map')}
-              aria-pressed={viewMode === 'map'}
-              title="Map view"
-            >
-              <MapIcon className="dc-view-toggle-icon" />
-              <span className="dc-view-toggle-label">Map</span>
-            </button>
-          </div>
-          <button
-            type="button"
-            className={`dc-filter-toggle ${filtersOpen ? 'active' : ''} ${hasActiveFilters ? 'has-filters' : ''}`}
-            onClick={() => setFiltersOpen(!filtersOpen)}
-          >
-            <FilterIcon className="dc-filter-toggle-icon" />
-            <span>
-              Filters{hasActiveFilters ? ' *' : ''}
-            </span>
-          </button>
         </div>
 
-        {/* Collapsible filters panel */}
-        {filtersOpen && (
-          <div className="dc-filter-panel">
-            {/* Sort */}
-            <div className="dc-filter-group">
-              <label className="dc-filter-label" id="dc-discover-sort-label">
-                Sort by
-              </label>
-              <div className="dc-sort-row" role="group" aria-labelledby="dc-discover-sort-label">
-                {SORT_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    className={`dc-sort-chip ${vm.filters.sortBy === opt.value ? 'selected' : ''}`}
-                    onClick={() => vm.updateSort(opt.value)}
-                  >
-                    <SortOptionIcon kind={opt.icon} className="dc-sort-chip-icon" />
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Radius */}
-            <div className="dc-filter-group">
-              <label className="dc-filter-label">Radius</label>
-              <div className="dc-chip-row">
-                {RADIUS_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    className={`dc-filter-chip ${vm.filters.radiusMeters === opt.value ? 'selected' : ''}`}
-                    onClick={() => vm.updateFilter('radiusMeters', opt.value)}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Privacy */}
-            <div className="dc-filter-group">
-              <label className="dc-filter-label">Privacy</label>
-              <div className="dc-chip-row">
-                {PRIVACY_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    className={`dc-filter-chip ${vm.filters.privacy === opt.value ? 'selected' : ''}`}
-                    onClick={() => vm.updateFilter('privacy', opt.value)}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Date range */}
-            <div className="dc-filter-group">
-              <label className="dc-filter-label">Date Range</label>
-              <div className="dc-date-row">
-                <input
-                  type="date"
-                  className="field-input dc-date-input"
-                  value={vm.filters.startFrom}
-                  onChange={(e) => vm.updateFilter('startFrom', e.target.value)}
-                  placeholder="From"
-                />
-                <span className="dc-date-sep">to</span>
-                <input
-                  type="date"
-                  className="field-input dc-date-input"
-                  value={vm.filters.startTo}
-                  onChange={(e) => vm.updateFilter('startTo', e.target.value)}
-                  placeholder="To"
-                />
-              </div>
-            </div>
-
-            {/* Clear */}
-            {hasActiveFilters && (
-              <button
-                type="button"
-                className="dc-clear-btn"
-                onClick={vm.clearFilters}
-              >
-                Clear All Filters
-              </button>
+        {(vm.modalLocationSearching ||
+          vm.modalLocationResults.length > 0 ||
+          vm.modalLocationQuery.trim().length >= 2) && (
+          <div className="dc-loc-modal-list-wrap">
+            {vm.modalLocationSearching ? (
+              <p className="dc-loc-modal-hint">Searching…</p>
+            ) : vm.modalLocationResults.length > 0 ? (
+              <ul className="dc-loc-modal-suggestions">
+                {vm.modalLocationResults.map((loc, i) => {
+                  const selected =
+                    vm.pendingLocation != null &&
+                    vm.pendingLocation.lat === loc.lat &&
+                    vm.pendingLocation.lon === loc.lon;
+                  return (
+                    <li key={`${loc.lat}-${loc.lon}-${i}`}>
+                      <button
+                        type="button"
+                        className={`dc-loc-modal-suggestion ${selected ? 'selected' : ''}`}
+                        onClick={() => vm.selectModalSuggestion(loc)}
+                      >
+                        {formatEventLocation(loc.display_name)}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="dc-loc-modal-hint">No locations found.</p>
             )}
           </div>
         )}
 
-        {/* Categories */}
-        {vm.categories.length > 0 && (
-          <div className="dc-category-block">
-            <p
-              className="dc-inline-control-label dc-category-label"
-              id="dc-discover-categories-label"
-            >
-              Categories
-            </p>
-            <div className="dc-category-row-with-expand">
-              <div
-                ref={categoryChipsRef}
-                className={`dc-category-chips ${categoryChipsNeedExpand && !categoriesExpanded ? 'dc-category-chips--collapsed' : ''}`}
-                role="group"
-                aria-labelledby="dc-discover-categories-label"
-              >
-                {vm.categories.map((cat) => (
-                  <button
-                    key={cat.id}
-                    type="button"
-                    className={`dc-category-chip ${vm.filters.categoryId === cat.id ? 'selected' : ''}`}
-                    onClick={() => vm.updateCategory(cat.id)}
-                  >
-                    {cat.name}
-                  </button>
-                ))}
-              </div>
-              {categoryChipsNeedExpand && (
-                <button
-                  type="button"
-                  className="dc-category-expand"
-                  onClick={() => setCategoriesExpanded((e) => !e)}
-                  aria-expanded={categoriesExpanded}
-                >
-                  <span>{categoriesExpanded ? 'Show less' : 'Show more'}</span>
-                  <ChevronDownIcon
-                    className={`dc-category-expand-chevron ${categoriesExpanded ? 'dc-category-expand-chevron--open' : ''}`}
-                  />
-                </button>
-              )}
-            </div>
-          </div>
-        )}
+        <button type="button" className="dc-loc-modal-apply" onClick={vm.applyModalLocation}>
+          Apply
+        </button>
       </div>
+    </div>
+  );
 
-      {vm.isLocationModalOpen && (
-        <div
-          className="dc-loc-modal-overlay"
-          role="presentation"
-          onClick={vm.closeLocationModal}
-        >
-          <div
-            className="dc-loc-modal"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="dc-loc-modal-title"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="dc-loc-modal-header">
-              <button
-                type="button"
-                className="dc-loc-modal-icon-btn"
-                onClick={vm.closeLocationModal}
-                aria-label="Close"
-              >
-                ×
-              </button>
-              <h2 id="dc-loc-modal-title" className="dc-loc-modal-title">
-                Choose location
-              </h2>
-              {vm.defaultProfileLocation ? (
-                <button
-                  type="button"
-                  className="dc-loc-modal-reset"
-                  onClick={vm.resetModalLocationDraft}
-                >
-                  Reset
-                </button>
-              ) : (
-                <span className="dc-loc-modal-header-spacer" aria-hidden />
-              )}
-            </div>
-
-            {vm.defaultProfileLocation && (
-              <div className="dc-loc-modal-section">
-                <p className="dc-loc-modal-section-label">Default</p>
-                <button
-                  type="button"
-                  className={`dc-loc-modal-pill ${
-                    vm.pendingLocation &&
-                    vm.pendingLocation.lat === vm.defaultProfileLocation.lat &&
-                    vm.pendingLocation.lon === vm.defaultProfileLocation.lon
-                      ? 'selected'
-                      : ''
-                  }`}
-                  onClick={vm.selectDefaultProfileInModal}
-                >
-                  <MapPinIcon className="dc-loc-modal-pill-icon" />
-                  <span>{formatEventLocation(vm.defaultProfileLocation.display_name)}</span>
-                </button>
-              </div>
-            )}
-
-            {vm.favoriteLocations.length > 0 && (
-              <div className="dc-loc-modal-section">
-                <p className="dc-loc-modal-section-label">Favorite locations</p>
-                <ul className="dc-loc-modal-fav-list">
-                  {vm.favoriteLocations.map((fav) => {
-                    const selected =
-                      vm.pendingLocation != null &&
-                      Number(vm.pendingLocation.lat) === fav.lat &&
-                      Number(vm.pendingLocation.lon) === fav.lon;
-                    return (
-                      <li key={fav.id}>
-                        <button
-                          type="button"
-                          className={`dc-loc-modal-fav-item ${selected ? 'selected' : ''}`}
-                          onClick={() => vm.selectFavoriteInModal(fav)}
-                        >
-                          <span className="dc-loc-modal-fav-name">{fav.name}</span>
-                          <span className="dc-loc-modal-fav-address">{fav.address}</span>
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            )}
-
-            <div className="dc-loc-modal-search">
-              <SearchIcon className="dc-loc-modal-search-icon" />
-              <input
-                type="text"
-                className="dc-loc-modal-input field-input"
-                placeholder="Search for a location"
-                value={vm.modalLocationQuery}
-                onChange={(e) => vm.updateModalLocationQuery(e.target.value)}
-                autoComplete="off"
-                autoCorrect="off"
-              />
-            </div>
-
-            <div className="dc-loc-modal-list-wrap">
-              {vm.modalLocationSearching ? (
-                <p className="dc-loc-modal-hint">Searching…</p>
-              ) : vm.modalLocationResults.length > 0 ? (
-                <ul className="dc-loc-modal-suggestions">
-                  {vm.modalLocationResults.map((loc, i) => {
-                    const selected =
-                      vm.pendingLocation != null &&
-                      vm.pendingLocation.lat === loc.lat &&
-                      vm.pendingLocation.lon === loc.lon;
-                    return (
-                      <li key={`${loc.lat}-${loc.lon}-${i}`}>
-                        <button
-                          type="button"
-                          className={`dc-loc-modal-suggestion ${selected ? 'selected' : ''}`}
-                          onClick={() => vm.selectModalSuggestion(loc)}
-                        >
-                          {formatEventLocation(loc.display_name)}
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              ) : vm.modalLocationQuery.trim().length >= 2 ? (
-                <p className="dc-loc-modal-hint">No locations found.</p>
-              ) : vm.pendingLocation ? (
-                <p className="dc-loc-modal-hint muted">Use favorites or default above, or search below.</p>
-              ) : (
-                <p className="dc-loc-modal-hint">Type at least 2 characters to search.</p>
-              )}
-            </div>
-
-            <button type="button" className="dc-loc-modal-apply" onClick={vm.applyModalLocation}>
-              {vm.pendingLocation &&
-              vm.defaultProfileLocation &&
-              vm.pendingLocation.lat === vm.defaultProfileLocation.lat &&
-              vm.pendingLocation.lon === vm.defaultProfileLocation.lon
-                ? 'Use default location'
-                : 'Apply'}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {viewMode === 'map' ? (
+  if (isMapMode) {
+    return (
+      <div className="dc-page dc-page--map">
         <DiscoverMapView
           events={vm.events}
           isLoading={vm.isLoading}
           error={vm.error}
           center={vm.mapCenter}
+          selectedEventId={selectedEventId}
+          onSelectEvent={setSelectedEventId}
           onRetry={vm.refresh}
         />
-      ) : (
+
+        <div
+          className={`dc-overlay dc-overlay-top-left ${
+            overlayCollapsed ? 'dc-overlay-top-left--collapsed' : ''
+          }`}
+        >
+          {titleBlock}
+          {searchToolbar}
+          {!overlayCollapsed && browserLocationPrompt}
+          {!overlayCollapsed && eventsListUnderSearch}
+        </div>
+
+        {categoriesBlock && (
+          <div className="dc-overlay dc-overlay-top-center">{categoriesBlock}</div>
+        )}
+
+        <div className="dc-overlay dc-overlay-top-right">{locationButton}</div>
+
+        {selectedEvent && (
+          <DiscoverEventSidePanel
+            event={selectedEvent}
+            onClose={() => setSelectedEventId(null)}
+          />
+        )}
+
+        {locationModal}
+        {filterModal}
+      </div>
+    );
+  }
+
+  // List view
+  return (
+    <div className="dc-page">
+      <header className="dc-page-header">
+        <div className="dc-page-header-text">
+          {titleBlock}
+        </div>
+        <div className="dc-page-header-location">{locationButton}</div>
+      </header>
+
+      {browserLocationPrompt}
+
+      <div className="dc-filters">
+        {searchToolbar}
+        {categoriesBlock}
+      </div>
+
+      {locationModal}
+      {filterModal}
+
+      {vm.error && (
+        <div className="error-banner">
+          {vm.error}
+          <button type="button" className="dc-retry-btn" onClick={vm.refresh}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {vm.isLoading && (
+        <div className="dc-loading">
+          <span className="spinner" />
+          <p>Loading events...</p>
+        </div>
+      )}
+
+      {!vm.isLoading && !vm.error && vm.events.length === 0 && (
+        <div className="dc-empty">
+          <h2>No events found</h2>
+          <p>Try adjusting your filters or search to find events.</p>
+        </div>
+      )}
+
+      {!vm.isLoading && vm.events.length > 0 && (
         <>
-          {/* Error */}
-          {vm.error && (
-            <div className="error-banner">
-              {vm.error}
-              <button type="button" className="dc-retry-btn" onClick={vm.refresh}>
-                Retry
+          <div className="dc-grid">
+            {vm.events.map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </div>
+
+          {vm.hasNext && (
+            <div className="dc-load-more">
+              <button
+                type="button"
+                className="dc-load-more-btn"
+                onClick={vm.loadMore}
+                disabled={vm.isLoadingMore}
+              >
+                {vm.isLoadingMore ? <span className="spinner" /> : 'Load More'}
               </button>
             </div>
-          )}
-
-          {/* Loading */}
-          {vm.isLoading && (
-            <div className="dc-loading">
-              <span className="spinner" />
-              <p>Loading events...</p>
-            </div>
-          )}
-
-          {/* Empty state */}
-          {!vm.isLoading && !vm.error && vm.events.length === 0 && (
-            <div className="dc-empty">
-              <h2>No events found</h2>
-              <p>Try adjusting your filters or search to find events.</p>
-            </div>
-          )}
-
-          {/* Event list */}
-          {!vm.isLoading && vm.events.length > 0 && (
-            <>
-              <div className="dc-grid">
-                {vm.events.map((event) => (
-                  <EventCard key={event.id} event={event} />
-                ))}
-              </div>
-
-              {/* Load more */}
-              {vm.hasNext && (
-                <div className="dc-load-more">
-                  <button
-                    type="button"
-                    className="dc-load-more-btn"
-                    onClick={vm.loadMore}
-                    disabled={vm.isLoadingMore}
-                  >
-                    {vm.isLoadingMore ? <span className="spinner" /> : 'Load More'}
-                  </button>
-                </div>
-              )}
-            </>
           )}
         </>
       )}

--- a/frontend/src/views/events/EventDetailMiniMap.tsx
+++ b/frontend/src/views/events/EventDetailMiniMap.tsx
@@ -1,7 +1,15 @@
-import { useMemo } from 'react';
-import { Circle, MapContainer, Marker, Polyline, TileLayer } from 'react-leaflet';
-import L from 'leaflet';
-import 'leaflet/dist/leaflet.css';
+import { useEffect, useMemo } from 'react';
+import {
+  AdvancedMarker,
+  Map as GoogleMap,
+  Pin,
+  useMap,
+} from '@vis.gl/react-google-maps';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  GOOGLE_MAPS_MAP_ID,
+  isGoogleMapsConfigured,
+} from '@/components/GoogleMapsProvider';
 import type { EventDetailLocation } from '@/models/event';
 import { APPROXIMATE_LOCATION_RADIUS_METERS } from '@/utils/locationApproximation';
 
@@ -9,65 +17,111 @@ interface EventDetailMiniMapProps {
   location: EventDetailLocation;
 }
 
-const markerIcon = L.icon({
-  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
-  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41],
-});
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+function ApproximateAreaCircle({
+  center,
+}: {
+  center: LatLng;
+}) {
+  const map = useMap();
+  useEffect(() => {
+    if (!map) return;
+    const circle = new google.maps.Circle({
+      map,
+      center,
+      radius: APPROXIMATE_LOCATION_RADIUS_METERS,
+      strokeColor: '#2563eb',
+      strokeOpacity: 1,
+      strokeWeight: 2,
+      fillColor: '#60a5fa',
+      fillOpacity: 0.22,
+      clickable: false,
+    });
+    return () => {
+      circle.setMap(null);
+    };
+  }, [center, map]);
+  return null;
+}
+
+function RoutePolyline({ path }: { path: LatLng[] }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!map || path.length < 2) return;
+    const polyline = new google.maps.Polyline({
+      map,
+      path,
+      strokeColor: '#7c3aed',
+      strokeOpacity: 1,
+      strokeWeight: 4,
+      clickable: false,
+    });
+    return () => {
+      polyline.setMap(null);
+    };
+  }, [map, path]);
+  return null;
+}
 
 export default function EventDetailMiniMap({ location }: EventDetailMiniMapProps) {
-  const anchor = useMemo(() => {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  const anchor = useMemo<LatLng | null>(() => {
     if (location.type === 'POINT' && location.point) {
-      return { lat: location.point.lat, lon: location.point.lon };
+      return { lat: location.point.lat, lng: location.point.lon };
     }
     if (location.type === 'ROUTE' && location.route_points.length > 0) {
-      return { lat: location.route_points[0].lat, lon: location.route_points[0].lon };
+      const first = location.route_points[0];
+      return { lat: first.lat, lng: first.lon };
     }
     return null;
   }, [location]);
 
-  if (!anchor) {
-    return null;
+  const routePath = useMemo<LatLng[]>(() => {
+    if (location.type !== 'ROUTE') return [];
+    return location.route_points.map((p) => ({ lat: p.lat, lng: p.lon }));
+  }, [location]);
+
+  if (!anchor) return null;
+
+  if (!isGoogleMapsConfigured()) {
+    return (
+      <div className="ed-map-surface ed-map-surface--placeholder" role="status">
+        <p>Map preview is unavailable. Configure VITE_GOOGLE_MAPS_API_KEY to view this location.</p>
+      </div>
+    );
   }
 
-  const polylinePositions: [number, number][] =
-    location.type === 'ROUTE'
-      ? location.route_points.map((p) => [p.lat, p.lon])
-      : [];
-
   return (
-    <MapContainer
-      center={[anchor.lat, anchor.lon]}
-      zoom={14}
-      scrollWheelZoom={false}
+    <GoogleMap
+      key={isDark ? 'dark' : 'light'}
+      mapId={GOOGLE_MAPS_MAP_ID}
+      defaultCenter={anchor}
+      defaultZoom={14}
+      colorScheme={isDark ? 'DARK' : 'LIGHT'}
+      gestureHandling="cooperative"
+      disableDefaultUI={false}
+      mapTypeControl={false}
+      streetViewControl={false}
+      fullscreenControl={false}
+      clickableIcons={false}
       className="ed-map-surface"
-      attributionControl
     >
-      <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      />
       {location.is_location_approximate ? (
-        <Circle
-          center={[anchor.lat, anchor.lon]}
-          radius={APPROXIMATE_LOCATION_RADIUS_METERS}
-          pathOptions={{
-            color: '#2563eb',
-            fillColor: '#60a5fa',
-            fillOpacity: 0.22,
-            weight: 2,
-          }}
-        />
+        <ApproximateAreaCircle center={anchor} />
       ) : (
-        <Marker position={[anchor.lat, anchor.lon]} icon={markerIcon} />
+        <AdvancedMarker position={anchor}>
+          <Pin background="#2563eb" borderColor="#1d4ed8" glyphColor="#ffffff" />
+        </AdvancedMarker>
       )}
-      {!location.is_location_approximate && polylinePositions.length > 1 && (
-        <Polyline positions={polylinePositions} pathOptions={{ color: '#7c3aed', weight: 4 }} />
+      {!location.is_location_approximate && routePath.length > 1 && (
+        <RoutePolyline path={routePath} />
       )}
-    </MapContainer>
+    </GoogleMap>
   );
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GOOGLE_MAPS_API_KEY?: string;
+  readonly VITE_GOOGLE_MAPS_MAP_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## 📋 Summary
Migrate the frontend map provider from Leaflet/OSM to Google Maps and rebuild the Discover page as an immersive, full-bleed map view with floating overlays, a centered filters modal, a scrollable in-map events list, and a dedicated right-side event details panel that fetches the full event detail from the backend.

## 🔄 Changes

**Map provider migration**
- Replace `leaflet` / `react-leaflet` / `@types/leaflet` with `@vis.gl/react-google-maps`.
- Add `frontend/src/components/GoogleMapsProvider.tsx` (`<APIProvider>` wrapper + graceful fallback when `VITE_GOOGLE_MAPS_API_KEY` is missing) and mount it in `App.tsx`.
- Add `VITE_GOOGLE_MAPS_API_KEY` / `VITE_GOOGLE_MAPS_MAP_ID` env wiring (`.env.example`, typed `vite-env.d.ts`, `.gitignore` for `.env*`).
- Update `frontend/AGENTS.md` to declare Google Maps as the new map stack.

**Discover page redesign (map mode)**
- Default view is now `'map'`, persisted in `localStorage` via the new `DiscoverViewModeContext`.
- Move the List/Map toggle into the global header (`AppShell`), rendered only on `/discover`, and drop it from the page toolbar.
- Restructure `DiscoverPage` as a full-bleed map with floating overlays:
  - Top-left: title card + search pill + Filters pill + collapse arrow + (collapsible) scrollable events list / browser-location prompt.
  - Top-center: horizontal category chips with "Show more / less".
  - Top-right: wider primary location button.
  - Right side: floating, rounded event details panel that opens on marker / list click.
- Filters now open a centered popup modal (`Sort by`, `Radius`, `Privacy`, `Date Range`, `Clear all`, `Done`).
- Categories chips have no card background or label and the "Show more" button sits inline right after the last chip.
- Search input adopts the long-pill shape to match the Filters button.
- Removed the "Approximate location" badge from the discover event cards.

**Google Maps Discover view + side panel**
- Rewrite `DiscoverMapView` to use `<Map>` + `<AdvancedMarker>` with theme-aware `colorScheme`, dense-cluster offsetting, and category-bubble markers (port of mobile's pattern; new `eventCategoryPresentation.ts` util).
- New `DiscoverEventSidePanel` floats with rounded corners, fetches the full event via `getEventDetail`, and shows category, lifecycle, title, privacy, date/time range, address (with optional approximate-area note), going / capacity, age + preferred gender, favorite count, host avatar + name + score, description (4-line clamp), tags, and a "Go to event page →" CTA.

**Location modal**
- Add a "Current location" section above Default — pill button when granted, "Need location permission" / "Requesting permission…" affordance otherwise, and a friendly notice when explicitly denied.
- Tightened section spacing.
- Apply button now always reads "Apply" (no more conditional "Use default location" label).

**`EventDetailMiniMap` migration**
- Rewrite using `<Map>` + `<AdvancedMarker>` / `<Pin>`, theme-aware. Approximate locations draw a `google.maps.Circle` (existing colors, 250 m radius); routes draw a `google.maps.Polyline` (#7c3aed, weight 4). Renders a placeholder when the API key is missing.

**Header polish**
- All header buttons normalized to a uniform `40px` height (`shell-nav-link`, `shell-view-toggle`, `shell-user-btn`, `shell-create-btn`, `shell-admin-btn`).
- Bigger SEM logo (height 48 → 56) without changing the 64 px header height.
- Bolder username; smaller (28 px) avatar inside the profile button so it doesn't touch the edges.

**CSS / theming**
- Drop Leaflet-specific CSS rules.
- Add `dc-page--map` full-bleed layout, overlay containers, marker bubble, side-panel, wider location button, filter modal, in-map events list, and a dark-mode override for every new surface (overlays still legible; map flips via Google's `colorScheme` prop).

## 🧪 Testing
- `cd frontend && npm install`
- `npm run build` — type-check + production build pass.
- `npm test` — all 134 tests across 24 files pass.
- Manual: copy `frontend/.env.example` → `frontend/.env.local` and set `VITE_GOOGLE_MAPS_API_KEY`, then `npm run dev`. On `/discover`:
  - Map loads with the saved default view; the global header List/Map toggle switches modes and persists across reloads (`localStorage`).
  - Title card / search pill / Filters pill / collapse arrow stay visible at top-left; the down-arrow collapses the events list and browser-location prompt and rotates 180° when collapsed.
  - Click a marker or a list item — the floating right-side panel opens with the full event detail (description, host, tags, etc.) and Escape / × closes it.
  - The Filters button opens a centered modal; toggling chips updates the result list and markers immediately.
  - The wider top-right location button opens the choose-location modal; "Use my current location", default, favorites, and search results all apply via a single "Apply" button.
  - Toggle dark mode — map tiles, overlays, side panel, and category chips all adapt.
