### PR TITLE
feat(backend-frontend): add event report actions to admin panel

### DIFF
--- a/backend/internal/adapter/in/postgres/admin_repo.go
+++ b/backend/internal/adapter/in/postgres/admin_repo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -475,6 +476,831 @@ func (r *AdminRepository) ListNotifications(ctx context.Context, input adminapp.
 	return &adminapp.ListNotificationsResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
 }
 
+func (r *AdminRepository) ListEventReports(ctx context.Context, input adminapp.ListEventReportsInput) (*adminapp.ListEventReportsResult, error) {
+	args := []any{}
+	where := []string{"TRUE"}
+	add := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	if input.Query != nil {
+		placeholder := add("%" + *input.Query + "%")
+		where = append(where, "(e.title ILIKE "+placeholder+" OR u.username ILIKE "+placeholder+" OR u.email ILIKE "+placeholder+" OR er.message ILIKE "+placeholder+")")
+	}
+	if input.Status != nil {
+		where = append(where, "er.status = "+add(input.Status.String()))
+	}
+	if input.ReportCategory != nil {
+		where = append(where, "er.report_category = "+add(string(*input.ReportCategory)))
+	}
+	if input.EventID != nil {
+		where = append(where, "er.event_id = "+add(*input.EventID))
+	}
+	if input.ReporterUserID != nil {
+		where = append(where, "er.reporter_user_id = "+add(*input.ReporterUserID))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "er.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "er.created_at <= "+add(*input.CreatedTo))
+	}
+	limitPlaceholder := add(input.Limit)
+	offsetPlaceholder := add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT er.id, er.event_id, e.title, er.reporter_user_id, u.username, u.email,
+		       er.report_category, er.message, er.image_url, er.status, er.created_at, er.updated_at, COUNT(*) OVER()
+		FROM event_report er
+		LEFT JOIN event e ON e.id = er.event_id
+		LEFT JOIN app_user u ON u.id = er.reporter_user_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY er.created_at DESC, er.id DESC
+		LIMIT `+limitPlaceholder+` OFFSET `+offsetPlaceholder, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list event reports: %w", err)
+	}
+	defer rows.Close()
+	items := []adminapp.AdminEventReportItem{}
+	totalCount := 0
+	for rows.Next() {
+		item, err := scanAdminEventReport(rows, &totalCount)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, *item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list event reports rows: %w", err)
+	}
+	return &adminapp.ListEventReportsResult{Items: items, PageMeta: pageMeta(input.PageInput, totalCount, len(items))}, nil
+}
+
+func (r *AdminRepository) ListCategories(ctx context.Context) (*adminapp.ListCategoriesResult, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, name, created_at, updated_at
+		FROM event_category
+		ORDER BY id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("admin list categories: %w", err)
+	}
+	defer rows.Close()
+	items := []adminapp.AdminCategoryItem{}
+	for rows.Next() {
+		var item adminapp.AdminCategoryItem
+		if err := rows.Scan(&item.ID, &item.Name, &item.CreatedAt, &item.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("admin scan category: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list categories rows: %w", err)
+	}
+	return &adminapp.ListCategoriesResult{Items: items}, nil
+}
+
+func (r *AdminRepository) CreateCategory(ctx context.Context, name string) (*adminapp.AdminCategoryItem, error) {
+	var item adminapp.AdminCategoryItem
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO event_category (name)
+		VALUES ($1)
+		RETURNING id, name, created_at, updated_at
+	`, name).Scan(&item.ID, &item.Name, &item.CreatedAt, &item.UpdatedAt)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, domain.ConflictError("category_already_exists", "The category already exists.")
+		}
+		return nil, fmt.Errorf("admin create category: %w", err)
+	}
+	return &item, nil
+}
+
+func (r *AdminRepository) DeleteCategory(ctx context.Context, categoryID int) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM event_category WHERE id = $1`, categoryID)
+	if err != nil {
+		if isForeignKeyViolation(err) {
+			return domain.ConflictError("category_in_use", "This category is used by one or more events.")
+		}
+		return fmt.Errorf("admin delete category: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NotFoundError("category_not_found", "The requested category does not exist.")
+	}
+	return nil
+}
+
+func (r *AdminRepository) UpdateEventReportStatus(ctx context.Context, reportID uuid.UUID, status domain.EventReportStatus) (*adminapp.AdminEventReportItem, error) {
+	item, err := scanAdminEventReportRow(r.db.QueryRow(ctx, `
+		WITH er AS (
+			UPDATE event_report
+			SET status = $2, updated_at = NOW()
+			WHERE id = $1
+			RETURNING id, event_id, reporter_user_id, report_category, message, image_url, status, created_at, updated_at
+		)
+		SELECT er.id, er.event_id, e.title, er.reporter_user_id, u.username, u.email,
+		       er.report_category, er.message, er.image_url, er.status, er.created_at, er.updated_at
+		FROM er
+		LEFT JOIN event e ON e.id = er.event_id
+		LEFT JOIN app_user u ON u.id = er.reporter_user_id
+	`, reportID, status))
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError("event_report_not_found", "The requested event report does not exist.")
+		}
+		return nil, err
+	}
+	return item, nil
+}
+
+func (r *AdminRepository) UpdateEventStatus(ctx context.Context, eventID uuid.UUID, status domain.EventStatus) (*adminapp.AdminEventItem, error) {
+	item, err := scanAdminEventRow(r.db.QueryRow(ctx, `
+		WITH e AS (
+			UPDATE event
+			SET status = $2, updated_at = NOW()
+			WHERE id = $1
+			RETURNING id, host_id, title, category_id, start_time, end_time, privacy_level, status,
+			          capacity, approved_participant_count, pending_participant_count, created_at, updated_at
+		)
+		SELECT e.id, e.host_id, u.username, e.title, e.category_id, c.name, e.start_time, e.end_time,
+		       e.privacy_level, e.status, e.capacity, e.approved_participant_count, e.pending_participant_count,
+		       e.created_at, e.updated_at
+		FROM e
+		JOIN app_user u ON u.id = e.host_id
+		LEFT JOIN event_category c ON c.id = e.category_id
+	`, eventID, status))
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+		return nil, err
+	}
+	return item, nil
+}
+
+func (r *AdminRepository) CancelEvent(ctx context.Context, eventID uuid.UUID) (bool, error) {
+	var current string
+	err := r.db.QueryRow(ctx, `SELECT status FROM event WHERE id = $1 FOR UPDATE`, eventID).Scan(&current)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, domain.NotFoundError(domain.ErrorCodeEventNotFound, "The requested event does not exist.")
+		}
+		return false, fmt.Errorf("admin lock event: %w", err)
+	}
+	if current == string(domain.EventStatusCanceled) {
+		return true, nil
+	}
+	if _, err := r.db.Exec(ctx, `UPDATE event SET status = $2, updated_at = NOW() WHERE id = $1`, eventID, domain.EventStatusCanceled); err != nil {
+		return false, fmt.Errorf("admin cancel event: %w", err)
+	}
+	return false, nil
+}
+
+func (r *AdminRepository) CancelEventParticipations(ctx context.Context, eventID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE participation
+		SET status = $2, updated_at = NOW()
+		WHERE event_id = $1
+		  AND status IN ($3, $4)
+	`, eventID, domain.ParticipationStatusCanceled, domain.ParticipationStatusApproved, domain.ParticipationStatusPending)
+	if err != nil {
+		return fmt.Errorf("admin cancel event participations: %w", err)
+	}
+	return nil
+}
+
+func (r *AdminRepository) CancelPendingInvitationsForEvent(ctx context.Context, eventID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE invitation SET status = $2, updated_at = NOW()
+		WHERE event_id = $1 AND status = $3
+	`, eventID, domain.InvitationStatusCanceled, domain.InvitationStatusPending)
+	return wrapExecErr(err, "admin cancel event invitations")
+}
+
+func (r *AdminRepository) CancelPendingJoinRequestsForEvent(ctx context.Context, eventID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE join_request SET status = $2, updated_at = NOW()
+		WHERE event_id = $1 AND status = $3
+	`, eventID, domain.JoinRequestStatusCanceled, domain.JoinRequestStatusPending)
+	return wrapExecErr(err, "admin cancel event join requests")
+}
+
+func (r *AdminRepository) GetUserStatus(ctx context.Context, userID uuid.UUID, forUpdate bool) (*domain.UserStatus, error) {
+	query := `SELECT status FROM app_user WHERE id = $1`
+	if forUpdate {
+		query += ` FOR UPDATE`
+	}
+	var raw string
+	err := r.db.QueryRow(ctx, query, userID).Scan(&raw)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("admin get user status: %w", err)
+	}
+	status, ok := domain.ParseUserStatus(raw)
+	if !ok {
+		return nil, fmt.Errorf("admin get user status: unknown user status %q", raw)
+	}
+	return &status, nil
+}
+
+func (r *AdminRepository) DeactivateUser(ctx context.Context, userID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `UPDATE app_user SET status = $2, updated_at = NOW() WHERE id = $1`, userID, domain.UserStatusDeactivated)
+	if err != nil {
+		return fmt.Errorf("admin deactivate user: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NotFoundError(domain.ErrorCodeUserNotFound, "The requested user does not exist.")
+	}
+	return nil
+}
+
+func (r *AdminRepository) RevokeRefreshTokensForUser(ctx context.Context, userID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `UPDATE refresh_token SET revoked_at = COALESCE(revoked_at, NOW()), updated_at = NOW() WHERE user_id = $1 AND revoked_at IS NULL`, userID)
+	return wrapExecErr(err, "admin revoke refresh tokens")
+}
+
+func (r *AdminRepository) RevokePushDevicesForUser(ctx context.Context, userID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `UPDATE user_push_device SET revoked_at = COALESCE(revoked_at, NOW()), updated_at = NOW() WHERE user_id = $1 AND revoked_at IS NULL`, userID)
+	return wrapExecErr(err, "admin revoke push devices")
+}
+
+func (r *AdminRepository) ListHostedCancelableEventIDs(ctx context.Context, hostID uuid.UUID) ([]uuid.UUID, error) {
+	rows, err := r.db.Query(ctx, `SELECT id FROM event WHERE host_id = $1 AND status IN ($2, $3) ORDER BY created_at ASC FOR UPDATE`, hostID, domain.EventStatusActive, domain.EventStatusInProgress)
+	if err != nil {
+		return nil, fmt.Errorf("admin list hosted cancelable events: %w", err)
+	}
+	defer rows.Close()
+	ids := []uuid.UUID{}
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("admin scan hosted event id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list hosted event ids rows: %w", err)
+	}
+	return ids, nil
+}
+
+func (r *AdminRepository) CancelUserParticipations(ctx context.Context, userID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE participation p
+		SET status = $2, updated_at = NOW()
+		FROM event e
+		WHERE e.id = p.event_id
+		  AND p.user_id = $1
+		  AND e.host_id <> $1
+		  AND p.status IN ($3, $4)
+	`, userID, domain.ParticipationStatusCanceled, domain.ParticipationStatusApproved, domain.ParticipationStatusPending)
+	return wrapExecErr(err, "admin cancel user participations")
+}
+
+func (r *AdminRepository) CancelUserTickets(ctx context.Context, userID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE ticket t
+		SET status = $2,
+		    canceled_at = COALESCE(t.canceled_at, NOW()),
+		    updated_at = NOW()
+		FROM participation p
+		JOIN event e ON e.id = p.event_id
+		WHERE p.id = t.participation_id
+		  AND p.user_id = $1
+		  AND e.host_id <> $1
+		  AND t.status IN ($3, $4)
+	`, userID, domain.TicketStatusCanceled, domain.TicketStatusActive, domain.TicketStatusPending)
+	return wrapExecErr(err, "admin cancel user tickets")
+}
+
+func (r *AdminRepository) CancelPendingInvitationsForUser(ctx context.Context, userID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE invitation SET status = $2, updated_at = NOW()
+		WHERE status = $3 AND (host_id = $1 OR invited_user_id = $1)
+	`, userID, domain.InvitationStatusCanceled, domain.InvitationStatusPending)
+	return wrapExecErr(err, "admin cancel user invitations")
+}
+
+func (r *AdminRepository) CancelPendingJoinRequestsForUser(ctx context.Context, userID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE join_request SET status = $2, updated_at = NOW()
+		WHERE status = $3 AND (user_id = $1 OR host_user_id = $1)
+	`, userID, domain.JoinRequestStatusCanceled, domain.JoinRequestStatusPending)
+	return wrapExecErr(err, "admin cancel user join requests")
+}
+
+func (r *AdminRepository) ListInvitations(ctx context.Context, input adminapp.ListInvitationsInput) (*adminapp.ListInvitationsResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.Query != nil {
+		p := add("%" + *input.Query + "%")
+		where = append(where, "(e.title ILIKE "+p+" OR hu.username ILIKE "+p+" OR iu.username ILIKE "+p+" OR iu.email ILIKE "+p+")")
+	}
+	if input.Status != nil {
+		where = append(where, "i.status = "+add(input.Status.String()))
+	}
+	if input.EventID != nil {
+		where = append(where, "i.event_id = "+add(*input.EventID))
+	}
+	if input.HostID != nil {
+		where = append(where, "i.host_id = "+add(*input.HostID))
+	}
+	if input.InvitedUserID != nil {
+		where = append(where, "i.invited_user_id = "+add(*input.InvitedUserID))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "i.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "i.created_at <= "+add(*input.CreatedTo))
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT i.id, i.event_id, e.title, i.host_id, hu.username, i.invited_user_id, iu.username, iu.email,
+		       i.status, i.message, i.expires_at, i.created_at, i.updated_at, COUNT(*) OVER()
+		FROM invitation i
+		JOIN event e ON e.id = i.event_id
+		JOIN app_user hu ON hu.id = i.host_id
+		JOIN app_user iu ON iu.id = i.invited_user_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY i.created_at DESC, i.id DESC
+		LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list invitations: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminInvitationItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminInvitationItem
+		var message pgtype.Text
+		var expiresAt pgtype.Timestamptz
+		if err := rows.Scan(&item.ID, &item.EventID, &item.EventTitle, &item.HostID, &item.HostUsername, &item.InvitedUserID, &item.InvitedUsername, &item.InvitedEmail, &item.Status, &message, &expiresAt, &item.CreatedAt, &item.UpdatedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan invitation: %w", err)
+		}
+		item.Message = textPtr(message)
+		item.ExpiresAt = timestamptzPtr(expiresAt)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list invitations rows: %w", err)
+	}
+	return &adminapp.ListInvitationsResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) UpdateInvitationStatus(ctx context.Context, invitationID uuid.UUID, status domain.InvitationStatus) (*adminapp.AdminInvitationItem, error) {
+	tag, err := r.db.Exec(ctx, `UPDATE invitation SET status = $2, updated_at = NOW() WHERE id = $1 AND status = $3`, invitationID, status, domain.InvitationStatusPending)
+	if err != nil {
+		return nil, fmt.Errorf("admin update invitation status: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, domain.NotFoundError(domain.ErrorCodeInvitationNotFound, "The requested pending invitation does not exist.")
+	}
+	var item adminapp.AdminInvitationItem
+	var message pgtype.Text
+	var expiresAt pgtype.Timestamptz
+	err = r.db.QueryRow(ctx, `
+		SELECT i.id, i.event_id, e.title, i.host_id, hu.username, i.invited_user_id, iu.username, iu.email,
+		       i.status, i.message, i.expires_at, i.created_at, i.updated_at
+		FROM invitation i
+		JOIN event e ON e.id = i.event_id
+		JOIN app_user hu ON hu.id = i.host_id
+		JOIN app_user iu ON iu.id = i.invited_user_id
+		WHERE i.id = $1
+	`, invitationID).Scan(&item.ID, &item.EventID, &item.EventTitle, &item.HostID, &item.HostUsername, &item.InvitedUserID, &item.InvitedUsername, &item.InvitedEmail, &item.Status, &message, &expiresAt, &item.CreatedAt, &item.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("admin load updated invitation: %w", err)
+	}
+	item.Message = textPtr(message)
+	item.ExpiresAt = timestamptzPtr(expiresAt)
+	return &item, nil
+}
+
+func (r *AdminRepository) ListJoinRequests(ctx context.Context, input adminapp.ListJoinRequestsInput) (*adminapp.ListJoinRequestsResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.Query != nil {
+		p := add("%" + *input.Query + "%")
+		where = append(where, "(e.title ILIKE "+p+" OR u.username ILIKE "+p+" OR u.email ILIKE "+p+" OR hu.username ILIKE "+p+")")
+	}
+	if input.Status != nil {
+		where = append(where, "jr.status = "+add(input.Status.String()))
+	}
+	if input.EventID != nil {
+		where = append(where, "jr.event_id = "+add(*input.EventID))
+	}
+	if input.UserID != nil {
+		where = append(where, "jr.user_id = "+add(*input.UserID))
+	}
+	if input.HostUserID != nil {
+		where = append(where, "jr.host_user_id = "+add(*input.HostUserID))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "jr.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "jr.created_at <= "+add(*input.CreatedTo))
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT jr.id, jr.event_id, e.title, jr.user_id, u.username, u.email, jr.host_user_id, hu.username,
+		       jr.status, jr.message, jr.image_url, jr.created_at, jr.updated_at, COUNT(*) OVER()
+		FROM join_request jr
+		JOIN event e ON e.id = jr.event_id
+		JOIN app_user u ON u.id = jr.user_id
+		JOIN app_user hu ON hu.id = jr.host_user_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY jr.created_at DESC, jr.id DESC
+		LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list join requests: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminJoinRequestItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminJoinRequestItem
+		var message, imageURL pgtype.Text
+		if err := rows.Scan(&item.ID, &item.EventID, &item.EventTitle, &item.UserID, &item.Username, &item.UserEmail, &item.HostUserID, &item.HostUsername, &item.Status, &message, &imageURL, &item.CreatedAt, &item.UpdatedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan join request: %w", err)
+		}
+		item.Message = textPtr(message)
+		item.ImageURL = textPtr(imageURL)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list join requests rows: %w", err)
+	}
+	return &adminapp.ListJoinRequestsResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) UpdateJoinRequestStatus(ctx context.Context, joinRequestID uuid.UUID, status domain.JoinRequestStatus) (*adminapp.AdminJoinRequestItem, error) {
+	tag, err := r.db.Exec(ctx, `UPDATE join_request SET status = $2, updated_at = NOW() WHERE id = $1 AND status = $3`, joinRequestID, status, domain.JoinRequestStatusPending)
+	if err != nil {
+		return nil, fmt.Errorf("admin update join request status: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, domain.NotFoundError(domain.ErrorCodeJoinRequestNotFound, "The requested pending join request does not exist.")
+	}
+	var item adminapp.AdminJoinRequestItem
+	var message, imageURL pgtype.Text
+	err = r.db.QueryRow(ctx, `
+		SELECT jr.id, jr.event_id, e.title, jr.user_id, u.username, u.email, jr.host_user_id, hu.username,
+		       jr.status, jr.message, jr.image_url, jr.created_at, jr.updated_at
+		FROM join_request jr
+		JOIN event e ON e.id = jr.event_id
+		JOIN app_user u ON u.id = jr.user_id
+		JOIN app_user hu ON hu.id = jr.host_user_id
+		WHERE jr.id = $1
+	`, joinRequestID).Scan(&item.ID, &item.EventID, &item.EventTitle, &item.UserID, &item.Username, &item.UserEmail, &item.HostUserID, &item.HostUsername, &item.Status, &message, &imageURL, &item.CreatedAt, &item.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("admin load updated join request: %w", err)
+	}
+	item.Message = textPtr(message)
+	item.ImageURL = textPtr(imageURL)
+	return &item, nil
+}
+
+func (r *AdminRepository) ListComments(ctx context.Context, input adminapp.ListCommentsInput) (*adminapp.ListCommentsResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.Query != nil {
+		p := add("%" + *input.Query + "%")
+		where = append(where, "(ec.message ILIKE "+p+" OR e.title ILIKE "+p+" OR u.username ILIKE "+p+" OR u.email ILIKE "+p+")")
+	}
+	if input.EventID != nil {
+		where = append(where, "ec.event_id = "+add(*input.EventID))
+	}
+	if input.UserID != nil {
+		where = append(where, "ec.user_id = "+add(*input.UserID))
+	}
+	if input.Type != nil {
+		where = append(where, "ec.comment_type = "+add(*input.Type))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "ec.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "ec.created_at <= "+add(*input.CreatedTo))
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT ec.id, ec.event_id, e.title, ec.user_id, u.username, u.email, ec.comment_type, ec.parent_id, ec.message, ec.created_at, ec.updated_at, COUNT(*) OVER()
+		FROM event_comment ec JOIN event e ON e.id = ec.event_id JOIN app_user u ON u.id = ec.user_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY ec.created_at DESC, ec.id DESC LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list comments: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminCommentItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminCommentItem
+		var parentID pgtype.UUID
+		if err := rows.Scan(&item.ID, &item.EventID, &item.EventTitle, &item.UserID, &item.Username, &item.UserEmail, &item.Type, &parentID, &item.Message, &item.CreatedAt, &item.UpdatedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan comment: %w", err)
+		}
+		item.ParentID = uuidPtr(parentID)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list comments rows: %w", err)
+	}
+	return &adminapp.ListCommentsResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) DeleteComment(ctx context.Context, commentID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM event_comment WHERE id = $1`, commentID)
+	if err != nil {
+		return fmt.Errorf("admin delete comment: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NotFoundError("comment_not_found", "The requested comment does not exist.")
+	}
+	return nil
+}
+
+func (r *AdminRepository) ListEventRatings(ctx context.Context, input adminapp.ListEventRatingsInput) (*adminapp.ListEventRatingsResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.EventID != nil {
+		where = append(where, "er.event_id = "+add(*input.EventID))
+	}
+	if input.UserID != nil {
+		where = append(where, "er.participant_user_id = "+add(*input.UserID))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "er.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "er.created_at <= "+add(*input.CreatedTo))
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT er.id, er.event_id, e.title, er.participant_user_id, u.username, u.email, er.rating::double precision, er.created_at, er.updated_at, COUNT(*) OVER()
+		FROM event_rating er JOIN event e ON e.id = er.event_id JOIN app_user u ON u.id = er.participant_user_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY er.created_at DESC, er.id DESC LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list event ratings: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminEventRatingItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminEventRatingItem
+		if err := rows.Scan(&item.ID, &item.EventID, &item.EventTitle, &item.ParticipantUserID, &item.Username, &item.UserEmail, &item.Score, &item.CreatedAt, &item.UpdatedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan event rating: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list event ratings rows: %w", err)
+	}
+	return &adminapp.ListEventRatingsResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) ListParticipantRatings(ctx context.Context, input adminapp.ListParticipantRatingsInput) (*adminapp.ListParticipantRatingsResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.EventID != nil {
+		where = append(where, "pr.event_id = "+add(*input.EventID))
+	}
+	if input.HostID != nil {
+		where = append(where, "pr.host_user_id = "+add(*input.HostID))
+	}
+	if input.UserID != nil {
+		where = append(where, "pr.participant_user_id = "+add(*input.UserID))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "pr.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "pr.created_at <= "+add(*input.CreatedTo))
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT pr.id, pr.event_id, e.title, pr.host_user_id, hu.username, pr.participant_user_id, pu.username,
+		       pr.rating::double precision, pr.created_at, pr.updated_at, COUNT(*) OVER()
+		FROM participant_rating pr
+		JOIN event e ON e.id = pr.event_id
+		JOIN app_user hu ON hu.id = pr.host_user_id
+		JOIN app_user pu ON pu.id = pr.participant_user_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY pr.created_at DESC, pr.id DESC LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list participant ratings: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminParticipantRatingItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminParticipantRatingItem
+		if err := rows.Scan(&item.ID, &item.EventID, &item.EventTitle, &item.HostUserID, &item.HostUsername, &item.ParticipantUserID, &item.ParticipantUsername, &item.Score, &item.CreatedAt, &item.UpdatedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan participant rating: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list participant ratings rows: %w", err)
+	}
+	return &adminapp.ListParticipantRatingsResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) DeleteEventRating(ctx context.Context, ratingID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM event_rating WHERE id = $1`, ratingID)
+	if err != nil {
+		return fmt.Errorf("admin delete event rating: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NotFoundError("rating_not_found", "The requested rating does not exist.")
+	}
+	return nil
+}
+
+func (r *AdminRepository) DeleteParticipantRating(ctx context.Context, ratingID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM participant_rating WHERE id = $1`, ratingID)
+	if err != nil {
+		return fmt.Errorf("admin delete participant rating: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NotFoundError("rating_not_found", "The requested rating does not exist.")
+	}
+	return nil
+}
+
+func (r *AdminRepository) ListFavoriteEvents(ctx context.Context, input adminapp.ListFavoriteEventsInput) (*adminapp.ListFavoriteEventsResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.UserID != nil {
+		where = append(where, "fe.user_id = "+add(*input.UserID))
+	}
+	if input.EventID != nil {
+		where = append(where, "fe.event_id = "+add(*input.EventID))
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "fe.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "fe.created_at <= "+add(*input.CreatedTo))
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT fe.id, fe.user_id, u.username, u.email, fe.event_id, e.title, fe.created_at, fe.updated_at, COUNT(*) OVER()
+		FROM favorite_event fe JOIN app_user u ON u.id = fe.user_id JOIN event e ON e.id = fe.event_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY fe.created_at DESC, fe.id DESC LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list favorite events: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminFavoriteEventItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminFavoriteEventItem
+		if err := rows.Scan(&item.ID, &item.UserID, &item.Username, &item.UserEmail, &item.EventID, &item.EventTitle, &item.CreatedAt, &item.UpdatedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan favorite event: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list favorite events rows: %w", err)
+	}
+	return &adminapp.ListFavoriteEventsResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) ListFavoriteLocations(ctx context.Context, input adminapp.ListFavoriteLocationsInput) (*adminapp.ListFavoriteLocationsResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.UserID != nil {
+		where = append(where, "fl.user_id = "+add(*input.UserID))
+	}
+	if input.Query != nil {
+		p := add("%" + *input.Query + "%")
+		where = append(where, "(fl.name ILIKE "+p+" OR fl.address ILIKE "+p+" OR u.username ILIKE "+p+" OR u.email ILIKE "+p+")")
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "fl.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "fl.created_at <= "+add(*input.CreatedTo))
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT fl.id, fl.user_id, u.username, u.email, fl.name, fl.address, fl.created_at, fl.updated_at, COUNT(*) OVER()
+		FROM favorite_location fl JOIN app_user u ON u.id = fl.user_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY fl.created_at DESC, fl.id DESC LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list favorite locations: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminFavoriteLocationItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminFavoriteLocationItem
+		var name, address pgtype.Text
+		if err := rows.Scan(&item.ID, &item.UserID, &item.Username, &item.UserEmail, &name, &address, &item.CreatedAt, &item.UpdatedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan favorite location: %w", err)
+		}
+		item.Name = textPtr(name)
+		item.Address = textPtr(address)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list favorite locations rows: %w", err)
+	}
+	return &adminapp.ListFavoriteLocationsResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) ListUserBadges(ctx context.Context, input adminapp.ListUserBadgesInput) (*adminapp.ListUserBadgesResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.UserID != nil {
+		where = append(where, "ub.user_id = "+add(*input.UserID))
+	}
+	if input.Query != nil {
+		p := add("%" + *input.Query + "%")
+		where = append(where, "(b.name ILIKE "+p+" OR b.slug ILIKE "+p+" OR u.username ILIKE "+p+" OR u.email ILIKE "+p+")")
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT ub.user_id, u.username, u.email, b.id, b.slug, b.name, b.category, ub.earned_at, COUNT(*) OVER()
+		FROM user_badge ub JOIN app_user u ON u.id = ub.user_id JOIN badge b ON b.id = ub.badge_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY ub.earned_at DESC, ub.user_id DESC LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list user badges: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminUserBadgeItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminUserBadgeItem
+		if err := rows.Scan(&item.UserID, &item.Username, &item.UserEmail, &item.BadgeID, &item.BadgeSlug, &item.BadgeName, &item.BadgeCategory, &item.EarnedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan user badge: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list user badges rows: %w", err)
+	}
+	return &adminapp.ListUserBadgesResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) ListPushDevices(ctx context.Context, input adminapp.ListPushDevicesInput) (*adminapp.ListPushDevicesResult, error) {
+	args, where := []any{}, []string{"TRUE"}
+	add := func(value any) string { args = append(args, value); return fmt.Sprintf("$%d", len(args)) }
+	if input.UserID != nil {
+		where = append(where, "d.user_id = "+add(*input.UserID))
+	}
+	if input.Platform != nil {
+		where = append(where, "d.platform = "+add(*input.Platform))
+	}
+	if input.Active != nil {
+		if *input.Active {
+			where = append(where, "d.revoked_at IS NULL")
+		} else {
+			where = append(where, "d.revoked_at IS NOT NULL")
+		}
+	}
+	if input.CreatedFrom != nil {
+		where = append(where, "d.created_at >= "+add(*input.CreatedFrom))
+	}
+	if input.CreatedTo != nil {
+		where = append(where, "d.created_at <= "+add(*input.CreatedTo))
+	}
+	limit, offset := add(input.Limit), add(input.Offset)
+	rows, err := r.db.Query(ctx, `
+		SELECT d.id, d.user_id, u.username, u.email, d.installation_id, d.platform, d.last_seen_at, d.revoked_at, d.created_at, d.updated_at, COUNT(*) OVER()
+		FROM user_push_device d JOIN app_user u ON u.id = d.user_id
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY d.last_seen_at DESC, d.id DESC LIMIT `+limit+` OFFSET `+offset, args...)
+	if err != nil {
+		return nil, fmt.Errorf("admin list push devices: %w", err)
+	}
+	defer rows.Close()
+	items, total := []adminapp.AdminPushDeviceItem{}, 0
+	for rows.Next() {
+		var item adminapp.AdminPushDeviceItem
+		var revokedAt pgtype.Timestamptz
+		if err := rows.Scan(&item.ID, &item.UserID, &item.Username, &item.UserEmail, &item.InstallationID, &item.Platform, &item.LastSeenAt, &revokedAt, &item.CreatedAt, &item.UpdatedAt, &total); err != nil {
+			return nil, fmt.Errorf("admin scan push device: %w", err)
+		}
+		item.RevokedAt = timestamptzPtr(revokedAt)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin list push devices rows: %w", err)
+	}
+	return &adminapp.ListPushDevicesResult{Items: items, PageMeta: pageMeta(input.PageInput, total, len(items))}, nil
+}
+
+func (r *AdminRepository) RevokePushDevice(ctx context.Context, deviceID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `UPDATE user_push_device SET revoked_at = COALESCE(revoked_at, NOW()), updated_at = NOW() WHERE id = $1`, deviceID)
+	if err != nil {
+		return fmt.Errorf("admin revoke push device: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NotFoundError("push_device_not_found", "The requested push device does not exist.")
+	}
+	return nil
+}
+
 func (r *AdminRepository) CountExistingUsers(ctx context.Context, userIDs []uuid.UUID) (int, error) {
 	if len(userIDs) == 0 {
 		return 0, nil
@@ -673,4 +1499,114 @@ func intPtr(value pgtype.Int4) *int {
 	}
 	converted := int(value.Int32)
 	return &converted
+}
+
+func scanAdminEventReport(rows pgx.Rows, totalCount *int) (*adminapp.AdminEventReportItem, error) {
+	var item adminapp.AdminEventReportItem
+	var eventTitle, reporterUsername, reporterEmail, imageURL pgtype.Text
+	if err := rows.Scan(
+		&item.ID,
+		&item.EventID,
+		&eventTitle,
+		&item.ReporterUserID,
+		&reporterUsername,
+		&reporterEmail,
+		&item.ReportCategory,
+		&item.Message,
+		&imageURL,
+		&item.Status,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+		totalCount,
+	); err != nil {
+		return nil, fmt.Errorf("admin scan event report: %w", err)
+	}
+	item.EventTitle = textPtr(eventTitle)
+	item.ReporterUsername = textPtr(reporterUsername)
+	item.ReporterEmail = textPtr(reporterEmail)
+	item.ImageURL = textPtr(imageURL)
+	return &item, nil
+}
+
+func scanAdminEventReportRow(row pgx.Row) (*adminapp.AdminEventReportItem, error) {
+	var item adminapp.AdminEventReportItem
+	var eventTitle, reporterUsername, reporterEmail, imageURL pgtype.Text
+	err := row.Scan(
+		&item.ID,
+		&item.EventID,
+		&eventTitle,
+		&item.ReporterUserID,
+		&reporterUsername,
+		&reporterEmail,
+		&item.ReportCategory,
+		&item.Message,
+		&imageURL,
+		&item.Status,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("admin scan event report row: %w", err)
+	}
+	item.EventTitle = textPtr(eventTitle)
+	item.ReporterUsername = textPtr(reporterUsername)
+	item.ReporterEmail = textPtr(reporterEmail)
+	item.ImageURL = textPtr(imageURL)
+	return &item, nil
+}
+
+func scanAdminEventRow(row pgx.Row) (*adminapp.AdminEventItem, error) {
+	var item adminapp.AdminEventItem
+	var categoryID pgtype.Int4
+	var categoryName pgtype.Text
+	var endTime pgtype.Timestamptz
+	var capacity pgtype.Int4
+	err := row.Scan(
+		&item.ID,
+		&item.HostID,
+		&item.HostUsername,
+		&item.Title,
+		&categoryID,
+		&categoryName,
+		&item.StartTime,
+		&endTime,
+		&item.PrivacyLevel,
+		&item.Status,
+		&capacity,
+		&item.ApprovedParticipantCount,
+		&item.PendingParticipantCount,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("admin scan event row: %w", err)
+	}
+	item.CategoryID = intPtr(categoryID)
+	item.CategoryName = textPtr(categoryName)
+	item.EndTime = timestamptzPtr(endTime)
+	item.Capacity = intPtr(capacity)
+	return &item, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+func isForeignKeyViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23503"
+}
+
+func wrapExecErr(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", operation, err)
 }

--- a/backend/internal/adapter/out/httpapi/admin_handler/admin_handler.go
+++ b/backend/internal/adapter/out/httpapi/admin_handler/admin_handler.go
@@ -27,13 +27,36 @@ func NewHandler(service admin.UseCase) *Handler {
 func RegisterRoutes(router fiber.Router, handler *Handler, adminAuth fiber.Handler) {
 	group := router.Group("/admin", adminAuth)
 	group.Get("/users", handler.ListUsers)
+	group.Post("/users/:user_id/deactivate", handler.DeactivateUser)
 	group.Get("/events", handler.ListEvents)
+	group.Patch("/events/:event_id/status", handler.UpdateEventStatus)
+	group.Post("/events/:event_id/cancel", handler.CancelEvent)
+	group.Get("/event-reports", handler.ListEventReports)
+	group.Patch("/event-reports/:report_id/status", handler.UpdateEventReportStatus)
+	group.Get("/categories", handler.ListCategories)
+	group.Post("/categories", handler.CreateCategory)
+	group.Delete("/categories/:category_id", handler.DeleteCategory)
 	group.Get("/participations", handler.ListParticipations)
 	group.Post("/participations", handler.CreateParticipation)
 	group.Post("/participations/:participation_id/cancel", handler.CancelParticipation)
 	group.Get("/tickets", handler.ListTickets)
 	group.Get("/notifications", handler.ListNotifications)
 	group.Post("/notifications", handler.CreateNotification)
+	group.Get("/invitations", handler.ListInvitations)
+	group.Patch("/invitations/:invitation_id/status", handler.UpdateInvitationStatus)
+	group.Get("/join-requests", handler.ListJoinRequests)
+	group.Patch("/join-requests/:join_request_id/status", handler.UpdateJoinRequestStatus)
+	group.Get("/comments", handler.ListComments)
+	group.Delete("/comments/:comment_id", handler.DeleteComment)
+	group.Get("/ratings/events", handler.ListEventRatings)
+	group.Delete("/ratings/events/:rating_id", handler.DeleteEventRating)
+	group.Get("/ratings/participants", handler.ListParticipantRatings)
+	group.Delete("/ratings/participants/:rating_id", handler.DeleteParticipantRating)
+	group.Get("/favorites/events", handler.ListFavoriteEvents)
+	group.Get("/favorites/locations", handler.ListFavoriteLocations)
+	group.Get("/badges/users", handler.ListUserBadges)
+	group.Get("/push-devices", handler.ListPushDevices)
+	group.Post("/push-devices/:device_id/revoke", handler.RevokePushDevice)
 }
 
 func (h *Handler) ListUsers(c *fiber.Ctx) error {
@@ -101,6 +124,98 @@ func (h *Handler) ListNotifications(c *fiber.Ctx) error {
 	return c.JSON(result)
 }
 
+func (h *Handler) ListEventReports(c *fiber.Ctx) error {
+	input, errs := parseListEventReportsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListEventReports(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	logAdminList(c, "admin.event_reports.list", len(result.Items), result.PageMeta, summarizeEventReports(input))
+	return c.JSON(result)
+}
+
+func (h *Handler) ListCategories(c *fiber.Ctx) error {
+	result, err := h.service.ListCategories(c.UserContext())
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) CreateCategory(c *fiber.Ctx) error {
+	input, errs := parseCreateCategoryInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.CreateCategory(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.Status(fiber.StatusCreated).JSON(result)
+}
+
+func (h *Handler) DeleteCategory(c *fiber.Ctx) error {
+	input, errs := parseDeleteCategoryInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	if err := h.service.DeleteCategory(c.UserContext(), input); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func (h *Handler) UpdateEventReportStatus(c *fiber.Ctx) error {
+	input, errs := parseUpdateEventReportStatusInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.UpdateEventReportStatus(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) UpdateEventStatus(c *fiber.Ctx) error {
+	input, errs := parseUpdateEventStatusInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.UpdateEventStatus(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) CancelEvent(c *fiber.Ctx) error {
+	input, errs := parseCancelEventInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.CancelEvent(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) DeactivateUser(c *fiber.Ctx) error {
+	input, errs := parseDeactivateUserInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.DeactivateUser(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
 func (h *Handler) CreateNotification(c *fiber.Ctx) error {
 	input, errs := parseCreateNotificationInput(c)
 	if len(errs) > 0 {
@@ -137,6 +252,182 @@ func (h *Handler) CancelParticipation(c *fiber.Ctx) error {
 	return c.JSON(result)
 }
 
+func (h *Handler) ListInvitations(c *fiber.Ctx) error {
+	input, errs := parseListInvitationsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListInvitations(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) UpdateInvitationStatus(c *fiber.Ctx) error {
+	input, errs := parseUpdateInvitationStatusInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.UpdateInvitationStatus(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) ListJoinRequests(c *fiber.Ctx) error {
+	input, errs := parseListJoinRequestsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListJoinRequests(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) UpdateJoinRequestStatus(c *fiber.Ctx) error {
+	input, errs := parseUpdateJoinRequestStatusInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.UpdateJoinRequestStatus(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) ListComments(c *fiber.Ctx) error {
+	input, errs := parseListCommentsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListComments(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) DeleteComment(c *fiber.Ctx) error {
+	input, errs := parseDeleteCommentInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	if err := h.service.DeleteComment(c.UserContext(), input); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func (h *Handler) ListEventRatings(c *fiber.Ctx) error {
+	input, errs := parseListEventRatingsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListEventRatings(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) DeleteEventRating(c *fiber.Ctx) error {
+	input, errs := parseDeleteRatingInput(c, "rating_id")
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	if err := h.service.DeleteEventRating(c.UserContext(), input); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func (h *Handler) ListParticipantRatings(c *fiber.Ctx) error {
+	input, errs := parseListParticipantRatingsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListParticipantRatings(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) DeleteParticipantRating(c *fiber.Ctx) error {
+	input, errs := parseDeleteRatingInput(c, "rating_id")
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	if err := h.service.DeleteParticipantRating(c.UserContext(), input); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func (h *Handler) ListFavoriteEvents(c *fiber.Ctx) error {
+	input, errs := parseListFavoriteEventsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListFavoriteEvents(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) ListFavoriteLocations(c *fiber.Ctx) error {
+	input, errs := parseListFavoriteLocationsInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListFavoriteLocations(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) ListUserBadges(c *fiber.Ctx) error {
+	input, errs := parseListUserBadgesInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListUserBadges(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) ListPushDevices(c *fiber.Ctx) error {
+	input, errs := parseListPushDevicesInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	result, err := h.service.ListPushDevices(c.UserContext(), input)
+	if err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.JSON(result)
+}
+
+func (h *Handler) RevokePushDevice(c *fiber.Ctx) error {
+	input, errs := parseRevokePushDeviceInput(c)
+	if len(errs) > 0 {
+		return httpapi.WriteError(c, domain.ValidationError(errs))
+	}
+	if err := h.service.RevokePushDevice(c.UserContext(), input); err != nil {
+		return httpapi.WriteError(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
 type createNotificationRequest struct {
 	UserIDs        []string          `json:"user_ids"`
 	DeliveryMode   string            `json:"delivery_mode"`
@@ -158,6 +449,19 @@ type createParticipationRequest struct {
 
 type cancelParticipationRequest struct {
 	Reason *string `json:"reason"`
+}
+
+type reasonRequest struct {
+	Reason *string `json:"reason"`
+}
+
+type statusRequest struct {
+	Status *string `json:"status"`
+	Reason *string `json:"reason"`
+}
+
+type createCategoryRequest struct {
+	Name string `json:"name"`
 }
 
 func parseCreateNotificationInput(c *fiber.Ctx) (admin.SendCustomNotificationInput, map[string]string) {
@@ -273,6 +577,68 @@ func parseCancelParticipationInput(c *fiber.Ctx) (admin.CancelParticipationInput
 	}, errs
 }
 
+func parseCreateCategoryInput(c *fiber.Ctx) (admin.CreateCategoryInput, map[string]string) {
+	var body createCategoryRequest
+	errs := map[string]string{}
+	if err := c.BodyParser(&body); err != nil {
+		errs["body"] = "must be a valid JSON object"
+	}
+	return admin.CreateCategoryInput{AdminUserID: httpapi.UserClaims(c).UserID, Name: body.Name}, errs
+}
+
+func parseDeleteCategoryInput(c *fiber.Ctx) (admin.DeleteCategoryInput, map[string]string) {
+	errs := map[string]string{}
+	id, err := strconv.Atoi(strings.TrimSpace(c.Params("category_id")))
+	if err != nil || id <= 0 {
+		errs["category_id"] = "must be a positive integer"
+	}
+	return admin.DeleteCategoryInput{AdminUserID: httpapi.UserClaims(c).UserID, CategoryID: id}, errs
+}
+
+func parseUpdateEventReportStatusInput(c *fiber.Ctx) (admin.UpdateEventReportStatusInput, map[string]string) {
+	errs := map[string]string{}
+	reportID := parsePathUUID(c, "report_id", errs)
+	body := parseStatusBody(c, errs)
+	var status domain.EventReportStatus
+	if body.Status == nil {
+		errs["status"] = "is required"
+	} else if parsed, ok := domain.ParseEventReportStatus(strings.TrimSpace(*body.Status)); !ok {
+		errs["status"] = "must be one of: PENDING, REVIEWED, DISMISSED"
+	} else {
+		status = parsed
+	}
+	return admin.UpdateEventReportStatusInput{AdminUserID: httpapi.UserClaims(c).UserID, ReportID: reportID, Status: status, Reason: optionalTrimmedPtr(body.Reason)}, errs
+}
+
+func parseUpdateEventStatusInput(c *fiber.Ctx) (admin.UpdateEventStatusInput, map[string]string) {
+	errs := map[string]string{}
+	eventID := parsePathUUID(c, "event_id", errs)
+	body := parseStatusBody(c, errs)
+	var status domain.EventStatus
+	if body.Status == nil {
+		errs["status"] = "is required"
+	} else if parsed, ok := domain.ParseEventStatus(strings.TrimSpace(*body.Status)); !ok {
+		errs["status"] = "must be one of: ACTIVE, IN_PROGRESS, CANCELED, COMPLETED"
+	} else {
+		status = parsed
+	}
+	return admin.UpdateEventStatusInput{AdminUserID: httpapi.UserClaims(c).UserID, EventID: eventID, Status: status, Reason: optionalTrimmedPtr(body.Reason)}, errs
+}
+
+func parseCancelEventInput(c *fiber.Ctx) (admin.CancelEventInput, map[string]string) {
+	errs := map[string]string{}
+	eventID := parsePathUUID(c, "event_id", errs)
+	body := parseReasonBody(c, errs)
+	return admin.CancelEventInput{AdminUserID: httpapi.UserClaims(c).UserID, EventID: eventID, Reason: optionalTrimmedPtr(body.Reason)}, errs
+}
+
+func parseDeactivateUserInput(c *fiber.Ctx) (admin.DeactivateUserInput, map[string]string) {
+	errs := map[string]string{}
+	userID := parsePathUUID(c, "user_id", errs)
+	body := parseReasonBody(c, errs)
+	return admin.DeactivateUserInput{AdminUserID: httpapi.UserClaims(c).UserID, UserID: userID, Reason: optionalTrimmedPtr(body.Reason)}, errs
+}
+
 func parseListUsersInput(c *fiber.Ctx) (admin.ListUsersInput, map[string]string) {
 	page, errs := parsePage(c)
 	input := admin.ListUsersInput{PageInput: page}
@@ -384,6 +750,192 @@ func parseListNotificationsInput(c *fiber.Ctx) (admin.ListNotificationsInput, ma
 	return input, errs
 }
 
+func parseListEventReportsInput(c *fiber.Ctx) (admin.ListEventReportsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListEventReportsInput{PageInput: page}
+	input.Query = optionalTrimmed(c.Query("q"))
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.ReporterUserID = parseOptionalUUID(c, "reporter_user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	if raw := strings.TrimSpace(c.Query("status")); raw != "" {
+		status, ok := domain.ParseEventReportStatus(raw)
+		if !ok {
+			errs["status"] = "must be one of: PENDING, REVIEWED, DISMISSED"
+		} else {
+			input.Status = &status
+		}
+	}
+	if raw := strings.TrimSpace(c.Query("report_category")); raw != "" {
+		category, ok := domain.ParseEventReportCategory(raw)
+		if !ok {
+			errs["report_category"] = "must be a valid report category"
+		} else {
+			input.ReportCategory = &category
+		}
+	}
+	return input, errs
+}
+
+func parseListInvitationsInput(c *fiber.Ctx) (admin.ListInvitationsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListInvitationsInput{PageInput: page, Query: optionalTrimmed(c.Query("q"))}
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.HostID = parseOptionalUUID(c, "host_id", errs)
+	input.InvitedUserID = parseOptionalUUID(c, "invited_user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	if raw := strings.TrimSpace(c.Query("status")); raw != "" {
+		status, ok := domain.ParseInvitationStatus(raw)
+		if !ok {
+			errs["status"] = "must be a valid invitation status"
+		} else {
+			input.Status = &status
+		}
+	}
+	return input, errs
+}
+
+func parseListJoinRequestsInput(c *fiber.Ctx) (admin.ListJoinRequestsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListJoinRequestsInput{PageInput: page, Query: optionalTrimmed(c.Query("q"))}
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.HostUserID = parseOptionalUUID(c, "host_user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	if raw := strings.TrimSpace(c.Query("status")); raw != "" {
+		status, ok := domain.ParseJoinRequestStatus(raw)
+		if !ok {
+			errs["status"] = "must be a valid join request status"
+		} else {
+			input.Status = &status
+		}
+	}
+	return input, errs
+}
+
+func parseListCommentsInput(c *fiber.Ctx) (admin.ListCommentsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListCommentsInput{PageInput: page, Query: optionalTrimmed(c.Query("q")), Type: optionalTrimmed(c.Query("type"))}
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	return input, errs
+}
+
+func parseListEventRatingsInput(c *fiber.Ctx) (admin.ListEventRatingsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListEventRatingsInput{PageInput: page}
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	return input, errs
+}
+
+func parseListParticipantRatingsInput(c *fiber.Ctx) (admin.ListParticipantRatingsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListParticipantRatingsInput{PageInput: page}
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.HostID = parseOptionalUUID(c, "host_id", errs)
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	return input, errs
+}
+
+func parseListFavoriteEventsInput(c *fiber.Ctx) (admin.ListFavoriteEventsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListFavoriteEventsInput{PageInput: page}
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.EventID = parseOptionalUUID(c, "event_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	return input, errs
+}
+
+func parseListFavoriteLocationsInput(c *fiber.Ctx) (admin.ListFavoriteLocationsInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListFavoriteLocationsInput{PageInput: page, Query: optionalTrimmed(c.Query("q"))}
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	return input, errs
+}
+
+func parseListUserBadgesInput(c *fiber.Ctx) (admin.ListUserBadgesInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListUserBadgesInput{PageInput: page, Query: optionalTrimmed(c.Query("q"))}
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	return input, errs
+}
+
+func parseListPushDevicesInput(c *fiber.Ctx) (admin.ListPushDevicesInput, map[string]string) {
+	page, errs := parsePage(c)
+	input := admin.ListPushDevicesInput{PageInput: page, Platform: optionalTrimmed(c.Query("platform"))}
+	input.UserID = parseOptionalUUID(c, "user_id", errs)
+	input.CreatedFrom = parseOptionalTime(c, "created_from", errs)
+	input.CreatedTo = parseOptionalTime(c, "created_to", errs)
+	if raw := strings.TrimSpace(c.Query("active")); raw != "" {
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			errs["active"] = "must be true or false"
+		} else {
+			input.Active = &value
+		}
+	}
+	return input, errs
+}
+
+func parseUpdateInvitationStatusInput(c *fiber.Ctx) (admin.UpdateInvitationStatusInput, map[string]string) {
+	errs := map[string]string{}
+	invitationID := parsePathUUID(c, "invitation_id", errs)
+	body := parseStatusBody(c, errs)
+	var status domain.InvitationStatus
+	if body.Status == nil {
+		errs["status"] = "is required"
+	} else if parsed, ok := domain.ParseInvitationStatus(strings.TrimSpace(*body.Status)); !ok {
+		errs["status"] = "must be a valid invitation status"
+	} else {
+		status = parsed
+	}
+	return admin.UpdateInvitationStatusInput{AdminUserID: httpapi.UserClaims(c).UserID, InvitationID: invitationID, Status: status, Reason: optionalTrimmedPtr(body.Reason)}, errs
+}
+
+func parseUpdateJoinRequestStatusInput(c *fiber.Ctx) (admin.UpdateJoinRequestStatusInput, map[string]string) {
+	errs := map[string]string{}
+	joinRequestID := parsePathUUID(c, "join_request_id", errs)
+	body := parseStatusBody(c, errs)
+	var status domain.JoinRequestStatus
+	if body.Status == nil {
+		errs["status"] = "is required"
+	} else if parsed, ok := domain.ParseJoinRequestStatus(strings.TrimSpace(*body.Status)); !ok {
+		errs["status"] = "must be a valid join request status"
+	} else {
+		status = parsed
+	}
+	return admin.UpdateJoinRequestStatusInput{AdminUserID: httpapi.UserClaims(c).UserID, JoinRequestID: joinRequestID, Status: status, Reason: optionalTrimmedPtr(body.Reason)}, errs
+}
+
+func parseDeleteCommentInput(c *fiber.Ctx) (admin.DeleteCommentInput, map[string]string) {
+	errs := map[string]string{}
+	return admin.DeleteCommentInput{AdminUserID: httpapi.UserClaims(c).UserID, CommentID: parsePathUUID(c, "comment_id", errs)}, errs
+}
+
+func parseDeleteRatingInput(c *fiber.Ctx, key string) (admin.DeleteRatingInput, map[string]string) {
+	errs := map[string]string{}
+	body := parseReasonBody(c, errs)
+	return admin.DeleteRatingInput{AdminUserID: httpapi.UserClaims(c).UserID, RatingID: parsePathUUID(c, key, errs), Reason: optionalTrimmedPtr(body.Reason)}, errs
+}
+
+func parseRevokePushDeviceInput(c *fiber.Ctx) (admin.RevokePushDeviceInput, map[string]string) {
+	errs := map[string]string{}
+	body := parseReasonBody(c, errs)
+	return admin.RevokePushDeviceInput{AdminUserID: httpapi.UserClaims(c).UserID, DeviceID: parsePathUUID(c, "device_id", errs), Reason: optionalTrimmedPtr(body.Reason)}, errs
+}
+
 func parsePage(c *fiber.Ctx) (admin.PageInput, map[string]string) {
 	errs := map[string]string{}
 	page := admin.PageInput{Limit: admin.DefaultLimit}
@@ -432,6 +984,33 @@ func parseOptionalUUID(c *fiber.Ctx, key string, errs map[string]string) *uuid.U
 		return nil
 	}
 	return &value
+}
+
+func parsePathUUID(c *fiber.Ctx, key string, errs map[string]string) uuid.UUID {
+	value, err := uuid.Parse(strings.TrimSpace(c.Params(key)))
+	if err != nil || value == uuid.Nil {
+		errs[key] = "must be a valid UUID"
+		return uuid.Nil
+	}
+	return value
+}
+
+func parseReasonBody(c *fiber.Ctx, errs map[string]string) reasonRequest {
+	var body reasonRequest
+	if len(c.Body()) > 0 {
+		if err := c.BodyParser(&body); err != nil {
+			errs["body"] = "must be a valid JSON object"
+		}
+	}
+	return body
+}
+
+func parseStatusBody(c *fiber.Ctx, errs map[string]string) statusRequest {
+	var body statusRequest
+	if err := c.BodyParser(&body); err != nil {
+		errs["body"] = "must be a valid JSON object"
+	}
+	return body
 }
 
 func parseOptionalInt(c *fiber.Ctx, key string, errs map[string]string) *int {
@@ -537,6 +1116,20 @@ func summarizeNotifications(input admin.ListNotificationsInput) string {
 		uuidPointerSummary("event_id", input.EventID),
 		httpapi.StringPtrSummary("type", input.Type),
 		boolPointerSummary("is_read", input.IsRead),
+		timePointerSummary("created_from", input.CreatedFrom),
+		timePointerSummary("created_to", input.CreatedTo),
+	)
+}
+
+func summarizeEventReports(input admin.ListEventReportsInput) string {
+	return httpapi.JoinSummary(
+		httpapi.CountSummary("limit", input.Limit),
+		httpapi.CountSummary("offset", input.Offset),
+		httpapi.StringPtrSummary("q", input.Query),
+		pointerSummary("status", input.Status),
+		pointerSummary("report_category", input.ReportCategory),
+		uuidPointerSummary("event_id", input.EventID),
+		uuidPointerSummary("reporter_user_id", input.ReporterUserID),
 		timePointerSummary("created_from", input.CreatedFrom),
 		timePointerSummary("created_to", input.CreatedTo),
 	)

--- a/backend/internal/adapter/out/httpapi/admin_handler/admin_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/admin_handler/admin_handler_test.go
@@ -50,6 +50,75 @@ func (s *stubAdminService) ListNotifications(_ context.Context, input admin.List
 	return &admin.ListNotificationsResult{Items: []admin.AdminNotificationItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
 }
 
+func (s *stubAdminService) ListEventReports(_ context.Context, input admin.ListEventReportsInput) (*admin.ListEventReportsResult, error) {
+	return &admin.ListEventReportsResult{Items: []admin.AdminEventReportItem{}, PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+
+func (s *stubAdminService) ListCategories(context.Context) (*admin.ListCategoriesResult, error) {
+	return &admin.ListCategoriesResult{}, nil
+}
+func (s *stubAdminService) CreateCategory(context.Context, admin.CreateCategoryInput) (*admin.AdminCategoryItem, error) {
+	return &admin.AdminCategoryItem{}, nil
+}
+func (s *stubAdminService) DeleteCategory(context.Context, admin.DeleteCategoryInput) error {
+	return nil
+}
+func (s *stubAdminService) UpdateEventReportStatus(context.Context, admin.UpdateEventReportStatusInput) (*admin.AdminEventReportItem, error) {
+	return &admin.AdminEventReportItem{}, nil
+}
+func (s *stubAdminService) UpdateEventStatus(context.Context, admin.UpdateEventStatusInput) (*admin.AdminEventItem, error) {
+	return &admin.AdminEventItem{}, nil
+}
+func (s *stubAdminService) CancelEvent(_ context.Context, input admin.CancelEventInput) (*admin.CancelEventResult, error) {
+	return &admin.CancelEventResult{EventID: input.EventID, Status: domain.EventStatusCanceled}, nil
+}
+func (s *stubAdminService) DeactivateUser(_ context.Context, input admin.DeactivateUserInput) (*admin.DeactivateUserResult, error) {
+	return &admin.DeactivateUserResult{UserID: input.UserID, Status: domain.UserStatusDeactivated}, nil
+}
+func (s *stubAdminService) ListInvitations(_ context.Context, input admin.ListInvitationsInput) (*admin.ListInvitationsResult, error) {
+	return &admin.ListInvitationsResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) UpdateInvitationStatus(context.Context, admin.UpdateInvitationStatusInput) (*admin.AdminInvitationItem, error) {
+	return &admin.AdminInvitationItem{}, nil
+}
+func (s *stubAdminService) ListJoinRequests(_ context.Context, input admin.ListJoinRequestsInput) (*admin.ListJoinRequestsResult, error) {
+	return &admin.ListJoinRequestsResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) UpdateJoinRequestStatus(context.Context, admin.UpdateJoinRequestStatusInput) (*admin.AdminJoinRequestItem, error) {
+	return &admin.AdminJoinRequestItem{}, nil
+}
+func (s *stubAdminService) ListComments(_ context.Context, input admin.ListCommentsInput) (*admin.ListCommentsResult, error) {
+	return &admin.ListCommentsResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) DeleteComment(context.Context, admin.DeleteCommentInput) error { return nil }
+func (s *stubAdminService) ListEventRatings(_ context.Context, input admin.ListEventRatingsInput) (*admin.ListEventRatingsResult, error) {
+	return &admin.ListEventRatingsResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) ListParticipantRatings(_ context.Context, input admin.ListParticipantRatingsInput) (*admin.ListParticipantRatingsResult, error) {
+	return &admin.ListParticipantRatingsResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) DeleteEventRating(context.Context, admin.DeleteRatingInput) error {
+	return nil
+}
+func (s *stubAdminService) DeleteParticipantRating(context.Context, admin.DeleteRatingInput) error {
+	return nil
+}
+func (s *stubAdminService) ListFavoriteEvents(_ context.Context, input admin.ListFavoriteEventsInput) (*admin.ListFavoriteEventsResult, error) {
+	return &admin.ListFavoriteEventsResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) ListFavoriteLocations(_ context.Context, input admin.ListFavoriteLocationsInput) (*admin.ListFavoriteLocationsResult, error) {
+	return &admin.ListFavoriteLocationsResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) ListUserBadges(_ context.Context, input admin.ListUserBadgesInput) (*admin.ListUserBadgesResult, error) {
+	return &admin.ListUserBadgesResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) ListPushDevices(_ context.Context, input admin.ListPushDevicesInput) (*admin.ListPushDevicesResult, error) {
+	return &admin.ListPushDevicesResult{PageMeta: admin.PageMeta{Limit: input.Limit, Offset: input.Offset}}, nil
+}
+func (s *stubAdminService) RevokePushDevice(context.Context, admin.RevokePushDeviceInput) error {
+	return nil
+}
+
 func (s *stubAdminService) SendCustomNotification(_ context.Context, input admin.SendCustomNotificationInput) (*admin.SendCustomNotificationResult, error) {
 	s.lastNotification = input
 	return &admin.SendCustomNotificationResult{TargetUserCount: len(input.UserIDs), CreatedCount: len(input.UserIDs)}, nil

--- a/backend/internal/application/admin/repository.go
+++ b/backend/internal/application/admin/repository.go
@@ -14,6 +14,40 @@ type Repository interface {
 	ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error)
 	ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error)
 	ListNotifications(ctx context.Context, input ListNotificationsInput) (*ListNotificationsResult, error)
+	ListEventReports(ctx context.Context, input ListEventReportsInput) (*ListEventReportsResult, error)
+	ListCategories(ctx context.Context) (*ListCategoriesResult, error)
+	CreateCategory(ctx context.Context, name string) (*AdminCategoryItem, error)
+	DeleteCategory(ctx context.Context, categoryID int) error
+	UpdateEventReportStatus(ctx context.Context, reportID uuid.UUID, status domain.EventReportStatus) (*AdminEventReportItem, error)
+	UpdateEventStatus(ctx context.Context, eventID uuid.UUID, status domain.EventStatus) (*AdminEventItem, error)
+	CancelEvent(ctx context.Context, eventID uuid.UUID) (alreadyCanceled bool, err error)
+	CancelEventParticipations(ctx context.Context, eventID uuid.UUID) error
+	CancelPendingInvitationsForEvent(ctx context.Context, eventID uuid.UUID) error
+	CancelPendingJoinRequestsForEvent(ctx context.Context, eventID uuid.UUID) error
+	GetUserStatus(ctx context.Context, userID uuid.UUID, forUpdate bool) (*domain.UserStatus, error)
+	DeactivateUser(ctx context.Context, userID uuid.UUID) error
+	RevokeRefreshTokensForUser(ctx context.Context, userID uuid.UUID) error
+	RevokePushDevicesForUser(ctx context.Context, userID uuid.UUID) error
+	ListHostedCancelableEventIDs(ctx context.Context, hostID uuid.UUID) ([]uuid.UUID, error)
+	CancelUserParticipations(ctx context.Context, userID uuid.UUID) error
+	CancelUserTickets(ctx context.Context, userID uuid.UUID) error
+	CancelPendingInvitationsForUser(ctx context.Context, userID uuid.UUID) error
+	CancelPendingJoinRequestsForUser(ctx context.Context, userID uuid.UUID) error
+	ListInvitations(ctx context.Context, input ListInvitationsInput) (*ListInvitationsResult, error)
+	UpdateInvitationStatus(ctx context.Context, invitationID uuid.UUID, status domain.InvitationStatus) (*AdminInvitationItem, error)
+	ListJoinRequests(ctx context.Context, input ListJoinRequestsInput) (*ListJoinRequestsResult, error)
+	UpdateJoinRequestStatus(ctx context.Context, joinRequestID uuid.UUID, status domain.JoinRequestStatus) (*AdminJoinRequestItem, error)
+	ListComments(ctx context.Context, input ListCommentsInput) (*ListCommentsResult, error)
+	DeleteComment(ctx context.Context, commentID uuid.UUID) error
+	ListEventRatings(ctx context.Context, input ListEventRatingsInput) (*ListEventRatingsResult, error)
+	ListParticipantRatings(ctx context.Context, input ListParticipantRatingsInput) (*ListParticipantRatingsResult, error)
+	DeleteEventRating(ctx context.Context, ratingID uuid.UUID) error
+	DeleteParticipantRating(ctx context.Context, ratingID uuid.UUID) error
+	ListFavoriteEvents(ctx context.Context, input ListFavoriteEventsInput) (*ListFavoriteEventsResult, error)
+	ListFavoriteLocations(ctx context.Context, input ListFavoriteLocationsInput) (*ListFavoriteLocationsResult, error)
+	ListUserBadges(ctx context.Context, input ListUserBadgesInput) (*ListUserBadgesResult, error)
+	ListPushDevices(ctx context.Context, input ListPushDevicesInput) (*ListPushDevicesResult, error)
+	RevokePushDevice(ctx context.Context, deviceID uuid.UUID) error
 	CountExistingUsers(ctx context.Context, userIDs []uuid.UUID) (int, error)
 	GetEventState(ctx context.Context, eventID uuid.UUID, forUpdate bool) (*AdminEventState, error)
 	CreateManualParticipation(ctx context.Context, eventID, userID uuid.UUID, status domain.ParticipationStatus) (*domain.Participation, error)

--- a/backend/internal/application/admin/service.go
+++ b/backend/internal/application/admin/service.go
@@ -294,3 +294,249 @@ func (s *Service) requireUsersExist(ctx context.Context, userIDs []uuid.UUID) er
 	}
 	return nil
 }
+
+func (s *Service) CreateCategory(ctx context.Context, input CreateCategoryInput) (*AdminCategoryItem, error) {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return nil, domain.ValidationError(map[string]string{"name": "is required"})
+	}
+	if len(name) > 50 {
+		return nil, domain.ValidationError(map[string]string{"name": "must be at most 50 characters"})
+	}
+	item, err := s.repo.CreateCategory(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "admin category created",
+		"operation", "admin.categories.create",
+		"admin_user_id", input.AdminUserID.String(),
+		"category_id", item.ID,
+	)
+	return item, nil
+}
+
+func (s *Service) DeleteCategory(ctx context.Context, input DeleteCategoryInput) error {
+	if input.CategoryID <= 0 {
+		return domain.ValidationError(map[string]string{"category_id": "must be a positive integer"})
+	}
+	if err := s.repo.DeleteCategory(ctx, input.CategoryID); err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "admin category deleted",
+		"operation", "admin.categories.delete",
+		"admin_user_id", input.AdminUserID.String(),
+		"category_id", input.CategoryID,
+	)
+	return nil
+}
+
+func (s *Service) UpdateEventReportStatus(ctx context.Context, input UpdateEventReportStatusInput) (*AdminEventReportItem, error) {
+	if input.ReportID == uuid.Nil {
+		return nil, domain.ValidationError(map[string]string{"report_id": "is required"})
+	}
+	item, err := s.repo.UpdateEventReportStatus(ctx, input.ReportID, input.Status)
+	if err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "admin event report status updated",
+		"operation", "admin.event_reports.status",
+		"admin_user_id", input.AdminUserID.String(),
+		"report_id", input.ReportID.String(),
+		"status", input.Status.String(),
+		"has_reason", input.Reason != nil && strings.TrimSpace(*input.Reason) != "",
+	)
+	return item, nil
+}
+
+func (s *Service) UpdateEventStatus(ctx context.Context, input UpdateEventStatusInput) (*AdminEventItem, error) {
+	if input.EventID == uuid.Nil {
+		return nil, domain.ValidationError(map[string]string{"event_id": "is required"})
+	}
+	if input.Status == domain.EventStatusCanceled {
+		if _, err := s.CancelEvent(ctx, CancelEventInput{AdminUserID: input.AdminUserID, EventID: input.EventID, Reason: input.Reason}); err != nil {
+			return nil, err
+		}
+		return s.repo.UpdateEventStatus(ctx, input.EventID, domain.EventStatusCanceled)
+	}
+	item, err := s.repo.UpdateEventStatus(ctx, input.EventID, input.Status)
+	if err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "admin event status updated",
+		"operation", "admin.events.status",
+		"admin_user_id", input.AdminUserID.String(),
+		"event_id", input.EventID.String(),
+		"status", input.Status.String(),
+		"has_reason", input.Reason != nil && strings.TrimSpace(*input.Reason) != "",
+	)
+	return item, nil
+}
+
+func (s *Service) CancelEvent(ctx context.Context, input CancelEventInput) (*CancelEventResult, error) {
+	if s.unitOfWork == nil || s.tickets == nil {
+		return nil, domain.ConflictError(domain.ErrorCodeAdminDependencyUnavailable, "Admin event mutations are not configured.")
+	}
+	if input.EventID == uuid.Nil {
+		return nil, domain.ValidationError(map[string]string{"event_id": "is required"})
+	}
+	result := &CancelEventResult{EventID: input.EventID, Status: domain.EventStatusCanceled}
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		alreadyCanceled, err := s.repo.CancelEvent(ctx, input.EventID)
+		if err != nil {
+			return err
+		}
+		result.AlreadyCanceled = alreadyCanceled
+		if alreadyCanceled {
+			return nil
+		}
+		if err := s.repo.CancelEventParticipations(ctx, input.EventID); err != nil {
+			return err
+		}
+		if err := s.tickets.CancelTicketsForEvent(ctx, input.EventID); err != nil {
+			return err
+		}
+		if err := s.repo.CancelPendingInvitationsForEvent(ctx, input.EventID); err != nil {
+			return err
+		}
+		return s.repo.CancelPendingJoinRequestsForEvent(ctx, input.EventID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "admin event canceled",
+		"operation", "admin.events.cancel",
+		"admin_user_id", input.AdminUserID.String(),
+		"event_id", input.EventID.String(),
+		"already_canceled", result.AlreadyCanceled,
+		"has_reason", input.Reason != nil && strings.TrimSpace(*input.Reason) != "",
+	)
+	return result, nil
+}
+
+func (s *Service) DeactivateUser(ctx context.Context, input DeactivateUserInput) (*DeactivateUserResult, error) {
+	if s.unitOfWork == nil || s.tickets == nil {
+		return nil, domain.ConflictError(domain.ErrorCodeAdminDependencyUnavailable, "Admin user mutations are not configured.")
+	}
+	if input.UserID == uuid.Nil {
+		return nil, domain.ValidationError(map[string]string{"user_id": "is required"})
+	}
+	result := &DeactivateUserResult{UserID: input.UserID, Status: domain.UserStatusDeactivated}
+	err := s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
+		status, err := s.repo.GetUserStatus(ctx, input.UserID, true)
+		if err != nil {
+			return err
+		}
+		if status == nil {
+			return domain.NotFoundError(domain.ErrorCodeUserNotFound, "The requested user does not exist.")
+		}
+		if *status == domain.UserStatusDeactivated {
+			result.AlreadyDeactivated = true
+			return nil
+		}
+		if err := s.repo.DeactivateUser(ctx, input.UserID); err != nil {
+			return err
+		}
+		if err := s.repo.RevokeRefreshTokensForUser(ctx, input.UserID); err != nil {
+			return err
+		}
+		if err := s.repo.RevokePushDevicesForUser(ctx, input.UserID); err != nil {
+			return err
+		}
+		eventIDs, err := s.repo.ListHostedCancelableEventIDs(ctx, input.UserID)
+		if err != nil {
+			return err
+		}
+		result.CanceledEventCount = len(eventIDs)
+		for _, eventID := range eventIDs {
+			alreadyCanceled, err := s.repo.CancelEvent(ctx, eventID)
+			if err != nil {
+				return err
+			}
+			if alreadyCanceled {
+				continue
+			}
+			if err := s.repo.CancelEventParticipations(ctx, eventID); err != nil {
+				return err
+			}
+			if err := s.tickets.CancelTicketsForEvent(ctx, eventID); err != nil {
+				return err
+			}
+			if err := s.repo.CancelPendingInvitationsForEvent(ctx, eventID); err != nil {
+				return err
+			}
+			if err := s.repo.CancelPendingJoinRequestsForEvent(ctx, eventID); err != nil {
+				return err
+			}
+		}
+		if err := s.repo.CancelUserParticipations(ctx, input.UserID); err != nil {
+			return err
+		}
+		if err := s.repo.CancelUserTickets(ctx, input.UserID); err != nil {
+			return err
+		}
+		if err := s.repo.CancelPendingInvitationsForUser(ctx, input.UserID); err != nil {
+			return err
+		}
+		return s.repo.CancelPendingJoinRequestsForUser(ctx, input.UserID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "admin user deactivated",
+		"operation", "admin.users.deactivate",
+		"admin_user_id", input.AdminUserID.String(),
+		"target_user_id", input.UserID.String(),
+		"already_deactivated", result.AlreadyDeactivated,
+		"canceled_event_count", result.CanceledEventCount,
+		"has_reason", input.Reason != nil && strings.TrimSpace(*input.Reason) != "",
+	)
+	return result, nil
+}
+
+func (s *Service) UpdateInvitationStatus(ctx context.Context, input UpdateInvitationStatusInput) (*AdminInvitationItem, error) {
+	if input.InvitationID == uuid.Nil {
+		return nil, domain.ValidationError(map[string]string{"invitation_id": "is required"})
+	}
+	if input.Status != domain.InvitationStatusCanceled {
+		return nil, domain.ValidationError(map[string]string{"status": "must be CANCELED"})
+	}
+	return s.repo.UpdateInvitationStatus(ctx, input.InvitationID, input.Status)
+}
+
+func (s *Service) UpdateJoinRequestStatus(ctx context.Context, input UpdateJoinRequestStatusInput) (*AdminJoinRequestItem, error) {
+	if input.JoinRequestID == uuid.Nil {
+		return nil, domain.ValidationError(map[string]string{"join_request_id": "is required"})
+	}
+	if input.Status != domain.JoinRequestStatusCanceled && input.Status != domain.JoinRequestStatusRejected {
+		return nil, domain.ValidationError(map[string]string{"status": "must be one of: CANCELED, REJECTED"})
+	}
+	return s.repo.UpdateJoinRequestStatus(ctx, input.JoinRequestID, input.Status)
+}
+
+func (s *Service) DeleteComment(ctx context.Context, input DeleteCommentInput) error {
+	if input.CommentID == uuid.Nil {
+		return domain.ValidationError(map[string]string{"comment_id": "is required"})
+	}
+	return s.repo.DeleteComment(ctx, input.CommentID)
+}
+
+func (s *Service) DeleteEventRating(ctx context.Context, input DeleteRatingInput) error {
+	if input.RatingID == uuid.Nil {
+		return domain.ValidationError(map[string]string{"rating_id": "is required"})
+	}
+	return s.repo.DeleteEventRating(ctx, input.RatingID)
+}
+
+func (s *Service) DeleteParticipantRating(ctx context.Context, input DeleteRatingInput) error {
+	if input.RatingID == uuid.Nil {
+		return domain.ValidationError(map[string]string{"rating_id": "is required"})
+	}
+	return s.repo.DeleteParticipantRating(ctx, input.RatingID)
+}
+
+func (s *Service) RevokePushDevice(ctx context.Context, input RevokePushDeviceInput) error {
+	if input.DeviceID == uuid.Nil {
+		return domain.ValidationError(map[string]string{"device_id": "is required"})
+	}
+	return s.repo.RevokePushDevice(ctx, input.DeviceID)
+}

--- a/backend/internal/application/admin/service_dto.go
+++ b/backend/internal/application/admin/service_dto.go
@@ -191,6 +191,362 @@ type ListNotificationsResult struct {
 	PageMeta
 }
 
+type ListEventReportsInput struct {
+	PageInput
+	CreatedRange
+	Query          *string
+	Status         *domain.EventReportStatus
+	ReportCategory *domain.EventReportCategory
+	EventID        *uuid.UUID
+	ReporterUserID *uuid.UUID
+}
+
+type AdminEventReportItem struct {
+	ID               uuid.UUID `json:"id"`
+	EventID          uuid.UUID `json:"event_id"`
+	EventTitle       *string   `json:"event_title"`
+	ReporterUserID   uuid.UUID `json:"reporter_user_id"`
+	ReporterUsername *string   `json:"reporter_username"`
+	ReporterEmail    *string   `json:"reporter_email"`
+	ReportCategory   string    `json:"report_category"`
+	Message          string    `json:"message"`
+	ImageURL         *string   `json:"image_url"`
+	Status           string    `json:"status"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type ListEventReportsResult struct {
+	Items []AdminEventReportItem `json:"items"`
+	PageMeta
+}
+
+type AdminCategoryItem struct {
+	ID        int       `json:"id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type ListCategoriesResult struct {
+	Items []AdminCategoryItem `json:"items"`
+}
+
+type CreateCategoryInput struct {
+	AdminUserID uuid.UUID
+	Name        string
+}
+
+type DeleteCategoryInput struct {
+	AdminUserID uuid.UUID
+	CategoryID  int
+}
+
+type UpdateEventReportStatusInput struct {
+	AdminUserID uuid.UUID
+	ReportID    uuid.UUID
+	Status      domain.EventReportStatus
+	Reason      *string
+}
+
+type UpdateEventStatusInput struct {
+	AdminUserID uuid.UUID
+	EventID     uuid.UUID
+	Status      domain.EventStatus
+	Reason      *string
+}
+
+type CancelEventInput struct {
+	AdminUserID uuid.UUID
+	EventID     uuid.UUID
+	Reason      *string
+}
+
+type CancelEventResult struct {
+	EventID         uuid.UUID          `json:"event_id"`
+	Status          domain.EventStatus `json:"status"`
+	AlreadyCanceled bool               `json:"already_canceled"`
+}
+
+type DeactivateUserInput struct {
+	AdminUserID uuid.UUID
+	UserID      uuid.UUID
+	Reason      *string
+}
+
+type DeactivateUserResult struct {
+	UserID             uuid.UUID         `json:"user_id"`
+	Status             domain.UserStatus `json:"status"`
+	AlreadyDeactivated bool              `json:"already_deactivated"`
+	CanceledEventCount int               `json:"canceled_event_count"`
+}
+
+type ListInvitationsInput struct {
+	PageInput
+	CreatedRange
+	Query         *string
+	Status        *domain.InvitationStatus
+	EventID       *uuid.UUID
+	HostID        *uuid.UUID
+	InvitedUserID *uuid.UUID
+}
+
+type AdminInvitationItem struct {
+	ID              uuid.UUID  `json:"id"`
+	EventID         uuid.UUID  `json:"event_id"`
+	EventTitle      string     `json:"event_title"`
+	HostID          uuid.UUID  `json:"host_id"`
+	HostUsername    string     `json:"host_username"`
+	InvitedUserID   uuid.UUID  `json:"invited_user_id"`
+	InvitedUsername string     `json:"invited_username"`
+	InvitedEmail    string     `json:"invited_email"`
+	Status          string     `json:"status"`
+	Message         *string    `json:"message"`
+	ExpiresAt       *time.Time `json:"expires_at"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+}
+
+type ListInvitationsResult struct {
+	Items []AdminInvitationItem `json:"items"`
+	PageMeta
+}
+
+type UpdateInvitationStatusInput struct {
+	AdminUserID  uuid.UUID
+	InvitationID uuid.UUID
+	Status       domain.InvitationStatus
+	Reason       *string
+}
+
+type ListJoinRequestsInput struct {
+	PageInput
+	CreatedRange
+	Query      *string
+	Status     *domain.JoinRequestStatus
+	EventID    *uuid.UUID
+	UserID     *uuid.UUID
+	HostUserID *uuid.UUID
+}
+
+type AdminJoinRequestItem struct {
+	ID           uuid.UUID `json:"id"`
+	EventID      uuid.UUID `json:"event_id"`
+	EventTitle   string    `json:"event_title"`
+	UserID       uuid.UUID `json:"user_id"`
+	Username     string    `json:"username"`
+	UserEmail    string    `json:"user_email"`
+	HostUserID   uuid.UUID `json:"host_user_id"`
+	HostUsername string    `json:"host_username"`
+	Status       string    `json:"status"`
+	Message      *string   `json:"message"`
+	ImageURL     *string   `json:"image_url"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+type ListJoinRequestsResult struct {
+	Items []AdminJoinRequestItem `json:"items"`
+	PageMeta
+}
+
+type UpdateJoinRequestStatusInput struct {
+	AdminUserID   uuid.UUID
+	JoinRequestID uuid.UUID
+	Status        domain.JoinRequestStatus
+	Reason        *string
+}
+
+type ListCommentsInput struct {
+	PageInput
+	CreatedRange
+	Query   *string
+	EventID *uuid.UUID
+	UserID  *uuid.UUID
+	Type    *string
+}
+
+type AdminCommentItem struct {
+	ID         uuid.UUID  `json:"id"`
+	EventID    uuid.UUID  `json:"event_id"`
+	EventTitle string     `json:"event_title"`
+	UserID     uuid.UUID  `json:"user_id"`
+	Username   string     `json:"username"`
+	UserEmail  string     `json:"user_email"`
+	Type       string     `json:"type"`
+	ParentID   *uuid.UUID `json:"parent_id"`
+	Message    string     `json:"message"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+}
+
+type ListCommentsResult struct {
+	Items []AdminCommentItem `json:"items"`
+	PageMeta
+}
+
+type DeleteCommentInput struct {
+	AdminUserID uuid.UUID
+	CommentID   uuid.UUID
+	Reason      *string
+}
+
+type ListEventRatingsInput struct {
+	PageInput
+	CreatedRange
+	EventID *uuid.UUID
+	UserID  *uuid.UUID
+}
+
+type AdminEventRatingItem struct {
+	ID                uuid.UUID `json:"id"`
+	EventID           uuid.UUID `json:"event_id"`
+	EventTitle        string    `json:"event_title"`
+	ParticipantUserID uuid.UUID `json:"participant_user_id"`
+	Username          string    `json:"username"`
+	UserEmail         string    `json:"user_email"`
+	Score             float64   `json:"score"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
+type ListEventRatingsResult struct {
+	Items []AdminEventRatingItem `json:"items"`
+	PageMeta
+}
+
+type ListParticipantRatingsInput struct {
+	PageInput
+	CreatedRange
+	EventID *uuid.UUID
+	HostID  *uuid.UUID
+	UserID  *uuid.UUID
+}
+
+type AdminParticipantRatingItem struct {
+	ID                  uuid.UUID `json:"id"`
+	EventID             uuid.UUID `json:"event_id"`
+	EventTitle          string    `json:"event_title"`
+	HostUserID          uuid.UUID `json:"host_user_id"`
+	HostUsername        string    `json:"host_username"`
+	ParticipantUserID   uuid.UUID `json:"participant_user_id"`
+	ParticipantUsername string    `json:"participant_username"`
+	Score               float64   `json:"score"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
+}
+
+type ListParticipantRatingsResult struct {
+	Items []AdminParticipantRatingItem `json:"items"`
+	PageMeta
+}
+
+type DeleteRatingInput struct {
+	AdminUserID uuid.UUID
+	RatingID    uuid.UUID
+	Reason      *string
+}
+
+type ListFavoriteEventsInput struct {
+	PageInput
+	CreatedRange
+	UserID  *uuid.UUID
+	EventID *uuid.UUID
+}
+
+type AdminFavoriteEventItem struct {
+	ID         uuid.UUID `json:"id"`
+	UserID     uuid.UUID `json:"user_id"`
+	Username   string    `json:"username"`
+	UserEmail  string    `json:"user_email"`
+	EventID    uuid.UUID `json:"event_id"`
+	EventTitle string    `json:"event_title"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type ListFavoriteEventsResult struct {
+	Items []AdminFavoriteEventItem `json:"items"`
+	PageMeta
+}
+
+type ListFavoriteLocationsInput struct {
+	PageInput
+	CreatedRange
+	UserID *uuid.UUID
+	Query  *string
+}
+
+type AdminFavoriteLocationItem struct {
+	ID        uuid.UUID `json:"id"`
+	UserID    uuid.UUID `json:"user_id"`
+	Username  string    `json:"username"`
+	UserEmail string    `json:"user_email"`
+	Name      *string   `json:"name"`
+	Address   *string   `json:"address"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type ListFavoriteLocationsResult struct {
+	Items []AdminFavoriteLocationItem `json:"items"`
+	PageMeta
+}
+
+type ListUserBadgesInput struct {
+	PageInput
+	UserID *uuid.UUID
+	Query  *string
+}
+
+type AdminUserBadgeItem struct {
+	UserID        uuid.UUID `json:"user_id"`
+	Username      string    `json:"username"`
+	UserEmail     string    `json:"user_email"`
+	BadgeID       int       `json:"badge_id"`
+	BadgeSlug     string    `json:"badge_slug"`
+	BadgeName     string    `json:"badge_name"`
+	BadgeCategory string    `json:"badge_category"`
+	EarnedAt      time.Time `json:"earned_at"`
+}
+
+type ListUserBadgesResult struct {
+	Items []AdminUserBadgeItem `json:"items"`
+	PageMeta
+}
+
+type ListPushDevicesInput struct {
+	PageInput
+	CreatedRange
+	UserID   *uuid.UUID
+	Platform *string
+	Active   *bool
+}
+
+type AdminPushDeviceItem struct {
+	ID             uuid.UUID  `json:"id"`
+	UserID         uuid.UUID  `json:"user_id"`
+	Username       string     `json:"username"`
+	UserEmail      string     `json:"user_email"`
+	InstallationID uuid.UUID  `json:"installation_id"`
+	Platform       string     `json:"platform"`
+	LastSeenAt     time.Time  `json:"last_seen_at"`
+	RevokedAt      *time.Time `json:"revoked_at"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+type ListPushDevicesResult struct {
+	Items []AdminPushDeviceItem `json:"items"`
+	PageMeta
+}
+
+type RevokePushDeviceInput struct {
+	AdminUserID uuid.UUID
+	DeviceID    uuid.UUID
+	Reason      *string
+}
+
 type SendCustomNotificationInput struct {
 	AdminUserID    uuid.UUID
 	UserIDs        []uuid.UUID
@@ -272,4 +628,48 @@ func (s *Service) ListTickets(ctx context.Context, input ListTicketsInput) (*Lis
 
 func (s *Service) ListNotifications(ctx context.Context, input ListNotificationsInput) (*ListNotificationsResult, error) {
 	return s.repo.ListNotifications(ctx, input)
+}
+
+func (s *Service) ListEventReports(ctx context.Context, input ListEventReportsInput) (*ListEventReportsResult, error) {
+	return s.repo.ListEventReports(ctx, input)
+}
+
+func (s *Service) ListCategories(ctx context.Context) (*ListCategoriesResult, error) {
+	return s.repo.ListCategories(ctx)
+}
+
+func (s *Service) ListInvitations(ctx context.Context, input ListInvitationsInput) (*ListInvitationsResult, error) {
+	return s.repo.ListInvitations(ctx, input)
+}
+
+func (s *Service) ListJoinRequests(ctx context.Context, input ListJoinRequestsInput) (*ListJoinRequestsResult, error) {
+	return s.repo.ListJoinRequests(ctx, input)
+}
+
+func (s *Service) ListComments(ctx context.Context, input ListCommentsInput) (*ListCommentsResult, error) {
+	return s.repo.ListComments(ctx, input)
+}
+
+func (s *Service) ListEventRatings(ctx context.Context, input ListEventRatingsInput) (*ListEventRatingsResult, error) {
+	return s.repo.ListEventRatings(ctx, input)
+}
+
+func (s *Service) ListParticipantRatings(ctx context.Context, input ListParticipantRatingsInput) (*ListParticipantRatingsResult, error) {
+	return s.repo.ListParticipantRatings(ctx, input)
+}
+
+func (s *Service) ListFavoriteEvents(ctx context.Context, input ListFavoriteEventsInput) (*ListFavoriteEventsResult, error) {
+	return s.repo.ListFavoriteEvents(ctx, input)
+}
+
+func (s *Service) ListFavoriteLocations(ctx context.Context, input ListFavoriteLocationsInput) (*ListFavoriteLocationsResult, error) {
+	return s.repo.ListFavoriteLocations(ctx, input)
+}
+
+func (s *Service) ListUserBadges(ctx context.Context, input ListUserBadgesInput) (*ListUserBadgesResult, error) {
+	return s.repo.ListUserBadges(ctx, input)
+}
+
+func (s *Service) ListPushDevices(ctx context.Context, input ListPushDevicesInput) (*ListPushDevicesResult, error) {
+	return s.repo.ListPushDevices(ctx, input)
 }

--- a/backend/internal/application/admin/service_test.go
+++ b/backend/internal/application/admin/service_test.go
@@ -44,6 +44,86 @@ func (r *fakeRepository) ListNotifications(context.Context, ListNotificationsInp
 	return nil, nil
 }
 
+func (r *fakeRepository) ListEventReports(context.Context, ListEventReportsInput) (*ListEventReportsResult, error) {
+	return nil, nil
+}
+
+func (r *fakeRepository) ListCategories(context.Context) (*ListCategoriesResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) CreateCategory(context.Context, string) (*AdminCategoryItem, error) {
+	return nil, nil
+}
+func (r *fakeRepository) DeleteCategory(context.Context, int) error { return nil }
+func (r *fakeRepository) UpdateEventReportStatus(context.Context, uuid.UUID, domain.EventReportStatus) (*AdminEventReportItem, error) {
+	return nil, nil
+}
+func (r *fakeRepository) UpdateEventStatus(context.Context, uuid.UUID, domain.EventStatus) (*AdminEventItem, error) {
+	return nil, nil
+}
+func (r *fakeRepository) CancelEvent(context.Context, uuid.UUID) (bool, error)       { return false, nil }
+func (r *fakeRepository) CancelEventParticipations(context.Context, uuid.UUID) error { return nil }
+func (r *fakeRepository) CancelPendingInvitationsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+func (r *fakeRepository) CancelPendingJoinRequestsForEvent(context.Context, uuid.UUID) error {
+	return nil
+}
+func (r *fakeRepository) GetUserStatus(context.Context, uuid.UUID, bool) (*domain.UserStatus, error) {
+	return nil, nil
+}
+func (r *fakeRepository) DeactivateUser(context.Context, uuid.UUID) error             { return nil }
+func (r *fakeRepository) RevokeRefreshTokensForUser(context.Context, uuid.UUID) error { return nil }
+func (r *fakeRepository) RevokePushDevicesForUser(context.Context, uuid.UUID) error   { return nil }
+func (r *fakeRepository) ListHostedCancelableEventIDs(context.Context, uuid.UUID) ([]uuid.UUID, error) {
+	return nil, nil
+}
+func (r *fakeRepository) CancelUserParticipations(context.Context, uuid.UUID) error { return nil }
+func (r *fakeRepository) CancelUserTickets(context.Context, uuid.UUID) error        { return nil }
+func (r *fakeRepository) CancelPendingInvitationsForUser(context.Context, uuid.UUID) error {
+	return nil
+}
+func (r *fakeRepository) CancelPendingJoinRequestsForUser(context.Context, uuid.UUID) error {
+	return nil
+}
+func (r *fakeRepository) ListInvitations(context.Context, ListInvitationsInput) (*ListInvitationsResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) UpdateInvitationStatus(context.Context, uuid.UUID, domain.InvitationStatus) (*AdminInvitationItem, error) {
+	return nil, nil
+}
+func (r *fakeRepository) ListJoinRequests(context.Context, ListJoinRequestsInput) (*ListJoinRequestsResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) UpdateJoinRequestStatus(context.Context, uuid.UUID, domain.JoinRequestStatus) (*AdminJoinRequestItem, error) {
+	return nil, nil
+}
+func (r *fakeRepository) ListComments(context.Context, ListCommentsInput) (*ListCommentsResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) DeleteComment(context.Context, uuid.UUID) error { return nil }
+func (r *fakeRepository) ListEventRatings(context.Context, ListEventRatingsInput) (*ListEventRatingsResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) ListParticipantRatings(context.Context, ListParticipantRatingsInput) (*ListParticipantRatingsResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) DeleteEventRating(context.Context, uuid.UUID) error       { return nil }
+func (r *fakeRepository) DeleteParticipantRating(context.Context, uuid.UUID) error { return nil }
+func (r *fakeRepository) ListFavoriteEvents(context.Context, ListFavoriteEventsInput) (*ListFavoriteEventsResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) ListFavoriteLocations(context.Context, ListFavoriteLocationsInput) (*ListFavoriteLocationsResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) ListUserBadges(context.Context, ListUserBadgesInput) (*ListUserBadgesResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) ListPushDevices(context.Context, ListPushDevicesInput) (*ListPushDevicesResult, error) {
+	return nil, nil
+}
+func (r *fakeRepository) RevokePushDevice(context.Context, uuid.UUID) error { return nil }
+
 func (r *fakeRepository) CountExistingUsers(context.Context, []uuid.UUID) (int, error) {
 	return r.existingUsers, nil
 }

--- a/backend/internal/application/admin/usecase.go
+++ b/backend/internal/application/admin/usecase.go
@@ -9,6 +9,29 @@ type UseCase interface {
 	ListParticipations(ctx context.Context, input ListParticipationsInput) (*ListParticipationsResult, error)
 	ListTickets(ctx context.Context, input ListTicketsInput) (*ListTicketsResult, error)
 	ListNotifications(ctx context.Context, input ListNotificationsInput) (*ListNotificationsResult, error)
+	ListEventReports(ctx context.Context, input ListEventReportsInput) (*ListEventReportsResult, error)
+	ListCategories(ctx context.Context) (*ListCategoriesResult, error)
+	CreateCategory(ctx context.Context, input CreateCategoryInput) (*AdminCategoryItem, error)
+	DeleteCategory(ctx context.Context, input DeleteCategoryInput) error
+	UpdateEventReportStatus(ctx context.Context, input UpdateEventReportStatusInput) (*AdminEventReportItem, error)
+	UpdateEventStatus(ctx context.Context, input UpdateEventStatusInput) (*AdminEventItem, error)
+	CancelEvent(ctx context.Context, input CancelEventInput) (*CancelEventResult, error)
+	DeactivateUser(ctx context.Context, input DeactivateUserInput) (*DeactivateUserResult, error)
+	ListInvitations(ctx context.Context, input ListInvitationsInput) (*ListInvitationsResult, error)
+	UpdateInvitationStatus(ctx context.Context, input UpdateInvitationStatusInput) (*AdminInvitationItem, error)
+	ListJoinRequests(ctx context.Context, input ListJoinRequestsInput) (*ListJoinRequestsResult, error)
+	UpdateJoinRequestStatus(ctx context.Context, input UpdateJoinRequestStatusInput) (*AdminJoinRequestItem, error)
+	ListComments(ctx context.Context, input ListCommentsInput) (*ListCommentsResult, error)
+	DeleteComment(ctx context.Context, input DeleteCommentInput) error
+	ListEventRatings(ctx context.Context, input ListEventRatingsInput) (*ListEventRatingsResult, error)
+	ListParticipantRatings(ctx context.Context, input ListParticipantRatingsInput) (*ListParticipantRatingsResult, error)
+	DeleteEventRating(ctx context.Context, input DeleteRatingInput) error
+	DeleteParticipantRating(ctx context.Context, input DeleteRatingInput) error
+	ListFavoriteEvents(ctx context.Context, input ListFavoriteEventsInput) (*ListFavoriteEventsResult, error)
+	ListFavoriteLocations(ctx context.Context, input ListFavoriteLocationsInput) (*ListFavoriteLocationsResult, error)
+	ListUserBadges(ctx context.Context, input ListUserBadgesInput) (*ListUserBadgesResult, error)
+	ListPushDevices(ctx context.Context, input ListPushDevicesInput) (*ListPushDevicesResult, error)
+	RevokePushDevice(ctx context.Context, input RevokePushDeviceInput) error
 	SendCustomNotification(ctx context.Context, input SendCustomNotificationInput) (*SendCustomNotificationResult, error)
 	CreateManualParticipation(ctx context.Context, input CreateManualParticipationInput) (*CreateManualParticipationResult, error)
 	CancelParticipation(ctx context.Context, input CancelParticipationInput) (*CancelParticipationResult, error)

--- a/backend/internal/application/auth/service.go
+++ b/backend/internal/application/auth/service.go
@@ -334,6 +334,9 @@ func (s *Service) Login(ctx context.Context, input LoginInput) (*Session, error)
 	if user.PasswordHash == "" || s.passwordHasher.Compare(user.PasswordHash, password) != nil {
 		return nil, domain.AuthError(domain.ErrorCodeInvalidCreds, "Invalid username or password.")
 	}
+	if user.Status != domain.UserStatusActive {
+		return nil, domain.AuthError(domain.ErrorCodeInvalidCreds, "Invalid username or password.")
+	}
 
 	var session *Session
 	err = s.unitOfWork.RunInTx(ctx, func(ctx context.Context) error {
@@ -396,6 +399,12 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string, deviceInfo *
 				return domain.AuthError(domain.ErrorCodeInvalidRefresh, "The refresh token is invalid or expired.")
 			}
 			return fmt.Errorf("lookup user by id: %w", err)
+		}
+		if user.Status != domain.UserStatusActive {
+			if err := s.repo.RevokeRefreshTokenFamily(ctx, current.FamilyID, now); err != nil {
+				return fmt.Errorf("revoke inactive user refresh token family: %w", err)
+			}
+			return domain.AuthError(domain.ErrorCodeInvalidRefresh, "The refresh token is invalid or expired.")
 		}
 		familyStartedAt, err := s.repo.GetRefreshTokenFamilyCreatedAt(ctx, current.FamilyID)
 		if err != nil {

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -118,6 +118,10 @@ func ParseEventStatus(value string) (EventStatus, bool) {
 	return status, ok
 }
 
+func (s EventStatus) String() string {
+	return string(s)
+}
+
 // GeoPoint is a single WGS84 coordinate used for event locations.
 type GeoPoint struct {
 	Lat float64

--- a/backend/internal/domain/event_report.go
+++ b/backend/internal/domain/event_report.go
@@ -48,10 +48,26 @@ var eventReportCategories = map[string]EventReportCategory{
 	string(EventReportCategoryOther):                EventReportCategoryOther,
 }
 
+var eventReportStatuses = map[string]EventReportStatus{
+	string(EventReportStatusPending):   EventReportStatusPending,
+	string(EventReportStatusReviewed):  EventReportStatusReviewed,
+	string(EventReportStatusDismissed): EventReportStatusDismissed,
+}
+
 // ParseEventReportCategory converts a wire string to an EventReportCategory.
 func ParseEventReportCategory(value string) (EventReportCategory, bool) {
 	category, ok := eventReportCategories[value]
 	return category, ok
+}
+
+// ParseEventReportStatus converts a wire string to an EventReportStatus.
+func ParseEventReportStatus(value string) (EventReportStatus, bool) {
+	status, ok := eventReportStatuses[value]
+	return status, ok
+}
+
+func (s EventReportStatus) String() string {
+	return string(s)
 }
 
 // EventReport stores a user-submitted report for an event.

--- a/backend/internal/domain/join_request.go
+++ b/backend/internal/domain/join_request.go
@@ -31,6 +31,10 @@ func ParseJoinRequestStatus(value string) (JoinRequestStatus, bool) {
 	return status, ok
 }
 
+func (s JoinRequestStatus) String() string {
+	return string(s)
+}
+
 // JoinRequest records a pending request to join a protected event.
 type JoinRequest struct {
 	ID              uuid.UUID

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -16,6 +16,8 @@ type UserRole string
 const (
 	// UserStatusActive is the default status assigned to newly registered users.
 	UserStatusActive = "active"
+	// UserStatusDeactivated prevents an account from continuing authenticated use.
+	UserStatusDeactivated UserStatus = "deactivated"
 
 	// UserRoleUser is the default non-admin role for regular accounts.
 	UserRoleUser UserRole = "USER"
@@ -29,7 +31,8 @@ var userRoles = map[string]UserRole{
 }
 
 var userStatuses = map[string]UserStatus{
-	UserStatusActive: UserStatus(UserStatusActive),
+	UserStatusActive:               UserStatus(UserStatusActive),
+	UserStatusDeactivated.String(): UserStatusDeactivated,
 }
 
 // ParseUserRole converts a wire string into a UserRole.

--- a/backend/migrations/000033_user_status_admin_indexes.down.sql
+++ b/backend/migrations/000033_user_status_admin_indexes.down.sql
@@ -1,0 +1,11 @@
+DROP INDEX IF EXISTS idx_join_request_status_created;
+DROP INDEX IF EXISTS idx_invitation_status_created;
+DROP INDEX IF EXISTS idx_event_report_category_created;
+DROP INDEX IF EXISTS idx_app_user_status_created;
+
+ALTER TABLE app_user
+    DROP CONSTRAINT IF EXISTS chk_app_user_status;
+
+ALTER TABLE app_user
+    ALTER COLUMN status DROP DEFAULT,
+    ALTER COLUMN status DROP NOT NULL;

--- a/backend/migrations/000033_user_status_admin_indexes.up.sql
+++ b/backend/migrations/000033_user_status_admin_indexes.up.sql
@@ -1,0 +1,27 @@
+UPDATE app_user
+SET status = 'active',
+    updated_at = NOW()
+WHERE status IS NULL OR btrim(status) = '';
+
+ALTER TABLE app_user
+    ALTER COLUMN status SET NOT NULL,
+    ALTER COLUMN status SET DEFAULT 'active';
+
+ALTER TABLE app_user
+    DROP CONSTRAINT IF EXISTS chk_app_user_status;
+
+ALTER TABLE app_user
+    ADD CONSTRAINT chk_app_user_status
+        CHECK (status IN ('active', 'deactivated'));
+
+CREATE INDEX IF NOT EXISTS idx_app_user_status_created
+    ON app_user (status, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_event_report_category_created
+    ON event_report (report_category, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_invitation_status_created
+    ON invitation (status, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_join_request_status_created
+    ON join_request (status, created_at DESC, id DESC);

--- a/docs/openapi/admin.yaml
+++ b/docs/openapi/admin.yaml
@@ -26,7 +26,7 @@ paths:
         - $ref: '#/components/parameters/TextQuery'
         - name: status
           in: query
-          schema: { type: string, enum: [active] }
+          schema: { type: string, enum: [active, deactivated] }
         - name: role
           in: query
           schema: { type: string, enum: [USER, ADMIN] }
@@ -53,6 +53,43 @@ paths:
         '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/users/{user_id}/deactivate:
+    post:
+      tags: [Admin]
+      summary: Deactivate a user account
+      operationId: adminDeactivateUser
+      description: |
+        Sets the account status to `deactivated`, revokes active sessions and push
+        devices, cancels hosted active/in-progress events, cancels active/pending
+        non-host participations and linked tickets, and cancels pending invitations
+        and join requests involving the user. Repeating the request is idempotent.
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminReasonRequest' }
+      responses:
+        '200':
+          description: User deactivated or already deactivated.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [user_id, status, already_deactivated, canceled_event_count]
+                properties:
+                  user_id: { type: string, format: uuid }
+                  status: { type: string, enum: [deactivated] }
+                  already_deactivated: { type: boolean }
+                  canceled_event_count: { type: integer }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
   /admin/events:
     get:
       tags: [Admin]
@@ -97,6 +134,182 @@ paths:
         '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/events/{event_id}/status:
+    patch:
+      tags: [Admin]
+      summary: Change event status
+      operationId: adminUpdateEventStatus
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminEventStatusRequest' }
+      responses:
+        '200':
+          description: Updated event row.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminEvent' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /admin/events/{event_id}/cancel:
+    post:
+      tags: [Admin]
+      summary: Cancel an event
+      operationId: adminCancelEvent
+      description: Cancels the event plus active/pending participations, linked tickets, pending invitations, and pending join requests in one application transaction.
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminReasonRequest' }
+      responses:
+        '200':
+          description: Event canceled or already canceled.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [event_id, status, already_canceled]
+                properties:
+                  event_id: { type: string, format: uuid }
+                  status: { type: string, enum: [CANCELED] }
+                  already_canceled: { type: boolean }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /admin/event-reports:
+    get:
+      tags: [Admin]
+      summary: List event reports
+      operationId: adminListEventReports
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/TextQuery'
+        - name: status
+          in: query
+          schema: { type: string, enum: [PENDING, REVIEWED, DISMISSED] }
+        - name: report_category
+          in: query
+          schema: { type: string, enum: [SAFETY, HARASSMENT, SPAM_OR_SCAM, INAPPROPRIATE_CONTENT, EVENT_NOT_AS_DESCRIBED, ILLEGAL_OR_DANGEROUS, OTHER] }
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: reporter_user_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: created_from
+          in: query
+          schema: { type: string, format: date-time }
+        - name: created_to
+          in: query
+          schema: { type: string, format: date-time }
+      responses:
+        '200':
+          description: Offset-paginated event reports.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminEventReport' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/event-reports/{report_id}/status:
+    patch:
+      tags: [Admin]
+      summary: Change event report moderation status
+      operationId: adminUpdateEventReportStatus
+      parameters:
+        - name: report_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminEventReportStatusRequest' }
+      responses:
+        '200':
+          description: Updated event report.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminEventReport' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /admin/categories:
+    get:
+      tags: [Admin]
+      summary: List event categories
+      operationId: adminListCategories
+      responses:
+        '200':
+          description: All event categories.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/AdminCategory' }
+    post:
+      tags: [Admin]
+      summary: Create event category
+      operationId: adminCreateCategory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminCreateCategoryRequest' }
+      responses:
+        '201':
+          description: Created category.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminCategory' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '409': { $ref: '#/components/responses/Conflict' }
+  /admin/categories/{category_id}:
+    delete:
+      tags: [Admin]
+      summary: Delete event category
+      operationId: adminDeleteCategory
+      description: Returns `409 category_in_use` when any event still references the category.
+      parameters:
+        - name: category_id
+          in: path
+          required: true
+          schema: { type: integer }
+      responses:
+        '204': { description: Category deleted. }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
   /admin/participations:
     get:
       tags: [Admin]
@@ -253,6 +466,420 @@ paths:
         '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/invitations:
+    get:
+      tags: [Admin]
+      summary: List invitations
+      operationId: adminListInvitations
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: status
+          in: query
+          schema: { type: string, enum: [PENDING, ACCEPTED, DECLINED, CANCELED] }
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: host_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: invited_user_id
+          in: query
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Offset-paginated invitations.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminInvitation' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/invitations/{invitation_id}/status:
+    patch:
+      tags: [Admin]
+      summary: Change invitation status
+      operationId: adminUpdateInvitationStatus
+      description: Admins may cancel pending invitations. Non-pending rows return a conflict.
+      parameters:
+        - name: invitation_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminInvitationStatusRequest' }
+      responses:
+        '200':
+          description: Updated invitation.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminInvitation' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+  /admin/join-requests:
+    get:
+      tags: [Admin]
+      summary: List join requests
+      operationId: adminListJoinRequests
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: status
+          in: query
+          schema: { type: string, enum: [PENDING, APPROVED, REJECTED, CANCELED] }
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: host_user_id
+          in: query
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Offset-paginated join requests.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminJoinRequest' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/join-requests/{join_request_id}/status:
+    patch:
+      tags: [Admin]
+      summary: Change join request status
+      operationId: adminUpdateJoinRequestStatus
+      description: Admins may cancel or reject pending join requests. Non-pending rows return a conflict.
+      parameters:
+        - name: join_request_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminJoinRequestStatusRequest' }
+      responses:
+        '200':
+          description: Updated join request.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminJoinRequest' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+  /admin/comments:
+    get:
+      tags: [Admin]
+      summary: List discussion and review comments
+      operationId: adminListComments
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: kind
+          in: query
+          schema: { type: string, enum: [DISCUSSION, REVIEW] }
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Offset-paginated comments.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminComment' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/comments/{comment_id}:
+    delete:
+      tags: [Admin]
+      summary: Delete a comment
+      operationId: adminDeleteComment
+      description: Hard-deletes the comment because the current schema has no comment soft-delete status.
+      parameters:
+        - name: comment_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '204': { description: Comment deleted. }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /admin/ratings/events:
+    get:
+      tags: [Admin]
+      summary: List event ratings
+      operationId: adminListEventRatings
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Offset-paginated event ratings.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminEventRating' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/ratings/events/{rating_id}:
+    delete:
+      tags: [Admin]
+      summary: Delete an event rating
+      operationId: adminDeleteEventRating
+      parameters:
+        - name: rating_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '204': { description: Event rating deleted. }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /admin/ratings/participants:
+    get:
+      tags: [Admin]
+      summary: List participant ratings
+      operationId: adminListParticipantRatings
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: rater_user_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: rated_user_id
+          in: query
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Offset-paginated participant ratings.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminParticipantRating' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/ratings/participants/{rating_id}:
+    delete:
+      tags: [Admin]
+      summary: Delete a participant rating
+      operationId: adminDeleteParticipantRating
+      parameters:
+        - name: rating_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '204': { description: Participant rating deleted. }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /admin/favorites/events:
+    get:
+      tags: [Admin]
+      summary: List favorite events
+      operationId: adminListFavoriteEvents
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: event_id
+          in: query
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Offset-paginated favorite events.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminFavoriteEvent' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/favorites/locations:
+    get:
+      tags: [Admin]
+      summary: List favorite locations
+      operationId: adminListFavoriteLocations
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Offset-paginated favorite locations.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminFavoriteLocation' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/badges/users:
+    get:
+      tags: [Admin]
+      summary: List user badges
+      operationId: adminListUserBadges
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Offset-paginated user badges.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminUserBadge' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/push-devices:
+    get:
+      tags: [Admin]
+      summary: List push devices
+      operationId: adminListPushDevices
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: user_id
+          in: query
+          schema: { type: string, format: uuid }
+        - name: active
+          in: query
+          schema: { type: boolean }
+      responses:
+        '200':
+          description: Offset-paginated push devices.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PageMeta'
+                  - type: object
+                    required: [items]
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AdminPushDevice' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /admin/push-devices/{device_id}/revoke:
+    post:
+      tags: [Admin]
+      summary: Revoke a push device
+      operationId: adminRevokePushDevice
+      parameters:
+        - name: device_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        '200':
+          description: Updated push device.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AdminPushDevice' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
   /admin/notifications:
     get:
       tags: [Admin]
@@ -374,7 +1001,7 @@ components:
         phone_number: { type: [string, 'null'] }
         email_verified: { type: boolean }
         last_login: { type: [string, 'null'], format: date-time }
-        status: { type: string, example: active }
+        status: { type: string, enum: [active, deactivated] }
         role: { type: string, enum: [USER, ADMIN] }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
@@ -537,6 +1164,195 @@ components:
         user_id: { type: string, format: uuid }
         status: { type: string, enum: [CANCELED] }
         already_canceled: { type: boolean }
+    AdminReasonRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        reason:
+          type: [string, 'null']
+          description: Optional admin note/reason accepted for audit-aware clients but not persisted yet.
+    AdminEventStatusRequest:
+      type: object
+      additionalProperties: false
+      required: [status]
+      properties:
+        status: { type: string, enum: [ACTIVE, IN_PROGRESS, CANCELED, COMPLETED] }
+        reason: { type: [string, 'null'] }
+    AdminEventReportStatusRequest:
+      type: object
+      additionalProperties: false
+      required: [status]
+      properties:
+        status: { type: string, enum: [PENDING, REVIEWED, DISMISSED] }
+        reason: { type: [string, 'null'] }
+    AdminInvitationStatusRequest:
+      type: object
+      additionalProperties: false
+      required: [status]
+      properties:
+        status: { type: string, enum: [CANCELED] }
+        reason: { type: [string, 'null'] }
+    AdminJoinRequestStatusRequest:
+      type: object
+      additionalProperties: false
+      required: [status]
+      properties:
+        status: { type: string, enum: [CANCELED, REJECTED] }
+        reason: { type: [string, 'null'] }
+    AdminCategory:
+      type: object
+      additionalProperties: false
+      required: [id, name, created_at, updated_at]
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminCreateCategoryRequest:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name: { type: string, minLength: 1, maxLength: 50 }
+    AdminEventReport:
+      type: object
+      additionalProperties: false
+      required: [id, event_id, reporter_user_id, report_category, message, status, created_at, updated_at]
+      properties:
+        id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        event_title: { type: [string, 'null'] }
+        reporter_user_id: { type: string, format: uuid }
+        reporter_username: { type: [string, 'null'] }
+        reporter_email: { type: [string, 'null'], format: email }
+        report_category: { type: string, enum: [SAFETY, HARASSMENT, SPAM_OR_SCAM, INAPPROPRIATE_CONTENT, EVENT_NOT_AS_DESCRIBED, ILLEGAL_OR_DANGEROUS, OTHER] }
+        message: { type: string }
+        image_url: { type: [string, 'null'] }
+        status: { type: string, enum: [PENDING, REVIEWED, DISMISSED] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminInvitation:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        event_title: { type: string }
+        host_id: { type: string, format: uuid }
+        host_username: { type: string }
+        invited_user_id: { type: string, format: uuid }
+        invited_username: { type: string }
+        invited_email: { type: string, format: email }
+        status: { type: string, enum: [PENDING, ACCEPTED, DECLINED, CANCELED] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminJoinRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        event_title: { type: string }
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        host_user_id: { type: string, format: uuid }
+        host_username: { type: string }
+        status: { type: string, enum: [PENDING, APPROVED, REJECTED, CANCELED] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminComment:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        kind: { type: string, enum: [DISCUSSION, REVIEW] }
+        event_id: { type: string, format: uuid }
+        event_title: { type: string }
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        body: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminEventRating:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        event_title: { type: string }
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        score: { type: integer, minimum: 1, maximum: 5 }
+        comment: { type: [string, 'null'] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminParticipantRating:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        event_id: { type: string, format: uuid }
+        event_title: { type: string }
+        rater_user_id: { type: string, format: uuid }
+        rater_username: { type: string }
+        rated_user_id: { type: string, format: uuid }
+        rated_username: { type: string }
+        score: { type: integer, minimum: 1, maximum: 5 }
+        comment: { type: [string, 'null'] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminFavoriteEvent:
+      type: object
+      additionalProperties: false
+      properties:
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        event_id: { type: string, format: uuid }
+        event_title: { type: string }
+        created_at: { type: string, format: date-time }
+    AdminFavoriteLocation:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        name: { type: string }
+        latitude: { type: number, format: double }
+        longitude: { type: number, format: double }
+        address: { type: [string, 'null'] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    AdminUserBadge:
+      type: object
+      additionalProperties: false
+      properties:
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        badge_id: { type: string, format: uuid }
+        badge_name: { type: string }
+        awarded_at: { type: string, format: date-time }
+    AdminPushDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        id: { type: string, format: uuid }
+        user_id: { type: string, format: uuid }
+        username: { type: string }
+        user_email: { type: string, format: email }
+        platform: { type: string }
+        token_last4: { type: string }
+        active: { type: boolean }
+        last_seen_at: { type: [string, 'null'], format: date-time }
+        revoked_at: { type: [string, 'null'], format: date-time }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
     ErrorResponse:
       type: object
       additionalProperties: false
@@ -564,6 +1380,16 @@ components:
           schema: { $ref: '#/components/schemas/ErrorResponse' }
     Forbidden:
       description: The bearer token is valid, but the user role is not ADMIN.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ErrorResponse' }
+    NotFound:
+      description: The requested admin resource does not exist.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ErrorResponse' }
+    Conflict:
+      description: The requested mutation conflicts with current state.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,8 +24,16 @@ import BackofficeLayout from './views/backoffice/BackofficeLayout';
 import UsersAdminPage from './views/backoffice/UsersAdminPage';
 import EventsAdminPage from './views/backoffice/EventsAdminPage';
 import EventReportsAdminPage from './views/backoffice/EventReportsAdminPage';
+import CategoriesAdminPage from './views/backoffice/CategoriesAdminPage';
 import ParticipationsAdminPage from './views/backoffice/ParticipationsAdminPage';
 import TicketsAdminPage from './views/backoffice/TicketsAdminPage';
+import InvitationsAdminPage from './views/backoffice/InvitationsAdminPage';
+import JoinRequestsAdminPage from './views/backoffice/JoinRequestsAdminPage';
+import CommentsAdminPage from './views/backoffice/CommentsAdminPage';
+import RatingsAdminPage from './views/backoffice/RatingsAdminPage';
+import FavoritesAdminPage from './views/backoffice/FavoritesAdminPage';
+import BadgesAdminPage from './views/backoffice/BadgesAdminPage';
+import PushDevicesAdminPage from './views/backoffice/PushDevicesAdminPage';
 import NotificationsAdminPage from './views/backoffice/NotificationsAdminPage';
 
 export default function App() {
@@ -64,8 +72,16 @@ export default function App() {
               <Route path="users" element={<UsersAdminPage />} />
               <Route path="events" element={<EventsAdminPage />} />
               <Route path="event-reports" element={<EventReportsAdminPage />} />
+              <Route path="categories" element={<CategoriesAdminPage />} />
               <Route path="participations" element={<ParticipationsAdminPage />} />
               <Route path="tickets" element={<TicketsAdminPage />} />
+              <Route path="invitations" element={<InvitationsAdminPage />} />
+              <Route path="join-requests" element={<JoinRequestsAdminPage />} />
+              <Route path="comments" element={<CommentsAdminPage />} />
+              <Route path="ratings" element={<RatingsAdminPage />} />
+              <Route path="favorites" element={<FavoritesAdminPage />} />
+              <Route path="badges" element={<BadgesAdminPage />} />
+              <Route path="push-devices" element={<PushDevicesAdminPage />} />
               <Route path="notifications" element={<NotificationsAdminPage />} />
             </Route>
             <Route path="/admin-panel" element={<Navigate to="/backoffice" replace />} />

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -13,7 +13,8 @@ const AUTH_NAV = [
   { to: '/discover', label: 'Discover' },
   { to: '/my-events', label: 'My Events' },
   { to: '/favorites', label: 'Favorites' },
-  { to: '/profile', label: 'Profile' },
+  { to: '/tickets', label: 'My Tickets' },
+  { to: '/invitations', label: 'Invitations' },
 ];
 
 export default function AppShell() {
@@ -185,7 +186,10 @@ export default function AppShell() {
                     </span>
                   )}
                 </NavLink>
-                <NavLink to="/events/create" className="shell-create-btn">
+                <NavLink
+                  to="/events/create"
+                  className={({ isActive }) => `shell-create-btn ${isActive ? 'active' : ''}`}
+                >
                   + Create Event
                 </NavLink>
                 {role === 'ADMIN' && (

--- a/frontend/src/models/admin.ts
+++ b/frontend/src/models/admin.ts
@@ -18,7 +18,7 @@ export interface AdminPageParams {
 
 export interface AdminUserFilters {
   q?: string;
-  status?: string;
+  status?: 'active' | 'deactivated' | '';
   role?: UserRole;
   created_from?: string;
   created_to?: string;
@@ -87,7 +87,7 @@ export interface AdminUser {
   phone_number: string | null;
   email_verified: boolean;
   last_login: string | null;
-  status: string;
+  status: 'active' | 'deactivated';
   role: UserRole;
   created_at: string;
   updated_at: string;
@@ -180,6 +180,207 @@ export interface AdminEventReport {
   message: string;
   image_url: string | null;
   status: 'PENDING' | 'REVIEWED' | 'DISMISSED';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminCategory {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminCreateCategoryRequest {
+  name: string;
+}
+
+export interface AdminUpdateStatusRequest<T extends string = string> {
+  status: T;
+  reason?: string | null;
+}
+
+export interface AdminReasonRequest {
+  reason?: string | null;
+}
+
+export interface AdminCancelEventResponse {
+  event_id: string;
+  status: 'CANCELED';
+  already_canceled: boolean;
+}
+
+export interface AdminDeactivateUserResponse {
+  user_id: string;
+  status: 'deactivated';
+  already_deactivated: boolean;
+  canceled_event_count: number;
+}
+
+export type AdminInvitationStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED' | 'CANCELED';
+export interface AdminInvitationFilters {
+  q?: string;
+  status?: AdminInvitationStatus;
+  event_id?: string;
+  host_id?: string;
+  invited_user_id?: string;
+  created_from?: string;
+  created_to?: string;
+}
+export interface AdminInvitation {
+  id: string;
+  event_id: string;
+  event_title: string;
+  host_id: string;
+  host_username: string;
+  invited_user_id: string;
+  invited_username: string;
+  invited_email: string;
+  status: AdminInvitationStatus;
+  message: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type AdminJoinRequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELED';
+export interface AdminJoinRequestFilters {
+  q?: string;
+  status?: AdminJoinRequestStatus;
+  event_id?: string;
+  user_id?: string;
+  host_user_id?: string;
+  created_from?: string;
+  created_to?: string;
+}
+export interface AdminJoinRequest {
+  id: string;
+  event_id: string;
+  event_title: string;
+  user_id: string;
+  username: string;
+  user_email: string;
+  host_user_id: string;
+  host_username: string;
+  status: AdminJoinRequestStatus;
+  message: string | null;
+  image_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminCommentFilters {
+  q?: string;
+  event_id?: string;
+  user_id?: string;
+  type?: 'DISCUSSION' | 'REVIEW';
+  created_from?: string;
+  created_to?: string;
+}
+export interface AdminComment {
+  id: string;
+  event_id: string;
+  event_title: string;
+  user_id: string;
+  username: string;
+  user_email: string;
+  type: 'DISCUSSION' | 'REVIEW';
+  parent_id: string | null;
+  message: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminRatingFilters {
+  event_id?: string;
+  user_id?: string;
+  host_id?: string;
+  created_from?: string;
+  created_to?: string;
+}
+export interface AdminEventRating {
+  id: string;
+  event_id: string;
+  event_title: string;
+  participant_user_id: string;
+  username: string;
+  user_email: string;
+  score: number;
+  created_at: string;
+  updated_at: string;
+}
+export interface AdminParticipantRating {
+  id: string;
+  event_id: string;
+  event_title: string;
+  host_user_id: string;
+  host_username: string;
+  participant_user_id: string;
+  participant_username: string;
+  score: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminFavoriteFilters {
+  q?: string;
+  user_id?: string;
+  event_id?: string;
+  created_from?: string;
+  created_to?: string;
+}
+export interface AdminFavoriteEvent {
+  id: string;
+  user_id: string;
+  username: string;
+  user_email: string;
+  event_id: string;
+  event_title: string;
+  created_at: string;
+  updated_at: string;
+}
+export interface AdminFavoriteLocation {
+  id: string;
+  user_id: string;
+  username: string;
+  user_email: string;
+  name: string | null;
+  address: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminUserBadgeFilters {
+  q?: string;
+  user_id?: string;
+}
+export interface AdminUserBadge {
+  user_id: string;
+  username: string;
+  user_email: string;
+  badge_id: number;
+  badge_slug: string;
+  badge_name: string;
+  badge_category: string;
+  earned_at: string;
+}
+
+export interface AdminPushDeviceFilters {
+  user_id?: string;
+  platform?: 'IOS' | 'ANDROID';
+  active?: string;
+  created_from?: string;
+  created_to?: string;
+}
+export interface AdminPushDevice {
+  id: string;
+  user_id: string;
+  username: string;
+  user_email: string;
+  installation_id: string;
+  platform: 'IOS' | 'ANDROID';
+  last_seen_at: string;
+  revoked_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -1,4 +1,4 @@
-import { apiGetAuth, apiPostAuth } from '@/services/api';
+import { apiDeleteAuth, apiGetAuth, apiPatchAuth, apiPostAuth } from '@/services/api';
 import type {
   AdminCancelParticipationRequest,
   AdminCancelParticipationResponse,
@@ -8,17 +8,39 @@ import type {
   AdminCreateParticipationResponse,
   AdminEvent,
   AdminEventFilters,
+  AdminCancelEventResponse,
+  AdminCategory,
+  AdminComment,
+  AdminCommentFilters,
+  AdminCreateCategoryRequest,
   AdminEventReport,
   AdminEventReportFilters,
+  AdminEventRating,
+  AdminFavoriteEvent,
+  AdminFavoriteFilters,
+  AdminFavoriteLocation,
+  AdminInvitation,
+  AdminInvitationFilters,
+  AdminJoinRequest,
+  AdminJoinRequestFilters,
   AdminListResponse,
   AdminNotification,
   AdminNotificationFilters,
   AdminPageParams,
   AdminParticipation,
   AdminParticipationFilters,
+  AdminParticipantRating,
+  AdminPushDevice,
+  AdminPushDeviceFilters,
+  AdminRatingFilters,
+  AdminReasonRequest,
   AdminTicket,
   AdminTicketFilters,
+  AdminUpdateStatusRequest,
   AdminUser,
+  AdminUserBadge,
+  AdminUserBadgeFilters,
+  AdminDeactivateUserResponse,
   AdminUserFilters,
 } from '@/models/admin';
 
@@ -97,6 +119,137 @@ export function listAdminEventReports(
     buildAdminListPath('/admin/event-reports', params),
     token,
   );
+}
+
+export function updateAdminEventReportStatus(
+  token: string,
+  reportId: string,
+  body: AdminUpdateStatusRequest<AdminEventReport['status']>,
+): Promise<AdminEventReport> {
+  return apiPatchAuth<AdminEventReport>(`/admin/event-reports/${encodeURIComponent(reportId)}/status`, body, token);
+}
+
+export function listAdminCategories(token: string): Promise<{ items: AdminCategory[] }> {
+  return apiGetAuth<{ items: AdminCategory[] }>('/admin/categories', token);
+}
+
+export function createAdminCategory(token: string, body: AdminCreateCategoryRequest): Promise<AdminCategory> {
+  return apiPostAuth<AdminCategory>('/admin/categories', body, token);
+}
+
+export function deleteAdminCategory(token: string, categoryId: number): Promise<void> {
+  return apiDeleteAuth<void>(`/admin/categories/${encodeURIComponent(String(categoryId))}`, token);
+}
+
+export function updateAdminEventStatus(
+  token: string,
+  eventId: string,
+  body: AdminUpdateStatusRequest<AdminEvent['status']>,
+): Promise<AdminEvent> {
+  return apiPatchAuth<AdminEvent>(`/admin/events/${encodeURIComponent(eventId)}/status`, body, token);
+}
+
+export function cancelAdminEvent(token: string, eventId: string, body: AdminReasonRequest = {}): Promise<AdminCancelEventResponse> {
+  return apiPostAuth<AdminCancelEventResponse>(`/admin/events/${encodeURIComponent(eventId)}/cancel`, body, token);
+}
+
+export function deactivateAdminUser(token: string, userId: string, body: AdminReasonRequest = {}): Promise<AdminDeactivateUserResponse> {
+  return apiPostAuth<AdminDeactivateUserResponse>(`/admin/users/${encodeURIComponent(userId)}/deactivate`, body, token);
+}
+
+export function listAdminInvitations(
+  token: string,
+  params: AdminPageParams & AdminInvitationFilters,
+): Promise<AdminListResponse<AdminInvitation>> {
+  return apiGetAuth<AdminListResponse<AdminInvitation>>(buildAdminListPath('/admin/invitations', params), token);
+}
+
+export function updateAdminInvitationStatus(
+  token: string,
+  invitationId: string,
+  body: AdminUpdateStatusRequest<AdminInvitation['status']>,
+): Promise<AdminInvitation> {
+  return apiPatchAuth<AdminInvitation>(`/admin/invitations/${encodeURIComponent(invitationId)}/status`, body, token);
+}
+
+export function listAdminJoinRequests(
+  token: string,
+  params: AdminPageParams & AdminJoinRequestFilters,
+): Promise<AdminListResponse<AdminJoinRequest>> {
+  return apiGetAuth<AdminListResponse<AdminJoinRequest>>(buildAdminListPath('/admin/join-requests', params), token);
+}
+
+export function updateAdminJoinRequestStatus(
+  token: string,
+  joinRequestId: string,
+  body: AdminUpdateStatusRequest<AdminJoinRequest['status']>,
+): Promise<AdminJoinRequest> {
+  return apiPatchAuth<AdminJoinRequest>(`/admin/join-requests/${encodeURIComponent(joinRequestId)}/status`, body, token);
+}
+
+export function listAdminComments(
+  token: string,
+  params: AdminPageParams & AdminCommentFilters,
+): Promise<AdminListResponse<AdminComment>> {
+  return apiGetAuth<AdminListResponse<AdminComment>>(buildAdminListPath('/admin/comments', params), token);
+}
+
+export function deleteAdminComment(token: string, commentId: string): Promise<void> {
+  return apiDeleteAuth<void>(`/admin/comments/${encodeURIComponent(commentId)}`, token);
+}
+
+export function listAdminEventRatings(
+  token: string,
+  params: AdminPageParams & AdminRatingFilters,
+): Promise<AdminListResponse<AdminEventRating>> {
+  return apiGetAuth<AdminListResponse<AdminEventRating>>(buildAdminListPath('/admin/ratings/events', params), token);
+}
+
+export function deleteAdminEventRating(token: string, ratingId: string): Promise<void> {
+  return apiDeleteAuth<void>(`/admin/ratings/events/${encodeURIComponent(ratingId)}`, token);
+}
+
+export function listAdminParticipantRatings(
+  token: string,
+  params: AdminPageParams & AdminRatingFilters,
+): Promise<AdminListResponse<AdminParticipantRating>> {
+  return apiGetAuth<AdminListResponse<AdminParticipantRating>>(buildAdminListPath('/admin/ratings/participants', params), token);
+}
+
+export function deleteAdminParticipantRating(token: string, ratingId: string): Promise<void> {
+  return apiDeleteAuth<void>(`/admin/ratings/participants/${encodeURIComponent(ratingId)}`, token);
+}
+
+export function listAdminFavoriteEvents(
+  token: string,
+  params: AdminPageParams & AdminFavoriteFilters,
+): Promise<AdminListResponse<AdminFavoriteEvent>> {
+  return apiGetAuth<AdminListResponse<AdminFavoriteEvent>>(buildAdminListPath('/admin/favorites/events', params), token);
+}
+
+export function listAdminFavoriteLocations(
+  token: string,
+  params: AdminPageParams & AdminFavoriteFilters,
+): Promise<AdminListResponse<AdminFavoriteLocation>> {
+  return apiGetAuth<AdminListResponse<AdminFavoriteLocation>>(buildAdminListPath('/admin/favorites/locations', params), token);
+}
+
+export function listAdminUserBadges(
+  token: string,
+  params: AdminPageParams & AdminUserBadgeFilters,
+): Promise<AdminListResponse<AdminUserBadge>> {
+  return apiGetAuth<AdminListResponse<AdminUserBadge>>(buildAdminListPath('/admin/badges/users', params), token);
+}
+
+export function listAdminPushDevices(
+  token: string,
+  params: AdminPageParams & AdminPushDeviceFilters,
+): Promise<AdminListResponse<AdminPushDevice>> {
+  return apiGetAuth<AdminListResponse<AdminPushDevice>>(buildAdminListPath('/admin/push-devices', params), token);
+}
+
+export function revokeAdminPushDevice(token: string, deviceId: string, body: AdminReasonRequest = {}): Promise<void> {
+  return apiPostAuth<void>(`/admin/push-devices/${encodeURIComponent(deviceId)}/revoke`, body, token);
 }
 
 export function createAdminNotification(

--- a/frontend/src/styles/backoffice.css
+++ b/frontend/src/styles/backoffice.css
@@ -42,6 +42,8 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  max-height: calc(100vh - 150px);
+  overflow-y: auto;
 }
 
 .bo-sidebar-link {
@@ -155,7 +157,8 @@
 
 .bo-filter-bar button,
 .bo-pagination button,
-.bo-state button {
+.bo-state button,
+.bo-inline-form button {
   min-height: 34px;
   padding: 6px 12px;
   border: 1px solid #111827;
@@ -165,6 +168,12 @@
   font-size: 13px;
   font-weight: 700;
   cursor: pointer;
+}
+
+.bo-inline-form {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .bo-filter-bar .bo-secondary-button {
@@ -522,6 +531,23 @@
   cursor: pointer;
 }
 
+.bo-row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.bo-row-actions select {
+  min-height: 34px;
+  padding: 6px 28px 6px 9px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111827;
+  font-size: 13px;
+}
+
 .bo-form-actions button:disabled,
 .bo-row-action:disabled {
   cursor: not-allowed;
@@ -632,6 +658,191 @@
   gap: 6px;
   color: #4b5563;
   font-size: 13px;
+}
+
+.bo-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(17, 24, 39, 0.72);
+}
+
+.bo-image-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: min(840px, 100%);
+  max-height: min(760px, 92vh);
+  padding: 16px;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #111827;
+  overflow: auto;
+}
+
+.bo-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.bo-modal-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.bo-image-modal img {
+  width: 100%;
+  max-height: 560px;
+  object-fit: contain;
+  border-radius: 6px;
+  background: #111827;
+}
+
+.bo-image-modal p {
+  margin: 0;
+  color: #374151;
+  line-height: 1.5;
+}
+
+:root[data-theme='dark'] .bo-sidebar {
+  border-right-color: #253044;
+  background: #111827;
+}
+
+:root[data-theme='dark'] .bo-sidebar-title {
+  border-bottom-color: #253044;
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .bo-sidebar-link {
+  color: #cbd5e1;
+}
+
+:root[data-theme='dark'] .bo-sidebar-link:hover {
+  background: #1f2937;
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .bo-sidebar-link.active {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+:root[data-theme='dark'] .bo-page-header h1,
+:root[data-theme='dark'] .bo-section-heading h2,
+:root[data-theme='dark'] .bo-report-linked-cell a,
+:root[data-theme='dark'] .bo-report-linked-cell strong,
+:root[data-theme='dark'] .bo-cell-stack strong {
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .bo-page-header p,
+:root[data-theme='dark'] .bo-muted,
+:root[data-theme='dark'] .bo-report-linked-cell span,
+:root[data-theme='dark'] .bo-cell-stack span,
+:root[data-theme='dark'] .bo-pagination-summary,
+:root[data-theme='dark'] .bo-pagination-controls label {
+  color: #9ca3af;
+}
+
+:root[data-theme='dark'] .bo-filter-bar,
+:root[data-theme='dark'] .bo-table-wrap,
+:root[data-theme='dark'] .bo-state,
+:root[data-theme='dark'] .bo-action-form,
+:root[data-theme='dark'] .bo-notification-composer,
+:root[data-theme='dark'] .bo-image-modal {
+  border-color: #253044;
+  background: #111827;
+  color: #d1d5db;
+}
+
+:root[data-theme='dark'] .bo-filter-bar input,
+:root[data-theme='dark'] .bo-filter-bar select,
+:root[data-theme='dark'] .bo-pagination select,
+:root[data-theme='dark'] .bo-field input,
+:root[data-theme='dark'] .bo-field select,
+:root[data-theme='dark'] .bo-field textarea,
+:root[data-theme='dark'] .bo-row-actions select {
+  border-color: #374151;
+  background-color: #0f172a;
+  color: #f9fafb;
+}
+
+:root[data-theme='dark'] .bo-table th,
+:root[data-theme='dark'] .bo-table td {
+  border-bottom-color: #253044;
+}
+
+:root[data-theme='dark'] .bo-table th {
+  background: #1f2937;
+  color: #e5e7eb;
+}
+
+:root[data-theme='dark'] .bo-table tbody tr:hover {
+  background: #172033;
+}
+
+:root[data-theme='dark'] .bo-id-cell button,
+:root[data-theme='dark'] .bo-secondary-button,
+:root[data-theme='dark'] .bo-filter-bar .bo-secondary-button {
+  border-color: #374151;
+  background: #0f172a;
+  color: #e5e7eb;
+}
+
+:root[data-theme='dark'] .bo-report-message,
+:root[data-theme='dark'] .bo-field,
+:root[data-theme='dark'] .bo-advanced-fields summary,
+:root[data-theme='dark'] .bo-image-modal p {
+  color: #d1d5db;
+}
+
+:root[data-theme='dark'] .bo-state-error {
+  border-color: #7f1d1d;
+  color: #fecaca;
+}
+
+:root[data-theme='dark'] .bo-result {
+  border-color: #166534;
+  background: #052e16;
+  color: #bbf7d0;
+}
+
+:root[data-theme='dark'] .bo-chip {
+  border-color: #374151;
+  background: #1f2937;
+  color: #e5e7eb;
+}
+
+:root[data-theme='dark'] .bo-status-pill {
+  background: #374151;
+  color: #e5e7eb;
+}
+
+:root[data-theme='dark'] .bo-status-pending {
+  background: #451a03;
+  color: #fcd34d;
+}
+
+:root[data-theme='dark'] .bo-status-active,
+:root[data-theme='dark'] .bo-status-approved,
+:root[data-theme='dark'] .bo-status-reviewed {
+  background: #064e3b;
+  color: #a7f3d0;
+}
+
+:root[data-theme='dark'] .bo-status-canceled,
+:root[data-theme='dark'] .bo-status-rejected,
+:root[data-theme='dark'] .bo-status-deactivated,
+:root[data-theme='dark'] .bo-status-revoked {
+  background: #7f1d1d;
+  color: #fecaca;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -730,17 +730,15 @@
 .dc-category-chips {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
   font-size: 12px;
+  overflow: visible;
 }
 
 .dc-category-chips--collapsed {
-  flex-wrap: nowrap;
-  overflow: hidden;
-}
-
-.dc-category-chips:not(.dc-category-chips--collapsed) {
   flex-wrap: wrap;
+  overflow: visible;
 }
 
 .dc-sort-row {
@@ -789,14 +787,15 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
+  min-width: 34px;
+  min-height: 28px;
+  padding: 5px 10px;
   border: 1px solid #d1d5db;
-  border-radius: 50%;
+  border-radius: 999px;
   background: #ffffff;
   color: #374151;
   font-size: 12px;
+  line-height: 1.25;
   cursor: pointer;
   transition: all 0.15s;
   box-sizing: border-box;
@@ -1237,13 +1236,11 @@
 
 /* Title card (top-left, above search) */
 .dc-title-card {
-  background: rgba(255, 255, 255, 0.94);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid rgba(15, 23, 42, 0.06);
-  border-radius: 14px;
-  padding: 12px 16px;
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  box-shadow: none;
 }
 
 .dc-title-card .dc-title {
@@ -1260,13 +1257,21 @@
 
 /* Map-mode search/filter toolbar inherits .dc-search-toolbar but sits in a card */
 .dc-page--map .dc-search-toolbar {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+}
+
+.dc-page--map .dc-title-card {
   background: rgba(255, 255, 255, 0.94);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid rgba(15, 23, 42, 0.06);
   border-radius: 14px;
-  padding: 8px;
-  margin: 0;
+  padding: 12px 16px;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
 }
 
@@ -2040,12 +2045,23 @@
 }
 
 :root[data-theme='dark'] .dc-title-card,
-:root[data-theme='dark'] .dc-page--map .dc-search-toolbar,
 :root[data-theme='dark'] .dc-page--map .dc-filter-panel,
 :root[data-theme='dark'] .dc-page--map .dc-location-prompt {
   background: rgba(8, 8, 8, 0.86);
   border-color: rgba(255, 255, 255, 0.06);
   color: #e5e7eb;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5);
+}
+
+:root[data-theme='dark'] .dc-title-card {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+:root[data-theme='dark'] .dc-page--map .dc-title-card {
+  background: rgba(8, 8, 8, 0.86);
+  border-color: rgba(255, 255, 255, 0.06);
   box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5);
 }
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -39,6 +39,18 @@ body {
   min-height: 100vh;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 :root[data-theme='dark'] input,
 :root[data-theme='dark'] textarea,
 :root[data-theme='dark'] select {

--- a/frontend/src/styles/invitations.css
+++ b/frontend/src/styles/invitations.css
@@ -286,3 +286,83 @@
     width: 100%;
   }
 }
+
+:root[data-theme='dark'] .inv-page-title,
+:root[data-theme='dark'] .inv-empty h2,
+:root[data-theme='dark'] .inv-card-title,
+:root[data-theme='dark'] .inv-card-host-name {
+  color: #e8e8e8;
+}
+
+:root[data-theme='dark'] .inv-page-subtitle,
+:root[data-theme='dark'] .inv-loading,
+:root[data-theme='dark'] .inv-empty p,
+:root[data-theme='dark'] .inv-card-meta,
+:root[data-theme='dark'] .inv-card-host-username,
+:root[data-theme='dark'] .inv-card-message {
+  color: #c6c6c6;
+}
+
+:root[data-theme='dark'] .inv-empty,
+:root[data-theme='dark'] .inv-card,
+:root[data-theme='dark'] .inv-card-message {
+  background: #222222;
+  border-color: #4f4f4f;
+  color: #dedede;
+}
+
+:root[data-theme='dark'] .inv-card:hover {
+  border-color: #777777;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.24);
+}
+
+:root[data-theme='dark'] .inv-card-cover {
+  background: #2b2b2b;
+}
+
+:root[data-theme='dark'] .inv-card-quote {
+  color: #9ca3af;
+}
+
+:root[data-theme='dark'] .inv-card-accept {
+  background: #eeeeee;
+  color: #181818;
+}
+
+:root[data-theme='dark'] .inv-card-accept:hover:not(:disabled) {
+  background: #d8d8d8;
+}
+
+:root[data-theme='dark'] .inv-card-decline,
+:root[data-theme='dark'] .inv-card-view {
+  background: #2b2b2b;
+  border: 1px solid #686868;
+  color: #e3e3e3;
+}
+
+:root[data-theme='dark'] .inv-card-decline {
+  color: #fca5a5;
+  border-color: #7f1d1d;
+}
+
+:root[data-theme='dark'] .inv-card-decline:hover:not(:disabled) {
+  background: rgba(127, 29, 29, 0.34);
+  border-color: #991b1b;
+  color: #fecaca;
+}
+
+:root[data-theme='dark'] .inv-card-view:hover:not(:disabled) {
+  background: #333333;
+  border-color: #8a8a8a;
+  color: #f5f5f5;
+}
+
+:root[data-theme='dark'] .inv-error {
+  background: rgba(127, 29, 29, 0.34);
+  border-color: #7f1d1d;
+  color: #fecaca;
+}
+
+:root[data-theme='dark'] .inv-error-dismiss {
+  color: #fecaca;
+}

--- a/frontend/src/styles/notifications.css
+++ b/frontend/src/styles/notifications.css
@@ -314,3 +314,75 @@
     width: 100%;
   }
 }
+
+:root[data-theme='dark'] .notif-page-title,
+:root[data-theme='dark'] .notif-row-title,
+:root[data-theme='dark'] .notif-empty h2 {
+  color: #e8e8e8;
+}
+
+:root[data-theme='dark'] .notif-page-subtitle,
+:root[data-theme='dark'] .notif-loading,
+:root[data-theme='dark'] .notif-empty p,
+:root[data-theme='dark'] .notif-row-event,
+:root[data-theme='dark'] .notif-row-summary,
+:root[data-theme='dark'] .notif-row-meta,
+:root[data-theme='dark'] .notif-row-time {
+  color: #c6c6c6;
+}
+
+:root[data-theme='dark'] .notif-empty,
+:root[data-theme='dark'] .notif-row {
+  background: #222222;
+  border-color: #4f4f4f;
+  color: #dedede;
+}
+
+:root[data-theme='dark'] .notif-row-unread {
+  background: #2a2a2a;
+  border-color: #686868;
+}
+
+:root[data-theme='dark'] .notif-row:hover {
+  border-color: #777777;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.24);
+}
+
+:root[data-theme='dark'] .notif-action-btn,
+:root[data-theme='dark'] .notif-row-delete {
+  background: #2b2b2b;
+  border-color: #686868;
+  color: #e3e3e3;
+}
+
+:root[data-theme='dark'] .notif-action-btn:hover:not(:disabled),
+:root[data-theme='dark'] .notif-row-delete:hover {
+  background: #333333;
+  border-color: #8a8a8a;
+  color: #f5f5f5;
+}
+
+:root[data-theme='dark'] .notif-action-danger {
+  color: #fca5a5;
+  border-color: #7f1d1d;
+}
+
+:root[data-theme='dark'] .notif-action-danger:hover:not(:disabled),
+:root[data-theme='dark'] .notif-row-delete:hover {
+  background: rgba(127, 29, 29, 0.34);
+  color: #fecaca;
+}
+
+:root[data-theme='dark'] .notif-row-delete {
+  border-left-color: #4f4f4f;
+}
+
+:root[data-theme='dark'] .notif-error {
+  background: rgba(127, 29, 29, 0.34);
+  border-color: #7f1d1d;
+  color: #fecaca;
+}
+
+:root[data-theme='dark'] .notif-error-dismiss {
+  color: #fecaca;
+}

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -44,7 +44,7 @@
 .shell-nav {
   display: flex;
   gap: 4px;
-  margin-left: 32px;
+  margin-left: 20px;
   flex: 1;
 }
 
@@ -78,7 +78,7 @@
 .shell-header-right {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .shell-theme-btn {
@@ -89,17 +89,16 @@
   justify-content: center;
   flex-shrink: 0;
   color: #374151;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
+  background: transparent;
+  border: 0;
   border-radius: 8px;
   cursor: pointer;
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+  transition: color 0.15s, background-color 0.15s, transform 0.15s;
 }
 
 .shell-theme-btn:hover {
   color: #111827;
-  background-color: #f9fafb;
-  border-color: #d1d5db;
+  background-color: #f3f4f6;
 }
 
 .shell-theme-icon {
@@ -122,23 +121,21 @@
   justify-content: center;
   flex-shrink: 0;
   color: #374151;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
+  background: transparent;
+  border: 0;
   border-radius: 8px;
   text-decoration: none;
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+  transition: color 0.15s, background-color 0.15s, transform 0.15s;
 }
 
 .shell-bell-btn:hover {
   color: #111827;
-  background-color: #f9fafb;
-  border-color: #d1d5db;
+  background-color: #f3f4f6;
 }
 
 .shell-bell-btn.active {
-  color: #111827;
-  background-color: #f1f5f9;
-  border-color: #d1d5db;
+  color: #ffffff;
+  background-color: #111827;
 }
 
 .shell-bell-icon {
@@ -174,16 +171,22 @@
   padding: 0 16px;
   font-size: 14px;
   font-weight: 600;
-  color: #ffffff;
-  background-color: #111827;
+  color: #111827;
+  background-color: #f3f4f6;
+  border: 0;
   text-decoration: none;
   border-radius: 8px;
   white-space: nowrap;
-  transition: background-color 0.15s;
+  transition: color 0.15s, background-color 0.15s, transform 0.15s;
 }
 
 .shell-create-btn:hover {
-  background-color: #0F172A;
+  background-color: #e5e7eb;
+}
+
+.shell-create-btn.active {
+  color: #ffffff;
+  background-color: #111827;
 }
 
 .shell-admin-btn {
@@ -196,12 +199,12 @@
   font-size: 14px;
   font-weight: 600;
   color: #111827;
-  background-color: #ffffff;
-  border: 1px solid #d1d5db;
+  background-color: transparent;
+  border: 0;
   text-decoration: none;
   border-radius: 8px;
   white-space: nowrap;
-  transition: all 0.15s;
+  transition: color 0.15s, background-color 0.15s, transform 0.15s;
 }
 
 .shell-admin-icon {
@@ -217,9 +220,8 @@
 
 .shell-admin-btn:hover,
 .shell-admin-btn.active {
-  color: #ffffff;
-  background-color: #111827;
-  border-color: #111827;
+  color: #111827;
+  background-color: #f3f4f6;
 }
 
 /* User menu */
@@ -233,17 +235,16 @@
   gap: 8px;
   height: 40px;
   box-sizing: border-box;
-  background: none;
-  border: 1px solid #e5e7eb;
+  background: transparent;
+  border: 0;
   border-radius: 8px;
   padding: 0 12px;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background-color 0.15s, transform 0.15s;
 }
 
 .shell-user-btn:hover {
-  border-color: #d1d5db;
-  background-color: #f9fafb;
+  background-color: #f3f4f6;
 }
 
 .shell-avatar {
@@ -419,8 +420,8 @@
   align-items: stretch;
   height: 40px;
   box-sizing: border-box;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background: #f3f4f6;
+  border: 0;
   border-radius: 8px;
   padding: 3px;
   gap: 2px;
@@ -451,13 +452,13 @@
 
 .shell-view-toggle-btn:hover:not(.active) {
   color: #111827;
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.72);
 }
 
 .shell-view-toggle-btn.active {
   background: #ffffff;
   color: #111827;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 1px 6px rgba(15, 23, 42, 0.08);
 }
 
 /* Responsive */
@@ -642,8 +643,8 @@
 :root[data-theme='dark'] .shell-admin-btn,
 :root[data-theme='dark'] .shell-signin-btn {
   color: #e5e7eb;
-  background: #050505;
-  border-color: #2a2a2a;
+  background: transparent;
+  border: 0;
 }
 
 :root[data-theme='dark'] .shell-theme-btn:hover,
@@ -652,19 +653,18 @@
 :root[data-theme='dark'] .shell-admin-btn.active,
 :root[data-theme='dark'] .shell-signin-btn:hover {
   color: #ffffff;
-  background-color: #111111;
-  border-color: #4b5563;
+  background-color: #2a2a2a;
 }
 
 :root[data-theme='dark'] .shell-create-btn,
 :root[data-theme='dark'] .shell-signup-btn {
-  color: #111827;
-  background-color: #f9fafb;
+  color: #eeeeee;
+  background-color: #2a2a2a;
 }
 
 :root[data-theme='dark'] .shell-create-btn:hover,
 :root[data-theme='dark'] .shell-signup-btn:hover {
-  background-color: #e5e7eb;
+  background-color: #363636;
 }
 
 :root[data-theme='dark'] .shell-username {
@@ -698,8 +698,8 @@
 }
 
 :root[data-theme='dark'] .shell-view-toggle {
-  background: #111111;
-  border-color: #2a2a2a;
+  background: #242424;
+  border: 0;
 }
 
 :root[data-theme='dark'] .shell-view-toggle-btn {
@@ -712,9 +712,9 @@
 }
 
 :root[data-theme='dark'] .shell-view-toggle-btn.active {
-  background: #202020;
+  background: #3a3a3a;
   color: #f9fafb;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.06);
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.24);
 }
 
 @media (max-width: 600px) {
@@ -764,8 +764,13 @@
 :root[data-theme='dark'] .shell-signin-btn,
 :root[data-theme='dark'] .shell-dropdown {
   color: #e7e7e7;
+  background: transparent;
+  border: 0;
+}
+
+:root[data-theme='dark'] .shell-dropdown {
   background: #202020;
-  border-color: #555555;
+  border: 1px solid #333333;
 }
 
 :root[data-theme='dark'] .shell-theme-btn:hover,
@@ -776,7 +781,6 @@
 :root[data-theme='dark'] .shell-dropdown-item:hover {
   color: #f3f3f3;
   background-color: #303030;
-  border-color: #777777;
 }
 
 :root[data-theme='dark'] .shell-create-btn,
@@ -784,7 +788,7 @@
 :root[data-theme='dark'] .shell-fab {
   color: #eeeeee;
   background: #2a2a2a;
-  border: 1px solid #777777;
+  border: 0;
 }
 
 :root[data-theme='dark'] .shell-create-btn:hover,
@@ -806,4 +810,21 @@
   :root[data-theme='dark'] .shell-overlay.visible {
     background: rgba(0, 0, 0, 0.42);
   }
+}
+
+/* Final header button states. */
+:root[data-theme='dark'] .shell-bell-btn {
+  color: #e7e7e7;
+  background: transparent;
+  border: 0;
+}
+
+:root[data-theme='dark'] .shell-bell-btn:hover {
+  color: #f3f3f3;
+  background: #303030;
+}
+
+:root[data-theme='dark'] .shell-bell-btn.active {
+  color: #f3f3f3;
+  background: #303030;
 }

--- a/frontend/src/styles/tickets.css
+++ b/frontend/src/styles/tickets.css
@@ -418,3 +418,82 @@
     white-space: normal;
   }
 }
+
+:root[data-theme='dark'] .tk-page-title,
+:root[data-theme='dark'] .tk-empty h2,
+:root[data-theme='dark'] .tk-card-title,
+:root[data-theme='dark'] .tk-detail-title,
+:root[data-theme='dark'] .tk-mobile-hint-title {
+  color: #e8e8e8;
+}
+
+:root[data-theme='dark'] .tk-page-subtitle,
+:root[data-theme='dark'] .tk-loading,
+:root[data-theme='dark'] .tk-empty p,
+:root[data-theme='dark'] .tk-card-event-time,
+:root[data-theme='dark'] .tk-card-address,
+:root[data-theme='dark'] .tk-card-meta,
+:root[data-theme='dark'] .tk-detail-status-desc,
+:root[data-theme='dark'] .tk-detail-section-title,
+:root[data-theme='dark'] .tk-detail-label,
+:root[data-theme='dark'] .tk-detail-secondary,
+:root[data-theme='dark'] .tk-mobile-hint-text,
+:root[data-theme='dark'] .tk-mobile-hint-notice {
+  color: #c6c6c6;
+}
+
+:root[data-theme='dark'] .tk-empty,
+:root[data-theme='dark'] .tk-card,
+:root[data-theme='dark'] .tk-detail,
+:root[data-theme='dark'] .tk-mobile-hint,
+:root[data-theme='dark'] .tk-mobile-hint-icon,
+:root[data-theme='dark'] .tk-mobile-hint-notice {
+  background: #222222;
+  border-color: #4f4f4f;
+  color: #dedede;
+}
+
+:root[data-theme='dark'] .tk-card:hover {
+  border-color: #777777;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.24);
+}
+
+:root[data-theme='dark'] .tk-card-footer,
+:root[data-theme='dark'] .tk-detail-header,
+:root[data-theme='dark'] .tk-detail-section {
+  border-color: #4f4f4f;
+}
+
+:root[data-theme='dark'] .tk-detail-value,
+:root[data-theme='dark'] .tk-detail-mono {
+  color: #e3e3e3;
+}
+
+:root[data-theme='dark'] .tk-back-link,
+:root[data-theme='dark'] .tk-retry-btn {
+  background: #2b2b2b;
+  border-color: #686868;
+  color: #e3e3e3;
+}
+
+:root[data-theme='dark'] .tk-back-link:hover,
+:root[data-theme='dark'] .tk-retry-btn:hover {
+  background: #333333;
+  border-color: #8a8a8a;
+  color: #f5f5f5;
+}
+
+:root[data-theme='dark'] .tk-error {
+  background: rgba(127, 29, 29, 0.34);
+  border-color: #7f1d1d;
+  color: #fecaca;
+}
+
+:root[data-theme='dark'] .tk-error-dismiss {
+  color: #fecaca;
+}
+
+:root[data-theme='dark'] .tk-mobile-hint-warn {
+  background: rgba(113, 63, 18, 0.28);
+  border-color: #92400e;
+}

--- a/frontend/src/viewmodels/admin/useAdminMutation.ts
+++ b/frontend/src/viewmodels/admin/useAdminMutation.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { ApiError } from '@/services/api';
+
+export function useAdminMutation(onSuccess?: () => void) {
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function run(id: string, action: () => Promise<unknown>, successMessage: string) {
+    setBusyId(id);
+    setError(null);
+    setMessage(null);
+    try {
+      await action();
+      setMessage(successMessage);
+      onSuccess?.();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Admin action failed.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return { busyId, error, message, run, clearMessage: () => setMessage(null) };
+}

--- a/frontend/src/views/backoffice/BackofficeLayout.tsx
+++ b/frontend/src/views/backoffice/BackofficeLayout.tsx
@@ -5,8 +5,16 @@ const SIDEBAR_ITEMS = [
   { to: '/backoffice/users', label: 'Users' },
   { to: '/backoffice/events', label: 'Events' },
   { to: '/backoffice/event-reports', label: 'Event Reports' },
+  { to: '/backoffice/categories', label: 'Categories' },
   { to: '/backoffice/participations', label: 'Participations' },
   { to: '/backoffice/tickets', label: 'Tickets' },
+  { to: '/backoffice/invitations', label: 'Invitations' },
+  { to: '/backoffice/join-requests', label: 'Join Requests' },
+  { to: '/backoffice/comments', label: 'Comments' },
+  { to: '/backoffice/ratings', label: 'Ratings' },
+  { to: '/backoffice/favorites', label: 'Favorites' },
+  { to: '/backoffice/badges', label: 'Badges' },
+  { to: '/backoffice/push-devices', label: 'Push Devices' },
   { to: '/backoffice/notifications', label: 'Notifications' },
 ];
 

--- a/frontend/src/views/backoffice/BackofficeListParts.tsx
+++ b/frontend/src/views/backoffice/BackofficeListParts.tsx
@@ -64,6 +64,73 @@ export function BackofficeIdCell({ id }: { id: string }) {
   );
 }
 
+export function BackofficeStatusPill({ status }: { status: string }) {
+  return <span className={`bo-status-pill bo-status-${status.toLowerCase().replace(/_/g, '-')}`}>{status}</span>;
+}
+
+export function BackofficeConfirmAction({
+  label,
+  confirmLabel = 'Confirm',
+  disabled,
+  busy,
+  onConfirm,
+}: {
+  label: string;
+  confirmLabel?: string;
+  disabled?: boolean;
+  busy?: boolean;
+  onConfirm: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  if (confirming) {
+    return (
+      <span className="bo-row-actions">
+        <button type="button" className="bo-row-action" disabled={busy} onClick={onConfirm}>
+          {busy ? 'Working...' : confirmLabel}
+        </button>
+        <button type="button" className="bo-secondary-button" onClick={() => setConfirming(false)} disabled={busy}>
+          Cancel
+        </button>
+      </span>
+    );
+  }
+  return (
+    <button type="button" className="bo-row-action" disabled={disabled || busy} onClick={() => setConfirming(true)}>
+      {busy ? 'Working...' : label}
+    </button>
+  );
+}
+
+export function BackofficeImageModal({
+  imageUrl,
+  title,
+  message,
+  onClose,
+}: {
+  imageUrl: string | null;
+  title: string;
+  message?: string;
+  onClose: () => void;
+}) {
+  if (!imageUrl) return null;
+  return (
+    <div className="bo-modal-backdrop" role="presentation" onClick={onClose}>
+      <div className="bo-image-modal" role="dialog" aria-modal="true" aria-label={title} onClick={(event) => event.stopPropagation()}>
+        <div className="bo-modal-header">
+          <h2>{title}</h2>
+          <button type="button" className="bo-secondary-button" onClick={onClose}>Close</button>
+        </div>
+        <img src={imageUrl} alt={title} />
+        {message && <p>{message}</p>}
+      </div>
+    </div>
+  );
+}
+
+export function BackofficeRowActions({ children }: { children: ReactNode }) {
+  return <div className="bo-row-actions">{children}</div>;
+}
+
 interface PaginationProps {
   offset: number;
   limit: number;

--- a/frontend/src/views/backoffice/BadgesAdminPage.tsx
+++ b/frontend/src/views/backoffice/BadgesAdminPage.tsx
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminUserBadgeFilters } from '@/models/admin';
+import { listAdminUserBadges } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminUserBadgeFilters = { q: '', user_id: '' };
+
+export default function BadgesAdminPage() {
+  const { token } = useAuth();
+  const vm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminUserBadges });
+  return (
+    <BackofficePageShell title="Badges" subtitle="Read-only visibility into earned user badges." filters={(
+      <>
+        <input aria-label="Search badges" placeholder="Search badge or user" value={vm.filters.q ?? ''} onChange={(e) => vm.setFilter('q', e.target.value)} />
+        <input aria-label="User ID" placeholder="User ID" value={vm.filters.user_id ?? ''} onChange={(e) => vm.setFilter('user_id', e.target.value)} />
+        <button type="button" onClick={vm.applyFilters}>Apply</button><button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+      </>
+    )}>
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap"><table className="bo-table"><thead><tr><th>User</th><th>Badge ID</th><th>Badge</th><th>Category</th><th>Earned</th></tr></thead><tbody>
+        {vm.items.map((item) => <tr key={`${item.user_id}:${item.badge_id}`}><td><BackofficeIdCell id={item.user_id} /> {item.username}<br /><span className="bo-muted">{item.user_email}</span></td><td>{item.badge_id}</td><td>{item.badge_name}<br /><span className="bo-muted">{item.badge_slug}</span></td><td>{item.badge_category}</td><td>{formatAdminDate(item.earned_at)}</td></tr>)}
+      </tbody></table></div>
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/CategoriesAdminPage.tsx
+++ b/frontend/src/views/backoffice/CategoriesAdminPage.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminCategory } from '@/models/admin';
+import { createAdminCategory, deleteAdminCategory, listAdminCategories } from '@/services/adminService';
+import { ApiError } from '@/services/api';
+import { BackofficeConfirmAction, BackofficeIdCell, BackofficePageShell, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+export default function CategoriesAdminPage() {
+  const { token } = useAuth();
+  const [items, setItems] = useState<AdminCategory[]>([]);
+  const [name, setName] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    if (!token) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await listAdminCategories(token);
+      setItems(result.items);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load categories.');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, [token]);
+
+  async function submitCreate(event: FormEvent) {
+    event.preventDefault();
+    if (!token) return;
+    setBusyId('create');
+    setError(null);
+    try {
+      await createAdminCategory(token, { name });
+      setName('');
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to create category.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function remove(categoryId: number) {
+    if (!token) return;
+    setBusyId(String(categoryId));
+    setError(null);
+    try {
+      await deleteAdminCategory(token, categoryId);
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to delete category.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <BackofficePageShell
+      title="Categories"
+      subtitle="View stable category IDs and manage the event category catalog."
+      filters={(
+        <form className="bo-inline-form" onSubmit={submitCreate}>
+          <input aria-label="New category name" placeholder="New category name" value={name} onChange={(event) => setName(event.target.value)} />
+          <button type="submit" disabled={busyId === 'create'}>{busyId === 'create' ? 'Adding...' : 'Add category'}</button>
+        </form>
+      )}
+    >
+      <BackofficeTableState isLoading={isLoading} error={error} empty={items.length === 0} onRetry={load} />
+      <div className="bo-table-wrap">
+        <table className="bo-table">
+          <thead><tr><th>ID</th><th>Name</th><th>Created</th><th>Updated</th><th>Actions</th></tr></thead>
+          <tbody>
+            {items.map((category) => (
+              <tr key={category.id}>
+                <td><BackofficeIdCell id={String(category.id)} /></td>
+                <td>{category.name}</td>
+                <td>{formatAdminDate(category.created_at)}</td>
+                <td>{formatAdminDate(category.updated_at)}</td>
+                <td>
+                  <BackofficeConfirmAction
+                    label="Delete"
+                    confirmLabel="Delete"
+                    busy={busyId === String(category.id)}
+                    onConfirm={() => void remove(category.id)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/CommentsAdminPage.tsx
+++ b/frontend/src/views/backoffice/CommentsAdminPage.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminCommentFilters } from '@/models/admin';
+import { deleteAdminComment, listAdminComments } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { useAdminMutation } from '@/viewmodels/admin/useAdminMutation';
+import { BackofficeConfirmAction, BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminCommentFilters = { q: '', event_id: '', user_id: '', type: undefined, created_from: '', created_to: '' };
+
+export default function CommentsAdminPage() {
+  const { token } = useAuth();
+  const vm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminComments });
+  const mutation = useAdminMutation(vm.retry);
+  return (
+    <BackofficePageShell title="Comments" subtitle="Inspect discussion and review comments." filters={(
+      <>
+        <input aria-label="Search comments" placeholder="Search message, event, user" value={vm.filters.q ?? ''} onChange={(e) => vm.setFilter('q', e.target.value)} />
+        <select aria-label="Comment type" value={vm.filters.type ?? ''} onChange={(e) => vm.setFilter('type', e.target.value === '' ? undefined : e.target.value as AdminCommentFilters['type'])}><option value="">Any type</option><option value="DISCUSSION">DISCUSSION</option><option value="REVIEW">REVIEW</option></select>
+        <input aria-label="Event ID" placeholder="Event ID" value={vm.filters.event_id ?? ''} onChange={(e) => vm.setFilter('event_id', e.target.value)} />
+        <input aria-label="User ID" placeholder="User ID" value={vm.filters.user_id ?? ''} onChange={(e) => vm.setFilter('user_id', e.target.value)} />
+        <button type="button" onClick={vm.applyFilters}>Apply</button><button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+      </>
+    )}>
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap"><table className="bo-table"><thead><tr><th>ID</th><th>Event</th><th>User</th><th>Type</th><th>Message</th><th>Created</th><th>Actions</th></tr></thead><tbody>
+        {vm.items.map((item) => <tr key={item.id}><td><BackofficeIdCell id={item.id} /></td><td>{item.event_title}</td><td>{item.username}<br /><span className="bo-muted">{item.user_email}</span></td><td><BackofficeStatusPill status={item.type} /></td><td className="bo-report-message">{item.message}</td><td>{formatAdminDate(item.created_at)}</td><td><BackofficeConfirmAction label="Delete" confirmLabel="Delete" busy={mutation.busyId === item.id} onConfirm={() => void mutation.run(item.id, () => deleteAdminComment(token!, item.id), 'Comment deleted.')} /></td></tr>)}
+      </tbody></table></div>
+      {mutation.error && <div className="bo-state bo-state-error">{mutation.error}</div>}
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/EventReportsAdminPage.tsx
+++ b/frontend/src/views/backoffice/EventReportsAdminPage.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import type { AdminEventReportFilters } from '@/models/admin';
-import { listAdminEventReports } from '@/services/adminService';
+import { listAdminEventReports, updateAdminEventReportStatus } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
-import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { useAdminMutation } from '@/viewmodels/admin/useAdminMutation';
+import { BackofficeIdCell, BackofficeImageModal, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminEventReportFilters = {
   q: '',
@@ -30,6 +31,9 @@ export default function EventReportsAdminPage() {
   const { token } = useAuth();
   const initialFilters = useMemo(() => INITIAL_FILTERS, []);
   const vm = useAdminListViewModel({ token, initialFilters, fetchPage: listAdminEventReports });
+  const mutation = useAdminMutation(vm.retry);
+  const [imageReportId, setImageReportId] = useState<string | null>(null);
+  const imageReport = vm.items.find((report) => report.id === imageReportId);
 
   return (
     <BackofficePageShell
@@ -73,6 +77,7 @@ export default function EventReportsAdminPage() {
               <th>Image</th>
               <th>Created</th>
               <th>Updated</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -80,9 +85,7 @@ export default function EventReportsAdminPage() {
               <tr key={report.id}>
                 <td><BackofficeIdCell id={report.id} /></td>
                 <td>
-                  <span className={`bo-status-pill bo-status-${report.status.toLowerCase()}`}>
-                    {report.status}
-                  </span>
+                  <BackofficeStatusPill status={report.status} />
                 </td>
                 <td>{REPORT_CATEGORY_LABELS[report.report_category] ?? report.report_category}</td>
                 <td>
@@ -100,19 +103,43 @@ export default function EventReportsAdminPage() {
                 <td className="bo-report-message">{report.message}</td>
                 <td>
                   {report.image_url ? (
-                    <a href={report.image_url} target="_blank" rel="noopener noreferrer">View</a>
+                    <button type="button" className="bo-row-action" onClick={() => setImageReportId(report.id)}>View image</button>
                   ) : (
                     '-'
                   )}
                 </td>
                 <td>{formatAdminDate(report.created_at)}</td>
                 <td>{formatAdminDate(report.updated_at)}</td>
+                <td>
+                  <select
+                    aria-label={`Change report status ${report.id}`}
+                    value={report.status}
+                    disabled={mutation.busyId === report.id}
+                    onChange={(event) => void mutation.run(
+                      report.id,
+                      () => updateAdminEventReportStatus(token!, report.id, { status: event.target.value as typeof report.status }),
+                      'Report status updated.',
+                    )}
+                  >
+                    <option value="PENDING">PENDING</option>
+                    <option value="REVIEWED">REVIEWED</option>
+                    <option value="DISMISSED">DISMISSED</option>
+                  </select>
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
+      {mutation.error && <div className="bo-state bo-state-error">{mutation.error}</div>}
+      {mutation.message && <div className="bo-result" role="status"><span>{mutation.message}</span></div>}
       <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+      <BackofficeImageModal
+        imageUrl={imageReport?.image_url ?? null}
+        title={imageReport?.event_title ?? 'Report image'}
+        message={imageReport?.message}
+        onClose={() => setImageReportId(null)}
+      />
     </BackofficePageShell>
   );
 }

--- a/frontend/src/views/backoffice/EventsAdminPage.tsx
+++ b/frontend/src/views/backoffice/EventsAdminPage.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import type { AdminEventFilters } from '@/models/admin';
-import { listAdminEvents } from '@/services/adminService';
+import { cancelAdminEvent, listAdminEvents, updateAdminEventStatus } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
-import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { useAdminMutation } from '@/viewmodels/admin/useAdminMutation';
+import { BackofficeConfirmAction, BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminEventFilters = {
   q: '',
@@ -19,6 +20,7 @@ export default function EventsAdminPage() {
   const { token } = useAuth();
   const initialFilters = useMemo(() => INITIAL_FILTERS, []);
   const vm = useAdminListViewModel({ token, initialFilters, fetchPage: listAdminEvents });
+  const mutation = useAdminMutation(vm.retry);
 
   return (
     <BackofficePageShell
@@ -65,6 +67,7 @@ export default function EventsAdminPage() {
               <th>Capacity</th>
               <th>Approved</th>
               <th>Pending</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -72,20 +75,47 @@ export default function EventsAdminPage() {
               <tr key={event.id}>
                 <td><BackofficeIdCell id={event.id} /></td>
                 <td>{event.title}</td>
-                <td>{event.host_username}</td>
+                <td><span>{event.host_username}</span> <BackofficeIdCell id={event.host_id} /></td>
                 <td>{event.category_name ?? event.category_id ?? '-'}</td>
                 <td>{event.privacy_level}</td>
-                <td>{event.status}</td>
+                <td><BackofficeStatusPill status={event.status} /></td>
                 <td>{formatAdminDate(event.start_time)}</td>
                 <td>{formatAdminDate(event.end_time)}</td>
                 <td>{event.capacity ?? '-'}</td>
                 <td>{event.approved_participant_count}</td>
                 <td>{event.pending_participant_count}</td>
+                <td>
+                  <div className="bo-row-actions">
+                    <select
+                      aria-label={`Change status for ${event.title}`}
+                      value={event.status}
+                      disabled={mutation.busyId === `${event.id}:status`}
+                      onChange={(change) => void mutation.run(
+                        `${event.id}:status`,
+                        () => updateAdminEventStatus(token!, event.id, { status: change.target.value as typeof event.status }),
+                        'Event status updated.',
+                      )}
+                    >
+                      <option value="ACTIVE">ACTIVE</option>
+                      <option value="IN_PROGRESS">IN_PROGRESS</option>
+                      <option value="CANCELED">CANCELED</option>
+                      <option value="COMPLETED">COMPLETED</option>
+                    </select>
+                    <BackofficeConfirmAction
+                      label="Cancel"
+                      disabled={event.status === 'CANCELED'}
+                      busy={mutation.busyId === `${event.id}:cancel`}
+                      onConfirm={() => void mutation.run(`${event.id}:cancel`, () => cancelAdminEvent(token!, event.id), 'Event canceled.')}
+                    />
+                  </div>
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
+      {mutation.error && <div className="bo-state bo-state-error">{mutation.error}</div>}
+      {mutation.message && <div className="bo-result" role="status"><span>{mutation.message}</span></div>}
       <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
     </BackofficePageShell>
   );

--- a/frontend/src/views/backoffice/FavoritesAdminPage.tsx
+++ b/frontend/src/views/backoffice/FavoritesAdminPage.tsx
@@ -1,0 +1,34 @@
+import { useMemo, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminFavoriteFilters } from '@/models/admin';
+import { listAdminFavoriteEvents, listAdminFavoriteLocations } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminFavoriteFilters = { q: '', user_id: '', event_id: '', created_from: '', created_to: '' };
+
+export default function FavoritesAdminPage() {
+  const { token } = useAuth();
+  const [tab, setTab] = useState<'events' | 'locations'>('events');
+  const eventVm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminFavoriteEvents });
+  const locationVm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminFavoriteLocations });
+  const vm = tab === 'events' ? eventVm : locationVm;
+  return (
+    <BackofficePageShell title="Favorites" subtitle="Read-only visibility into saved events and locations." filters={(
+      <>
+        <button type="button" className={tab === 'events' ? '' : 'bo-secondary-button'} onClick={() => setTab('events')}>Events</button>
+        <button type="button" className={tab === 'locations' ? '' : 'bo-secondary-button'} onClick={() => setTab('locations')}>Locations</button>
+        {tab === 'locations' && <input aria-label="Search locations" placeholder="Search location or user" value={locationVm.filters.q ?? ''} onChange={(e) => locationVm.setFilter('q', e.target.value)} />}
+        <input aria-label="User ID" placeholder="User ID" value={vm.filters.user_id ?? ''} onChange={(e) => vm.setFilter('user_id', e.target.value)} />
+        {tab === 'events' && <input aria-label="Event ID" placeholder="Event ID" value={eventVm.filters.event_id ?? ''} onChange={(e) => eventVm.setFilter('event_id', e.target.value)} />}
+        <button type="button" onClick={vm.applyFilters}>Apply</button><button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+      </>
+    )}>
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap"><table className="bo-table"><thead><tr><th>ID</th><th>User</th><th>{tab === 'events' ? 'Event' : 'Location'}</th><th>Created</th></tr></thead><tbody>
+        {tab === 'events' ? eventVm.items.map((item) => <tr key={item.id}><td><BackofficeIdCell id={item.id} /></td><td>{item.username}<br /><span className="bo-muted">{item.user_email}</span></td><td>{item.event_title}</td><td>{formatAdminDate(item.created_at)}</td></tr>) : locationVm.items.map((item) => <tr key={item.id}><td><BackofficeIdCell id={item.id} /></td><td>{item.username}<br /><span className="bo-muted">{item.user_email}</span></td><td>{item.name ?? item.address ?? '-'}</td><td>{formatAdminDate(item.created_at)}</td></tr>)}
+      </tbody></table></div>
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/InvitationsAdminPage.tsx
+++ b/frontend/src/views/backoffice/InvitationsAdminPage.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminInvitationFilters } from '@/models/admin';
+import { listAdminInvitations, updateAdminInvitationStatus } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { useAdminMutation } from '@/viewmodels/admin/useAdminMutation';
+import { BackofficeConfirmAction, BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminInvitationFilters = { q: '', status: undefined, event_id: '', host_id: '', invited_user_id: '', created_from: '', created_to: '' };
+
+export default function InvitationsAdminPage() {
+  const { token } = useAuth();
+  const vm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminInvitations });
+  const mutation = useAdminMutation(vm.retry);
+  return (
+    <BackofficePageShell title="Invitations" subtitle="Inspect and cancel pending event invitations." filters={(
+      <>
+        <input aria-label="Search invitations" placeholder="Search event or user" value={vm.filters.q ?? ''} onChange={(e) => vm.setFilter('q', e.target.value)} />
+        <select aria-label="Invitation status" value={vm.filters.status ?? ''} onChange={(e) => vm.setFilter('status', e.target.value === '' ? undefined : e.target.value as AdminInvitationFilters['status'])}>
+          <option value="">Any status</option><option value="PENDING">PENDING</option><option value="ACCEPTED">ACCEPTED</option><option value="DECLINED">DECLINED</option><option value="EXPIRED">EXPIRED</option><option value="CANCELED">CANCELED</option>
+        </select>
+        <input aria-label="Event ID" placeholder="Event ID" value={vm.filters.event_id ?? ''} onChange={(e) => vm.setFilter('event_id', e.target.value)} />
+        <input aria-label="Host ID" placeholder="Host ID" value={vm.filters.host_id ?? ''} onChange={(e) => vm.setFilter('host_id', e.target.value)} />
+        <input aria-label="Invited user ID" placeholder="Invited user ID" value={vm.filters.invited_user_id ?? ''} onChange={(e) => vm.setFilter('invited_user_id', e.target.value)} />
+        <button type="button" onClick={vm.applyFilters}>Apply</button><button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+      </>
+    )}>
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap"><table className="bo-table"><thead><tr><th>ID</th><th>Event</th><th>Host</th><th>Invited</th><th>Status</th><th>Expires</th><th>Created</th><th>Actions</th></tr></thead><tbody>
+        {vm.items.map((item) => <tr key={item.id}><td><BackofficeIdCell id={item.id} /></td><td>{item.event_title}</td><td>{item.host_username}</td><td>{item.invited_username}<br /><span className="bo-muted">{item.invited_email}</span></td><td><BackofficeStatusPill status={item.status} /></td><td>{formatAdminDate(item.expires_at)}</td><td>{formatAdminDate(item.created_at)}</td><td><BackofficeConfirmAction label="Cancel" disabled={item.status !== 'PENDING'} busy={mutation.busyId === item.id} onConfirm={() => void mutation.run(item.id, () => updateAdminInvitationStatus(token!, item.id, { status: 'CANCELED' }), 'Invitation canceled.')} /></td></tr>)}
+      </tbody></table></div>
+      {mutation.error && <div className="bo-state bo-state-error">{mutation.error}</div>}
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/JoinRequestsAdminPage.tsx
+++ b/frontend/src/views/backoffice/JoinRequestsAdminPage.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminJoinRequestFilters } from '@/models/admin';
+import { listAdminJoinRequests, updateAdminJoinRequestStatus } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { useAdminMutation } from '@/viewmodels/admin/useAdminMutation';
+import { BackofficeConfirmAction, BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminJoinRequestFilters = { q: '', status: undefined, event_id: '', user_id: '', host_user_id: '', created_from: '', created_to: '' };
+
+export default function JoinRequestsAdminPage() {
+  const { token } = useAuth();
+  const vm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminJoinRequests });
+  const mutation = useAdminMutation(vm.retry);
+  return (
+    <BackofficePageShell title="Join Requests" subtitle="Inspect protected-event join requests and moderate pending rows." filters={(
+      <>
+        <input aria-label="Search join requests" placeholder="Search event or user" value={vm.filters.q ?? ''} onChange={(e) => vm.setFilter('q', e.target.value)} />
+        <select aria-label="Join request status" value={vm.filters.status ?? ''} onChange={(e) => vm.setFilter('status', e.target.value === '' ? undefined : e.target.value as AdminJoinRequestFilters['status'])}>
+          <option value="">Any status</option><option value="PENDING">PENDING</option><option value="APPROVED">APPROVED</option><option value="REJECTED">REJECTED</option><option value="CANCELED">CANCELED</option>
+        </select>
+        <input aria-label="Event ID" placeholder="Event ID" value={vm.filters.event_id ?? ''} onChange={(e) => vm.setFilter('event_id', e.target.value)} />
+        <input aria-label="User ID" placeholder="User ID" value={vm.filters.user_id ?? ''} onChange={(e) => vm.setFilter('user_id', e.target.value)} />
+        <input aria-label="Host user ID" placeholder="Host user ID" value={vm.filters.host_user_id ?? ''} onChange={(e) => vm.setFilter('host_user_id', e.target.value)} />
+        <button type="button" onClick={vm.applyFilters}>Apply</button><button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+      </>
+    )}>
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap"><table className="bo-table"><thead><tr><th>ID</th><th>Event</th><th>User</th><th>Host</th><th>Status</th><th>Message</th><th>Created</th><th>Actions</th></tr></thead><tbody>
+        {vm.items.map((item) => <tr key={item.id}><td><BackofficeIdCell id={item.id} /></td><td>{item.event_title}</td><td>{item.username}<br /><span className="bo-muted">{item.user_email}</span></td><td>{item.host_username}</td><td><BackofficeStatusPill status={item.status} /></td><td className="bo-message-cell"><span>{item.message ?? '-'}</span></td><td>{formatAdminDate(item.created_at)}</td><td><div className="bo-row-actions"><BackofficeConfirmAction label="Reject" disabled={item.status !== 'PENDING'} busy={mutation.busyId === `${item.id}:reject`} onConfirm={() => void mutation.run(`${item.id}:reject`, () => updateAdminJoinRequestStatus(token!, item.id, { status: 'REJECTED' }), 'Join request rejected.')} /><BackofficeConfirmAction label="Cancel" disabled={item.status !== 'PENDING'} busy={mutation.busyId === `${item.id}:cancel`} onConfirm={() => void mutation.run(`${item.id}:cancel`, () => updateAdminJoinRequestStatus(token!, item.id, { status: 'CANCELED' }), 'Join request canceled.')} /></div></td></tr>)}
+      </tbody></table></div>
+      {mutation.error && <div className="bo-state bo-state-error">{mutation.error}</div>}
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/ParticipationsAdminPage.tsx
+++ b/frontend/src/views/backoffice/ParticipationsAdminPage.tsx
@@ -4,7 +4,7 @@ import type { AdminParticipationFilters } from '@/models/admin';
 import { listAdminParticipations } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
 import { useAdminParticipationActionsViewModel } from '@/viewmodels/admin/useAdminParticipationActionsViewModel';
-import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminParticipationFilters = {
   q: '',
@@ -126,7 +126,7 @@ export default function ParticipationsAdminPage() {
                   <td>{participation.event_title}</td>
                   <td>{participation.username}</td>
                   <td>{participation.user_email}</td>
-                  <td>{participation.status}</td>
+                  <td><BackofficeStatusPill status={participation.status} /></td>
                   <td>{formatAdminDate(participation.reconfirmed_at)}</td>
                   <td>{formatAdminDate(participation.created_at)}</td>
                   <td>{formatAdminDate(participation.updated_at)}</td>

--- a/frontend/src/views/backoffice/PushDevicesAdminPage.tsx
+++ b/frontend/src/views/backoffice/PushDevicesAdminPage.tsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminPushDeviceFilters } from '@/models/admin';
+import { listAdminPushDevices, revokeAdminPushDevice } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { useAdminMutation } from '@/viewmodels/admin/useAdminMutation';
+import { BackofficeConfirmAction, BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminPushDeviceFilters = { user_id: '', platform: undefined, active: '', created_from: '', created_to: '' };
+
+export default function PushDevicesAdminPage() {
+  const { token } = useAuth();
+  const vm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminPushDevices });
+  const mutation = useAdminMutation(vm.retry);
+  return (
+    <BackofficePageShell title="Push Devices" subtitle="Inspect and revoke registered push devices." filters={(
+      <>
+        <input aria-label="User ID" placeholder="User ID" value={vm.filters.user_id ?? ''} onChange={(e) => vm.setFilter('user_id', e.target.value)} />
+        <select aria-label="Platform" value={vm.filters.platform ?? ''} onChange={(e) => vm.setFilter('platform', e.target.value === '' ? undefined : e.target.value as AdminPushDeviceFilters['platform'])}><option value="">Any platform</option><option value="IOS">IOS</option><option value="ANDROID">ANDROID</option></select>
+        <select aria-label="Active" value={vm.filters.active ?? ''} onChange={(e) => vm.setFilter('active', e.target.value)}><option value="">Any state</option><option value="true">Active</option><option value="false">Revoked</option></select>
+        <button type="button" onClick={vm.applyFilters}>Apply</button><button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+      </>
+    )}>
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap"><table className="bo-table"><thead><tr><th>ID</th><th>User</th><th>Platform</th><th>State</th><th>Last seen</th><th>Actions</th></tr></thead><tbody>
+        {vm.items.map((item) => <tr key={item.id}><td><BackofficeIdCell id={item.id} /></td><td>{item.username}<br /><span className="bo-muted">{item.user_email}</span></td><td>{item.platform}</td><td><BackofficeStatusPill status={item.revoked_at ? 'REVOKED' : 'ACTIVE'} /></td><td>{formatAdminDate(item.last_seen_at)}</td><td><BackofficeConfirmAction label="Revoke" disabled={Boolean(item.revoked_at)} busy={mutation.busyId === item.id} onConfirm={() => void mutation.run(item.id, () => revokeAdminPushDevice(token!, item.id), 'Device revoked.')} /></td></tr>)}
+      </tbody></table></div>
+      {mutation.error && <div className="bo-state bo-state-error">{mutation.error}</div>}
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/RatingsAdminPage.tsx
+++ b/frontend/src/views/backoffice/RatingsAdminPage.tsx
@@ -1,0 +1,37 @@
+import { useMemo, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import type { AdminRatingFilters } from '@/models/admin';
+import { deleteAdminEventRating, deleteAdminParticipantRating, listAdminEventRatings, listAdminParticipantRatings } from '@/services/adminService';
+import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
+import { useAdminMutation } from '@/viewmodels/admin/useAdminMutation';
+import { BackofficeConfirmAction, BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+
+const INITIAL_FILTERS: AdminRatingFilters = { event_id: '', user_id: '', host_id: '', created_from: '', created_to: '' };
+
+export default function RatingsAdminPage() {
+  const { token } = useAuth();
+  const [tab, setTab] = useState<'events' | 'participants'>('events');
+  const eventVm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminEventRatings });
+  const participantVm = useAdminListViewModel({ token, initialFilters: useMemo(() => INITIAL_FILTERS, []), fetchPage: listAdminParticipantRatings });
+  const vm = tab === 'events' ? eventVm : participantVm;
+  const mutation = useAdminMutation(vm.retry);
+  return (
+    <BackofficePageShell title="Ratings" subtitle="Review event and participant ratings; delete outliers when moderation requires it." filters={(
+      <>
+        <button type="button" className={tab === 'events' ? '' : 'bo-secondary-button'} onClick={() => setTab('events')}>Event ratings</button>
+        <button type="button" className={tab === 'participants' ? '' : 'bo-secondary-button'} onClick={() => setTab('participants')}>Participant ratings</button>
+        <input aria-label="Event ID" placeholder="Event ID" value={vm.filters.event_id ?? ''} onChange={(e) => vm.setFilter('event_id', e.target.value)} />
+        <input aria-label="User ID" placeholder="User ID" value={vm.filters.user_id ?? ''} onChange={(e) => vm.setFilter('user_id', e.target.value)} />
+        {tab === 'participants' && <input aria-label="Host ID" placeholder="Host ID" value={participantVm.filters.host_id ?? ''} onChange={(e) => participantVm.setFilter('host_id', e.target.value)} />}
+        <button type="button" onClick={vm.applyFilters}>Apply</button><button type="button" className="bo-secondary-button" onClick={vm.clearFilters}>Clear</button>
+      </>
+    )}>
+      <BackofficeTableState isLoading={vm.isLoading} error={vm.error} empty={vm.items.length === 0} onRetry={vm.retry} />
+      <div className="bo-table-wrap"><table className="bo-table"><thead><tr><th>ID</th><th>Event</th><th>User</th><th>Score</th><th>Created</th><th>Actions</th></tr></thead><tbody>
+        {tab === 'events' ? eventVm.items.map((item) => <tr key={item.id}><td><BackofficeIdCell id={item.id} /></td><td>{item.event_title}</td><td>{item.username}<br /><span className="bo-muted">{item.user_email}</span></td><td>{item.score}</td><td>{formatAdminDate(item.created_at)}</td><td><BackofficeConfirmAction label="Delete" confirmLabel="Delete" busy={mutation.busyId === item.id} onConfirm={() => void mutation.run(item.id, () => deleteAdminEventRating(token!, item.id), 'Rating deleted.')} /></td></tr>) : participantVm.items.map((item) => <tr key={item.id}><td><BackofficeIdCell id={item.id} /></td><td>{item.event_title}</td><td>{item.participant_username}<br /><span className="bo-muted">Host: {item.host_username}</span></td><td>{item.score}</td><td>{formatAdminDate(item.created_at)}</td><td><BackofficeConfirmAction label="Delete" confirmLabel="Delete" busy={mutation.busyId === item.id} onConfirm={() => void mutation.run(item.id, () => deleteAdminParticipantRating(token!, item.id), 'Rating deleted.')} /></td></tr>)}
+      </tbody></table></div>
+      {mutation.error && <div className="bo-state bo-state-error">{mutation.error}</div>}
+      <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
+    </BackofficePageShell>
+  );
+}

--- a/frontend/src/views/backoffice/TicketsAdminPage.tsx
+++ b/frontend/src/views/backoffice/TicketsAdminPage.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { AdminTicketFilters } from '@/models/admin';
 import { listAdminTickets } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
-import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminTicketFilters = {
   q: '',
@@ -68,7 +68,7 @@ export default function TicketsAdminPage() {
                 <td>{ticket.event_title}</td>
                 <td>{ticket.username}</td>
                 <td>{ticket.user_email}</td>
-                <td>{ticket.status}</td>
+                <td><BackofficeStatusPill status={ticket.status} /></td>
                 <td>{formatAdminDate(ticket.expires_at)}</td>
                 <td>{formatAdminDate(ticket.used_at)}</td>
                 <td>{formatAdminDate(ticket.canceled_at)}</td>

--- a/frontend/src/views/backoffice/UsersAdminPage.tsx
+++ b/frontend/src/views/backoffice/UsersAdminPage.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import type { AdminUserFilters } from '@/models/admin';
-import { listAdminUsers } from '@/services/adminService';
+import { deactivateAdminUser, listAdminUsers } from '@/services/adminService';
 import { useAdminListViewModel } from '@/viewmodels/admin/useAdminListViewModel';
-import { BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
+import { useAdminMutation } from '@/viewmodels/admin/useAdminMutation';
+import { BackofficeConfirmAction, BackofficeIdCell, BackofficePageShell, BackofficePagination, BackofficeStatusPill, BackofficeTableState, formatAdminDate } from './BackofficeListParts';
 
 const INITIAL_FILTERS: AdminUserFilters = {
   q: '',
@@ -21,6 +22,7 @@ export default function UsersAdminPage() {
     initialFilters,
     fetchPage: listAdminUsers,
   });
+  const mutation = useAdminMutation(vm.retry);
 
   return (
     <BackofficePageShell
@@ -29,9 +31,10 @@ export default function UsersAdminPage() {
       filters={(
         <>
           <input aria-label="Search users" placeholder="Search username, email, phone" value={vm.filters.q ?? ''} onChange={(event) => vm.setFilter('q', event.target.value)} />
-          <select aria-label="User status" value={vm.filters.status ?? ''} onChange={(event) => vm.setFilter('status', event.target.value)}>
+          <select aria-label="User status" value={vm.filters.status ?? ''} onChange={(event) => vm.setFilter('status', event.target.value as AdminUserFilters['status'])}>
             <option value="">Any status</option>
             <option value="active">active</option>
+            <option value="deactivated">deactivated</option>
           </select>
           <select aria-label="User role" value={vm.filters.role ?? ''} onChange={(event) => vm.setFilter('role', event.target.value === '' ? undefined : event.target.value as AdminUserFilters['role'])}>
             <option value="">Any role</option>
@@ -59,6 +62,7 @@ export default function UsersAdminPage() {
               <th>Verified</th>
               <th>Created</th>
               <th>Updated</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -69,15 +73,26 @@ export default function UsersAdminPage() {
                 <td>{user.email}</td>
                 <td>{user.phone_number ?? '-'}</td>
                 <td>{user.role}</td>
-                <td>{user.status}</td>
+                <td><BackofficeStatusPill status={user.status} /></td>
                 <td>{user.email_verified ? 'Yes' : 'No'}</td>
                 <td>{formatAdminDate(user.created_at)}</td>
                 <td>{formatAdminDate(user.updated_at)}</td>
+                <td>
+                  <BackofficeConfirmAction
+                    label="Deactivate"
+                    confirmLabel="Deactivate"
+                    disabled={user.status === 'deactivated'}
+                    busy={mutation.busyId === user.id}
+                    onConfirm={() => void mutation.run(user.id, () => deactivateAdminUser(token!, user.id), 'User deactivated.')}
+                  />
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
+      {mutation.error && <div className="bo-state bo-state-error">{mutation.error}</div>}
+      {mutation.message && <div className="bo-result" role="status"><span>{mutation.message}</span></div>}
       <BackofficePagination {...vm} onPrevious={vm.previousPage} onNext={vm.nextPage} onLimitChange={vm.changeLimit} />
     </BackofficePageShell>
   );

--- a/frontend/src/views/discover/DiscoverPage.tsx
+++ b/frontend/src/views/discover/DiscoverPage.tsx
@@ -161,8 +161,8 @@ function SortOptionIcon({ kind, className }: { kind: 'time' | 'distance'; classN
   );
 }
 
-/** Number of categories that fit comfortably in one row before showing expand */
-const CATEGORY_SINGLE_ROW_THRESHOLD = 7;
+/** Maximum number of category chips rendered before the expand control. */
+const CATEGORY_COLLAPSED_COUNT = 8;
 
 const PRIVACY_OPTIONS: { label: string; value: PrivacyFilter }[] = [
   { label: 'All', value: 'ALL' },
@@ -293,7 +293,7 @@ export default function DiscoverPage() {
   const isMapMode = viewMode === 'map';
 
   useLayoutEffect(() => {
-    const needsExpand = vm.categories.length > CATEGORY_SINGLE_ROW_THRESHOLD;
+    const needsExpand = vm.categories.length > CATEGORY_COLLAPSED_COUNT;
     setCategoryChipsNeedExpand(needsExpand);
     if (!needsExpand && categoriesExpanded) {
       setCategoriesExpanded(false);
@@ -533,6 +533,11 @@ export default function DiscoverPage() {
     </div>
   );
 
+  const visibleCategories =
+    categoryChipsNeedExpand && !categoriesExpanded
+      ? vm.categories.slice(0, CATEGORY_COLLAPSED_COUNT)
+      : vm.categories;
+
   const categoriesBlock = vm.categories.length > 0 && (
     <div className="dc-category-block">
       <div
@@ -542,7 +547,7 @@ export default function DiscoverPage() {
         role="group"
         aria-label="Event categories"
       >
-        {vm.categories.map((cat) => (
+        {visibleCategories.map((cat) => (
           <button
             key={cat.id}
             type="button"
@@ -564,6 +569,9 @@ export default function DiscoverPage() {
                 categoriesExpanded ? 'dc-category-expand-chevron--open' : ''
               }`}
             />
+            <span className="sr-only">
+              {categoriesExpanded ? 'Collapse categories' : 'Expand categories'}
+            </span>
           </button>
         )}
       </div>


### PR DESCRIPTION
## 📋 Summary
Adds admin moderation actions for event reports and related domain entities, giving backoffice admins tools to review reports, moderate content, manage user/event status, and operate across key admin resources.

## 🔄 Changes
- Added backend admin usecases, repository methods, handlers, and DTOs for moderation actions.
- Added event report status updates, event status/cancel actions, user deactivation, invitation/join request status updates, comment/rating deletion, push device revocation, and participation actions.
- Added admin list/action support for categories, comments, ratings, favorites, badges, push devices, invitations, and join requests.
- Updated domain status models and admin indexes/migrations for moderation queries.
- Updated `docs/openapi/admin.yaml` with the new admin endpoints and schemas.
- Extended the backoffice UI with new admin pages, routes, service methods, typed models, shared mutation handling, and moderation controls.

## 🧪 Testing
- Added/updated backend admin service and HTTP handler tests for the new moderation actions.
- To verify locally: run backend tests and open `/backoffice` as an admin to exercise report status changes and the new moderation pages/actions.

## 🔗 Related
Closes #481 , Closes #268