### PR TITLE
fix(frontend): allow hosts to end in-progress events

### DIFF
--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -280,6 +280,13 @@ export function cancelEvent(
   return apiPatchAuth<void>(`/events/${eventId}/cancel`, {}, token);
 }
 
+export function completeEvent(
+  eventId: string,
+  token: string,
+): Promise<void> {
+  return apiPatchAuth<void>(`/events/${eventId}/complete`, {}, token);
+}
+
 export function upsertEventRating(
   eventId: string,
   request: RatingWriteRequest,

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -1092,6 +1092,28 @@
   cursor: not-allowed;
 }
 
+.ed-complete-event-btn {
+  width: 100%;
+  padding: 12px 24px;
+  border-radius: 10px;
+  border: 1px solid #0f766e;
+  background: #ecfeff;
+  color: #115e59;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ed-complete-event-btn:hover:not(:disabled) {
+  background-color: #cffafe;
+}
+
+.ed-complete-event-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Confirmation modal */
 .ed-modal-overlay {
   position: fixed;

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -15,6 +15,7 @@ import {
   approveJoinRequest,
   rejectJoinRequest,
   cancelEvent,
+  completeEvent,
   addFavorite,
   removeFavorite,
   upsertEventRating,
@@ -493,6 +494,8 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
 
   const [cancelLoading, setCancelLoading] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);
+  const [completeLoading, setCompleteLoading] = useState(false);
+  const [completeError, setCompleteError] = useState<string | null>(null);
 
   const handleCancel = useCallback(async () => {
     if (!eventId || !token) return;
@@ -514,6 +517,29 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
       }
     } finally {
       setCancelLoading(false);
+    }
+  }, [eventId, token, refreshEventDetail, refreshHostManagement]);
+
+  const handleComplete = useCallback(async () => {
+    if (!eventId || !token) return;
+    setCompleteLoading(true);
+    setCompleteError(null);
+
+    try {
+      await completeEvent(eventId, token);
+      await Promise.all([refreshEventDetail(), refreshHostManagement()]);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const errorMap: Record<string, string> = {
+          event_complete_not_allowed: 'Only the event host can end this event.',
+          event_not_completable: 'This event cannot be ended right now.',
+        };
+        setCompleteError(errorMap[err.code] ?? err.message);
+      } else {
+        setCompleteError('Failed to end event. Please try again.');
+      }
+    } finally {
+      setCompleteLoading(false);
     }
   }, [eventId, token, refreshEventDetail, refreshHostManagement]);
 
@@ -591,6 +617,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   const dismissLeaveError = useCallback(() => setLeaveError(null), []);
   const dismissModerateError = useCallback(() => setModerateError(null), []);
   const dismissCancelError = useCallback(() => setCancelError(null), []);
+  const dismissCompleteError = useCallback(() => setCompleteError(null), []);
   const dismissViewerRatingError = useCallback(() => setViewerRatingError(null), []);
   const dismissParticipantRatingError = useCallback(() => setParticipantRatingError(null), []);
   const dismissCoverImageError = useCallback(() => setCoverImageError(null), []);
@@ -778,6 +805,8 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     moderateError,
     cancelLoading,
     cancelError,
+    completeLoading,
+    completeError,
     favoriteLoading,
     reportLoading,
     reportError,
@@ -797,12 +826,14 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     handleApprove,
     handleReject,
     handleCancel,
+    handleComplete,
     dismissJoinError,
     dismissLeaveError,
     dismissViewerRatingError,
     dismissParticipantRatingError,
     dismissModerateError,
     dismissCancelError,
+    dismissCompleteError,
     coverImageUploading,
     coverImageError,
     coverImageSuccessMessage,

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -114,6 +114,8 @@ function makeReadyViewModel(event: EventDetailResponse) {
     moderateError: null,
     cancelLoading: false,
     cancelError: null,
+    completeLoading: false,
+    completeError: null,
     favoriteLoading: false,
     reportLoading: false,
     reportError: null,
@@ -127,6 +129,7 @@ function makeReadyViewModel(event: EventDetailResponse) {
     handleApprove: vi.fn(),
     handleReject: vi.fn(),
     handleCancel: vi.fn(),
+    handleComplete: vi.fn(),
     handleFavoriteToggle: vi.fn(),
     handleReportEvent: vi.fn(),
     dismissJoinError: vi.fn(),
@@ -135,6 +138,7 @@ function makeReadyViewModel(event: EventDetailResponse) {
     dismissParticipantRatingError: vi.fn(),
     dismissModerateError: vi.fn(),
     dismissCancelError: vi.fn(),
+    dismissCompleteError: vi.fn(),
     dismissReportError: vi.fn(),
     dismissReportSuccess: vi.fn(),
     coverImageUploading: false,
@@ -160,6 +164,24 @@ function makeReadyViewModel(event: EventDetailResponse) {
 }
 
 describe('EventDetailPage ratings', () => {
+  it('lets the host end an in-progress event from the management section', async () => {
+    const event = makeBaseEvent();
+    event.status = 'IN_PROGRESS';
+    event.viewer_context.is_host = true;
+
+    const vm = makeReadyViewModel(event);
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /end event/i }));
+    fireEvent.click(screen.getByRole('button', { name: /yes, end event/i }));
+
+    await waitFor(() => {
+      expect(vm.handleComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('opens the report modal from the flag button and submits the selected reason', async () => {
     const event = makeBaseEvent();
     const vm = makeReadyViewModel(event);

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -1346,6 +1346,45 @@ function CancelConfirmModal({
   );
 }
 
+function CompleteConfirmModal({
+  onConfirm,
+  onClose,
+  loading,
+}: {
+  onConfirm: () => void;
+  onClose: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="ed-modal-overlay" onClick={onClose}>
+      <div className="ed-modal" onClick={(e) => e.stopPropagation()}>
+        <h3 className="ed-modal-title">End Event</h3>
+        <p className="ed-modal-text">
+          Are you sure you want to end this event now? The event will be marked as completed.
+        </p>
+        <div className="ed-modal-actions">
+          <button
+            type="button"
+            className="ed-modal-cancel-btn"
+            onClick={onClose}
+            disabled={loading}
+          >
+            Go Back
+          </button>
+          <button
+            type="button"
+            className="ed-modal-confirm-btn"
+            onClick={onConfirm}
+            disabled={loading}
+          >
+            {loading ? <span className="spinner" /> : 'Yes, End Event'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ReportEventModal({
   loading,
   error,
@@ -1564,6 +1603,10 @@ function EventContent({
   cancelError,
   onCancel,
   onDismissCancelError,
+  completeLoading,
+  completeError,
+  onComplete,
+  onDismissCompleteError,
   favoriteLoading,
   onFavoriteToggle,
   reportLoading,
@@ -1631,6 +1674,10 @@ function EventContent({
   cancelError: string | null;
   onCancel: () => void;
   onDismissCancelError: () => void;
+  completeLoading: boolean;
+  completeError: string | null;
+  onComplete: () => void;
+  onDismissCompleteError: () => void;
   favoriteLoading: boolean;
   onFavoriteToggle: () => void;
   reportLoading: boolean;
@@ -1674,6 +1721,7 @@ function EventContent({
   const navigate = useNavigate();
   const coverFileInputRef = useRef<HTMLInputElement>(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [showCompleteModal, setShowCompleteModal] = useState(false);
   const [showReportModal, setShowReportModal] = useState(false);
   const [activeParticipantEditorId, setActiveParticipantEditorId] = useState<string | null>(null);
   const hostCanRateParticipants = (
@@ -1986,6 +2034,25 @@ function EventContent({
               </div>
             )}
 
+            {event.status === 'IN_PROGRESS' && (
+              <div className="ed-mgmt-group">
+                {completeError && (
+                  <div className="ed-join-error" style={{ marginBottom: 10 }}>
+                    <span>{completeError}</span>
+                    <button type="button" className="ed-join-error-dismiss" onClick={onDismissCompleteError}>&times;</button>
+                  </div>
+                )}
+                <button
+                  type="button"
+                  className="ed-complete-event-btn"
+                  onClick={() => setShowCompleteModal(true)}
+                  disabled={completeLoading}
+                >
+                  End Event
+                </button>
+              </div>
+            )}
+
             {/* Approved participants */}
             <div className="ed-mgmt-group">
               <h3 className="ed-mgmt-title">
@@ -2155,6 +2222,17 @@ function EventContent({
         />
       )}
 
+      {showCompleteModal && (
+        <CompleteConfirmModal
+          loading={completeLoading}
+          onConfirm={() => {
+            onComplete();
+            setShowCompleteModal(false);
+          }}
+          onClose={() => setShowCompleteModal(false)}
+        />
+      )}
+
       {showReportModal && (
         <ReportEventModal
           loading={reportLoading}
@@ -2254,6 +2332,10 @@ export default function EventDetailPage() {
       cancelError={vm.cancelError}
       onCancel={vm.handleCancel}
       onDismissCancelError={vm.dismissCancelError}
+      completeLoading={vm.completeLoading}
+      completeError={vm.completeError}
+      onComplete={vm.handleComplete}
+      onDismissCompleteError={vm.dismissCompleteError}
       favoriteLoading={vm.favoriteLoading}
       onFavoriteToggle={vm.handleFavoriteToggle}
       reportLoading={vm.reportLoading}


### PR DESCRIPTION
## 📋 Summary
This PR adds a frontend host action for ending events that are already in progress. The backend already supports completing `ACTIVE` and `IN_PROGRESS` events via the complete endpoint, but the web UI only exposed cancellation for active events. This change closes that gap by letting hosts explicitly mark in-progress events as completed from the event detail page.

## 🔄 Changes
- Added frontend support for the existing `PATCH /events/{id}/complete` endpoint.
- Added a host-only `End Event` action in the event detail management section when an event status is `IN_PROGRESS`.
- Added a confirmation modal before completing the event.
- Added frontend loading and error handling for the complete-event flow in the event detail view model.
- Added a targeted event detail test covering the new host completion action.

## 🧪 Testing
- Ran targeted frontend test:
  - `cd frontend && npm test -- src/views/events/EventDetailPage.test.tsx`
- Verified the new host action flow locally against the local stack on `http://localhost`

## 🔗 Related
Related to the existing backend complete-event support
