### PR TITLE
feat(frontend): add public profile page and profile assets

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import TicketsPage from './views/tickets/TicketsPage';
 import TicketDetailPage from './views/tickets/TicketDetailPage';
 import FavoritesPage from './views/favorites/FavoritesPage';
 import ProfilePage from './views/profile/ProfilePage';
+import PublicProfilePage from './views/profile/PublicProfilePage';
 import NotFoundView from './views/fallback/NotFoundView';
 import BackofficeLayout from './views/backoffice/BackofficeLayout';
 import UsersAdminPage from './views/backoffice/UsersAdminPage';
@@ -64,6 +65,7 @@ export default function App() {
             <Route path="/tickets/:ticketId" element={<ProtectedRoute><TicketDetailPage /></ProtectedRoute>} />
             <Route path="/favorites" element={<ProtectedRoute><FavoritesPage /></ProtectedRoute>} />
             <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
+            <Route path="/users/:userId" element={<PublicProfilePage />} />
             <Route
               path="/backoffice"
               element={<AdminRoute><BackofficeLayout /></AdminRoute>}

--- a/frontend/src/models/profile.ts
+++ b/frontend/src/models/profile.ts
@@ -33,6 +33,31 @@ export interface UserProfile {
   avatar_url?: string;
 }
 
+export interface ProfileEquipmentItem {
+  id: string;
+  name: string;
+  description?: string | null;
+  image_url?: string | null;
+}
+
+export interface ShowcaseImageItem {
+  id: string;
+  image_url: string;
+}
+
+export interface PublicProfile {
+  user_id: string;
+  username: string;
+  display_name?: string | null;
+  avatar_url?: string | null;
+  bio?: string | null;
+  final_score?: number | null;
+  host_rating_count: number;
+  participant_rating_count: number;
+  equipment: ProfileEquipmentItem[];
+  showcase_images: ShowcaseImageItem[];
+}
+
 export interface UpdateProfileRequest {
   display_name?: string | null;
   bio?: string | null;
@@ -91,6 +116,22 @@ export interface ImageUploadInitResponse {
 
 export interface ImageUploadConfirmRequest {
   confirm_token: string;
+}
+
+export interface EquipmentListResponse {
+  items: ProfileEquipmentItem[];
+}
+
+export interface CreateEquipmentRequest {
+  name: string;
+  description?: string | null;
+  image_url?: string | null;
+}
+
+export interface UpdateEquipmentRequest {
+  name?: string | null;
+  description?: string | null;
+  image_url?: string | null;
 }
 
 export type BadgeCategory = 'HOSTING' | 'PARTICIPATION' | 'SOCIAL';

--- a/frontend/src/services/profileService.test.ts
+++ b/frontend/src/services/profileService.test.ts
@@ -32,6 +32,115 @@ describe('profileService.changePassword', () => {
   });
 });
 
+describe('profileService public profile', () => {
+  it('fetches the public profile endpoint without authentication', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      user_id: 'user-123',
+      username: 'hiker',
+      host_rating_count: 0,
+      participant_rating_count: 0,
+      equipment: [],
+      showcase_images: [],
+    }), { status: 200 }));
+
+    await profileService.getPublicProfile('user-123');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/users/user-123/profile', expect.objectContaining({
+      method: 'GET',
+      headers: expect.objectContaining({
+        'Content-Type': 'application/json',
+      }),
+      cache: 'no-store',
+    }));
+  });
+});
+
+describe('profileService equipment', () => {
+  it('creates an equipment item for the authenticated user', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ id: 'eq-1', name: 'Trail Shoes' }), { status: 201 }));
+
+    await profileService.createEquipment({
+      name: 'Trail Shoes',
+      description: 'Grip-heavy shoes for mixed terrain.',
+      image_url: 'https://example.com/shoes.jpg',
+    }, 'access-token');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/me/equipment', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        name: 'Trail Shoes',
+        description: 'Grip-heavy shoes for mixed terrain.',
+        image_url: 'https://example.com/shoes.jpg',
+      }),
+    }));
+  });
+
+  it('updates an equipment item for the authenticated user', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ id: 'eq-1', name: 'Trail Shoes' }), { status: 200 }));
+
+    await profileService.updateEquipment('eq-1', {
+      description: 'Updated description',
+    }, 'access-token');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/me/equipment/eq-1', expect.objectContaining({
+      method: 'PATCH',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        description: 'Updated description',
+      }),
+    }));
+  });
+});
+
+describe('profileService showcase images', () => {
+  it('requests showcase upload instructions for the authenticated user', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      base_url: 'https://cdn.example.com/image.jpg',
+      version: 1,
+      confirm_token: 'confirm-token',
+      uploads: [],
+    }), { status: 200 }));
+
+    await profileService.getShowcaseUploadUrl('access-token');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/me/showcase-images/upload-url', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({}),
+    }));
+  });
+
+  it('confirms a showcase image upload for the authenticated user', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      id: 'showcase-1',
+      image_url: 'https://cdn.example.com/image.jpg',
+    }), { status: 201 }));
+
+    await profileService.confirmShowcaseUpload({ confirm_token: 'confirm-token' }, 'access-token');
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/me/showcase-images/confirm', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        confirm_token: 'confirm-token',
+      }),
+    }));
+  });
+});
+
 describe('profileService badges', () => {
   it('fetches the authenticated user badges endpoint', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] }), { status: 200 }));

--- a/frontend/src/services/profileService.ts
+++ b/frontend/src/services/profileService.ts
@@ -1,17 +1,23 @@
-import { apiGetAuth, apiPatchAuth, apiPostAuth, apiDeleteAuth } from './api';
+import { apiDeleteAuth, apiGet, apiGetAuth, apiPatchAuth, apiPostAuth } from './api';
 import {
-  UserProfile,
-  EventSummary,
-  UpdateProfileRequest,
+  BadgeCatalogResponse,
   ChangePasswordRequest,
-  ImageUploadInitResponse,
-  ImageUploadConfirmRequest,
+  CreateEquipmentRequest,
+  EventSummary,
+  EquipmentListResponse,
   FavoriteLocation,
   FavoriteLocationsResponse,
-  CreateFavoriteLocationRequest,
+  ImageUploadConfirmRequest,
+  ImageUploadInitResponse,
+  PublicProfile,
+  ShowcaseImageItem,
+  UpdateEquipmentRequest,
   UpdateFavoriteLocationRequest,
+  UserProfile,
+  UpdateProfileRequest,
+  CreateFavoriteLocationRequest,
+  ProfileEquipmentItem,
   UserBadgesResponse,
-  BadgeCatalogResponse,
 } from '../models/profile';
 
 interface EventListResponse {
@@ -24,6 +30,10 @@ interface EventListResponse {
 export const profileService = {
   async getMyProfile(token: string): Promise<UserProfile> {
     return apiGetAuth<UserProfile>('/me', token);
+  },
+
+  async getPublicProfile(userId: string): Promise<PublicProfile> {
+    return apiGet<PublicProfile>(`/users/${userId}/profile`);
   },
 
   async updateMyProfile(data: UpdateProfileRequest, token: string): Promise<void> {
@@ -60,6 +70,35 @@ export const profileService = {
 
   async confirmAvatarUpload(body: ImageUploadConfirmRequest, token: string): Promise<void> {
     return apiPostAuth<void>('/me/avatar/confirm', body, token);
+  },
+
+  async getMyEquipment(token: string): Promise<ProfileEquipmentItem[]> {
+    const res = await apiGetAuth<EquipmentListResponse>('/me/equipment', token);
+    return res.items ?? [];
+  },
+
+  async createEquipment(data: CreateEquipmentRequest, token: string): Promise<ProfileEquipmentItem> {
+    return apiPostAuth<ProfileEquipmentItem>('/me/equipment', data, token);
+  },
+
+  async updateEquipment(id: string, data: UpdateEquipmentRequest, token: string): Promise<ProfileEquipmentItem> {
+    return apiPatchAuth<ProfileEquipmentItem>(`/me/equipment/${id}`, data, token);
+  },
+
+  async deleteEquipment(id: string, token: string): Promise<void> {
+    return apiDeleteAuth<void>(`/me/equipment/${id}`, token);
+  },
+
+  async getShowcaseUploadUrl(token: string): Promise<ImageUploadInitResponse> {
+    return apiPostAuth<ImageUploadInitResponse>('/me/showcase-images/upload-url', {}, token);
+  },
+
+  async confirmShowcaseUpload(body: ImageUploadConfirmRequest, token: string): Promise<ShowcaseImageItem> {
+    return apiPostAuth<ShowcaseImageItem>('/me/showcase-images/confirm', body, token);
+  },
+
+  async deleteShowcaseImage(id: string, token: string): Promise<void> {
+    return apiDeleteAuth<void>(`/me/showcase-images/${id}`, token);
   },
 
   async getFavoriteLocations(token: string): Promise<FavoriteLocation[]> {

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -404,6 +404,31 @@
   border: 1px solid #e5e7eb;
 }
 
+.ed-host-avatar-link,
+.ed-host-link,
+.ed-mgmt-avatar-link,
+.ed-mgmt-user-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.ed-host-avatar-link,
+.ed-mgmt-avatar-link {
+  flex-shrink: 0;
+}
+
+.ed-host-link,
+.ed-mgmt-user-link {
+  min-width: 0;
+}
+
+.ed-host-link:hover .ed-host-name,
+.ed-host-link:hover .ed-host-username,
+.ed-mgmt-user-link:hover .ed-mgmt-name,
+.ed-mgmt-user-link:hover .ed-mgmt-username {
+  color: #2563eb;
+}
+
 .ed-host-info {
   flex: 1;
   min-width: 0;
@@ -975,6 +1000,10 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
+}
+
+.ed-mgmt-user-link {
+  flex: 1;
 }
 
 .ed-mgmt-name {

--- a/frontend/src/styles/profile.css
+++ b/frontend/src/styles/profile.css
@@ -8,6 +8,10 @@
   color: #111827;
 }
 
+.profile-container-wide {
+  max-width: 880px;
+}
+
 .profile-header {
   display: flex;
   justify-content: space-between;
@@ -618,6 +622,352 @@
 
 .profile-badge-detail.locked {
   color: #6b7280;
+}
+
+.profile-public-hero {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 1.4rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #f9fafb 0%, #ffffff 58%, #eff6ff 100%);
+  margin-bottom: 1.75rem;
+}
+
+.profile-public-avatar {
+  width: 112px;
+  height: 112px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e5e7eb;
+  border: 3px solid #dbeafe;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.3rem;
+  font-weight: 700;
+  color: #475569;
+}
+
+.profile-public-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-public-copy {
+  min-width: 0;
+}
+
+.profile-public-eyebrow {
+  margin: 0 0 0.4rem;
+  color: #64748b;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.profile-public-name {
+  margin: 0;
+  color: #111827;
+  font-size: 2rem;
+  line-height: 1.08;
+}
+
+.profile-public-username {
+  margin: 0.35rem 0 0;
+  color: #475569;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.profile-public-bio {
+  margin: 0.85rem 0 0;
+  color: #374151;
+  font-size: 0.98rem;
+  line-height: 1.7;
+  max-width: 60ch;
+}
+
+.profile-public-bio.is-empty {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+.profile-public-rating-card {
+  min-width: 190px;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  background: #111827;
+  color: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.18);
+}
+
+.profile-public-rating-value {
+  font-size: 1.5rem;
+  font-weight: 800;
+}
+
+.profile-public-rating-summary {
+  font-size: 0.9rem;
+  color: #cbd5e1;
+}
+
+.profile-public-rating-breakdown {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.profile-public-section {
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.profile-public-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.profile-public-section-title {
+  margin: 0;
+  color: #111827;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.profile-public-section-subtitle {
+  margin: 0.35rem 0 0;
+  color: #6b7280;
+  font-size: 0.92rem;
+}
+
+.profile-public-section-actions {
+  flex-shrink: 0;
+}
+
+.profile-public-empty,
+.profile-public-state {
+  padding: 1.2rem 1rem;
+  border: 1px dashed #d1d5db;
+  border-radius: 14px;
+  background: #f9fafb;
+  color: #6b7280;
+  text-align: center;
+}
+
+.profile-public-state h1,
+.profile-public-state p {
+  margin: 0;
+}
+
+.profile-public-state p + .profile-public-retry {
+  margin-top: 1rem;
+}
+
+.profile-public-state.inline p {
+  margin-bottom: 0.9rem;
+}
+
+.profile-public-retry {
+  width: auto;
+  min-width: 140px;
+}
+
+.profile-equipment-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.profile-equipment-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  background: #ffffff;
+  overflow: hidden;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.05);
+}
+
+.profile-equipment-image {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  background: #e5e7eb;
+}
+
+.profile-equipment-image-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #475569;
+  background: linear-gradient(135deg, #dbeafe 0%, #f8fafc 100%);
+}
+
+.profile-equipment-content {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-height: 160px;
+}
+
+.profile-equipment-name {
+  margin: 0;
+  color: #111827;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.profile-equipment-description {
+  margin: 0.45rem 0 0;
+  color: #4b5563;
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.profile-equipment-description.is-empty {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+.profile-equipment-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: auto;
+}
+
+.profile-showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.profile-showcase-item {
+  position: relative;
+  margin: 0;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  background: #f8fafc;
+  min-height: 180px;
+}
+
+.profile-showcase-image {
+  width: 100%;
+  height: 100%;
+  min-height: 180px;
+  display: block;
+  object-fit: cover;
+}
+
+.profile-showcase-actions {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+}
+
+.profile-showcase-remove,
+.profile-inline-btn {
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #111827;
+  padding: 0.45rem 0.8rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.profile-inline-btn.danger,
+.profile-showcase-remove {
+  color: #991b1b;
+}
+
+.profile-inline-btn:hover:not(:disabled),
+.profile-showcase-remove:hover:not(:disabled) {
+  background: #ffffff;
+  border-color: #9ca3af;
+}
+
+.profile-inline-btn:disabled,
+.profile-showcase-remove:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.profile-inline-action-btn {
+  width: auto;
+}
+
+.profile-inline-form {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.profile-inline-form-header h3 {
+  margin: 0;
+  color: #111827;
+  font-size: 1rem;
+}
+
+.profile-inline-form-header p {
+  margin: 0.35rem 0 1rem;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.profile-section-feedback {
+  margin-top: 0.9rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  font-size: 0.92rem;
+}
+
+.profile-section-feedback.error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+}
+
+@media (max-width: 760px) {
+  .profile-public-hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .profile-public-avatar {
+    margin: 0 auto;
+  }
+
+  .profile-public-bio {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .profile-public-rating-card {
+    min-width: 0;
+  }
+
+  .profile-public-section-header,
+  .profile-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .profile-badge-detail-icon {

--- a/frontend/src/viewmodels/profile/useProfileViewModel.ts
+++ b/frontend/src/viewmodels/profile/useProfileViewModel.ts
@@ -1,12 +1,13 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { ApiError } from '@/services/api';
 import {
   CatalogBadge,
   EarnedBadge,
   EventSummary,
-  UserProfile,
+  PublicProfile,
   UpdateProfileRequest,
+  UserProfile,
 } from '../../models/profile';
 import { profileService } from '../../services/profileService';
 import { prepareAvatarBlobs } from '../../utils/imageResize';
@@ -24,6 +25,22 @@ type ChangePasswordErrors = {
   confirmPassword?: string;
 };
 
+type EquipmentDraft = {
+  id: string | null;
+  name: string;
+  description: string;
+  imageUrl: string;
+};
+
+function createEmptyEquipmentDraft(): EquipmentDraft {
+  return {
+    id: null,
+    name: '',
+    description: '',
+    imageUrl: '',
+  };
+}
+
 function getBackendValidationMessage(err: ApiError): string {
   const details = err.details ? Object.values(err.details).filter(Boolean) : [];
   return details.length > 0 ? details.join(' ') : err.message;
@@ -32,28 +49,28 @@ function getBackendValidationMessage(err: ApiError): string {
 export function useProfileViewModel(token: string | null) {
   const { setProfileSummary } = useAuth();
   const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [publicProfile, setPublicProfile] = useState<PublicProfile | null>(null);
   const [hostedEvents, setHostedEvents] = useState<EventSummary[]>([]);
   const [attendedEvents, setAttendedEvents] = useState<EventSummary[]>([]);
   const [earnedBadges, setEarnedBadges] = useState<EarnedBadge[]>([]);
   const [badgeCatalog, setBadgeCatalog] = useState<CatalogBadge[]>([]);
 
-  // UI states
   const [isLoading, setIsLoading] = useState(true);
+  const [publicProfileLoading, setPublicProfileLoading] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [publicProfileError, setPublicProfileError] = useState<string | null>(null);
   const [badgeError, setBadgeError] = useState<string | null>(null);
   const [badgesLoading, setBadgesLoading] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Form Draft states
   const [displayName, setDisplayName] = useState('');
   const [bio, setBio] = useState('');
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
 
-  // Default location states
   const [locationQuery, setLocationQuery] = useState('');
   const [locationSuggestions, setLocationSuggestions] = useState<LocationSuggestion[]>([]);
   const [selectedLocation, setSelectedLocation] = useState<{ address: string; lat: number; lon: number } | null>(null);
@@ -61,7 +78,6 @@ export function useProfileViewModel(token: string | null) {
   const [locationCleared, setLocationCleared] = useState(false);
   const locationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Change password states
   const [isPasswordFormOpen, setIsPasswordFormOpen] = useState(false);
   const [isChangingPassword, setIsChangingPassword] = useState(false);
   const [currentPassword, setCurrentPassword] = useState('');
@@ -71,6 +87,30 @@ export function useProfileViewModel(token: string | null) {
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const [passwordSuccess, setPasswordSuccess] = useState<string | null>(null);
   const passwordSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [isEquipmentEditorOpen, setIsEquipmentEditorOpen] = useState(false);
+  const [equipmentDraft, setEquipmentDraft] = useState<EquipmentDraft>(createEmptyEquipmentDraft());
+  const [equipmentSubmitting, setEquipmentSubmitting] = useState(false);
+  const [equipmentDeletingId, setEquipmentDeletingId] = useState<string | null>(null);
+  const [equipmentError, setEquipmentError] = useState<string | null>(null);
+
+  const [showcaseUploading, setShowcaseUploading] = useState(false);
+  const [showcaseRemovingId, setShowcaseRemovingId] = useState<string | null>(null);
+  const [showcaseError, setShowcaseError] = useState<string | null>(null);
+
+  const fetchPublicProfile = useCallback(async (userId: string) => {
+    setPublicProfileLoading(true);
+    setPublicProfileError(null);
+    try {
+      const data = await profileService.getPublicProfile(userId);
+      setPublicProfile(data);
+    } catch (err: unknown) {
+      setPublicProfile(null);
+      setPublicProfileError(err instanceof Error ? err.message : 'Failed to load public profile sections.');
+    } finally {
+      setPublicProfileLoading(false);
+    }
+  }, []);
 
   const fetchProfile = useCallback(async () => {
     if (!token) return;
@@ -89,7 +129,11 @@ export function useProfileViewModel(token: string | null) {
       setBio(data.bio || '');
       setSelectedLocation(
         data.default_location_address
-          ? { address: formatEventLocation(data.default_location_address), lat: data.default_location_lat!, lon: data.default_location_lon! }
+          ? {
+              address: formatEventLocation(data.default_location_address),
+              lat: data.default_location_lat!,
+              lon: data.default_location_lon!,
+            }
           : null,
       );
       setLocationQuery('');
@@ -106,14 +150,17 @@ export function useProfileViewModel(token: string | null) {
         avatarUrl: data.avatar_url ?? null,
         displayName: data.display_name ?? null,
       });
+      void fetchPublicProfile(data.id);
     } catch (err: unknown) {
       setHostedEvents([]);
       setAttendedEvents([]);
+      setPublicProfile(null);
+      setPublicProfileLoading(false);
       setError(err instanceof Error ? err.message : 'Failed to load profile');
     } finally {
       setIsLoading(false);
     }
-  }, [token, setProfileSummary]);
+  }, [fetchPublicProfile, token, setProfileSummary]);
 
   const fetchBadges = useCallback(async () => {
     if (!token) return;
@@ -136,8 +183,8 @@ export function useProfileViewModel(token: string | null) {
   }, [token]);
 
   useEffect(() => {
-    fetchProfile();
-    fetchBadges();
+    void fetchProfile();
+    void fetchBadges();
   }, [fetchBadges, fetchProfile]);
 
   useEffect(
@@ -148,6 +195,11 @@ export function useProfileViewModel(token: string | null) {
     },
     [],
   );
+
+  const refreshPublicProfile = useCallback(async () => {
+    if (!profile?.id) return;
+    await fetchPublicProfile(profile.id);
+  }, [fetchPublicProfile, profile?.id]);
 
   const handleLocationSearch = useCallback((query: string) => {
     setLocationQuery(query);
@@ -204,7 +256,11 @@ export function useProfileViewModel(token: string | null) {
       setAvatarPreview(null);
       setSelectedLocation(
         profile?.default_location_address
-          ? { address: formatEventLocation(profile.default_location_address), lat: profile.default_location_lat!, lon: profile.default_location_lon! }
+          ? {
+              address: formatEventLocation(profile.default_location_address),
+              lat: profile.default_location_lat!,
+              lon: profile.default_location_lon!,
+            }
           : null,
       );
       setLocationQuery('');
@@ -252,7 +308,6 @@ export function useProfileViewModel(token: string | null) {
         bio: bio.trim() || null,
       };
 
-      // Include location if changed
       if (locationCleared) {
         updatePayload.default_location_address = null;
         updatePayload.default_location_lat = null;
@@ -373,8 +428,150 @@ export function useProfileViewModel(token: string | null) {
     }
   }, [currentPassword, newPassword, resetPasswordForm, token, validateChangePassword]);
 
+  const updateEquipmentDraft = useCallback((field: 'name' | 'description' | 'imageUrl', value: string) => {
+    setEquipmentDraft((current) => ({ ...current, [field]: value }));
+  }, []);
+
+  const startCreatingEquipment = useCallback(() => {
+    setEquipmentDraft(createEmptyEquipmentDraft());
+    setEquipmentError(null);
+    setIsEquipmentEditorOpen(true);
+  }, []);
+
+  const startEditingEquipment = useCallback((item: NonNullable<PublicProfile['equipment']>[number]) => {
+    setEquipmentDraft({
+      id: item.id,
+      name: item.name,
+      description: item.description ?? '',
+      imageUrl: item.image_url ?? '',
+    });
+    setEquipmentError(null);
+    setIsEquipmentEditorOpen(true);
+  }, []);
+
+  const cancelEquipmentEditor = useCallback(() => {
+    setEquipmentDraft(createEmptyEquipmentDraft());
+    setEquipmentError(null);
+    setIsEquipmentEditorOpen(false);
+  }, []);
+
+  const handleEquipmentSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    setEquipmentError(null);
+
+    if (!token) {
+      setEquipmentError('Authentication token is missing.');
+      return;
+    }
+
+    const trimmedName = equipmentDraft.name.trim();
+    if (!trimmedName) {
+      setEquipmentError('Equipment name is required.');
+      return;
+    }
+
+    setEquipmentSubmitting(true);
+    try {
+      const payload = {
+        name: trimmedName,
+        description: equipmentDraft.description.trim() || null,
+        image_url: equipmentDraft.imageUrl.trim() || null,
+      };
+
+      if (equipmentDraft.id) {
+        await profileService.updateEquipment(equipmentDraft.id, payload, token);
+      } else {
+        await profileService.createEquipment(payload, token);
+      }
+
+      await refreshPublicProfile();
+      cancelEquipmentEditor();
+    } catch (err: unknown) {
+      setEquipmentError(err instanceof Error ? err.message : 'Failed to save equipment.');
+    } finally {
+      setEquipmentSubmitting(false);
+    }
+  }, [cancelEquipmentEditor, equipmentDraft, refreshPublicProfile, token]);
+
+  const handleDeleteEquipment = useCallback(async (equipmentId: string) => {
+    if (!token) {
+      setEquipmentError('Authentication token is missing.');
+      return;
+    }
+
+    setEquipmentDeletingId(equipmentId);
+    setEquipmentError(null);
+
+    try {
+      await profileService.deleteEquipment(equipmentId, token);
+      await refreshPublicProfile();
+      if (equipmentDraft.id === equipmentId) {
+        cancelEquipmentEditor();
+      }
+    } catch (err: unknown) {
+      setEquipmentError(err instanceof Error ? err.message : 'Failed to delete equipment.');
+    } finally {
+      setEquipmentDeletingId(null);
+    }
+  }, [cancelEquipmentEditor, equipmentDraft.id, refreshPublicProfile, token]);
+
+  const handleShowcaseUpload = useCallback(async (file: File) => {
+    if (!token) {
+      setShowcaseError('Authentication token is missing.');
+      return;
+    }
+
+    setShowcaseUploading(true);
+    setShowcaseError(null);
+
+    try {
+      const { original, small } = await prepareAvatarBlobs(file);
+      const uploadInit = await profileService.getShowcaseUploadUrl(token);
+
+      for (const instruction of uploadInit.uploads) {
+        const blob = instruction.variant === 'ORIGINAL' ? original : small;
+        const res = await fetch(instruction.url, {
+          method: instruction.method,
+          headers: instruction.headers,
+          body: blob,
+        });
+        if (!res.ok) throw new Error(`Image upload failed (${instruction.variant})`);
+      }
+
+      await profileService.confirmShowcaseUpload({ confirm_token: uploadInit.confirm_token }, token);
+      await refreshPublicProfile();
+    } catch (err: unknown) {
+      setShowcaseError(err instanceof Error ? err.message : 'Failed to upload showcase image.');
+    } finally {
+      setShowcaseUploading(false);
+    }
+  }, [refreshPublicProfile, token]);
+
+  const handleDeleteShowcaseImage = useCallback(async (showcaseImageId: string) => {
+    if (!token) {
+      setShowcaseError('Authentication token is missing.');
+      return;
+    }
+
+    setShowcaseRemovingId(showcaseImageId);
+    setShowcaseError(null);
+
+    try {
+      await profileService.deleteShowcaseImage(showcaseImageId, token);
+      await refreshPublicProfile();
+    } catch (err: unknown) {
+      setShowcaseError(err instanceof Error ? err.message : 'Failed to remove showcase image.');
+    } finally {
+      setShowcaseRemovingId(null);
+    }
+  }, [refreshPublicProfile, token]);
+
   return {
     profile,
+    publicProfile,
+    publicProfileLoading,
+    publicProfileError,
+    refreshPublicProfile,
     hostedEvents,
     attendedEvents,
     earnedBadges,
@@ -395,7 +592,6 @@ export function useProfileViewModel(token: string | null) {
     handleFileChange,
     handleEditToggle,
     handleSave,
-    // Default location
     locationQuery,
     handleLocationSearch,
     locationSuggestions,
@@ -404,7 +600,6 @@ export function useProfileViewModel(token: string | null) {
     clearLocation,
     isSearchingLocation,
     locationCleared,
-    // Change password
     isPasswordFormOpen,
     togglePasswordForm,
     currentPassword,
@@ -418,5 +613,21 @@ export function useProfileViewModel(token: string | null) {
     passwordSuccess,
     isChangingPassword,
     handleChangePassword,
+    isEquipmentEditorOpen,
+    equipmentDraft,
+    updateEquipmentDraft,
+    equipmentSubmitting,
+    equipmentDeletingId,
+    equipmentError,
+    startCreatingEquipment,
+    startEditingEquipment,
+    cancelEquipmentEditor,
+    handleEquipmentSubmit,
+    handleDeleteEquipment,
+    showcaseUploading,
+    showcaseRemovingId,
+    showcaseError,
+    handleShowcaseUpload,
+    handleDeleteShowcaseImage,
   };
 }

--- a/frontend/src/viewmodels/profile/usePublicProfileViewModel.ts
+++ b/frontend/src/viewmodels/profile/usePublicProfileViewModel.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { PublicProfile } from '@/models/profile';
+import { profileService } from '@/services/profileService';
+
+export function usePublicProfileViewModel(userId: string | undefined) {
+  const [profile, setProfile] = useState<PublicProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProfile = useCallback(async () => {
+    if (!userId) {
+      setProfile(null);
+      setError('User id is missing.');
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await profileService.getPublicProfile(userId);
+      setProfile(data);
+    } catch (err: unknown) {
+      setProfile(null);
+      setError(err instanceof Error ? err.message : 'Failed to load public profile.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchProfile();
+  }, [fetchProfile]);
+
+  return {
+    profile,
+    isLoading,
+    error,
+    retry: fetchProfile,
+  };
+}

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -160,6 +160,49 @@ function makeReadyViewModel(event: EventDetailResponse) {
 }
 
 describe('EventDetailPage ratings', () => {
+  it('links the host name block to the public profile page', () => {
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(makeBaseEvent()));
+
+    renderPage();
+
+    const hostLinks = screen.getAllByRole('link', { name: /host user/i });
+    expect(hostLinks).toHaveLength(2);
+    hostLinks.forEach((link) => {
+      expect(link.getAttribute('href')).toBe('/users/host-1');
+    });
+  });
+
+  it('links approved participants to the public profile page from the management list', () => {
+    const event = makeBaseEvent();
+    event.viewer_context.is_host = true;
+
+    const vm = makeReadyViewModel(event);
+    vm.approvedParticipants = [{
+      participation_id: 'participation-1',
+      status: 'APPROVED',
+      created_at: '2026-04-01T17:00:00Z',
+      updated_at: '2026-04-01T17:00:00Z',
+      host_rating: null,
+      user: {
+        id: 'participant-1',
+        username: 'walker1',
+        display_name: 'Walker One',
+        avatar_url: null,
+        final_score: 4.2,
+        rating_count: 6,
+      },
+    }];
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    const participantLinks = screen.getAllByRole('link', { name: /walker one/i });
+    expect(participantLinks).toHaveLength(2);
+    participantLinks.forEach((link) => {
+      expect(link.getAttribute('href')).toBe('/users/participant-1');
+    });
+  });
+
   it('opens the report modal from the flag button and submits the selected reason', async () => {
     const event = makeBaseEvent();
     const vm = makeReadyViewModel(event);

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -1208,34 +1208,45 @@ function HostParticipantRatingItem({
 
   return (
     <li className="ed-mgmt-item ed-mgmt-item-participant">
-      <UserAvatar
-        username={participant.user.username}
-        displayName={participant.user.display_name}
-        avatarUrl={participant.user.avatar_url}
-        size="sm"
-        variant="muted"
-      />
+      <Link
+        to={`/users/${participant.user.id}`}
+        className="ed-mgmt-avatar-link"
+        aria-label={`View ${getDisplayName(participant.user)}'s profile`}
+      >
+        <UserAvatar
+          username={participant.user.username}
+          displayName={participant.user.display_name}
+          avatarUrl={participant.user.avatar_url}
+          size="sm"
+          variant="muted"
+        />
+      </Link>
 
-      <div className="ed-mgmt-user-info">
-        <div className="ed-mgmt-user-topline">
-          <span className="ed-mgmt-name">{getDisplayName(participant.user)}</span>
-          {participant.user.final_score != null && (
-            <span className="ed-mgmt-user-score">{'★'} {participant.user.final_score.toFixed(1)} ({participant.user.rating_count})</span>
-          )}
-        </div>
-        <span className="ed-mgmt-username">@{participant.user.username}</span>
+      <Link
+        to={`/users/${participant.user.id}`}
+        className="ed-mgmt-user-link"
+      >
+        <div className="ed-mgmt-user-info">
+          <div className="ed-mgmt-user-topline">
+            <span className="ed-mgmt-name">{getDisplayName(participant.user)}</span>
+            {participant.user.final_score != null && (
+              <span className="ed-mgmt-user-score">{'★'} {participant.user.final_score.toFixed(1)} ({participant.user.rating_count})</span>
+            )}
+          </div>
+          <span className="ed-mgmt-username">@{participant.user.username}</span>
 
-        <div className="ed-participant-rating-summary">
-          {existingRating ? (
-            <>
-              <span className="ed-participant-rating-badge">{renderStars(existingRating.rating)} {existingRating.rating}/5</span>
-              {existingRating.message && (
-                <span className="ed-participant-rating-message">"{existingRating.message}"</span>
-              )}
-            </>
-          ) : null}
+          <div className="ed-participant-rating-summary">
+            {existingRating ? (
+              <>
+                <span className="ed-participant-rating-badge">{renderStars(existingRating.rating)} {existingRating.rating}/5</span>
+                {existingRating.message && (
+                  <span className="ed-participant-rating-message">"{existingRating.message}"</span>
+                )}
+              </>
+            ) : null}
+          </div>
         </div>
-      </div>
+      </Link>
 
       {canEdit && (
         <button
@@ -1885,17 +1896,25 @@ function EventContent({
         <div className="ed-section">
           <h2 className="ed-section-title">Host</h2>
           <div className="ed-host">
-            <UserAvatar
-              username={event.host.username}
-              displayName={event.host.display_name}
-              avatarUrl={event.host.avatar_url}
-              size="md"
-              variant="accent"
-            />
-            <div className="ed-host-info">
-              <p className="ed-host-name">{event.host.display_name ?? event.host.username}</p>
-              <p className="ed-host-username">@{event.host.username}</p>
-            </div>
+            <Link
+              to={`/users/${event.host.id}`}
+              className="ed-host-avatar-link"
+              aria-label={`View ${event.host.display_name ?? event.host.username}'s profile`}
+            >
+              <UserAvatar
+                username={event.host.username}
+                displayName={event.host.display_name}
+                avatarUrl={event.host.avatar_url}
+                size="md"
+                variant="accent"
+              />
+            </Link>
+            <Link to={`/users/${event.host.id}`} className="ed-host-link">
+              <div className="ed-host-info">
+                <p className="ed-host-name">{event.host.display_name ?? event.host.username}</p>
+                <p className="ed-host-username">@{event.host.username}</p>
+              </div>
+            </Link>
             {event.host_score.final_score != null && (
               <span className="ed-host-score">
                 {'★'} {event.host_score.final_score.toFixed(1)}

--- a/frontend/src/views/profile/ProfilePage.tsx
+++ b/frontend/src/views/profile/ProfilePage.tsx
@@ -8,6 +8,7 @@ import { useProfileViewModel } from '../../viewmodels/profile/useProfileViewMode
 import type { BadgeCategory, CatalogBadge, EarnedBadge, EventSummary } from '../../models/profile';
 import { getEventLifecyclePresentation } from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
+import { ProfileEquipmentSection, ProfileShowcaseSection } from './ProfilePublicSections';
 
 const ACCEPTED_TYPES = 'image/jpeg,image/png,image/webp';
 const MAX_SIZE_MB = 10;
@@ -530,6 +531,10 @@ export default function ProfilePage() {
   const { token } = useAuth();
   const {
     profile,
+    publicProfile,
+    publicProfileLoading,
+    publicProfileError,
+    refreshPublicProfile,
     hostedEvents,
     attendedEvents,
     earnedBadges,
@@ -571,10 +576,27 @@ export default function ProfilePage() {
     passwordSuccess,
     isChangingPassword,
     handleChangePassword,
+    isEquipmentEditorOpen,
+    equipmentDraft,
+    updateEquipmentDraft,
+    equipmentSubmitting,
+    equipmentDeletingId,
+    equipmentError,
+    startCreatingEquipment,
+    startEditingEquipment,
+    cancelEquipmentEditor,
+    handleEquipmentSubmit,
+    handleDeleteEquipment,
+    showcaseUploading,
+    showcaseRemovingId,
+    showcaseError,
+    handleShowcaseUpload,
+    handleDeleteShowcaseImage,
   } = useProfileViewModel(token);
   const [activeHistoryTab, setActiveHistoryTab] = useState<ProfileHistoryTab>('hosted');
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const showcaseInputRef = useRef<HTMLInputElement>(null);
 
   const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null;
@@ -585,6 +607,18 @@ export default function ProfilePage() {
       return;
     }
     handleFileChange(file);
+  };
+
+  const onShowcaseFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    if (!file) return;
+    if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+      alert(`File must be smaller than ${MAX_SIZE_MB} MB.`);
+      e.target.value = '';
+      return;
+    }
+    void handleShowcaseUpload(file);
+    e.target.value = '';
   };
 
   if (isLoading) {
@@ -623,8 +657,176 @@ export default function ProfilePage() {
     />
   );
 
+  const publicProfileSections = publicProfileLoading && !publicProfile ? (
+    <section className="profile-public-section">
+      <div className="profile-public-state inline">
+        <p>Loading equipment and showcase...</p>
+      </div>
+    </section>
+  ) : publicProfile ? (
+    <>
+      <ProfileEquipmentSection
+        items={publicProfile.equipment}
+        actions={(
+          <button
+            type="button"
+            className="edit-toggle-btn profile-inline-action-btn"
+            onClick={startCreatingEquipment}
+            disabled={equipmentSubmitting || equipmentDeletingId !== null}
+          >
+            Add Equipment
+          </button>
+        )}
+        itemActions={(item) => (
+          <>
+            <button
+              type="button"
+              className="profile-inline-btn"
+              onClick={() => startEditingEquipment(item)}
+              disabled={equipmentSubmitting || equipmentDeletingId === item.id}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              className="profile-inline-btn danger"
+              onClick={() => {
+                if (window.confirm('Delete this equipment item?')) {
+                  void handleDeleteEquipment(item.id);
+                }
+              }}
+              disabled={equipmentSubmitting || equipmentDeletingId === item.id}
+            >
+              {equipmentDeletingId === item.id ? 'Deleting...' : 'Delete'}
+            </button>
+          </>
+        )}
+        emptyMessage="You have not added any equipment yet."
+      />
+
+      {equipmentError ? (
+        <div className="profile-section-feedback error" role="alert">
+          {equipmentError}
+        </div>
+      ) : null}
+
+      {isEquipmentEditorOpen ? (
+        <form className="profile-inline-form" onSubmit={handleEquipmentSubmit}>
+          <div className="profile-inline-form-header">
+            <h3>{equipmentDraft.id ? 'Edit equipment' : 'Add equipment'}</h3>
+            <p>Share the gear you want other members to see on your profile.</p>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="equipment-name">Name</label>
+            <input
+              id="equipment-name"
+              type="text"
+              value={equipmentDraft.name}
+              onChange={(e) => updateEquipmentDraft('name', e.target.value)}
+              maxLength={64}
+              placeholder="Trail shoes, hydration pack, climbing rope..."
+              disabled={equipmentSubmitting}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="equipment-description">Description</label>
+            <textarea
+              id="equipment-description"
+              value={equipmentDraft.description}
+              onChange={(e) => updateEquipmentDraft('description', e.target.value)}
+              maxLength={512}
+              placeholder="Add a short note about fit, terrain, or why this item matters to you."
+              disabled={equipmentSubmitting}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="equipment-image">Image URL</label>
+            <input
+              id="equipment-image"
+              type="url"
+              value={equipmentDraft.imageUrl}
+              onChange={(e) => updateEquipmentDraft('imageUrl', e.target.value)}
+              placeholder="https://example.com/gear.jpg"
+              disabled={equipmentSubmitting}
+            />
+          </div>
+
+          <div className="form-actions">
+            <button
+              type="button"
+              className="cancel-btn"
+              onClick={cancelEquipmentEditor}
+              disabled={equipmentSubmitting}
+            >
+              Cancel
+            </button>
+            <button type="submit" className="save-btn" disabled={equipmentSubmitting}>
+              {equipmentSubmitting ? 'Saving...' : equipmentDraft.id ? 'Save Changes' : 'Add Equipment'}
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      <input
+        ref={showcaseInputRef}
+        type="file"
+        accept={ACCEPTED_TYPES}
+        onChange={onShowcaseFileChange}
+        style={{ display: 'none' }}
+      />
+
+      <ProfileShowcaseSection
+        items={publicProfile.showcase_images}
+        actions={(
+          <button
+            type="button"
+            className="edit-toggle-btn profile-inline-action-btn"
+            onClick={() => showcaseInputRef.current?.click()}
+            disabled={showcaseUploading}
+          >
+            {showcaseUploading ? 'Uploading...' : 'Upload Image'}
+          </button>
+        )}
+        imageActions={(image) => (
+          <button
+            type="button"
+            className="profile-showcase-remove"
+            onClick={() => {
+              if (window.confirm('Remove this showcase image?')) {
+                void handleDeleteShowcaseImage(image.id);
+              }
+            }}
+            disabled={showcaseRemovingId === image.id}
+            aria-label="Remove showcase image"
+          >
+            {showcaseRemovingId === image.id ? 'Removing...' : 'Remove'}
+          </button>
+        )}
+        emptyMessage="You have not uploaded any showcase images yet."
+      />
+
+      {showcaseError ? (
+        <div className="profile-section-feedback error" role="alert">
+          {showcaseError}
+        </div>
+      ) : null}
+    </>
+  ) : (
+    <section className="profile-public-section">
+      <div className="profile-public-state inline">
+        <p>{publicProfileError ?? 'Public profile sections are unavailable right now.'}</p>
+        <button type="button" className="save-btn profile-public-retry" onClick={() => void refreshPublicProfile()}>
+          Retry
+        </button>
+      </div>
+    </section>
+  );
+
   return (
-    <div className="profile-container">
+    <div className="profile-container profile-container-wide">
       <div className="profile-header">
         <h1>Your Profile</h1>
         <button
@@ -704,6 +906,8 @@ export default function ProfilePage() {
           badgeError={badgeError}
           onRetry={refreshBadges}
         />
+
+        {publicProfileSections}
 
         {changePasswordSection}
 
@@ -877,6 +1081,8 @@ export default function ProfilePage() {
               </button>
             </div>
           </form>
+
+          {publicProfileSections}
 
           {changePasswordSection}
         </div>

--- a/frontend/src/views/profile/ProfilePublicSections.tsx
+++ b/frontend/src/views/profile/ProfilePublicSections.tsx
@@ -1,0 +1,145 @@
+import type { ProfileEquipmentItem, PublicProfile, ShowcaseImageItem } from '@/models/profile';
+
+function getProfileInitial(profile: Pick<PublicProfile, 'display_name' | 'username'>): string {
+  const source = profile.display_name?.trim() || profile.username;
+  return source.charAt(0).toUpperCase() || '?';
+}
+
+function formatRatingSummary(profile: Pick<PublicProfile, 'host_rating_count' | 'participant_rating_count'>): string {
+  const totalRatings = profile.host_rating_count + profile.participant_rating_count;
+  if (totalRatings === 0) return 'No ratings yet';
+  return `${totalRatings} rating${totalRatings === 1 ? '' : 's'} collected`;
+}
+
+export function ProfilePublicHero({
+  profile,
+  eyebrow,
+}: {
+  profile: Pick<
+    PublicProfile,
+    'avatar_url' | 'bio' | 'display_name' | 'final_score' | 'host_rating_count' | 'participant_rating_count' | 'username'
+  >;
+  eyebrow?: string;
+}) {
+  return (
+    <section className="profile-public-hero">
+      <div className="profile-public-avatar" aria-hidden={!profile.avatar_url}>
+        {profile.avatar_url ? (
+          <img src={profile.avatar_url} alt="" />
+        ) : (
+          <span>{getProfileInitial(profile)}</span>
+        )}
+      </div>
+
+      <div className="profile-public-copy">
+        {eyebrow ? <p className="profile-public-eyebrow">{eyebrow}</p> : null}
+        <h1 className="profile-public-name">{profile.display_name ?? profile.username}</h1>
+        <p className="profile-public-username">@{profile.username}</p>
+        <p className={`profile-public-bio ${profile.bio ? '' : 'is-empty'}`}>
+          {profile.bio?.trim() || 'No bio provided yet.'}
+        </p>
+      </div>
+
+      <div className="profile-public-rating-card" aria-label="Profile rating">
+        <span className="profile-public-rating-value">
+          {profile.final_score != null ? `★ ${profile.final_score.toFixed(1)}` : 'New'}
+        </span>
+        <span className="profile-public-rating-summary">{formatRatingSummary(profile)}</span>
+        <span className="profile-public-rating-breakdown">
+          Host: {profile.host_rating_count} · Participant: {profile.participant_rating_count}
+        </span>
+      </div>
+    </section>
+  );
+}
+
+export function ProfileEquipmentSection({
+  items,
+  actions,
+  itemActions,
+  emptyMessage,
+}: {
+  items: ProfileEquipmentItem[];
+  actions?: React.ReactNode;
+  itemActions?: (item: ProfileEquipmentItem) => React.ReactNode;
+  emptyMessage: string;
+}) {
+  return (
+    <section className="profile-public-section">
+      <div className="profile-public-section-header">
+        <div>
+          <h2 className="profile-public-section-title">Equipment</h2>
+          <p className="profile-public-section-subtitle">Gear and essentials this member wants to highlight.</p>
+        </div>
+        {actions ? <div className="profile-public-section-actions">{actions}</div> : null}
+      </div>
+
+      {items.length > 0 ? (
+        <div className="profile-equipment-grid">
+          {items.map((item) => (
+            <article key={item.id} className="profile-equipment-card">
+              {item.image_url ? (
+                <img src={item.image_url} alt="" className="profile-equipment-image" />
+              ) : (
+                <div className="profile-equipment-image profile-equipment-image-placeholder" aria-hidden>
+                  {item.name.charAt(0).toUpperCase()}
+                </div>
+              )}
+
+              <div className="profile-equipment-content">
+                <div>
+                  <h3 className="profile-equipment-name">{item.name}</h3>
+                  {item.description ? (
+                    <p className="profile-equipment-description">{item.description}</p>
+                  ) : (
+                    <p className="profile-equipment-description is-empty">No description provided.</p>
+                  )}
+                </div>
+                {itemActions ? <div className="profile-equipment-actions">{itemActions(item)}</div> : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="profile-public-empty">{emptyMessage}</div>
+      )}
+    </section>
+  );
+}
+
+export function ProfileShowcaseSection({
+  items,
+  actions,
+  imageActions,
+  emptyMessage,
+}: {
+  items: ShowcaseImageItem[];
+  actions?: React.ReactNode;
+  imageActions?: (image: ShowcaseImageItem) => React.ReactNode;
+  emptyMessage: string;
+}) {
+  return (
+    <section className="profile-public-section">
+      <div className="profile-public-section-header">
+        <div>
+          <h2 className="profile-public-section-title">Showcase</h2>
+          <p className="profile-public-section-subtitle">Moments, snapshots, and visual highlights shared on the profile.</p>
+        </div>
+        {actions ? <div className="profile-public-section-actions">{actions}</div> : null}
+      </div>
+
+      {items.length > 0 ? (
+        <div className="profile-showcase-grid">
+          {items.map((image) => (
+            <figure key={image.id} className="profile-showcase-item">
+              <img src={image.image_url} alt="" className="profile-showcase-image" loading="lazy" />
+              {imageActions ? <figcaption className="profile-showcase-actions">{imageActions(image)}</figcaption> : null}
+            </figure>
+          ))}
+        </div>
+      ) : (
+        <div className="profile-public-empty">{emptyMessage}</div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/views/profile/PublicProfilePage.test.tsx
+++ b/frontend/src/views/profile/PublicProfilePage.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { PublicProfile } from '@/models/profile';
+import PublicProfilePage from './PublicProfilePage';
+
+const mockUsePublicProfileViewModel = vi.fn();
+
+vi.mock('../../viewmodels/profile/usePublicProfileViewModel', () => ({
+  usePublicProfileViewModel: (...args: unknown[]) => mockUsePublicProfileViewModel(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makePublicProfile(): PublicProfile {
+  return {
+    user_id: 'user-1',
+    username: 'summitseeker',
+    display_name: 'Summit Seeker',
+    avatar_url: null,
+    bio: 'Weekend hiker and route planner.',
+    final_score: 4.8,
+    host_rating_count: 7,
+    participant_rating_count: 3,
+    equipment: [
+      {
+        id: 'equipment-1',
+        name: 'Trail Shoes',
+        description: 'Reliable grip for mixed terrain.',
+        image_url: null,
+      },
+    ],
+    showcase_images: [
+      {
+        id: 'showcase-1',
+        image_url: 'https://cdn.example.com/showcase-1.jpg',
+      },
+    ],
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/users/user-1']}>
+      <Routes>
+        <Route path="/users/:userId" element={<PublicProfilePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('PublicProfilePage', () => {
+  it('renders public profile sections without private account fields', () => {
+    mockUsePublicProfileViewModel.mockReturnValue({
+      profile: makePublicProfile(),
+      isLoading: false,
+      error: null,
+      retry: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Summit Seeker')).toBeDefined();
+    expect(screen.getByText('@summitseeker')).toBeDefined();
+    expect(screen.getByText(/weekend hiker and route planner/i)).toBeDefined();
+    expect(screen.getByText('Trail Shoes')).toBeDefined();
+    expect(screen.queryByText(/email/i)).toBeNull();
+    expect(screen.queryByText(/default location/i)).toBeNull();
+  });
+
+  it('renders a loading state while the profile is being fetched', () => {
+    mockUsePublicProfileViewModel.mockReturnValue({
+      profile: null,
+      isLoading: true,
+      error: null,
+      retry: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(screen.getByText(/loading profile/i)).toBeDefined();
+  });
+
+  it('renders an error state and retries when requested', () => {
+    const retry = vi.fn();
+    mockUsePublicProfileViewModel.mockReturnValue({
+      profile: null,
+      isLoading: false,
+      error: 'Profile not found.',
+      retry,
+    });
+
+    renderPage();
+
+    expect(screen.getByText(/profile not found/i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(retry).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/views/profile/PublicProfilePage.tsx
+++ b/frontend/src/views/profile/PublicProfilePage.tsx
@@ -1,0 +1,50 @@
+import '@/styles/profile.css';
+import { useParams } from 'react-router-dom';
+import { ProfileEquipmentSection, ProfilePublicHero, ProfileShowcaseSection } from './ProfilePublicSections';
+import { usePublicProfileViewModel } from '../../viewmodels/profile/usePublicProfileViewModel';
+
+export default function PublicProfilePage() {
+  const { userId } = useParams<{ userId: string }>();
+  const { profile, isLoading, error, retry } = usePublicProfileViewModel(userId);
+
+  if (isLoading) {
+    return (
+      <div className="profile-container profile-container-wide">
+        <div className="profile-public-state">
+          <h1>Public Profile</h1>
+          <p>Loading profile...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="profile-container profile-container-wide">
+        <div className="profile-public-state">
+          <h1>Public Profile</h1>
+          <p>{error ?? 'This profile could not be loaded.'}</p>
+          <button type="button" className="save-btn profile-public-retry" onClick={() => void retry()}>
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="profile-container profile-container-wide">
+      <ProfilePublicHero profile={profile} eyebrow="Public profile" />
+
+      <ProfileEquipmentSection
+        items={profile.equipment}
+        emptyMessage="This member has not listed any equipment yet."
+      />
+
+      <ProfileShowcaseSection
+        items={profile.showcase_images}
+        emptyMessage="No showcase images have been added yet."
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 📋 Summary
This PR adds the frontend experience for public user profiles and the new profile asset sections introduced by the backend profile APIs. It lets users open read-only public profile pages, browse a member’s profile details/equipment/showcase content, and manage their own equipment/showcase items from the existing profile page.

## 🔄 Changes
- Added a new public profile route: `/users/:userId`
- Added a dedicated public profile page that displays:
  - avatar
  - display name
  - username
  - bio
  - rating summary
  - equipment
  - showcase images
- Updated the existing `/profile` page to support:
  - creating, editing, and deleting equipment items
  - uploading and removing showcase images
  - reusing the same public-profile sections for a more consistent UI
- Added links from event detail screens to public profile pages for:
  - event host
  - approved participants
- Extended frontend profile models and service calls for:
  - public profile fetch
  - equipment CRUD
  - showcase upload/confirm/delete
- Added targeted frontend tests for:
  - profile service behavior
  - public profile page rendering
  - event detail profile navigation

## 🧪 Testing
- Ran targeted frontend tests:
  - `cd frontend && npm test -- src/services/profileService.test.ts src/views/profile/PublicProfilePage.test.tsx src/views/events/EventDetailPage.test.tsx`
- Ran production build:
  - `cd frontend && npm run build`
- Smoke-tested the local app against the local backend stack on `http://localhost`

## 🔗 Related
Closes #496  
Related to #495
