### PR TITLE
feat(backend): add public profile equipment and showcase APIs

### DIFF
--- a/backend/internal/adapter/in/postgres/profile_repo.go
+++ b/backend/internal/adapter/in/postgres/profile_repo.go
@@ -139,6 +139,62 @@ func (r *ProfileRepository) GetProfile(ctx context.Context, userID uuid.UUID) (*
 	return &up, nil
 }
 
+// GetPublicProfile returns the public-safe projection for another user's profile.
+func (r *ProfileRepository) GetPublicProfile(ctx context.Context, userID uuid.UUID) (*domain.PublicUserProfile, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT
+			u.id,
+			u.username,
+			p.display_name,
+			p.avatar_url,
+			p.bio,
+			us.final_score,
+			COALESCE(us.hosted_event_rating_count, 0),
+			COALESCE(us.participant_rating_count, 0)
+		FROM app_user u
+		LEFT JOIN profile p ON p.user_id = u.id
+		LEFT JOIN user_score us ON us.user_id = u.id
+		WHERE u.id = $1
+	`, userID)
+
+	var (
+		profileRecord          domain.PublicUserProfile
+		displayName            pgtype.Text
+		avatarURL              pgtype.Text
+		bio                    pgtype.Text
+		finalScore             pgtype.Float8
+		hostRatingCount        int
+		participantRatingCount int
+	)
+
+	if err := row.Scan(
+		&profileRecord.UserID,
+		&profileRecord.Username,
+		&displayName,
+		&avatarURL,
+		&bio,
+		&finalScore,
+		&hostRatingCount,
+		&participantRatingCount,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get public profile: %w", err)
+	}
+
+	profileRecord.DisplayName = textPtr(displayName)
+	profileRecord.AvatarURL = textPtr(avatarURL)
+	profileRecord.Bio = textPtr(bio)
+	if finalScore.Valid {
+		profileRecord.FinalScore = &finalScore.Float64
+	}
+	profileRecord.HostRatingCount = hostRatingCount
+	profileRecord.ParticipantRatingCount = participantRatingCount
+
+	return &profileRecord, nil
+}
+
 // GetHostedEvents returns a summary of all events created by the given user.
 func (r *ProfileRepository) GetHostedEvents(ctx context.Context, userID uuid.UUID) ([]domain.EventSummary, error) {
 	rows, err := r.pool.Query(ctx, `
@@ -262,6 +318,180 @@ func (r *ProfileRepository) GetCanceledEvents(ctx context.Context, userID uuid.U
 	return scanEventSummaries(rows)
 }
 
+// ListEquipment returns the user's equipment entries ordered newest-first.
+func (r *ProfileRepository) ListEquipment(ctx context.Context, userID uuid.UUID) ([]domain.ProfileEquipment, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, user_id, name, description, image_url, created_at, updated_at
+		FROM profile_equipment
+		WHERE user_id = $1
+		ORDER BY created_at DESC, id DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list profile equipment: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]domain.ProfileEquipment, 0)
+	for rows.Next() {
+		item, err := scanProfileEquipment(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, *item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate profile equipment: %w", err)
+	}
+	return items, nil
+}
+
+// GetEquipmentByID returns one equipment item by its identifier.
+func (r *ProfileRepository) GetEquipmentByID(ctx context.Context, equipmentID uuid.UUID) (*domain.ProfileEquipment, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, user_id, name, description, image_url, created_at, updated_at
+		FROM profile_equipment
+		WHERE id = $1
+	`, equipmentID)
+	item, err := scanProfileEquipment(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get profile equipment: %w", err)
+	}
+	return item, nil
+}
+
+// CreateEquipment inserts one equipment item for the given user.
+func (r *ProfileRepository) CreateEquipment(ctx context.Context, params profileapp.CreateEquipmentParams) (*domain.ProfileEquipment, error) {
+	row := r.db.QueryRow(ctx, `
+		INSERT INTO profile_equipment (user_id, name, description, image_url)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, user_id, name, description, image_url, created_at, updated_at
+	`, params.UserID, params.Name, params.Description, params.ImageURL)
+	item, err := scanProfileEquipment(row)
+	if err != nil {
+		return nil, fmt.Errorf("create profile equipment: %w", err)
+	}
+	return item, nil
+}
+
+// UpdateEquipment updates one equipment item identified by id.
+func (r *ProfileRepository) UpdateEquipment(ctx context.Context, params profileapp.UpdateEquipmentParams) (*domain.ProfileEquipment, error) {
+	setClauses := "updated_at = now()"
+	args := []any{params.EquipmentID}
+
+	if params.Name != nil {
+		setClauses += fmt.Sprintf(", name = $%d", len(args)+1)
+		args = append(args, *params.Name)
+	}
+	if params.Description != nil {
+		setClauses += fmt.Sprintf(", description = $%d", len(args)+1)
+		args = append(args, *params.Description)
+	}
+	if params.ImageURL != nil {
+		setClauses += fmt.Sprintf(", image_url = $%d", len(args)+1)
+		args = append(args, *params.ImageURL)
+	}
+
+	row := r.db.QueryRow(ctx, fmt.Sprintf(`
+		UPDATE profile_equipment
+		SET %s
+		WHERE id = $1
+		RETURNING id, user_id, name, description, image_url, created_at, updated_at
+	`, setClauses), args...)
+	item, err := scanProfileEquipment(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("update profile equipment: %w", err)
+	}
+	return item, nil
+}
+
+// DeleteEquipment deletes one equipment item by id.
+func (r *ProfileRepository) DeleteEquipment(ctx context.Context, equipmentID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM profile_equipment WHERE id = $1`, equipmentID)
+	if err != nil {
+		return fmt.Errorf("delete profile equipment: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+// ListShowcaseImages returns the user's showcase images ordered newest-first.
+func (r *ProfileRepository) ListShowcaseImages(ctx context.Context, userID uuid.UUID) ([]domain.ProfileShowcaseImage, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, user_id, image_url, created_at, updated_at
+		FROM profile_showcase_image
+		WHERE user_id = $1
+		ORDER BY created_at DESC, id DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list showcase images: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]domain.ProfileShowcaseImage, 0)
+	for rows.Next() {
+		item, err := scanProfileShowcaseImage(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, *item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate showcase images: %w", err)
+	}
+	return items, nil
+}
+
+// GetShowcaseImageByID returns one showcase image by its identifier.
+func (r *ProfileRepository) GetShowcaseImageByID(ctx context.Context, showcaseImageID uuid.UUID) (*domain.ProfileShowcaseImage, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, user_id, image_url, created_at, updated_at
+		FROM profile_showcase_image
+		WHERE id = $1
+	`, showcaseImageID)
+	item, err := scanProfileShowcaseImage(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get showcase image: %w", err)
+	}
+	return item, nil
+}
+
+// CreateShowcaseImage inserts a new showcase image row for the given user.
+func (r *ProfileRepository) CreateShowcaseImage(ctx context.Context, userID uuid.UUID, imageURL string) (*domain.ProfileShowcaseImage, error) {
+	row := r.db.QueryRow(ctx, `
+		INSERT INTO profile_showcase_image (user_id, image_url)
+		VALUES ($1, $2)
+		RETURNING id, user_id, image_url, created_at, updated_at
+	`, userID, imageURL)
+	item, err := scanProfileShowcaseImage(row)
+	if err != nil {
+		return nil, fmt.Errorf("create showcase image: %w", err)
+	}
+	return item, nil
+}
+
+// DeleteShowcaseImage deletes one showcase image by id.
+func (r *ProfileRepository) DeleteShowcaseImage(ctx context.Context, showcaseImageID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM profile_showcase_image WHERE id = $1`, showcaseImageID)
+	if err != nil {
+		return fmt.Errorf("delete showcase image: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
 // SearchUsers returns lightweight user summaries ordered for username picker relevance.
 func (r *ProfileRepository) SearchUsers(ctx context.Context, query string, limit int) ([]profileapp.UserSearchRecord, error) {
 	rows, err := r.pool.Query(ctx, `
@@ -297,6 +527,42 @@ func (r *ProfileRepository) SearchUsers(ctx context.Context, query string, limit
 		return nil, fmt.Errorf("iterate user search results: %w", err)
 	}
 	return records, nil
+}
+
+func scanProfileEquipment(row interface{ Scan(...any) error }) (*domain.ProfileEquipment, error) {
+	var (
+		item        domain.ProfileEquipment
+		description pgtype.Text
+		imageURL    pgtype.Text
+	)
+	if err := row.Scan(
+		&item.ID,
+		&item.UserID,
+		&item.Name,
+		&description,
+		&imageURL,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	item.Description = textPtr(description)
+	item.ImageURL = textPtr(imageURL)
+	return &item, nil
+}
+
+func scanProfileShowcaseImage(row interface{ Scan(...any) error }) (*domain.ProfileShowcaseImage, error) {
+	var item domain.ProfileShowcaseImage
+	if err := row.Scan(
+		&item.ID,
+		&item.UserID,
+		&item.ImageURL,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &item, nil
 }
 
 func scanEventSummaries(rows interface {

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler.go
@@ -26,6 +26,8 @@ func RegisterRoutes(router fiber.Router, handler *Handler, auth fiber.Handler) {
 	me := router.Group("/me", auth)
 	me.Post("/avatar/upload-url", handler.CreateProfileAvatarUpload)
 	me.Post("/avatar/confirm", handler.ConfirmProfileAvatarUpload)
+	me.Post("/showcase-images/upload-url", handler.CreateProfileShowcaseImageUpload)
+	me.Post("/showcase-images/confirm", handler.ConfirmProfileShowcaseImageUpload)
 
 	events := router.Group("/events", auth)
 	events.Post("/:id/image/upload-url", handler.CreateEventImageUpload)
@@ -78,6 +80,52 @@ func (h *Handler) ConfirmProfileAvatarUpload(c *fiber.Ctx) error {
 	)
 
 	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// CreateProfileShowcaseImageUpload handles POST /me/showcase-images/upload-url.
+func (h *Handler) CreateProfileShowcaseImageUpload(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+
+	result, err := h.service.CreateProfileShowcaseImageUpload(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"showcase image upload URL created",
+		httpapi.OperationAttr("image_upload.profile_showcase.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("base_url", result.BaseURL),
+		slog.Int("upload_count", len(result.Uploads)),
+	)
+
+	return c.JSON(result)
+}
+
+// ConfirmProfileShowcaseImageUpload handles POST /me/showcase-images/confirm.
+func (h *Handler) ConfirmProfileShowcaseImageUpload(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+
+	body, err := parseConfirmBody(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	result, err := h.service.ConfirmProfileShowcaseImageUpload(c.UserContext(), claims.UserID, body)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"showcase image upload confirmed",
+		httpapi.OperationAttr("image_upload.profile_showcase.confirm"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("showcase_image_id", result.ID),
+	)
+
+	return c.Status(fiber.StatusCreated).JSON(result)
 }
 
 // CreateEventImageUpload handles POST /events/:id/image/upload-url.

--- a/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/image_upload_handler/image_upload_handler_test.go
@@ -15,26 +15,29 @@ import (
 )
 
 type stubImageUploadService struct {
-	createProfileResult *imageupload.CreateUploadResult
-	createEventResult   *imageupload.CreateUploadResult
-	createReviewResult  *imageupload.CreateUploadResult
-	createJoinResult    *imageupload.CreateUploadResult
-	createReportResult  *imageupload.CreateUploadResult
-	createProfileErr    error
-	createEventErr      error
-	createReviewErr     error
-	createJoinErr       error
-	createReportErr     error
-	confirmProfileErr   error
-	confirmEventErr     error
-	confirmReviewErr    error
-	confirmReportErr    error
-	lastEventID         uuid.UUID
-	lastReviewEventID   uuid.UUID
-	lastJoinEventID     uuid.UUID
-	lastReportEventID   uuid.UUID
-	lastConfirmInput    imageupload.ConfirmUploadInput
-	lastConfirmEventID  uuid.UUID
+	createProfileResult  *imageupload.CreateUploadResult
+	createShowcaseResult *imageupload.CreateUploadResult
+	createEventResult    *imageupload.CreateUploadResult
+	createReviewResult   *imageupload.CreateUploadResult
+	createJoinResult     *imageupload.CreateUploadResult
+	createReportResult   *imageupload.CreateUploadResult
+	createProfileErr     error
+	createShowcaseErr    error
+	createEventErr       error
+	createReviewErr      error
+	createJoinErr        error
+	createReportErr      error
+	confirmProfileErr    error
+	confirmShowcaseErr   error
+	confirmEventErr      error
+	confirmReviewErr     error
+	confirmReportErr     error
+	lastEventID          uuid.UUID
+	lastReviewEventID    uuid.UUID
+	lastJoinEventID      uuid.UUID
+	lastReportEventID    uuid.UUID
+	lastConfirmInput     imageupload.ConfirmUploadInput
+	lastConfirmEventID   uuid.UUID
 }
 
 func (s *stubImageUploadService) CreateProfileAvatarUpload(_ context.Context, _ uuid.UUID) (*imageupload.CreateUploadResult, error) {
@@ -50,6 +53,27 @@ func (s *stubImageUploadService) CreateProfileAvatarUpload(_ context.Context, _ 
 func (s *stubImageUploadService) ConfirmProfileAvatarUpload(_ context.Context, _ uuid.UUID, input imageupload.ConfirmUploadInput) error {
 	s.lastConfirmInput = input
 	return s.confirmProfileErr
+}
+
+func (s *stubImageUploadService) CreateProfileShowcaseImageUpload(_ context.Context, _ uuid.UUID) (*imageupload.CreateUploadResult, error) {
+	if s.createShowcaseErr != nil {
+		return nil, s.createShowcaseErr
+	}
+	if s.createShowcaseResult != nil {
+		return s.createShowcaseResult, nil
+	}
+	return defaultUploadResult(), nil
+}
+
+func (s *stubImageUploadService) ConfirmProfileShowcaseImageUpload(_ context.Context, _ uuid.UUID, input imageupload.ConfirmUploadInput) (*imageupload.ConfirmShowcaseImageResult, error) {
+	s.lastConfirmInput = input
+	if s.confirmShowcaseErr != nil {
+		return nil, s.confirmShowcaseErr
+	}
+	return &imageupload.ConfirmShowcaseImageResult{
+		ID:       uuid.NewString(),
+		ImageURL: "https://cdn.example/showcase.jpg",
+	}, nil
 }
 
 func (s *stubImageUploadService) CreateEventImageUpload(_ context.Context, _ uuid.UUID, eventID uuid.UUID) (*imageupload.CreateUploadResult, error) {
@@ -253,6 +277,66 @@ func TestConfirmProfileAvatarUploadInvalidTokenReturns400(t *testing.T) {
 
 	if resp.StatusCode != fiber.StatusBadRequest {
 		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+}
+
+func TestCreateProfileShowcaseImageUploadReturnsSignedInstructions(t *testing.T) {
+	svc := &stubImageUploadService{}
+	app := newTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodPost, "/me/showcase-images/upload-url", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+
+	var body imageupload.CreateUploadResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.BaseURL == "" || body.ConfirmToken == "" || len(body.Uploads) != 2 {
+		t.Fatalf("unexpected response body: %+v", body)
+	}
+}
+
+func TestConfirmProfileShowcaseImageUploadReturnsCreatedItem(t *testing.T) {
+	svc := &stubImageUploadService{}
+	app := newTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(
+		fiber.MethodPost,
+		"/me/showcase-images/confirm",
+		bytes.NewBufferString(`{"confirm_token":"showcase-token"}`),
+	)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("expected status %d, got %d", fiber.StatusCreated, resp.StatusCode)
+	}
+
+	var body imageupload.ConfirmShowcaseImageResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if body.ID == "" || body.ImageURL == "" {
+		t.Fatalf("unexpected response body: %+v", body)
+	}
+	if svc.lastConfirmInput.ConfirmToken != "showcase-token" {
+		t.Fatalf("expected confirm token to be forwarded, got %q", svc.lastConfirmInput.ConfirmToken)
 	}
 }
 

--- a/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
+++ b/backend/internal/adapter/out/httpapi/profile_handler/profile_handler.go
@@ -36,6 +36,11 @@ func RegisterProfileRoutes(router fiber.Router, handler *ProfileHandler, auth fi
 	me.Get("", handler.GetMyProfile)
 	me.Patch("", handler.UpdateMyProfile)
 	me.Post("/change-password", handler.ChangePassword)
+	me.Get("/equipment", handler.ListMyEquipment)
+	me.Post("/equipment", handler.CreateMyEquipment)
+	me.Patch("/equipment/:equipment_id", handler.UpdateMyEquipment)
+	me.Delete("/equipment/:equipment_id", handler.DeleteMyEquipment)
+	me.Delete("/showcase-images/:showcase_image_id", handler.DeleteMyShowcaseImage)
 	me.Get("/events/hosted", handler.GetMyHostedEvents)
 	me.Get("/events/upcoming", handler.GetMyUpcomingEvents)
 	me.Get("/events/completed", handler.GetMyCompletedEvents)
@@ -45,6 +50,9 @@ func RegisterProfileRoutes(router fiber.Router, handler *ProfileHandler, auth fi
 	me.Get("/invitations/:invitationId", handler.GetReceivedInvitation)
 	me.Post("/invitations/:invitationId/accept", handler.AcceptInvitation)
 	me.Post("/invitations/:invitationId/decline", handler.DeclineInvitation)
+
+	users := router.Group("/users")
+	users.Get("/:user_id/profile", handler.GetPublicProfile)
 }
 
 // GetMyProfile handles GET /me.
@@ -61,6 +69,28 @@ func (h *ProfileHandler) GetMyProfile(c *fiber.Ctx) error {
 		"my profile fetched",
 		httpapi.OperationAttr("profile.get"),
 		httpapi.UserIDAttr(claims.UserID),
+	)
+
+	return c.JSON(result)
+}
+
+// GetPublicProfile handles GET /users/:user_id/profile.
+func (h *ProfileHandler) GetPublicProfile(c *fiber.Ctx) error {
+	userID, err := parseUserIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	result, err := h.service.GetPublicProfile(c.UserContext(), userID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"public profile fetched",
+		httpapi.OperationAttr("profile.public.get"),
+		slog.String("target_user_id", userID.String()),
 	)
 
 	return c.JSON(result)
@@ -136,6 +166,148 @@ func (h *ProfileHandler) GetMyCanceledEvents(c *fiber.Ctx) error {
 		slog.Int("result_count", len(events)),
 	)
 	return c.JSON(fiber.Map{"events": events})
+}
+
+type createEquipmentBody struct {
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
+	ImageURL    *string `json:"image_url"`
+}
+
+type updateEquipmentBody struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	ImageURL    *string `json:"image_url"`
+}
+
+// ListMyEquipment handles GET /me/equipment.
+func (h *ProfileHandler) ListMyEquipment(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	result, err := h.service.ListMyEquipment(c.UserContext(), claims.UserID)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"my equipment fetched",
+		httpapi.OperationAttr("profile.equipment.list"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.Int("result_count", len(result.Items)),
+	)
+
+	return c.JSON(result)
+}
+
+// CreateMyEquipment handles POST /me/equipment.
+func (h *ProfileHandler) CreateMyEquipment(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+
+	var body createEquipmentBody
+	if err := c.BodyParser(&body); err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"body": "must be valid JSON"}))
+	}
+
+	result, err := h.service.CreateMyEquipment(c.UserContext(), profile.CreateEquipmentInput{
+		UserID:      claims.UserID,
+		Name:        body.Name,
+		Description: body.Description,
+		ImageURL:    body.ImageURL,
+	})
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"equipment created",
+		httpapi.OperationAttr("profile.equipment.create"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("equipment_id", result.ID),
+	)
+
+	return c.Status(fiber.StatusCreated).JSON(result)
+}
+
+// UpdateMyEquipment handles PATCH /me/equipment/:equipment_id.
+func (h *ProfileHandler) UpdateMyEquipment(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	equipmentID, err := parseEquipmentIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	var body updateEquipmentBody
+	if err := c.BodyParser(&body); err != nil {
+		return httpapi.WriteError(c, domain.ValidationError(map[string]string{"body": "must be valid JSON"}))
+	}
+
+	result, err := h.service.UpdateMyEquipment(c.UserContext(), profile.UpdateEquipmentInput{
+		UserID:      claims.UserID,
+		EquipmentID: equipmentID,
+		Name:        body.Name,
+		Description: body.Description,
+		ImageURL:    body.ImageURL,
+	})
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"equipment updated",
+		httpapi.OperationAttr("profile.equipment.update"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("equipment_id", equipmentID.String()),
+	)
+
+	return c.JSON(result)
+}
+
+// DeleteMyEquipment handles DELETE /me/equipment/:equipment_id.
+func (h *ProfileHandler) DeleteMyEquipment(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	equipmentID, err := parseEquipmentIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	if err := h.service.DeleteMyEquipment(c.UserContext(), claims.UserID, equipmentID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"equipment deleted",
+		httpapi.OperationAttr("profile.equipment.delete"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("equipment_id", equipmentID.String()),
+	)
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// DeleteMyShowcaseImage handles DELETE /me/showcase-images/:showcase_image_id.
+func (h *ProfileHandler) DeleteMyShowcaseImage(c *fiber.Ctx) error {
+	claims := httpapi.UserClaims(c)
+	showcaseImageID, err := parseShowcaseImageIDParam(c)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	if err := h.service.DeleteMyShowcaseImage(c.UserContext(), claims.UserID, showcaseImageID); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+
+	httpapi.LogInfo(
+		c.UserContext(),
+		"showcase image deleted",
+		httpapi.OperationAttr("profile.showcase.delete"),
+		httpapi.UserIDAttr(claims.UserID),
+		slog.String("showcase_image_id", showcaseImageID.String()),
+	)
+
+	return c.SendStatus(fiber.StatusNoContent)
 }
 
 // updateProfileBody is the request body for PATCH /me.
@@ -366,6 +538,30 @@ func parseInvitationIDParam(c *fiber.Ctx) (uuid.UUID, error) {
 	id, err := uuid.Parse(c.Params("invitationId"))
 	if err != nil {
 		return uuid.Nil, domain.ValidationError(map[string]string{"invitation_id": "must be a valid UUID"})
+	}
+	return id, nil
+}
+
+func parseUserIDParam(c *fiber.Ctx) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Params("user_id"))
+	if err != nil {
+		return uuid.Nil, domain.ValidationError(map[string]string{"user_id": "must be a valid UUID"})
+	}
+	return id, nil
+}
+
+func parseEquipmentIDParam(c *fiber.Ctx) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Params("equipment_id"))
+	if err != nil {
+		return uuid.Nil, domain.ValidationError(map[string]string{"equipment_id": "must be a valid UUID"})
+	}
+	return id, nil
+}
+
+func parseShowcaseImageIDParam(c *fiber.Ctx) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Params("showcase_image_id"))
+	if err != nil {
+		return uuid.Nil, domain.ValidationError(map[string]string{"showcase_image_id": "must be a valid UUID"})
 	}
 	return id, nil
 }

--- a/backend/internal/application/imageupload/repository.go
+++ b/backend/internal/application/imageupload/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
 )
 
@@ -11,6 +12,7 @@ import (
 type ProfileRepository interface {
 	GetAvatarVersion(ctx context.Context, userID uuid.UUID) (int, error)
 	SetAvatarIfVersion(ctx context.Context, userID uuid.UUID, expectedVersion, nextVersion int, baseURL string, updatedAt time.Time) (bool, error)
+	CreateShowcaseImage(ctx context.Context, userID uuid.UUID, imageURL string) (*domain.ProfileShowcaseImage, error)
 }
 
 // EventRepository exposes the persistence required for event image uploads.

--- a/backend/internal/application/imageupload/service.go
+++ b/backend/internal/application/imageupload/service.go
@@ -109,6 +109,46 @@ func (s *Service) ConfirmProfileAvatarUpload(ctx context.Context, userID uuid.UU
 	return nil
 }
 
+// CreateProfileShowcaseImageUpload prepares a direct-upload flow for one
+// showcase image owned by the authenticated user.
+func (s *Service) CreateProfileShowcaseImageUpload(ctx context.Context, userID uuid.UUID) (*CreateUploadResult, error) {
+	uploadID := uuid.NewString()
+
+	return s.createUpload(ctx, uploadDescriptor{
+		Resource:     ResourceProfileShowcase,
+		OwnerUserID:  userID,
+		NextVersion:  1,
+		OriginalKey:  fmt.Sprintf("profiles/%s/showcase/%s", userID, uploadID),
+		UploadID:     uploadID,
+		CurrentEvent: nil,
+	})
+}
+
+// ConfirmProfileShowcaseImageUpload verifies the uploaded objects and persists
+// a new showcase image row for the authenticated user.
+func (s *Service) ConfirmProfileShowcaseImageUpload(ctx context.Context, userID uuid.UUID, input ConfirmUploadInput) (*ConfirmShowcaseImageResult, error) {
+	payload, err := s.verifyConfirmToken(input, ResourceProfileShowcase)
+	if err != nil {
+		return nil, err
+	}
+	if payload.OwnerUserID != userID || payload.EventID != nil {
+		return nil, invalidConfirmTokenError()
+	}
+	if err := s.ensureUploadedObjectsExist(ctx, payload); err != nil {
+		return nil, err
+	}
+
+	imageRecord, err := s.profileRepo.CreateShowcaseImage(ctx, userID, payload.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConfirmShowcaseImageResult{
+		ID:       imageRecord.ID.String(),
+		ImageURL: imageRecord.ImageURL,
+	}, nil
+}
+
 // CreateEventImageUpload prepares a versioned direct-upload flow for an event cover image.
 func (s *Service) CreateEventImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error) {
 	state, err := s.eventRepo.GetEventImageState(ctx, eventID)

--- a/backend/internal/application/imageupload/service_dto.go
+++ b/backend/internal/application/imageupload/service_dto.go
@@ -9,6 +9,7 @@ import (
 // Supported upload resource types.
 const (
 	ResourceProfileAvatar    = "PROFILE_AVATAR"
+	ResourceProfileShowcase  = "PROFILE_SHOWCASE_IMAGE"
 	ResourceEventImage       = "EVENT_IMAGE"
 	ResourceEventReviewImage = "EVENT_REVIEW_IMAGE"
 	ResourceJoinRequestImage = "EVENT_JOIN_REQUEST_IMAGE"
@@ -51,6 +52,13 @@ type ConfirmReviewImageResult struct {
 // after token and object validation.
 type ConfirmJoinRequestImageResult struct {
 	BaseURL string `json:"base_url"`
+}
+
+// ConfirmShowcaseImageResult exposes the persisted showcase image after token
+// and object validation.
+type ConfirmShowcaseImageResult struct {
+	ID       string `json:"id"`
+	ImageURL string `json:"image_url"`
 }
 
 // ConfirmReportImageResult exposes the uploaded report image URL after token

--- a/backend/internal/application/imageupload/service_test.go
+++ b/backend/internal/application/imageupload/service_test.go
@@ -21,6 +21,9 @@ type fakeProfileRepo struct {
 	lastUpdatedAt         time.Time
 	setResult             bool
 	getAvatarVersionCalls int
+	createdShowcaseImage  *domain.ProfileShowcaseImage
+	lastShowcaseUserID    uuid.UUID
+	lastShowcaseImageURL  string
 }
 
 func (r *fakeProfileRepo) GetAvatarVersion(_ context.Context, _ uuid.UUID) (int, error) {
@@ -47,6 +50,22 @@ func (r *fakeProfileRepo) SetAvatarIfVersion(
 		return false, r.setErr
 	}
 	return r.setResult, nil
+}
+
+func (r *fakeProfileRepo) CreateShowcaseImage(_ context.Context, userID uuid.UUID, imageURL string) (*domain.ProfileShowcaseImage, error) {
+	r.lastShowcaseUserID = userID
+	r.lastShowcaseImageURL = imageURL
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.createdShowcaseImage != nil {
+		return r.createdShowcaseImage, nil
+	}
+	return &domain.ProfileShowcaseImage{
+		ID:       uuid.New(),
+		UserID:   userID,
+		ImageURL: imageURL,
+	}, nil
 }
 
 type fakeEventRepo struct {
@@ -323,6 +342,32 @@ func TestConfirmProfileAvatarUploadRejectsStaleVersion(t *testing.T) {
 	}
 	if appErr.Code != domain.ErrorCodeImageUploadVersionConflict {
 		t.Fatalf("expected error code %q, got %q", domain.ErrorCodeImageUploadVersionConflict, appErr.Code)
+	}
+}
+
+func TestConfirmProfileShowcaseImageUploadPersistsShowcaseImage(t *testing.T) {
+	svc, profileRepo, _, storage, tokens := newServiceForTests()
+	userID := uuid.New()
+
+	_, err := svc.CreateProfileShowcaseImageUpload(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("CreateProfileShowcaseImageUpload() error = %v", err)
+	}
+	storage.existingKeys[tokens.payload.OriginalKey] = true
+	storage.existingKeys[tokens.payload.SmallKey] = true
+
+	result, err := svc.ConfirmProfileShowcaseImageUpload(context.Background(), userID, ConfirmUploadInput{ConfirmToken: "confirm-token"})
+	if err != nil {
+		t.Fatalf("ConfirmProfileShowcaseImageUpload() error = %v", err)
+	}
+	if profileRepo.lastShowcaseUserID != userID {
+		t.Fatalf("expected showcase image user %s, got %s", userID, profileRepo.lastShowcaseUserID)
+	}
+	if profileRepo.lastShowcaseImageURL != tokens.payload.BaseURL {
+		t.Fatalf("expected showcase image URL %q, got %q", tokens.payload.BaseURL, profileRepo.lastShowcaseImageURL)
+	}
+	if result.ImageURL != tokens.payload.BaseURL {
+		t.Fatalf("expected result image URL %q, got %q", tokens.payload.BaseURL, result.ImageURL)
 	}
 }
 

--- a/backend/internal/application/imageupload/usecase.go
+++ b/backend/internal/application/imageupload/usecase.go
@@ -10,6 +10,8 @@ import (
 type UseCase interface {
 	CreateProfileAvatarUpload(ctx context.Context, userID uuid.UUID) (*CreateUploadResult, error)
 	ConfirmProfileAvatarUpload(ctx context.Context, userID uuid.UUID, input ConfirmUploadInput) error
+	CreateProfileShowcaseImageUpload(ctx context.Context, userID uuid.UUID) (*CreateUploadResult, error)
+	ConfirmProfileShowcaseImageUpload(ctx context.Context, userID uuid.UUID, input ConfirmUploadInput) (*ConfirmShowcaseImageResult, error)
 	CreateEventImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error)
 	ConfirmEventImageUpload(ctx context.Context, userID, eventID uuid.UUID, input ConfirmUploadInput) error
 	CreateEventReviewImageUpload(ctx context.Context, userID, eventID uuid.UUID) (*CreateUploadResult, error)

--- a/backend/internal/application/profile/repository.go
+++ b/backend/internal/application/profile/repository.go
@@ -10,11 +10,21 @@ import (
 // Repository is the application-layer persistence port for profile flows.
 type Repository interface {
 	GetProfile(ctx context.Context, userID uuid.UUID) (*domain.UserProfile, error)
+	GetPublicProfile(ctx context.Context, userID uuid.UUID) (*domain.PublicUserProfile, error)
 	UpdateProfile(ctx context.Context, params UpdateProfileParams) error
 	GetHostedEvents(ctx context.Context, userID uuid.UUID) ([]domain.EventSummary, error)
 	GetUpcomingEvents(ctx context.Context, userID uuid.UUID) ([]domain.EventSummary, error)
 	GetCompletedEvents(ctx context.Context, userID uuid.UUID) ([]domain.EventSummary, error)
 	GetCanceledEvents(ctx context.Context, userID uuid.UUID) ([]domain.EventSummary, error)
+	ListEquipment(ctx context.Context, userID uuid.UUID) ([]domain.ProfileEquipment, error)
+	GetEquipmentByID(ctx context.Context, equipmentID uuid.UUID) (*domain.ProfileEquipment, error)
+	CreateEquipment(ctx context.Context, params CreateEquipmentParams) (*domain.ProfileEquipment, error)
+	UpdateEquipment(ctx context.Context, params UpdateEquipmentParams) (*domain.ProfileEquipment, error)
+	DeleteEquipment(ctx context.Context, equipmentID uuid.UUID) error
+	ListShowcaseImages(ctx context.Context, userID uuid.UUID) ([]domain.ProfileShowcaseImage, error)
+	GetShowcaseImageByID(ctx context.Context, showcaseImageID uuid.UUID) (*domain.ProfileShowcaseImage, error)
+	CreateShowcaseImage(ctx context.Context, userID uuid.UUID, imageURL string) (*domain.ProfileShowcaseImage, error)
+	DeleteShowcaseImage(ctx context.Context, showcaseImageID uuid.UUID) error
 	SearchUsers(ctx context.Context, query string, limit int) ([]UserSearchRecord, error)
 	GetPasswordHash(ctx context.Context, userID uuid.UUID) (string, error)
 	UpdatePasswordHash(ctx context.Context, userID uuid.UUID, newHash string) error

--- a/backend/internal/application/profile/service.go
+++ b/backend/internal/application/profile/service.go
@@ -2,6 +2,7 @@ package profile
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/bounswe/bounswe2026group11/backend/internal/application/uow"
@@ -71,6 +72,40 @@ func (s *Service) GetMyProfile(ctx context.Context, userID uuid.UUID) (*GetProfi
 	return result, nil
 }
 
+// GetPublicProfile returns the public-safe projection of another user's
+// profile, enriched with equipment and showcase images.
+func (s *Service) GetPublicProfile(ctx context.Context, userID uuid.UUID) (*PublicProfileResult, error) {
+	profileRecord, err := s.repo.GetPublicProfile(ctx, userID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeUserNotFound, "The requested user does not exist.")
+		}
+		return nil, err
+	}
+
+	equipment, err := s.repo.ListEquipment(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	showcaseImages, err := s.repo.ListShowcaseImages(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PublicProfileResult{
+		UserID:                 profileRecord.UserID.String(),
+		Username:               profileRecord.Username,
+		DisplayName:            profileRecord.DisplayName,
+		AvatarURL:              profileRecord.AvatarURL,
+		Bio:                    profileRecord.Bio,
+		FinalScore:             profileRecord.FinalScore,
+		HostRatingCount:        profileRecord.HostRatingCount,
+		ParticipantRatingCount: profileRecord.ParticipantRatingCount,
+		Equipment:              toEquipmentItems(equipment),
+		ShowcaseImages:         toShowcaseImageItems(showcaseImages),
+	}, nil
+}
+
 // GetMyHostedEvents returns events created by the user.
 func (s *Service) GetMyHostedEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error) {
 	events, err := s.repo.GetHostedEvents(ctx, userID)
@@ -110,6 +145,112 @@ func (s *Service) GetMyCanceledEvents(ctx context.Context, userID uuid.UUID) ([]
 	return toEventSummaries(events), nil
 }
 
+// ListMyEquipment returns the authenticated user's equipment entries.
+func (s *Service) ListMyEquipment(ctx context.Context, userID uuid.UUID) (*ListEquipmentResult, error) {
+	items, err := s.repo.ListEquipment(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return &ListEquipmentResult{Items: toEquipmentItems(items)}, nil
+}
+
+// CreateMyEquipment validates and persists one equipment item for the
+// authenticated user.
+func (s *Service) CreateMyEquipment(ctx context.Context, input CreateEquipmentInput) (*EquipmentItem, error) {
+	validated, appErr := validateCreateEquipmentInput(input)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	var created *domain.ProfileEquipment
+	if err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		var err error
+		created, err = s.repo.CreateEquipment(ctx, CreateEquipmentParams{
+			UserID:      validated.UserID,
+			Name:        validated.Name,
+			Description: validated.Description,
+			ImageURL:    validated.ImageURL,
+		})
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return toEquipmentItem(*created), nil
+}
+
+// UpdateMyEquipment updates one of the authenticated user's equipment entries.
+func (s *Service) UpdateMyEquipment(ctx context.Context, input UpdateEquipmentInput) (*EquipmentItem, error) {
+	validated, appErr := validateUpdateEquipmentInput(input)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	var updated *domain.ProfileEquipment
+	if err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		existing, err := s.repo.GetEquipmentByID(ctx, validated.EquipmentID)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				return domain.NotFoundError(domain.ErrorCodeProfileEquipmentNotFound, "The requested equipment item does not exist.")
+			}
+			return err
+		}
+		if existing.UserID != validated.UserID {
+			return domain.ForbiddenError(domain.ErrorCodeProfileMutationNotAllowed, "You can only modify your own profile resources.")
+		}
+
+		updated, err = s.repo.UpdateEquipment(ctx, UpdateEquipmentParams{
+			EquipmentID: validated.EquipmentID,
+			Name:        validated.Name,
+			Description: validated.Description,
+			ImageURL:    validated.ImageURL,
+		})
+		if err != nil && errors.Is(err, domain.ErrNotFound) {
+			return domain.NotFoundError(domain.ErrorCodeProfileEquipmentNotFound, "The requested equipment item does not exist.")
+		}
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return toEquipmentItem(*updated), nil
+}
+
+// DeleteMyEquipment deletes one of the authenticated user's equipment entries.
+func (s *Service) DeleteMyEquipment(ctx context.Context, userID, equipmentID uuid.UUID) error {
+	return s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		existing, err := s.repo.GetEquipmentByID(ctx, equipmentID)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				return domain.NotFoundError(domain.ErrorCodeProfileEquipmentNotFound, "The requested equipment item does not exist.")
+			}
+			return err
+		}
+		if existing.UserID != userID {
+			return domain.ForbiddenError(domain.ErrorCodeProfileMutationNotAllowed, "You can only modify your own profile resources.")
+		}
+		return s.repo.DeleteEquipment(ctx, equipmentID)
+	})
+}
+
+// DeleteMyShowcaseImage deletes one of the authenticated user's showcase
+// images.
+func (s *Service) DeleteMyShowcaseImage(ctx context.Context, userID, showcaseImageID uuid.UUID) error {
+	return s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		existing, err := s.repo.GetShowcaseImageByID(ctx, showcaseImageID)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				return domain.NotFoundError(domain.ErrorCodeProfileShowcaseImageNotFound, "The requested showcase image does not exist.")
+			}
+			return err
+		}
+		if existing.UserID != userID {
+			return domain.ForbiddenError(domain.ErrorCodeProfileMutationNotAllowed, "You can only modify your own profile resources.")
+		}
+		return s.repo.DeleteShowcaseImage(ctx, showcaseImageID)
+	})
+}
+
 // SearchUsers returns lightweight user summaries for username picker UIs.
 func (s *Service) SearchUsers(ctx context.Context, input UserSearchInput) (*UserSearchResult, error) {
 	query := strings.TrimSpace(input.Query)
@@ -146,6 +287,39 @@ func toEventSummaries(events []domain.EventSummary) []EventSummary {
 			ImageURL:          e.ImageURL,
 			ParticipantsCount: e.ApprovedParticipantCount,
 			LocationAddress:   e.LocationAddress,
+		}
+	}
+	return result
+}
+
+func toEquipmentItems(items []domain.ProfileEquipment) []EquipmentItem {
+	result := make([]EquipmentItem, len(items))
+	for i, item := range items {
+		result[i] = EquipmentItem{
+			ID:          item.ID.String(),
+			Name:        item.Name,
+			Description: item.Description,
+			ImageURL:    item.ImageURL,
+		}
+	}
+	return result
+}
+
+func toEquipmentItem(item domain.ProfileEquipment) *EquipmentItem {
+	return &EquipmentItem{
+		ID:          item.ID.String(),
+		Name:        item.Name,
+		Description: item.Description,
+		ImageURL:    item.ImageURL,
+	}
+}
+
+func toShowcaseImageItems(items []domain.ProfileShowcaseImage) []ShowcaseImageItem {
+	result := make([]ShowcaseImageItem, len(items))
+	for i, item := range items {
+		result[i] = ShowcaseImageItem{
+			ID:       item.ID.String(),
+			ImageURL: item.ImageURL,
 		}
 	}
 	return result

--- a/backend/internal/application/profile/service_dto.go
+++ b/backend/internal/application/profile/service_dto.go
@@ -63,6 +63,40 @@ type GetProfileResult struct {
 	ParticipantScore       *ParticipantScore `json:"participant_score"`
 }
 
+// PublicProfileResult is the public-safe profile payload returned when one
+// user views another user's profile.
+type PublicProfileResult struct {
+	UserID                 string              `json:"user_id"`
+	Username               string              `json:"username"`
+	DisplayName            *string             `json:"display_name"`
+	AvatarURL              *string             `json:"avatar_url"`
+	Bio                    *string             `json:"bio"`
+	FinalScore             *float64            `json:"final_score"`
+	HostRatingCount        int                 `json:"host_rating_count"`
+	ParticipantRatingCount int                 `json:"participant_rating_count"`
+	Equipment              []EquipmentItem     `json:"equipment"`
+	ShowcaseImages         []ShowcaseImageItem `json:"showcase_images"`
+}
+
+// EquipmentItem is one user-owned equipment entry.
+type EquipmentItem struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
+	ImageURL    *string `json:"image_url"`
+}
+
+// ShowcaseImageItem is one user-owned showcase image entry.
+type ShowcaseImageItem struct {
+	ID       string `json:"id"`
+	ImageURL string `json:"image_url"`
+}
+
+// ListEquipmentResult wraps the authenticated user's equipment list.
+type ListEquipmentResult struct {
+	Items []EquipmentItem `json:"items"`
+}
+
 // UpdateProfileInput is the input to the UpdateMyProfile use case.
 // All fields are optional (pointer = omitted means no change).
 type UpdateProfileInput struct {
@@ -77,6 +111,39 @@ type UpdateProfileInput struct {
 	DisplayName            *string
 	Bio                    *string
 	AvatarURL              *string
+}
+
+// CreateEquipmentInput is the input for creating one equipment item.
+type CreateEquipmentInput struct {
+	UserID      uuid.UUID
+	Name        string
+	Description *string
+	ImageURL    *string
+}
+
+// CreateEquipmentParams is passed to the repository layer.
+type CreateEquipmentParams struct {
+	UserID      uuid.UUID
+	Name        string
+	Description *string
+	ImageURL    *string
+}
+
+// UpdateEquipmentInput is the input for updating one equipment item.
+type UpdateEquipmentInput struct {
+	UserID      uuid.UUID
+	EquipmentID uuid.UUID
+	Name        *string
+	Description *string
+	ImageURL    *string
+}
+
+// UpdateEquipmentParams is passed to the repository layer.
+type UpdateEquipmentParams struct {
+	EquipmentID uuid.UUID
+	Name        *string
+	Description *string
+	ImageURL    *string
 }
 
 // UpdateProfileParams is passed to the repository layer.

--- a/backend/internal/application/profile/service_test.go
+++ b/backend/internal/application/profile/service_test.go
@@ -19,15 +19,25 @@ func (u *fakeUnitOfWork) RunInTx(ctx context.Context, fn func(ctx context.Contex
 }
 
 type fakeProfileRepo struct {
-	profile         *domain.UserProfile
-	profileErr      error
-	passwordHash    string
-	hostedEvents    []domain.EventSummary
-	upcomingEvents  []domain.EventSummary
-	completedEvents []domain.EventSummary
-	canceledEvents  []domain.EventSummary
-	searchUsers     []UserSearchRecord
-	eventsErr       error
+	profile                    *domain.UserProfile
+	publicProfile              *domain.PublicUserProfile
+	profileErr                 error
+	passwordHash               string
+	hostedEvents               []domain.EventSummary
+	upcomingEvents             []domain.EventSummary
+	completedEvents            []domain.EventSummary
+	canceledEvents             []domain.EventSummary
+	searchUsers                []UserSearchRecord
+	equipment                  []domain.ProfileEquipment
+	equipmentRecord            *domain.ProfileEquipment
+	showcaseImages             []domain.ProfileShowcaseImage
+	showcaseRecord             *domain.ProfileShowcaseImage
+	eventsErr                  error
+	equipmentErr               error
+	lastCreateEquipmentParams  CreateEquipmentParams
+	lastUpdateEquipmentParams  UpdateEquipmentParams
+	lastDeletedEquipmentID     uuid.UUID
+	lastDeletedShowcaseImageID uuid.UUID
 }
 
 func (r *fakeProfileRepo) GetProfile(_ context.Context, _ uuid.UUID) (*domain.UserProfile, error) {
@@ -36,6 +46,10 @@ func (r *fakeProfileRepo) GetProfile(_ context.Context, _ uuid.UUID) (*domain.Us
 
 func (r *fakeProfileRepo) UpdateProfile(_ context.Context, _ UpdateProfileParams) error {
 	return nil
+}
+
+func (r *fakeProfileRepo) GetPublicProfile(_ context.Context, _ uuid.UUID) (*domain.PublicUserProfile, error) {
+	return r.publicProfile, r.profileErr
 }
 
 func (r *fakeProfileRepo) GetHostedEvents(_ context.Context, _ uuid.UUID) ([]domain.EventSummary, error) {
@@ -56,6 +70,93 @@ func (r *fakeProfileRepo) GetCanceledEvents(_ context.Context, _ uuid.UUID) ([]d
 
 func (r *fakeProfileRepo) SearchUsers(_ context.Context, _ string, _ int) ([]UserSearchRecord, error) {
 	return r.searchUsers, r.eventsErr
+}
+
+func (r *fakeProfileRepo) ListEquipment(_ context.Context, _ uuid.UUID) ([]domain.ProfileEquipment, error) {
+	return r.equipment, r.equipmentErr
+}
+
+func (r *fakeProfileRepo) GetEquipmentByID(_ context.Context, _ uuid.UUID) (*domain.ProfileEquipment, error) {
+	if r.equipmentErr != nil {
+		return nil, r.equipmentErr
+	}
+	if r.equipmentRecord == nil {
+		return nil, domain.ErrNotFound
+	}
+	return r.equipmentRecord, nil
+}
+
+func (r *fakeProfileRepo) CreateEquipment(_ context.Context, params CreateEquipmentParams) (*domain.ProfileEquipment, error) {
+	r.lastCreateEquipmentParams = params
+	if r.equipmentErr != nil {
+		return nil, r.equipmentErr
+	}
+	item := &domain.ProfileEquipment{
+		ID:          uuid.New(),
+		UserID:      params.UserID,
+		Name:        params.Name,
+		Description: params.Description,
+		ImageURL:    params.ImageURL,
+	}
+	r.equipmentRecord = item
+	return item, nil
+}
+
+func (r *fakeProfileRepo) UpdateEquipment(_ context.Context, params UpdateEquipmentParams) (*domain.ProfileEquipment, error) {
+	r.lastUpdateEquipmentParams = params
+	if r.equipmentErr != nil {
+		return nil, r.equipmentErr
+	}
+	if r.equipmentRecord == nil {
+		return nil, domain.ErrNotFound
+	}
+	if params.Name != nil {
+		r.equipmentRecord.Name = *params.Name
+	}
+	if params.Description != nil {
+		r.equipmentRecord.Description = params.Description
+	}
+	if params.ImageURL != nil {
+		r.equipmentRecord.ImageURL = params.ImageURL
+	}
+	return r.equipmentRecord, nil
+}
+
+func (r *fakeProfileRepo) DeleteEquipment(_ context.Context, equipmentID uuid.UUID) error {
+	r.lastDeletedEquipmentID = equipmentID
+	return r.equipmentErr
+}
+
+func (r *fakeProfileRepo) ListShowcaseImages(_ context.Context, _ uuid.UUID) ([]domain.ProfileShowcaseImage, error) {
+	return r.showcaseImages, r.equipmentErr
+}
+
+func (r *fakeProfileRepo) GetShowcaseImageByID(_ context.Context, _ uuid.UUID) (*domain.ProfileShowcaseImage, error) {
+	if r.equipmentErr != nil {
+		return nil, r.equipmentErr
+	}
+	if r.showcaseRecord == nil {
+		return nil, domain.ErrNotFound
+	}
+	return r.showcaseRecord, nil
+}
+
+func (r *fakeProfileRepo) CreateShowcaseImage(_ context.Context, userID uuid.UUID, imageURL string) (*domain.ProfileShowcaseImage, error) {
+	if r.equipmentErr != nil {
+		return nil, r.equipmentErr
+	}
+	item := &domain.ProfileShowcaseImage{
+		ID:       uuid.New(),
+		UserID:   userID,
+		ImageURL: imageURL,
+	}
+	r.showcaseRecord = item
+	return item, nil
+}
+
+func (r *fakeProfileRepo) DeleteShowcaseImage(_ context.Context, showcaseImageID uuid.UUID) error {
+	r.lastDeletedShowcaseImageID = showcaseImageID
+	return r.equipmentErr
 }
 
 func (r *fakeProfileRepo) GetPasswordHash(_ context.Context, _ uuid.UUID) (string, error) {
@@ -191,6 +292,51 @@ func TestGetMyProfilePropagatesRepoError(t *testing.T) {
 	}
 }
 
+func TestGetPublicProfileIncludesEquipmentAndShowcase(t *testing.T) {
+	repo := &fakeProfileRepo{
+		publicProfile: &domain.PublicUserProfile{
+			UserID:                 uuid.New(),
+			Username:               "runner",
+			HostRatingCount:        3,
+			ParticipantRatingCount: 5,
+		},
+		equipment: []domain.ProfileEquipment{
+			{ID: uuid.New(), UserID: uuid.New(), Name: "Shoes"},
+		},
+		showcaseImages: []domain.ProfileShowcaseImage{
+			{ID: uuid.New(), UserID: uuid.New(), ImageURL: "https://cdn.example/showcase.jpg"},
+		},
+	}
+
+	result, err := newService(repo).GetPublicProfile(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("GetPublicProfile() error = %v", err)
+	}
+	if len(result.Equipment) != 1 {
+		t.Fatalf("expected 1 equipment item, got %d", len(result.Equipment))
+	}
+	if len(result.ShowcaseImages) != 1 {
+		t.Fatalf("expected 1 showcase image, got %d", len(result.ShowcaseImages))
+	}
+	if result.HostRatingCount != 3 || result.ParticipantRatingCount != 5 {
+		t.Fatalf("unexpected rating counts: %+v", result)
+	}
+}
+
+func TestGetPublicProfileMapsUserNotFound(t *testing.T) {
+	repo := &fakeProfileRepo{profileErr: domain.ErrNotFound}
+
+	_, err := newService(repo).GetPublicProfile(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	appErr, ok := err.(*domain.AppError)
+	if !ok || appErr.Code != domain.ErrorCodeUserNotFound {
+		t.Fatalf("expected user_not_found AppError, got %v", err)
+	}
+}
+
 // --- event summary privacy_level tests ---
 
 func TestGetMyHostedEventsIncludesPrivacyLevel(t *testing.T) {
@@ -248,6 +394,79 @@ func TestGetMyCanceledEventsIncludesPrivacyLevel(t *testing.T) {
 
 	if events[0].PrivacyLevel != "PRIVATE" {
 		t.Fatalf("expected PRIVATE, got %q", events[0].PrivacyLevel)
+	}
+}
+
+func TestCreateMyEquipmentNormalizesOptionalFields(t *testing.T) {
+	repo := &fakeProfileRepo{}
+	svc := newService(repo)
+
+	description := "  lightweight  "
+	imageURL := "   "
+	item, err := svc.CreateMyEquipment(context.Background(), CreateEquipmentInput{
+		UserID:      uuid.New(),
+		Name:        "  Trail Shoes ",
+		Description: &description,
+		ImageURL:    &imageURL,
+	})
+	if err != nil {
+		t.Fatalf("CreateMyEquipment() error = %v", err)
+	}
+	if item.Name != "Trail Shoes" {
+		t.Fatalf("expected trimmed name, got %q", item.Name)
+	}
+	if repo.lastCreateEquipmentParams.Description == nil || *repo.lastCreateEquipmentParams.Description != "lightweight" {
+		t.Fatalf("expected trimmed description, got %+v", repo.lastCreateEquipmentParams.Description)
+	}
+	if repo.lastCreateEquipmentParams.ImageURL != nil {
+		t.Fatalf("expected blank image_url to clear, got %+v", repo.lastCreateEquipmentParams.ImageURL)
+	}
+}
+
+func TestUpdateMyEquipmentRejectsForeignOwner(t *testing.T) {
+	ownerID := uuid.New()
+	callerID := uuid.New()
+	repo := &fakeProfileRepo{
+		equipmentRecord: &domain.ProfileEquipment{
+			ID:     uuid.New(),
+			UserID: ownerID,
+			Name:   "Tent",
+		},
+	}
+	svc := newService(repo)
+
+	name := "New Tent"
+	_, err := svc.UpdateMyEquipment(context.Background(), UpdateEquipmentInput{
+		UserID:      callerID,
+		EquipmentID: repo.equipmentRecord.ID,
+		Name:        &name,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	appErr, ok := err.(*domain.AppError)
+	if !ok || appErr.Code != domain.ErrorCodeProfileMutationNotAllowed {
+		t.Fatalf("expected profile_mutation_not_allowed, got %v", err)
+	}
+}
+
+func TestDeleteMyShowcaseImageRejectsForeignOwner(t *testing.T) {
+	repo := &fakeProfileRepo{
+		showcaseRecord: &domain.ProfileShowcaseImage{
+			ID:       uuid.New(),
+			UserID:   uuid.New(),
+			ImageURL: "https://cdn.example/showcase.jpg",
+		},
+	}
+	svc := newService(repo)
+
+	err := svc.DeleteMyShowcaseImage(context.Background(), uuid.New(), repo.showcaseRecord.ID)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	appErr, ok := err.(*domain.AppError)
+	if !ok || appErr.Code != domain.ErrorCodeProfileMutationNotAllowed {
+		t.Fatalf("expected profile_mutation_not_allowed, got %v", err)
 	}
 }
 

--- a/backend/internal/application/profile/usecase.go
+++ b/backend/internal/application/profile/usecase.go
@@ -9,11 +9,17 @@ import (
 // UseCase is the inbound application port for profile flows.
 type UseCase interface {
 	GetMyProfile(ctx context.Context, userID uuid.UUID) (*GetProfileResult, error)
+	GetPublicProfile(ctx context.Context, userID uuid.UUID) (*PublicProfileResult, error)
 	UpdateMyProfile(ctx context.Context, input UpdateProfileInput) error
 	GetMyHostedEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error)
 	GetMyUpcomingEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error)
 	GetMyCompletedEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error)
 	GetMyCanceledEvents(ctx context.Context, userID uuid.UUID) ([]EventSummary, error)
+	ListMyEquipment(ctx context.Context, userID uuid.UUID) (*ListEquipmentResult, error)
+	CreateMyEquipment(ctx context.Context, input CreateEquipmentInput) (*EquipmentItem, error)
+	UpdateMyEquipment(ctx context.Context, input UpdateEquipmentInput) (*EquipmentItem, error)
+	DeleteMyEquipment(ctx context.Context, userID, equipmentID uuid.UUID) error
+	DeleteMyShowcaseImage(ctx context.Context, userID, showcaseImageID uuid.UUID) error
 	SearchUsers(ctx context.Context, input UserSearchInput) (*UserSearchResult, error)
 	ChangePassword(ctx context.Context, input ChangePasswordInput) error
 }

--- a/backend/internal/application/profile/validator.go
+++ b/backend/internal/application/profile/validator.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -153,4 +154,85 @@ func validateUpdateProfileInput(input UpdateProfileInput) (*UpdateProfileInput, 
 	}
 
 	return &out, nil
+}
+
+func validateCreateEquipmentInput(input CreateEquipmentInput) (*CreateEquipmentInput, *domain.AppError) {
+	details := make(map[string]string)
+
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		details["name"] = "must not be empty"
+	} else if len(name) > 64 {
+		details["name"] = "must be at most 64 characters"
+	}
+
+	description := normalizeOptionalEquipmentText(input.Description, 512, "description", details)
+	imageURL := normalizeOptionalEquipmentText(input.ImageURL, 512, "image_url", details)
+
+	if len(details) > 0 {
+		return nil, domain.ValidationError(details)
+	}
+
+	return &CreateEquipmentInput{
+		UserID:      input.UserID,
+		Name:        name,
+		Description: description,
+		ImageURL:    imageURL,
+	}, nil
+}
+
+func validateUpdateEquipmentInput(input UpdateEquipmentInput) (*UpdateEquipmentInput, *domain.AppError) {
+	details := make(map[string]string)
+
+	var (
+		name        *string
+		description *string
+		imageURL    *string
+	)
+
+	if input.Name != nil {
+		trimmed := strings.TrimSpace(*input.Name)
+		if trimmed == "" {
+			details["name"] = "must not be empty"
+		} else if len(trimmed) > 64 {
+			details["name"] = "must be at most 64 characters"
+		} else {
+			name = &trimmed
+		}
+	}
+
+	description = normalizeOptionalEquipmentText(input.Description, 512, "description", details)
+	imageURL = normalizeOptionalEquipmentText(input.ImageURL, 512, "image_url", details)
+
+	if input.Name == nil && input.Description == nil && input.ImageURL == nil {
+		details["body"] = "must include at least one updatable field"
+	}
+
+	if len(details) > 0 {
+		return nil, domain.ValidationError(details)
+	}
+
+	return &UpdateEquipmentInput{
+		UserID:      input.UserID,
+		EquipmentID: input.EquipmentID,
+		Name:        name,
+		Description: description,
+		ImageURL:    imageURL,
+	}, nil
+}
+
+func normalizeOptionalEquipmentText(value *string, maxLen int, field string, details map[string]string) *string {
+	if value == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	if len(trimmed) > maxLen {
+		details[field] = "must be at most " + strconv.Itoa(maxLen) + " characters"
+		return nil
+	}
+	return &trimmed
 }

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -66,6 +66,9 @@ const (
 	ErrorCodeAgeRequirementNotMet             = "age_requirement_not_met"
 	ErrorCodeGenderRequirementNotMet          = "gender_requirement_not_met"
 	ErrorCodeProfileIncomplete                = "profile_incomplete"
+	ErrorCodeProfileMutationNotAllowed        = "profile_mutation_not_allowed"
+	ErrorCodeProfileEquipmentNotFound         = "profile_equipment_not_found"
+	ErrorCodeProfileShowcaseImageNotFound     = "profile_showcase_image_not_found"
 
 	ErrorCodeImageUploadTokenInvalid    = "image_upload_token_invalid"
 	ErrorCodeImageUploadNotAllowed      = "image_upload_not_allowed"

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -17,6 +17,39 @@ type Profile struct {
 	UpdatedAt   time.Time
 }
 
+// PublicUserProfile is the public-safe profile projection returned when one
+// user views another user's profile.
+type PublicUserProfile struct {
+	UserID                 uuid.UUID
+	Username               string
+	DisplayName            *string
+	AvatarURL              *string
+	Bio                    *string
+	FinalScore             *float64
+	HostRatingCount        int
+	ParticipantRatingCount int
+}
+
+// ProfileEquipment is one user-owned equipment entry shown on public profiles.
+type ProfileEquipment struct {
+	ID          uuid.UUID
+	UserID      uuid.UUID
+	Name        string
+	Description *string
+	ImageURL    *string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// ProfileShowcaseImage is one user-owned showcase image entry.
+type ProfileShowcaseImage struct {
+	ID        uuid.UUID
+	UserID    uuid.UUID
+	ImageURL  string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 // EventSummary is a lightweight event projection used in profile responses.
 type EventSummary struct {
 	ID                       uuid.UUID

--- a/backend/migrations/000034_profile_public_assets.down.sql
+++ b/backend/migrations/000034_profile_public_assets.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS profile_showcase_image;
+DROP TABLE IF EXISTS profile_equipment;

--- a/backend/migrations/000034_profile_public_assets.up.sql
+++ b/backend/migrations/000034_profile_public_assets.up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE profile_equipment (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    image_url TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_profile_equipment_user
+        FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_profile_equipment_user_id
+    ON profile_equipment(user_id, created_at DESC, id DESC);
+
+CREATE TABLE profile_showcase_image (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    image_url TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_profile_showcase_image_user
+        FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_profile_showcase_image_user_id
+    ON profile_showcase_image(user_id, created_at DESC, id DESC);

--- a/backend/tests_integration/profile_test.go
+++ b/backend/tests_integration/profile_test.go
@@ -1,0 +1,277 @@
+//go:build integration
+
+package tests_integration
+
+import (
+	"context"
+	"testing"
+
+	postgresrepo "github.com/bounswe/bounswe2026group11/backend/internal/adapter/in/postgres"
+	imageuploadapp "github.com/bounswe/bounswe2026group11/backend/internal/application/imageupload"
+	profileapp "github.com/bounswe/bounswe2026group11/backend/internal/application/profile"
+	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
+	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
+	"github.com/google/uuid"
+)
+
+func TestGetPublicProfileReturnsPublicSafeProfile(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	pool := common.RequirePool(t)
+	user := common.GivenUser(t, harness.AuthRepo)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM app_user WHERE id = $1`, user.ID)
+	})
+
+	if err := harness.AuthRepo.CreateProfile(context.Background(), user.ID); err != nil {
+		t.Fatalf("CreateProfile() error = %v", err)
+	}
+
+	displayName := "Public Runner"
+	bio := "Long-distance hiker."
+	avatarURL := "https://cdn.example/avatar.jpg"
+	if err := harness.ProfileService.UpdateMyProfile(context.Background(), profileapp.UpdateProfileInput{
+		UserID:      user.ID,
+		DisplayName: &displayName,
+		Bio:         &bio,
+		AvatarURL:   &avatarURL,
+	}); err != nil {
+		t.Fatalf("UpdateMyProfile() error = %v", err)
+	}
+
+	if _, err := harness.ProfileService.CreateMyEquipment(context.Background(), profileapp.CreateEquipmentInput{
+		UserID: user.ID,
+		Name:   "Trail Poles",
+	}); err != nil {
+		t.Fatalf("CreateMyEquipment() error = %v", err)
+	}
+
+	if _, err := postgresrepo.NewProfileRepository(pool).CreateShowcaseImage(context.Background(), user.ID, "https://cdn.example/showcase.jpg"); err != nil {
+		t.Fatalf("CreateShowcaseImage() error = %v", err)
+	}
+
+	finalScore := 4.8
+	if _, err := pool.Exec(
+		context.Background(),
+		`INSERT INTO user_score (
+			user_id,
+			participant_score,
+			participant_rating_count,
+			hosted_event_score,
+			hosted_event_rating_count,
+			final_score
+		) VALUES ($1, $2, $3, $4, $5, $6)`,
+		user.ID,
+		4.6,
+		7,
+		4.9,
+		3,
+		finalScore,
+	); err != nil {
+		t.Fatalf("insert user_score error = %v", err)
+	}
+
+	result, err := harness.ProfileService.GetPublicProfile(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("GetPublicProfile() error = %v", err)
+	}
+
+	if result.UserID != user.ID.String() {
+		t.Fatalf("expected user_id %q, got %q", user.ID.String(), result.UserID)
+	}
+	if result.Username != user.Username {
+		t.Fatalf("expected username %q, got %q", user.Username, result.Username)
+	}
+	if result.DisplayName == nil || *result.DisplayName != displayName {
+		t.Fatalf("expected display_name %q, got %+v", displayName, result.DisplayName)
+	}
+	if result.FinalScore == nil || *result.FinalScore != finalScore {
+		t.Fatalf("expected final_score %v, got %+v", finalScore, result.FinalScore)
+	}
+	if result.HostRatingCount != 3 || result.ParticipantRatingCount != 7 {
+		t.Fatalf("unexpected rating counts: host=%d participant=%d", result.HostRatingCount, result.ParticipantRatingCount)
+	}
+	if len(result.Equipment) != 1 {
+		t.Fatalf("expected 1 equipment item, got %d", len(result.Equipment))
+	}
+	if len(result.ShowcaseImages) != 1 {
+		t.Fatalf("expected 1 showcase image, got %d", len(result.ShowcaseImages))
+	}
+}
+
+func TestGetPublicProfileReturnsNotFoundForUnknownUser(t *testing.T) {
+	harness := common.NewEventHarness(t)
+
+	_, err := harness.ProfileService.GetPublicProfile(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	appErr, ok := err.(*domain.AppError)
+	if !ok || appErr.Code != domain.ErrorCodeUserNotFound {
+		t.Fatalf("expected user_not_found AppError, got %v", err)
+	}
+}
+
+func TestMyEquipmentCRUDFlow(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	pool := common.RequirePool(t)
+	user := common.GivenUser(t, harness.AuthRepo)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM app_user WHERE id = $1`, user.ID)
+	})
+
+	if err := harness.AuthRepo.CreateProfile(context.Background(), user.ID); err != nil {
+		t.Fatalf("CreateProfile() error = %v", err)
+	}
+
+	description := "Waterproof"
+	imageURL := "https://cdn.example/jacket.jpg"
+	created, err := harness.ProfileService.CreateMyEquipment(context.Background(), profileapp.CreateEquipmentInput{
+		UserID:      user.ID,
+		Name:        "Jacket",
+		Description: &description,
+		ImageURL:    &imageURL,
+	})
+	if err != nil {
+		t.Fatalf("CreateMyEquipment() error = %v", err)
+	}
+
+	listed, err := harness.ProfileService.ListMyEquipment(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("ListMyEquipment() error = %v", err)
+	}
+	if len(listed.Items) != 1 {
+		t.Fatalf("expected 1 equipment item, got %d", len(listed.Items))
+	}
+
+	equipmentID := uuid.MustParse(created.ID)
+	updatedDescription := "Waterproof shell"
+	updated, err := harness.ProfileService.UpdateMyEquipment(context.Background(), profileapp.UpdateEquipmentInput{
+		UserID:      user.ID,
+		EquipmentID: equipmentID,
+		Description: &updatedDescription,
+	})
+	if err != nil {
+		t.Fatalf("UpdateMyEquipment() error = %v", err)
+	}
+	if updated.Description == nil || *updated.Description != updatedDescription {
+		t.Fatalf("expected updated description %q, got %+v", updatedDescription, updated.Description)
+	}
+
+	if err := harness.ProfileService.DeleteMyEquipment(context.Background(), user.ID, equipmentID); err != nil {
+		t.Fatalf("DeleteMyEquipment() error = %v", err)
+	}
+
+	listed, err = harness.ProfileService.ListMyEquipment(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("ListMyEquipment() error = %v", err)
+	}
+	if len(listed.Items) != 0 {
+		t.Fatalf("expected equipment list to be empty, got %d items", len(listed.Items))
+	}
+}
+
+func TestMyEquipmentUpdateRejectsForeignOwner(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	pool := common.RequirePool(t)
+	owner := common.GivenUser(t, harness.AuthRepo)
+	attacker := common.GivenUser(t, harness.AuthRepo)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM app_user WHERE id IN ($1, $2)`, owner.ID, attacker.ID)
+	})
+
+	if err := harness.AuthRepo.CreateProfile(context.Background(), owner.ID); err != nil {
+		t.Fatalf("CreateProfile(owner) error = %v", err)
+	}
+	if err := harness.AuthRepo.CreateProfile(context.Background(), attacker.ID); err != nil {
+		t.Fatalf("CreateProfile(attacker) error = %v", err)
+	}
+
+	item, err := harness.ProfileService.CreateMyEquipment(context.Background(), profileapp.CreateEquipmentInput{
+		UserID: owner.ID,
+		Name:   "Stove",
+	})
+	if err != nil {
+		t.Fatalf("CreateMyEquipment() error = %v", err)
+	}
+
+	equipmentID := uuid.MustParse(item.ID)
+	newName := "Compromised Stove"
+	_, err = harness.ProfileService.UpdateMyEquipment(context.Background(), profileapp.UpdateEquipmentInput{
+		UserID:      attacker.ID,
+		EquipmentID: equipmentID,
+		Name:        &newName,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	appErr, ok := err.(*domain.AppError)
+	if !ok || appErr.Code != domain.ErrorCodeProfileMutationNotAllowed || appErr.Status != domain.StatusForbidden {
+		t.Fatalf("expected forbidden profile_mutation_not_allowed, got %v", err)
+	}
+}
+
+func TestShowcaseImageLifecycleAndOwnership(t *testing.T) {
+	harness := common.NewEventHarness(t)
+	pool := common.RequirePool(t)
+	owner := common.GivenUser(t, harness.AuthRepo)
+	attacker := common.GivenUser(t, harness.AuthRepo)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM app_user WHERE id IN ($1, $2)`, owner.ID, attacker.ID)
+	})
+
+	if err := harness.AuthRepo.CreateProfile(context.Background(), owner.ID); err != nil {
+		t.Fatalf("CreateProfile(owner) error = %v", err)
+	}
+	if err := harness.AuthRepo.CreateProfile(context.Background(), attacker.ID); err != nil {
+		t.Fatalf("CreateProfile(attacker) error = %v", err)
+	}
+
+	service, storage, tokens := newIntegrationImageUploadService(t)
+	_, err := service.CreateProfileShowcaseImageUpload(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("CreateProfileShowcaseImageUpload() error = %v", err)
+	}
+	storage.existing[tokens.payload.OriginalKey] = true
+	storage.existing[tokens.payload.SmallKey] = true
+
+	confirmed, err := service.ConfirmProfileShowcaseImageUpload(
+		context.Background(),
+		owner.ID,
+		imageuploadapp.ConfirmUploadInput{ConfirmToken: "confirm-token"},
+	)
+	if err != nil {
+		t.Fatalf("ConfirmProfileShowcaseImageUpload() error = %v", err)
+	}
+
+	showcaseImageID := uuid.MustParse(confirmed.ID)
+	publicProfile, err := harness.ProfileService.GetPublicProfile(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("GetPublicProfile() error = %v", err)
+	}
+	if len(publicProfile.ShowcaseImages) != 1 {
+		t.Fatalf("expected 1 showcase image, got %d", len(publicProfile.ShowcaseImages))
+	}
+
+	err = harness.ProfileService.DeleteMyShowcaseImage(context.Background(), attacker.ID, showcaseImageID)
+	if err == nil {
+		t.Fatal("expected ownership error, got nil")
+	}
+	appErr, ok := err.(*domain.AppError)
+	if !ok || appErr.Code != domain.ErrorCodeProfileMutationNotAllowed || appErr.Status != domain.StatusForbidden {
+		t.Fatalf("expected forbidden profile_mutation_not_allowed, got %v", err)
+	}
+
+	if err := harness.ProfileService.DeleteMyShowcaseImage(context.Background(), owner.ID, showcaseImageID); err != nil {
+		t.Fatalf("DeleteMyShowcaseImage() error = %v", err)
+	}
+
+	publicProfile, err = harness.ProfileService.GetPublicProfile(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("GetPublicProfile() error = %v", err)
+	}
+	if len(publicProfile.ShowcaseImages) != 0 {
+		t.Fatalf("expected showcase images to be empty after delete, got %d", len(publicProfile.ShowcaseImages))
+	}
+}

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -43,6 +43,32 @@ CREATE TABLE profile (
     CONSTRAINT fk_profile_user FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
 );
 
+CREATE TABLE profile_equipment (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    image_url TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_profile_equipment_user FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_profile_equipment_user_id ON profile_equipment(user_id, created_at DESC, id DESC);
+
+CREATE TABLE profile_showcase_image (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    image_url TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_profile_showcase_image_user FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_profile_showcase_image_user_id ON profile_showcase_image(user_id, created_at DESC, id DESC);
+
 -- =========================
 -- REFRESH TOKEN (access = stateless JWT, not stored)
 -- =========================

--- a/docs/openapi/profile.yaml
+++ b/docs/openapi/profile.yaml
@@ -64,6 +64,214 @@ paths:
         "401":
           description: Missing or invalid access token.
 
+  /users/{user_id}/profile:
+    get:
+      summary: Get another user's public profile
+      description: >
+        Returns a public-safe profile projection for the requested user. This
+        surface intentionally excludes private account fields such as email,
+        phone number, default location, verification state, and account status.
+      tags:
+        - Profile
+      parameters:
+        - $ref: "#/components/parameters/UserIdParam"
+      responses:
+        "200":
+          description: Public profile retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicProfile"
+        "400":
+          description: Invalid user id.
+        "404":
+          description: User not found.
+
+  /me/equipment:
+    get:
+      summary: List the authenticated user's equipment
+      description: Returns the caller's equipment items in reverse chronological order.
+      tags:
+        - Profile
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Equipment retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EquipmentListResponse"
+        "401":
+          description: Missing or invalid access token.
+
+    post:
+      summary: Create an equipment item
+      description: Creates one equipment item for the authenticated user.
+      tags:
+        - Profile
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateEquipmentRequest"
+      responses:
+        "201":
+          description: Equipment item created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileEquipmentItem"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Missing or invalid access token.
+
+  /me/equipment/{equipment_id}:
+    patch:
+      summary: Update an equipment item
+      description: Updates one equipment item owned by the authenticated user.
+      tags:
+        - Profile
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/EquipmentIdParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEquipmentRequest"
+      responses:
+        "200":
+          description: Equipment item updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileEquipmentItem"
+        "400":
+          description: Invalid equipment id or validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Missing or invalid access token.
+        "403":
+          description: The equipment item belongs to a different user.
+        "404":
+          description: Equipment item not found.
+
+    delete:
+      summary: Delete an equipment item
+      description: Deletes one equipment item owned by the authenticated user.
+      tags:
+        - Profile
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/EquipmentIdParam"
+      responses:
+        "204":
+          description: Equipment item deleted successfully.
+        "400":
+          description: Invalid equipment id.
+        "401":
+          description: Missing or invalid access token.
+        "403":
+          description: The equipment item belongs to a different user.
+        "404":
+          description: Equipment item not found.
+
+  /me/showcase-images/upload-url:
+    post:
+      summary: Create direct-upload URLs for a showcase image
+      description: >
+        Reuses the same two-step presigned upload flow as avatar uploads, but
+        persists the confirmed image as a standalone showcase entry instead of
+        replacing the profile avatar.
+      tags:
+        - Profile
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Presigned upload instructions created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImageUploadInitResponse"
+        "401":
+          description: Missing or invalid access token.
+
+  /me/showcase-images/confirm:
+    post:
+      summary: Confirm an uploaded showcase image
+      description: >
+        Confirms a previously presigned showcase image upload and persists the
+        resulting image as a user-owned showcase entry.
+      tags:
+        - Profile
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImageUploadConfirmRequest"
+      responses:
+        "201":
+          description: Showcase image persisted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShowcaseImageItem"
+        "400":
+          description: Invalid request body or expired/invalid confirm token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Missing or invalid access token.
+        "409":
+          description: Upload incomplete.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /me/showcase-images/{showcase_image_id}:
+    delete:
+      summary: Delete a showcase image
+      description: Deletes one showcase image owned by the authenticated user.
+      tags:
+        - Profile
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ShowcaseImageIdParam"
+      responses:
+        "204":
+          description: Showcase image deleted successfully.
+        "400":
+          description: Invalid showcase image id.
+        "401":
+          description: Missing or invalid access token.
+        "403":
+          description: The showcase image belongs to a different user.
+        "404":
+          description: Showcase image not found.
+
   /me/events/hosted:
     get:
       summary: Get the current user's hosted events
@@ -364,6 +572,27 @@ components:
       bearerFormat: JWT
 
   parameters:
+    UserIdParam:
+      name: user_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    EquipmentIdParam:
+      name: equipment_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    ShowcaseImageIdParam:
+      name: showcase_image_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     InvitationIdParam:
       name: invitation_id
       in: path
@@ -489,6 +718,136 @@ components:
           minimum: 0
           description: Total number of ratings received in this role.
           example: 8
+
+    PublicProfile:
+      type: object
+      additionalProperties: false
+      required:
+        - user_id
+        - username
+        - host_rating_count
+        - participant_rating_count
+        - equipment
+        - showcase_images
+      properties:
+        user_id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        display_name:
+          type:
+            - string
+            - "null"
+        avatar_url:
+          type:
+            - string
+            - "null"
+        bio:
+          type:
+            - string
+            - "null"
+        final_score:
+          type:
+            - number
+            - "null"
+          format: double
+        host_rating_count:
+          type: integer
+          minimum: 0
+        participant_rating_count:
+          type: integer
+          minimum: 0
+        equipment:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProfileEquipmentItem"
+        showcase_images:
+          type: array
+          items:
+            $ref: "#/components/schemas/ShowcaseImageItem"
+
+    ProfileEquipmentItem:
+      type: object
+      additionalProperties: false
+      required: [id, name]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type:
+            - string
+            - "null"
+        image_url:
+          type:
+            - string
+            - "null"
+
+    ShowcaseImageItem:
+      type: object
+      additionalProperties: false
+      required: [id, image_url]
+      properties:
+        id:
+          type: string
+          format: uuid
+        image_url:
+          type: string
+
+    EquipmentListResponse:
+      type: object
+      additionalProperties: false
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProfileEquipmentItem"
+
+    CreateEquipmentRequest:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 64
+        description:
+          type:
+            - string
+            - "null"
+          maxLength: 512
+        image_url:
+          type:
+            - string
+            - "null"
+          maxLength: 512
+
+    UpdateEquipmentRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type:
+            - string
+            - "null"
+          minLength: 1
+          maxLength: 64
+        description:
+          type:
+            - string
+            - "null"
+          maxLength: 512
+        image_url:
+          type:
+            - string
+            - "null"
+          maxLength: 512
 
     EventSummaryList:
       type: object


### PR DESCRIPTION
## 📋 Summary
This PR adds the backend contract for public user profiles, including equipment and showcase image sections. It introduces a public profile read endpoint, authenticated equipment CRUD endpoints, and showcase image upload/delete flows built on the existing presigned upload pattern so frontend and mobile clients can render richer user profiles safely without exposing private account fields.

## 🔄 Changes
- Added `GET /users/{user_id}/profile` to return a public-safe profile payload with:
  - `user_id`, `username`, `display_name`, `avatar_url`, `bio`
  - `final_score`, `host_rating_count`, `participant_rating_count`
  - `equipment[]`
  - `showcase_images[]`
- Kept private/internal fields out of the public profile response:
  - `email`, `phone_number`, `default_location_*`, `email_verified_at`, `last_login`, `status`
- Added authenticated equipment endpoints under `/me`:
  - `GET /me/equipment`
  - `POST /me/equipment`
  - `PATCH /me/equipment/{equipment_id}`
  - `DELETE /me/equipment/{equipment_id}`
- Added showcase image endpoints under `/me`:
  - `POST /me/showcase-images/upload-url`
  - `POST /me/showcase-images/confirm`
  - `DELETE /me/showcase-images/{showcase_image_id}`
- Reused the existing presigned image upload + confirm flow for showcase images via the image upload service/handler.
- Added ownership enforcement for equipment updates/deletes and showcase image deletes.
- Added new persistence support for profile equipment and showcase images, including migration `000033_profile_public_assets`.
- Updated domain and application-layer profile projections to include public profile, equipment, and showcase image models.
- Updated `docs/openapi/profile.yaml` and `docs/db/schema.sql` to document the new backend contract and schema additions.

## 🧪 Testing
- Ran backend unit tests:
  - `cd backend && GOTOOLCHAIN=local env GOCACHE=/private/tmp/go-cache GOMODCACHE=/private/tmp/go-mod-cache go test ./...`
- Ran backend integration tests:
  - `cd backend && GOTOOLCHAIN=local env GOCACHE=/private/tmp/go-cache GOMODCACHE=/private/tmp/go-mod-cache go test -race -count=1 -tags=integration ./tests_integration/...`
- Ran full backend gate:
  - `cd backend && env GOCACHE=/private/tmp/go-cache GOMODCACHE=/private/tmp/go-mod-cache ./shipcheck.sh`

## 🔗 Related
Closes #495
