### PR TITLE
fix(backend): enable ticketing for all event privacy levels

### DIFF
--- a/backend/internal/adapter/in/postgres/ticket_repo.go
+++ b/backend/internal/adapter/in/postgres/ticket_repo.go
@@ -30,7 +30,7 @@ func NewTicketRepository(pool *pgxpool.Pool) *TicketRepository {
 	}
 }
 
-// CreateTicketForParticipation creates or reactivates a non-terminal ticket for an approved participation.
+// CreateTicketForParticipation creates or reactivates the ticket for an approved participation.
 func (r *TicketRepository) CreateTicketForParticipation(ctx context.Context, participationID uuid.UUID, status domain.TicketStatus) (*domain.Ticket, error) {
 	row := r.db.QueryRow(ctx, `
 		WITH participation_event AS (

--- a/backend/internal/adapter/in/postgres/ticket_repo.go
+++ b/backend/internal/adapter/in/postgres/ticket_repo.go
@@ -30,7 +30,7 @@ func NewTicketRepository(pool *pgxpool.Pool) *TicketRepository {
 	}
 }
 
-// CreateTicketForParticipation creates or reactivates a non-terminal ticket for an invite-gated participation.
+// CreateTicketForParticipation creates or reactivates a non-terminal ticket for an approved participation.
 func (r *TicketRepository) CreateTicketForParticipation(ctx context.Context, participationID uuid.UUID, status domain.TicketStatus) (*domain.Ticket, error) {
 	row := r.db.QueryRow(ctx, `
 		WITH participation_event AS (
@@ -39,14 +39,13 @@ func (r *TicketRepository) CreateTicketForParticipation(ctx context.Context, par
 			FROM participation p
 			JOIN event e ON e.id = p.event_id
 			WHERE p.id = $1
-			  AND e.privacy_level IN ($3, $6)
 		),
 		existing AS (
 			SELECT t.id
 			FROM ticket t
 			JOIN participation_event pe ON pe.participation_id = t.participation_id
 			ORDER BY
-				CASE WHEN t.status IN ($4, $5) THEN 0 ELSE 1 END,
+				CASE WHEN t.status IN ($3, $4) THEN 0 ELSE 1 END,
 				t.updated_at DESC,
 				t.created_at DESC
 			LIMIT 1
@@ -84,12 +83,12 @@ func (r *TicketRepository) CreateTicketForParticipation(ctx context.Context, par
 		       expires_at, used_at, canceled_at, created_at, updated_at
 		FROM inserted
 		LIMIT 1
-	`, participationID, status, domain.PrivacyProtected, domain.TicketStatusActive, domain.TicketStatusPending, domain.PrivacyPrivate)
+	`, participationID, status, domain.TicketStatusActive, domain.TicketStatusPending)
 
 	ticket, err := scanTicket(row)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
-			return nil, domain.NotFoundError(domain.ErrorCodeTicketNotFound, "The linked protected participation does not exist.")
+			return nil, domain.NotFoundError(domain.ErrorCodeTicketNotFound, "The linked participation does not exist.")
 		}
 		return nil, fmt.Errorf("create ticket for participation: %w", err)
 	}

--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -141,7 +141,7 @@ func (s *Service) CreateManualParticipation(ctx context.Context, input CreateMan
 			Status:          participation.Status,
 		}
 
-		if eventState.PrivacyLevel == domain.PrivacyProtected && participation.Status == domain.ParticipationStatusApproved {
+		if participation.Status == domain.ParticipationStatusApproved {
 			createdTicket, err := s.tickets.CreateTicketForParticipation(ctx, participation, domain.TicketStatusActive)
 			if err != nil {
 				return err

--- a/backend/internal/application/admin/service_test.go
+++ b/backend/internal/application/admin/service_test.go
@@ -1,0 +1,147 @@
+package admin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+type fakeUnitOfWork struct {
+	callCount int
+}
+
+func (u *fakeUnitOfWork) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	u.callCount++
+	return fn(ctx)
+}
+
+type fakeRepository struct {
+	eventState    *AdminEventState
+	participation *domain.Participation
+	existingUsers int
+}
+
+func (r *fakeRepository) ListUsers(context.Context, ListUsersInput) (*ListUsersResult, error) {
+	return nil, nil
+}
+
+func (r *fakeRepository) ListEvents(context.Context, ListEventsInput) (*ListEventsResult, error) {
+	return nil, nil
+}
+
+func (r *fakeRepository) ListParticipations(context.Context, ListParticipationsInput) (*ListParticipationsResult, error) {
+	return nil, nil
+}
+
+func (r *fakeRepository) ListTickets(context.Context, ListTicketsInput) (*ListTicketsResult, error) {
+	return nil, nil
+}
+
+func (r *fakeRepository) ListNotifications(context.Context, ListNotificationsInput) (*ListNotificationsResult, error) {
+	return nil, nil
+}
+
+func (r *fakeRepository) CountExistingUsers(context.Context, []uuid.UUID) (int, error) {
+	return r.existingUsers, nil
+}
+
+func (r *fakeRepository) GetEventState(context.Context, uuid.UUID, bool) (*AdminEventState, error) {
+	return r.eventState, nil
+}
+
+func (r *fakeRepository) CreateManualParticipation(context.Context, uuid.UUID, uuid.UUID, domain.ParticipationStatus) (*domain.Participation, error) {
+	return r.participation, nil
+}
+
+func (r *fakeRepository) GetParticipationByID(context.Context, uuid.UUID, bool) (*domain.Participation, error) {
+	return nil, nil
+}
+
+func (r *fakeRepository) CancelParticipation(context.Context, uuid.UUID) (*domain.Participation, bool, error) {
+	return nil, false, nil
+}
+
+type fakeTicketLifecycle struct {
+	createCallCount   int
+	lastParticipation *domain.Participation
+	lastStatus        domain.TicketStatus
+}
+
+func (f *fakeTicketLifecycle) CreateTicketForParticipation(_ context.Context, participation *domain.Participation, status domain.TicketStatus) (*domain.Ticket, error) {
+	f.createCallCount++
+	f.lastParticipation = participation
+	f.lastStatus = status
+	return &domain.Ticket{ID: uuid.New(), ParticipationID: participation.ID, Status: status}, nil
+}
+
+func (f *fakeTicketLifecycle) CancelTicketForParticipation(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeTicketLifecycle) CancelTicketsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeTicketLifecycle) ExpireTicketsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeTicketLifecycle) MarkTicketsPendingForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeTicketLifecycle) ActivatePendingTicketsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+
+var _ ticket.LifecycleUseCase = (*fakeTicketLifecycle)(nil)
+
+func TestCreateManualParticipationCreatesTicketForPublicApprovedParticipation(t *testing.T) {
+	// given
+	eventID := uuid.New()
+	userID := uuid.New()
+	participationID := uuid.New()
+	repo := &fakeRepository{
+		eventState: &AdminEventState{
+			ID:           eventID,
+			PrivacyLevel: domain.PrivacyPublic,
+		},
+		participation: &domain.Participation{
+			ID:      participationID,
+			EventID: eventID,
+			UserID:  userID,
+			Status:  domain.ParticipationStatusApproved,
+		},
+		existingUsers: 1,
+	}
+	tickets := &fakeTicketLifecycle{}
+	service := NewService(repo, WithMutationDependencies(nil, tickets, &fakeUnitOfWork{}))
+
+	// when
+	result, err := service.CreateManualParticipation(context.Background(), CreateManualParticipationInput{
+		AdminUserID: uuid.New(),
+		EventID:     eventID,
+		UserID:      userID,
+		Status:      domain.ParticipationStatusApproved,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("CreateManualParticipation() error = %v", err)
+	}
+	if tickets.createCallCount != 1 {
+		t.Fatalf("expected ticket creation once, got %d", tickets.createCallCount)
+	}
+	if tickets.lastParticipation == nil || tickets.lastParticipation.ID != participationID {
+		t.Fatalf("expected ticket participation %s, got %+v", participationID, tickets.lastParticipation)
+	}
+	if tickets.lastStatus != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE ticket status, got %q", tickets.lastStatus)
+	}
+	if result.TicketStatus == nil || *result.TicketStatus != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE ticket status in result, got %+v", result.TicketStatus)
+	}
+}

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -491,7 +491,24 @@ func (s *Service) JoinEvent(ctx context.Context, userID, eventID uuid.UUID) (*Jo
 		return nil, err
 	}
 
-	p, err := s.participationService.CreateApprovedParticipation(ctx, eventID, userID)
+	var (
+		p             *domain.Participation
+		ticketCreated bool
+	)
+	err = s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		var err error
+		p, err = s.participationService.CreateApprovedParticipation(ctx, eventID, userID)
+		if err != nil {
+			return err
+		}
+		if s.ticketService != nil {
+			if _, err := s.ticketService.CreateTicketForParticipation(ctx, p, domain.TicketStatusActive); err != nil {
+				return err
+			}
+			ticketCreated = true
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -506,6 +523,7 @@ func (s *Service) JoinEvent(ctx context.Context, userID, eventID uuid.UUID) (*Jo
 		"participation_id", p.ID.String(),
 		"participation_status", p.Status.String(),
 		"accepted_event_version", acceptedVersion,
+		"ticket_created", ticketCreated,
 	)
 
 	return &JoinEventResult{
@@ -601,7 +619,7 @@ func (s *Service) ReconfirmParticipation(ctx context.Context, userID, eventID uu
 			reconfirmedAt = *participation.ReconfirmedAt
 		}
 
-		if s.ticketService != nil && (snapshot.Event.PrivacyLevel == domain.PrivacyProtected || snapshot.Event.PrivacyLevel == domain.PrivacyPrivate) {
+		if s.ticketService != nil {
 			t, err := s.ticketService.CreateTicketForParticipation(ctx, participation, domain.TicketStatusActive)
 			if err != nil {
 				return err

--- a/backend/internal/application/event/service_test.go
+++ b/backend/internal/application/event/service_test.go
@@ -433,6 +433,8 @@ type fakeTicketLifecycle struct {
 	cancelParticipationCallCount int
 	cancelEventCallCount         int
 	expireEventCallCount         int
+	lastCreatedParticipation     *domain.Participation
+	lastCreatedStatus            domain.TicketStatus
 	lastParticipationID          uuid.UUID
 	lastCancelEventID            uuid.UUID
 	lastExpireEventID            uuid.UUID
@@ -443,6 +445,8 @@ type fakeTicketLifecycle struct {
 
 func (s *fakeTicketLifecycle) CreateTicketForParticipation(_ context.Context, participation *domain.Participation, status domain.TicketStatus) (*domain.Ticket, error) {
 	s.createCallCount++
+	s.lastCreatedParticipation = participation
+	s.lastCreatedStatus = status
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -1765,10 +1769,10 @@ func TestUpdateEventRejectsCapacityBelowApprovedAndPendingCount(t *testing.T) {
 	}
 }
 
-func TestReconfirmParticipationCreatesActiveTicketForProtectedEvent(t *testing.T) {
+func TestReconfirmParticipationCreatesActiveTicketForPublicEvent(t *testing.T) {
 	// given
 	hostID := uuid.New()
-	ev := editableEvent(hostID)
+	ev := publicEvent(hostID)
 	svc, _, participationService, _, ticketService := newTestEventServiceWithEventAndTickets(ev)
 	userID := uuid.New()
 
@@ -2080,6 +2084,55 @@ func TestJoinEventSuccessReturnsApproved(t *testing.T) {
 	}
 	if participationService.lastEventID != ev.ID || participationService.lastUserID != joinerID {
 		t.Fatalf("expected participation service to receive event %s and user %s", ev.ID, joinerID)
+	}
+}
+
+func TestJoinEventCreatesActiveTicketForPublicEvent(t *testing.T) {
+	hostID := uuid.New()
+	joinerID := uuid.New()
+	ev := publicEvent(hostID)
+	svc, _, participationService, _, ticketService := newTestEventServiceWithEventAndTickets(ev)
+
+	result, err := svc.JoinEvent(context.Background(), joinerID, ev.ID)
+
+	if err != nil {
+		t.Fatalf("JoinEvent() error = %v", err)
+	}
+	if ticketService.createCallCount != 1 {
+		t.Fatalf("expected ticket creation once, got %d", ticketService.createCallCount)
+	}
+	if ticketService.lastCreatedStatus != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE ticket status, got %q", ticketService.lastCreatedStatus)
+	}
+	if ticketService.lastCreatedParticipation == nil {
+		t.Fatal("expected participation to be forwarded to ticket service")
+	}
+	if ticketService.lastCreatedParticipation.ID != uuid.MustParse(result.ParticipationID) {
+		t.Fatalf("expected ticket participation %s, got %s", result.ParticipationID, ticketService.lastCreatedParticipation.ID)
+	}
+	if participationService.callCount != 1 {
+		t.Fatalf("expected participation service to be called once")
+	}
+}
+
+func TestJoinEventRollsBackUnitOfWorkWhenTicketCreationFails(t *testing.T) {
+	hostID := uuid.New()
+	joinerID := uuid.New()
+	ev := publicEvent(hostID)
+	svc, _, participationService, _, ticketService := newTestEventServiceWithEventAndTickets(ev)
+	ticketService.err = errors.New("ticket create failed")
+
+	_, err := svc.JoinEvent(context.Background(), joinerID, ev.ID)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	uow := svc.unitOfWork.(*fakeUnitOfWork)
+	if uow.rollbackCount != 1 || uow.commitCount != 0 {
+		t.Fatalf("expected rollback without commit, got rollbacks=%d commits=%d", uow.rollbackCount, uow.commitCount)
+	}
+	if participationService.callCount != 1 {
+		t.Fatalf("expected participation service to be called once before ticket creation failure")
 	}
 }
 

--- a/backend/internal/application/invitation/cursor_test.go
+++ b/backend/internal/application/invitation/cursor_test.go
@@ -85,6 +85,7 @@ func TestBuildNextPastInvitationCursor(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected non-nil cursor when hasNext=true")
+		return
 	}
 	decoded, err := decodePastInvitationCursor(*got)
 	if err != nil {

--- a/backend/internal/application/join_request/service_test.go
+++ b/backend/internal/application/join_request/service_test.go
@@ -488,6 +488,7 @@ func TestCancelJoinRequestDelegatesToRepo(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected result, got nil")
+		return
 	}
 	if result.Status != domain.JoinRequestStatusCanceled {
 		t.Fatalf("expected status CANCELED, got %s", result.Status)

--- a/backend/internal/application/participation/service_test.go
+++ b/backend/internal/application/participation/service_test.go
@@ -173,6 +173,7 @@ func TestLeaveParticipationDelegatesToRepo(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected participation result, got nil")
+		return
 	}
 	if repo.leaveCallCount != 1 {
 		t.Fatalf("expected leave repo to be called once, got %d", repo.leaveCallCount)

--- a/backend/internal/application/ticket/service.go
+++ b/backend/internal/application/ticket/service.go
@@ -50,7 +50,7 @@ func NewService(repo Repository, unitOfWork uow.UnitOfWork, tokens QRTokenManage
 	}
 }
 
-// CreateTicketForParticipation creates the protected-event ticket linked to an approved participation.
+// CreateTicketForParticipation creates the event ticket linked to an approved participation.
 func (s *Service) CreateTicketForParticipation(ctx context.Context, participation *domain.Participation, status domain.TicketStatus) (*domain.Ticket, error) {
 	ctx, span := tracer.Start(ctx, "ticket.create_for_participation")
 	defer span.End()
@@ -477,9 +477,6 @@ func validateQRAccess(record TicketAccessRecord, proximityMeters float64, now ti
 	if record.EventStatus != domain.EventStatusActive && record.EventStatus != domain.EventStatusInProgress {
 		return domain.ConflictError(domain.ErrorCodeTicketNotActive, "The event is not accepting ticket access.")
 	}
-	if record.PrivacyLevel != domain.PrivacyProtected {
-		return domain.ConflictError(domain.ErrorCodeTicketNotActive, "Only PROTECTED events support tickets.")
-	}
 	if !record.Ticket.ExpiresAt.After(now) {
 		return domain.ConflictError(domain.ErrorCodeTicketNotActive, "The ticket has expired.")
 	}
@@ -506,9 +503,6 @@ func scanRejectReason(record TicketScanRecord, claims QRTokenClaims, tokenHash s
 		return RejectReasonParticipationInvalid
 	}
 	if record.EventStatus != domain.EventStatusActive && record.EventStatus != domain.EventStatusInProgress {
-		return RejectReasonEventInvalid
-	}
-	if record.PrivacyLevel != domain.PrivacyProtected {
 		return RejectReasonEventInvalid
 	}
 	if claims.Version != record.Ticket.QRTokenVersion {

--- a/backend/internal/application/ticket/service_test.go
+++ b/backend/internal/application/ticket/service_test.go
@@ -148,6 +148,27 @@ func TestIssueQRTokenStoresNextVersionAndHash(t *testing.T) {
 	}
 }
 
+func TestIssueQRTokenAllowsPublicEvent(t *testing.T) {
+	// given
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	record := activeTicketAccessRecord(now)
+	record.PrivacyLevel = domain.PrivacyPublic
+	repo := &fakeTicketRepo{accessRecord: record}
+	service := NewService(repo, &fakeUnitOfWork{}, &fakeTokenManager{}, Settings{QRTokenTTL: 10 * time.Second, ProximityMeters: 200})
+	service.now = func() time.Time { return now }
+
+	// when
+	result, err := service.IssueQRToken(context.Background(), record.UserID, record.Ticket.ID, QRTokenInput{Lat: 41, Lon: 29})
+
+	// then
+	if err != nil {
+		t.Fatalf("IssueQRToken() error = %v", err)
+	}
+	if result.Token == "" {
+		t.Fatal("expected QR token to be issued for PUBLIC event ticket")
+	}
+}
+
 func TestIssueQRTokenRejectsFarLocation(t *testing.T) {
 	// given
 	now := time.Now().UTC()
@@ -221,6 +242,35 @@ func TestScanTicketRejectsOldVersion(t *testing.T) {
 	}
 	if result.Result != ScanResultRejected || result.Reason == nil || *result.Reason != RejectReasonTokenOldVersion {
 		t.Fatalf("expected old-version rejection, got %+v", result)
+	}
+}
+
+func TestScanTicketAcceptsPrivateEventTicket(t *testing.T) {
+	// given
+	now := time.Now().UTC()
+	record := activeTicketScanRecord(now)
+	record.PrivacyLevel = domain.PrivacyPrivate
+	claims := &QRTokenClaims{
+		TicketID:        record.Ticket.ID,
+		ParticipationID: record.Participation.ID,
+		EventID:         record.EventID,
+		UserID:          record.UserID,
+		Version:         record.Ticket.QRTokenVersion,
+		IssuedAt:        now,
+		ExpiresAt:       now.Add(10 * time.Second),
+	}
+	repo := &fakeTicketRepo{scanRecord: record}
+	service := NewService(repo, &fakeUnitOfWork{}, &fakeTokenManager{verifyClaims: claims}, Settings{})
+
+	// when
+	result, err := service.ScanTicket(context.Background(), record.HostID, record.EventID, ScanTicketInput{QRToken: "signed-token"})
+
+	// then
+	if err != nil {
+		t.Fatalf("ScanTicket() error = %v", err)
+	}
+	if result.Result != ScanResultAccepted || result.TicketStatus == nil || *result.TicketStatus != domain.TicketStatusUsed {
+		t.Fatalf("expected accepted USED result, got %+v", result)
 	}
 }
 

--- a/backend/tests_integration/ticket_test.go
+++ b/backend/tests_integration/ticket_test.go
@@ -136,7 +136,7 @@ func TestPrivateReconfirmReactivatesPendingTicketAfterEventEdit(t *testing.T) {
 	}
 }
 
-func TestPublicJoinCreatesNoTicket(t *testing.T) {
+func TestPublicJoinCreatesActiveTicket(t *testing.T) {
 	harness := common.NewEventHarness(t)
 	host := common.GivenUser(t, harness.AuthRepo)
 	participant := common.GivenUser(t, harness.AuthRepo)
@@ -150,8 +150,14 @@ func TestPublicJoinCreatesNoTicket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListMyTickets() error = %v", err)
 	}
-	if len(tickets.Items) != 0 {
-		t.Fatalf("expected no tickets for public join, got %d", len(tickets.Items))
+	if len(tickets.Items) != 1 {
+		t.Fatalf("expected 1 ticket, got %d", len(tickets.Items))
+	}
+	if tickets.Items[0].Status != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE ticket, got %q", tickets.Items[0].Status)
+	}
+	if tickets.Items[0].Event.ID != eventRef.ID.String() {
+		t.Fatalf("expected ticket for event %s, got %s", eventRef.ID, tickets.Items[0].Event.ID)
 	}
 }
 

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -375,9 +375,9 @@ paths:
         Allows an authenticated participant with `PENDING` participation status to
         reconfirm attendance for the latest event details. On success the
         participation becomes `APPROVED`, `reconfirmed_at` and
-        `last_confirmed_event_version` are updated, and protected/private event
-        tickets, including existing `PENDING` tickets created by an event edit,
-        are reactivated as `ACTIVE`.
+        `last_confirmed_event_version` are updated, and the participant's ticket,
+        including an existing `PENDING` ticket created by an event edit, is
+        reactivated as `ACTIVE`.
       operationId: reconfirmEventParticipation
       security:
         - bearerAuth: []
@@ -1516,7 +1516,7 @@ paths:
       summary: Join a public event
       description: |
         Directly joins a **PUBLIC** event. Creates an APPROVED participation record for the
-        authenticated user.
+        authenticated user and provisions an `ACTIVE` ticket for event entry flows.
 
         Rules:
         - The event must exist and have `privacy_level: PUBLIC`.

--- a/docs/openapi/ticket.yaml
+++ b/docs/openapi/ticket.yaml
@@ -3,7 +3,7 @@ info:
   title: Social Event Mapper Ticket API
   version: 0.1.0
   description: |
-    Ticket endpoints for protected-event mobile entry flows.
+    Ticket endpoints for mobile entry flows across public, protected, and private events.
 
     QR display and QR scanning are product-supported only in the mobile app. QR
     stream and scan endpoints require `X-Client-Surface: MOBILE` in addition to
@@ -12,7 +12,7 @@ servers:
   - url: /api
 tags:
   - name: Tickets
-    description: Protected-event ticket list, detail, QR stream, and host scan contracts.
+    description: Ticket list, detail, QR stream, and host scan contracts across supported event privacy levels.
 security:
   - bearerAuth: []
 paths:
@@ -58,7 +58,7 @@ paths:
       description: |
         Opens a Server-Sent Events stream and emits an initial `qr_token`, then a
         refreshed token every 10 seconds. The backend validates ticket ownership,
-        ACTIVE ticket status, APPROVED participation, ACTIVE/IN_PROGRESS protected
+        ACTIVE ticket status, APPROVED participation, ACTIVE/IN_PROGRESS
         event status, ticket business expiry, and 200-meter proximity before issuing
         each token.
       parameters:
@@ -279,7 +279,7 @@ components:
           $ref: '#/components/schemas/EventStatus'
         privacy_level:
           type: string
-          enum: [PROTECTED]
+          enum: [PUBLIC, PROTECTED, PRIVATE]
         start_time:
           type: string
           format: date-time


### PR DESCRIPTION
## 📋 Summary
This PR enables ticket creation and QR access across all supported event privacy levels. Previously, ticket issuance and QR validation were effectively limited to protected/private flows. With this change, public joins, protected approvals, private invitations, and approved reconfirmations all produce compatible tickets that can be used through the same QR entry flow.

## 🔄 Changes
- Updated `JoinEvent` so direct joins on `PUBLIC` events create an `APPROVED` participation and an `ACTIVE` ticket in the same transaction.
- Updated event reconfirmation so ticket reactivation is no longer limited by event privacy level.
- Removed ticket-repository privacy filtering so ticket creation/reactivation works for approved participations regardless of event privacy.
- Removed QR issuance / scan-time privacy gating so valid tickets for `PUBLIC`, `PROTECTED`, and `PRIVATE` events can all access the mobile QR flow.
- Updated admin manual participation creation so approved participations also get tickets regardless of event privacy.
- Added/updated backend tests for:
  - public join ticket creation
  - rollback when ticket creation fails during public join
  - public-event reconfirmation ticket creation
  - QR issuance for public events
  - QR scan acceptance for private events
  - admin manual approved participation ticket creation
- Updated OpenAPI docs for event join/reconfirmation and ticket APIs to reflect multi-privacy-level ticket support.
- Fixed three pre-existing nil-guard test warnings so `staticcheck` passes in the full backend gate.

## 🧪 Testing
- Ran targeted package tests:
  - `cd backend && GOTOOLCHAIN=local env GOCACHE=/private/tmp/go-cache GOMODCACHE=/private/tmp/go-mod-cache go test ./internal/application/event ./internal/application/ticket ./internal/application/admin ./internal/adapter/in/postgres`
- Ran full backend gate:
  - `cd backend && env GOCACHE=/private/tmp/go-cache GOMODCACHE=/private/tmp/go-mod-cache ./shipcheck.sh`

## 🔗 Related
Closes #547
