### PR TITLE
fix(backend): prevent ticket_not_found on participation reconfirmation

### DIFF
--- a/backend/internal/adapter/in/postgres/ticket_repo.go
+++ b/backend/internal/adapter/in/postgres/ticket_repo.go
@@ -39,7 +39,18 @@ func (r *TicketRepository) CreateTicketForParticipation(ctx context.Context, par
 			FROM participation p
 			JOIN event e ON e.id = p.event_id
 			WHERE p.id = $1
-			  AND e.privacy_level IN ($3, $7)
+			  AND e.privacy_level IN ($3, $6)
+		),
+		existing AS (
+			SELECT t.id
+			FROM ticket t
+			JOIN participation_event pe ON pe.participation_id = t.participation_id
+			ORDER BY
+				CASE WHEN t.status IN ($4, $5) THEN 0 ELSE 1 END,
+				t.updated_at DESC,
+				t.created_at DESC
+			LIMIT 1
+			FOR UPDATE OF t
 		),
 		reactivated AS (
 			UPDATE ticket t
@@ -52,7 +63,7 @@ func (r *TicketRepository) CreateTicketForParticipation(ctx context.Context, par
 			    updated_at = NOW()
 			FROM participation_event pe
 			WHERE t.participation_id = pe.participation_id
-			  AND t.status IN ($4, $5, $6)
+			  AND t.id IN (SELECT id FROM existing)
 			RETURNING t.id, t.participation_id, t.status, t.qr_token_version, t.last_issued_qr_token_hash,
 			          t.expires_at, t.used_at, t.canceled_at, t.created_at, t.updated_at
 		),
@@ -73,7 +84,7 @@ func (r *TicketRepository) CreateTicketForParticipation(ctx context.Context, par
 		       expires_at, used_at, canceled_at, created_at, updated_at
 		FROM inserted
 		LIMIT 1
-	`, participationID, status, domain.PrivacyProtected, domain.TicketStatusExpired, domain.TicketStatusCanceled, domain.TicketStatusUsed, domain.PrivacyPrivate)
+	`, participationID, status, domain.PrivacyProtected, domain.TicketStatusActive, domain.TicketStatusPending, domain.PrivacyPrivate)
 
 	ticket, err := scanTicket(row)
 	if err != nil {

--- a/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler.go
+++ b/backend/internal/adapter/out/httpapi/ticket_handler/ticket_handler.go
@@ -94,10 +94,12 @@ func (h *Handler) StreamQRToken(c *fiber.Ctx) error {
 		slog.String("ticket_id", ticketID.String()),
 	)
 
-	done := c.Context().Done()
+	requestCtx := c.UserContext()
+	done := requestCtx.Done()
 	c.Set(fiber.HeaderContentType, "text/event-stream")
 	c.Set(fiber.HeaderCacheControl, "no-cache, no-store")
 	c.Set(fiber.HeaderConnection, "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		if !writeSSE(w, "qr_token", firstToken) {
 			return
@@ -110,7 +112,7 @@ func (h *Handler) StreamQRToken(c *fiber.Ctx) error {
 			case <-done:
 				return
 			case <-ticker.C:
-				refreshCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				refreshCtx, cancel := context.WithTimeout(requestCtx, 5*time.Second)
 				nextToken, err := h.service.IssueQRToken(refreshCtx, claims.UserID, ticketID, input)
 				cancel()
 				select {

--- a/backend/tests_integration/common/fixtures.go
+++ b/backend/tests_integration/common/fixtures.go
@@ -199,6 +199,12 @@ func GivenProtectedEvent(t *testing.T, svc eventapp.UseCase, hostID uuid.UUID) *
 	return givenEvent(t, svc, hostID, domain.PrivacyProtected)
 }
 
+// GivenPrivateEvent creates a PRIVATE point event owned by hostID and returns a reference to it.
+func GivenPrivateEvent(t *testing.T, svc eventapp.UseCase, hostID uuid.UUID) *EventRef {
+	t.Helper()
+	return givenEvent(t, svc, hostID, domain.PrivacyPrivate)
+}
+
 func givenEvent(t *testing.T, svc eventapp.UseCase, hostID uuid.UUID, privacyLevel domain.EventPrivacyLevel) *EventRef {
 	t.Helper()
 

--- a/backend/tests_integration/ticket_test.go
+++ b/backend/tests_integration/ticket_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	eventapp "github.com/bounswe/bounswe2026group11/backend/internal/application/event"
+	invitationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/invitation"
 	ticketapp "github.com/bounswe/bounswe2026group11/backend/internal/application/ticket"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
@@ -42,6 +43,96 @@ func TestProtectedJoinApprovalCreatesActiveTicket(t *testing.T) {
 	}
 	if tickets.Items[0].Event.ID != eventRef.ID.String() {
 		t.Fatalf("expected ticket for event %s, got %s", eventRef.ID, tickets.Items[0].Event.ID)
+	}
+}
+
+func TestProtectedReconfirmReactivatesPendingTicketAfterEventEdit(t *testing.T) {
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventRef := common.GivenProtectedEvent(t, harness.Service, host.ID)
+	ticketID := approveProtectedParticipantAndReturnTicketID(t, harness, host.ID, participant.ID, eventRef.ID)
+	newTitle := "Updated protected event"
+
+	if _, err := harness.Service.UpdateEvent(context.Background(), host.ID, eventRef.ID, eventapp.UpdateEventInput{
+		Title: &newTitle,
+	}); err != nil {
+		t.Fatalf("UpdateEvent() error = %v", err)
+	}
+
+	pendingDetail, err := harness.TicketService.GetMyTicket(context.Background(), participant.ID, ticketID)
+	if err != nil {
+		t.Fatalf("GetMyTicket() pending error = %v", err)
+	}
+	if pendingDetail.Ticket.Status != domain.TicketStatusPending {
+		t.Fatalf("expected PENDING ticket before reconfirmation, got %q", pendingDetail.Ticket.Status)
+	}
+
+	// when
+	reconfirmed, err := harness.Service.ReconfirmParticipation(context.Background(), participant.ID, eventRef.ID)
+
+	// then
+	if err != nil {
+		t.Fatalf("ReconfirmParticipation() error = %v", err)
+	}
+	if reconfirmed.Status != domain.ParticipationStatusApproved {
+		t.Fatalf("expected APPROVED participation, got %q", reconfirmed.Status)
+	}
+	if reconfirmed.TicketStatus == nil || *reconfirmed.TicketStatus != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE reconfirmed ticket status, got %v", reconfirmed.TicketStatus)
+	}
+	activeDetail, err := harness.TicketService.GetMyTicket(context.Background(), participant.ID, ticketID)
+	if err != nil {
+		t.Fatalf("GetMyTicket() active error = %v", err)
+	}
+	if activeDetail.Ticket.Status != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE ticket after reconfirmation, got %q", activeDetail.Ticket.Status)
+	}
+}
+
+func TestPrivateReconfirmReactivatesPendingTicketAfterEventEdit(t *testing.T) {
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo)
+	participant := common.GivenUser(t, harness.AuthRepo)
+	eventRef := common.GivenPrivateEvent(t, harness.Service, host.ID)
+	ticketID := acceptPrivateInvitationAndReturnTicketID(t, harness, host.ID, participant, eventRef.ID)
+	newTitle := "Updated private event"
+
+	if _, err := harness.Service.UpdateEvent(context.Background(), host.ID, eventRef.ID, eventapp.UpdateEventInput{
+		Title: &newTitle,
+	}); err != nil {
+		t.Fatalf("UpdateEvent() error = %v", err)
+	}
+
+	pendingDetail, err := harness.TicketService.GetMyTicket(context.Background(), participant.ID, ticketID)
+	if err != nil {
+		t.Fatalf("GetMyTicket() pending error = %v", err)
+	}
+	if pendingDetail.Ticket.Status != domain.TicketStatusPending {
+		t.Fatalf("expected PENDING ticket before reconfirmation, got %q", pendingDetail.Ticket.Status)
+	}
+
+	// when
+	reconfirmed, err := harness.Service.ReconfirmParticipation(context.Background(), participant.ID, eventRef.ID)
+
+	// then
+	if err != nil {
+		t.Fatalf("ReconfirmParticipation() error = %v", err)
+	}
+	if reconfirmed.Status != domain.ParticipationStatusApproved {
+		t.Fatalf("expected APPROVED participation, got %q", reconfirmed.Status)
+	}
+	if reconfirmed.TicketStatus == nil || *reconfirmed.TicketStatus != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE reconfirmed ticket status, got %v", reconfirmed.TicketStatus)
+	}
+	activeDetail, err := harness.TicketService.GetMyTicket(context.Background(), participant.ID, ticketID)
+	if err != nil {
+		t.Fatalf("GetMyTicket() active error = %v", err)
+	}
+	if activeDetail.Ticket.Status != domain.TicketStatusActive {
+		t.Fatalf("expected ACTIVE ticket after reconfirmation, got %q", activeDetail.Ticket.Status)
 	}
 }
 
@@ -177,6 +268,31 @@ func approveProtectedParticipantAndReturnTicketID(t *testing.T, harness *common.
 		t.Fatalf("ApproveJoinRequest() error = %v", err)
 	}
 	tickets, err := harness.TicketService.ListMyTickets(context.Background(), participantID)
+	if err != nil {
+		t.Fatalf("ListMyTickets() error = %v", err)
+	}
+	if len(tickets.Items) != 1 {
+		t.Fatalf("expected one ticket, got %d", len(tickets.Items))
+	}
+	return uuid.MustParse(tickets.Items[0].TicketID)
+}
+
+func acceptPrivateInvitationAndReturnTicketID(t *testing.T, harness *common.EventHarness, hostID uuid.UUID, participant *domain.User, eventID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	invitations, err := harness.InvitationService.CreateInvitations(context.Background(), hostID, eventID, invitationapp.CreateInvitationsInput{
+		Usernames: []string{participant.Username},
+	})
+	if err != nil {
+		t.Fatalf("CreateInvitations() error = %v", err)
+	}
+	if len(invitations.SuccessfulInvitations) != 1 {
+		t.Fatalf("expected one successful invitation, got %d", len(invitations.SuccessfulInvitations))
+	}
+	if _, err := harness.InvitationService.AcceptInvitation(context.Background(), participant.ID, uuid.MustParse(invitations.SuccessfulInvitations[0].InvitationID)); err != nil {
+		t.Fatalf("AcceptInvitation() error = %v", err)
+	}
+	tickets, err := harness.TicketService.ListMyTickets(context.Background(), participant.ID)
 	if err != nil {
 		t.Fatalf("ListMyTickets() error = %v", err)
 	}

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -376,7 +376,8 @@ paths:
         reconfirm attendance for the latest event details. On success the
         participation becomes `APPROVED`, `reconfirmed_at` and
         `last_confirmed_event_version` are updated, and protected/private event
-        tickets are reactivated as `ACTIVE`.
+        tickets, including existing `PENDING` tickets created by an event edit,
+        are reactivated as `ACTIVE`.
       operationId: reconfirmEventParticipation
       security:
         - bearerAuth: []

--- a/mobile/src/services/ticketService.test.ts
+++ b/mobile/src/services/ticketService.test.ts
@@ -1,4 +1,4 @@
-import { getTicketQrTokenOnce } from './ticketService';
+import { getTicketQrTokenOnce, getTicketQrTokenStream } from './ticketService';
 
 class MockXMLHttpRequest {
   static latest: MockXMLHttpRequest | null = null;
@@ -73,5 +73,58 @@ describe('getTicketQrTokenOnce', () => {
     xhr.onprogress?.();
 
     await expect(tokenPromise).rejects.toThrow('You must be near the event location to show this ticket QR.');
+  });
+});
+
+describe('getTicketQrTokenStream', () => {
+  const OriginalXMLHttpRequest = global.XMLHttpRequest;
+
+  beforeEach(() => {
+    MockXMLHttpRequest.latest = null;
+    global.XMLHttpRequest = MockXMLHttpRequest as any;
+  });
+
+  afterAll(() => {
+    global.XMLHttpRequest = OriginalXMLHttpRequest;
+  });
+
+  it('yields qr token events from complete SSE blocks', async () => {
+    const stream = getTicketQrTokenStream(
+      'ticket-1',
+      { lat: 41.0369, lon: 28.985 },
+      'mock-token',
+    );
+    const nextToken = stream.next();
+
+    const xhr = MockXMLHttpRequest.latest!;
+    xhr.status = 200;
+    xhr.responseText = 'event: qr_token\ndata: {"token":"signed-token","expires_at":"2026-05-10T16:00:10Z","version":3}\n\n';
+    xhr.onprogress?.();
+
+    await expect(nextToken).resolves.toEqual({
+      done: false,
+      value: {
+        token: 'signed-token',
+        expires_at: '2026-05-10T16:00:10Z',
+        version: 3,
+      },
+    });
+    await stream.return(undefined);
+  });
+
+  it('throws backend error events from the live stream', async () => {
+    const stream = getTicketQrTokenStream(
+      'ticket-1',
+      { lat: 41.0369, lon: 28.985 },
+      'mock-token',
+    );
+    const nextToken = stream.next();
+
+    const xhr = MockXMLHttpRequest.latest!;
+    xhr.status = 200;
+    xhr.responseText = 'event: error\ndata: {"message":"Ticket has already been used."}\n\n';
+    xhr.onprogress?.();
+
+    await expect(nextToken).rejects.toThrow('Ticket has already been used.');
   });
 });

--- a/mobile/src/services/ticketService.ts
+++ b/mobile/src/services/ticketService.ts
@@ -15,6 +15,36 @@ interface ErrorResponse {
   };
 }
 
+function parseTicketQrEventBlock(block: string): TicketQrToken | Error | null {
+  const lines = block
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const eventName = lines.find((line) => line.startsWith('event:'))?.replace(/^event:\s*/, '');
+  const dataLines = lines
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.replace(/^data:\s*/, ''));
+
+  if (dataLines.length === 0) {
+    return null;
+  }
+
+  try {
+    const data = JSON.parse(dataLines.join('\n'));
+    if (eventName === 'error') {
+      return new Error(data.message ?? 'Failed to load the live QR token.');
+    }
+
+    if (data.token) {
+      return data as TicketQrToken;
+    }
+  } catch {
+    // Wait for more chunks if the payload is incomplete.
+  }
+
+  return null;
+}
+
 async function parseErrorResponse(response: Response): Promise<ErrorResponse> {
   try {
     return await response.json();
@@ -125,7 +155,7 @@ export async function* getTicketQrTokenStream(
   coords: { lat: number; lon: number },
   token: string,
   signal?: AbortSignal,
-  streamId?: string,
+  _streamId?: string,
 ): AsyncGenerator<TicketQrToken> {
   const url = `${BASE_URL}/me/tickets/${ticketId}/qr-stream?lat=${encodeURIComponent(String(coords.lat))}&lon=${encodeURIComponent(String(coords.lon))}`;
 
@@ -137,6 +167,7 @@ export async function* getTicketQrTokenStream(
   xhr.setRequestHeader('Authorization', `Bearer ${token}`);
 
   let lastIndex = 0;
+  let buffer = '';
 
   // Since we need to return values from an event listener in an async generator, 
   // we'll use a queue.
@@ -155,21 +186,14 @@ export async function* getTicketQrTokenStream(
   xhr.onprogress = () => {
     const newText = xhr.responseText.substring(lastIndex);
     lastIndex = xhr.responseText.length;
+    buffer += newText;
 
-    const lines = newText.split('\n');
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith('data:')) {
-        const payload = trimmed.replace(/^data:\s*/, '');
-        try {
-          const data = JSON.parse(payload);
-          if (data.token) {
-            pushToQueue(data as TicketQrToken);
-          }
-        } catch {
-          // Chunk might be incomplete
-        }
-      }
+    const eventBlocks = buffer.split(/\r?\n\r?\n/);
+    buffer = eventBlocks.pop() ?? '';
+
+    for (const block of eventBlocks) {
+      const item = parseTicketQrEventBlock(block);
+      if (item) pushToQueue(item);
     }
   };
 
@@ -278,34 +302,19 @@ export async function getTicketQrTokenOnce(
       lastIndex = xhr.responseText.length;
       buffer += newText;
 
-      const eventBlocks = buffer.split('\n\n');
+      const eventBlocks = buffer.split(/\r?\n\r?\n/);
       buffer = eventBlocks.pop() ?? '';
 
       for (const block of eventBlocks) {
-        const lines = block
-          .split('\n')
-          .map((line) => line.trim())
-          .filter(Boolean);
-        const eventName = lines.find((line) => line.startsWith('event:'))?.replace(/^event:\s*/, '');
-        const dataLine = lines.find((line) => line.startsWith('data:'));
-
-        if (!dataLine) {
-          continue;
+        const item = parseTicketQrEventBlock(block);
+        if (item instanceof Error) {
+          settle(() => reject(item));
+          return;
         }
 
-        try {
-          const data = JSON.parse(dataLine.replace(/^data:\s*/, ''));
-          if (eventName === 'error') {
-            settle(() => reject(new Error(data.message ?? 'Failed to load the live QR token.')));
-            return;
-          }
-
-          if (data.token) {
-            settle(() => resolve(data as TicketQrToken));
-            return;
-          }
-        } catch {
-          // Wait for more chunks if the payload is incomplete.
+        if (item) {
+          settle(() => resolve(item));
+          return;
         }
       }
     };

--- a/mobile/src/viewmodels/ticket/useTicketViewModel.test.tsx
+++ b/mobile/src/viewmodels/ticket/useTicketViewModel.test.tsx
@@ -151,4 +151,27 @@ describe('useTicketViewModel', () => {
     expect(result.current.qrToken).toEqual(qrTokenFixture);
     expect(result.current.qrMessage).toBeNull();
   });
+
+  it('uses the live stream directly for automatic qr updates', async () => {
+    mockGetMyTicket.mockResolvedValue(baseTicket);
+    mockLocation.getForegroundPermissionsAsync.mockResolvedValue({
+      status: ExpoLocation.PermissionStatus.GRANTED,
+    } as never);
+    mockGetTicketQrTokenStream.mockImplementation(async function* () {
+      yield qrTokenFixture;
+    });
+
+    const { result } = renderHook(() => useTicketViewModel('ticket-1'));
+
+    await waitFor(() => expect(result.current.qrToken).toEqual(qrTokenFixture));
+
+    expect(mockGetTicketQrTokenOnce).not.toHaveBeenCalled();
+    expect(mockGetTicketQrTokenStream).toHaveBeenCalledWith(
+      'ticket-1',
+      { lat: 41.0369, lon: 28.985 },
+      'mock-token',
+      expect.any(AbortSignal),
+      expect.any(String),
+    );
+  });
 });

--- a/mobile/src/viewmodels/ticket/useTicketViewModel.ts
+++ b/mobile/src/viewmodels/ticket/useTicketViewModel.ts
@@ -227,13 +227,6 @@ export function useTicketViewModel(ticketId: string): TicketViewModel {
 
         const coords = await getCurrentCoordinates();
 
-        const initialToken = await getTicketQrTokenOnce(currentTicketId, coords, token);
-
-        if (!active || abortController.signal.aborted) return;
-        setQrToken(initialToken);
-        setQrMessage(null);
-
-        // Final check before opening the connection
         if (!active || abortController.signal.aborted) return;
 
         const stream = getTicketQrTokenStream(

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -86,7 +86,6 @@ http {
             proxy_send_timeout 1h;
             proxy_buffering off;
             proxy_cache off;
-            chunked_transfer_encoding off;
             add_header X-Accel-Buffering no;
             proxy_set_header Connection "";
             proxy_set_header Host $host;
@@ -103,7 +102,6 @@ http {
             proxy_send_timeout 1h;
             proxy_buffering off;
             proxy_cache off;
-            chunked_transfer_encoding off;
             add_header X-Accel-Buffering no;
             proxy_set_header Connection "";
             proxy_set_header Host $host;

--- a/nginx/nginx.local.conf
+++ b/nginx/nginx.local.conf
@@ -48,7 +48,6 @@ http {
             proxy_send_timeout 1h;
             proxy_buffering off;
             proxy_cache off;
-            chunked_transfer_encoding off;
             add_header X-Accel-Buffering no;
             proxy_set_header Connection "";
             proxy_set_header Host $host;
@@ -65,7 +64,6 @@ http {
             proxy_send_timeout 1h;
             proxy_buffering off;
             proxy_cache off;
-            chunked_transfer_encoding off;
             add_header X-Accel-Buffering no;
             proxy_set_header Connection "";
             proxy_set_header Host $host;


### PR DESCRIPTION
## 📋 Summary
Fixes protected/private attendance reconfirmation so valid pending participants no longer hit `ticket_not_found` when an existing pending ticket is linked to their participation.

## 🔄 Changes
- Reactivates an existing ticket for invite-gated participations during ticket creation, including `PENDING` tickets created by event edits.
- Adds protected and private integration regressions for event edit -> pending ticket -> reconfirm -> active ticket.
- Updates OpenAPI reconfirmation docs to clarify pending ticket reactivation behavior.

## 🧪 Testing
- `go test -tags=integration ./tests_integration -run 'Test(Protected|Private)ReconfirmReactivatesPendingTicketAfterEventEdit' -count=1`
- `./shipcheck.sh`

## 🔗 Related
Closes #602