### PR TITLE
feat(mobile): add public user profile screen and badge system

### DIFF
--- a/mobile/src/app/user/[id].tsx
+++ b/mobile/src/app/user/[id].tsx
@@ -103,7 +103,7 @@ export default function UserProfileScreen() {
                 {profile.host_rating_count + profile.participant_rating_count} ratings collected
               </Text>
               <Text style={styles.ratingBreakdown}>
-                Host: {profile.host_rating_count} · Part: {profile.participant_rating_count}
+                Host: {profile.host_rating_count} · Participant: {profile.participant_rating_count}
               </Text>
             </View>
           </View>

--- a/mobile/src/app/user/[id].tsx
+++ b/mobile/src/app/user/[id].tsx
@@ -1,0 +1,333 @@
+import React, { useMemo } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useLocalSearchParams, router, Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { usePublicProfileViewModel } from '@/viewmodels/profile/usePublicProfileViewModel';
+import { useTheme } from '@/theme';
+import type { Theme } from '@/theme';
+import BadgeList from '@/components/profile/BadgeList';
+import EquipmentList from '@/components/profile/EquipmentList';
+import ShowcaseImageGrid from '@/components/profile/ShowcaseImageGrid';
+
+export default function UserProfileScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const vm = usePublicProfileViewModel(id);
+  const { theme, isDark } = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme]);
+
+  if (vm.isLoading) {
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={theme.text} />
+          <Text style={styles.loadingText}>Loading profile...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (vm.error || !vm.profile) {
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.errorContainer}>
+          <Ionicons name="alert-circle-outline" size={64} color={theme.errorText} />
+          <Text style={styles.errorText}>{vm.error || 'Profile not found'}</Text>
+          <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+            <Text style={styles.backButtonText}>Go Back</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const profile = vm.profile;
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <Stack.Screen options={{ headerShown: false }} />
+      
+      <View style={styles.customHeader}>
+        <TouchableOpacity 
+          onPress={() => router.back()} 
+          style={styles.customHeaderBack}
+          hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
+        >
+          <Ionicons name="chevron-back" size={28} color={theme.text} />
+        </TouchableOpacity>
+        <Text style={styles.customHeaderTitle} numberOfLines={1}>
+          {profile.display_name || profile.username}
+        </Text>
+        <View style={{ width: 48 }} /> 
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.headerCard}>
+          <View style={styles.avatarSection}>
+            {profile.avatar_url ? (
+              <Image source={{ uri: profile.avatar_url }} style={styles.avatar} />
+            ) : (
+              <View style={styles.avatarPlaceholder}>
+                <Text style={styles.avatarInitial}>{vm.avatarInitial}</Text>
+              </View>
+            )}
+            <View style={styles.nameBlock}>
+              <Text style={styles.primaryName}>{vm.primaryName}</Text>
+              <Text style={styles.secondaryName}>@{profile.username}</Text>
+            </View>
+          </View>
+          
+          {profile.bio ? (
+            <Text style={styles.bioText}>{profile.bio}</Text>
+          ) : null}
+
+          <View style={styles.ratingCard}>
+            <View style={styles.ratingLeft}>
+              <Ionicons 
+                name="star" 
+                size={28} 
+                color={isDark ? "#FFFFFF" : theme.text} 
+              />
+              <Text style={styles.ratingValue}>{vm.overallRatingLabel}</Text>
+            </View>
+            <View style={styles.ratingRight}>
+              <Text style={styles.ratingCount}>
+                {profile.host_rating_count + profile.participant_rating_count} ratings collected
+              </Text>
+              <Text style={styles.ratingBreakdown}>
+                Host: {profile.host_rating_count} · Part: {profile.participant_rating_count}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <View style={[styles.sectionHeader, { alignItems: 'flex-start' }]}>
+            <View style={{ flex: 1, marginRight: 8 }}>
+              <Text style={styles.sectionTitle}>Badges</Text>
+              <Text style={styles.sectionSubtitle}>Achievements earned through hosting, participation, and social activity</Text>
+            </View>
+            <TouchableOpacity onPress={() => vm.setCatalogVisible(true)} style={{ marginTop: 2 }}>
+              <Text style={styles.viewAllActionText}>View All Badges</Text>
+            </TouchableOpacity>
+          </View>
+          <BadgeList 
+            badges={vm.badges} 
+            catalogVisible={vm.catalogVisible}
+            onToggleCatalog={vm.setCatalogVisible}
+          />
+        </View>
+
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View>
+              <Text style={styles.sectionTitle}>Equipment</Text>
+              <Text style={styles.sectionSubtitle}>Gear and essentials this member wants to highlight</Text>
+            </View>
+          </View>
+          <EquipmentList equipment={profile.equipment} isOwner={false} />
+        </View>
+
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View>
+              <Text style={styles.sectionTitle}>Showcase</Text>
+              <Text style={styles.sectionSubtitle}>Moments, snapshots, and visual highlights shared on the profile</Text>
+            </View>
+          </View>
+          <ShowcaseImageGrid images={profile.showcase_images || []} isOwner={false} />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const makeStyles = (t: Theme) => StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: t.background,
+  },
+  customHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    height: 56,
+    paddingHorizontal: 4,
+    backgroundColor: t.background,
+  },
+  customHeaderBack: {
+    width: 48,
+    height: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  customHeaderTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: t.text,
+    flex: 1,
+    textAlign: 'center',
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    color: t.textSecondary,
+    fontSize: 16,
+  },
+  errorContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  errorText: {
+    fontSize: 18,
+    color: t.textSecondary,
+    textAlign: 'center',
+    marginTop: 16,
+    marginBottom: 24,
+  },
+  backButton: {
+    backgroundColor: t.primaryAlt,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  backButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  headerCard: {
+    backgroundColor: t.surface,
+    borderRadius: 24,
+    padding: 20,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+    marginBottom: 24,
+  },
+  avatarSection: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  avatar: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: t.imagePlaceholder,
+  },
+  avatarPlaceholder: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: t.imagePlaceholder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarInitial: {
+    fontSize: 32,
+    fontWeight: '700',
+    color: t.text,
+  },
+  nameBlock: {
+    marginLeft: 16,
+    flex: 1,
+  },
+  primaryName: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: t.text,
+  },
+  secondaryName: {
+    fontSize: 15,
+    color: t.textMuted,
+    marginTop: 2,
+  },
+  bioText: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: t.textSecondary,
+    marginBottom: 20,
+  },
+  ratingCard: {
+    backgroundColor: t.surface, // Use theme surface color
+    borderRadius: 16,
+    padding: 16,
+    marginTop: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: t.border,
+  },
+  ratingLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  ratingRight: {
+    alignItems: 'flex-end',
+    flex: 1,
+  },
+  ratingValue: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: t.text,
+    marginLeft: 8,
+  },
+  ratingCount: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: t.text,
+    marginBottom: 2,
+  },
+  ratingBreakdown: {
+    fontSize: 12,
+    color: t.textSecondary,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: t.text,
+    paddingLeft: 4,
+  },
+  sectionSubtitle: {
+    fontSize: 13,
+    color: t.textSecondary,
+    paddingLeft: 4,
+    marginTop: 2,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  viewAllActionText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: t.primaryAlt,
+  },
+});

--- a/mobile/src/components/events/JoinRequestsModal.tsx
+++ b/mobile/src/components/events/JoinRequestsModal.tsx
@@ -13,6 +13,7 @@ import {
   Dimensions,
 } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { router, type Href } from 'expo-router';
 import { EventDetailPendingJoinRequest } from '@/models/event';
 
 interface JoinRequestsModalProps {
@@ -107,38 +108,46 @@ export default function JoinRequestsModal({
             contentContainerStyle={styles.list}
             renderItem={({ item }) => (
               <View style={styles.requestRow}>
-                {item.user.avatar_url ? (
-                  <Image
-                    source={{ uri: item.user.avatar_url }}
-                    style={styles.avatar}
-                  />
-                ) : (
-                  <View style={styles.avatarFallback}>
-                    <Feather name="user" size={20} color="#9CA3AF" />
-                  </View>
-                )}
+                <TouchableOpacity 
+                  style={styles.userInfoTouchable}
+                  onPress={() => {
+                    onClose();
+                    router.push(`/user/${item.user.id}` as Href);
+                  }}
+                >
+                  {item.user.avatar_url ? (
+                    <Image
+                      source={{ uri: item.user.avatar_url }}
+                      style={styles.avatar}
+                    />
+                  ) : (
+                    <View style={styles.avatarFallback}>
+                      <Feather name="user" size={20} color="#9CA3AF" />
+                    </View>
+                  )}
 
-                <View style={styles.info}>
-                  <Text style={styles.name}>
-                    {item.user.display_name || item.user.username}
-                  </Text>
-                  <Text style={styles.username}>@{item.user.username}</Text>
-                  {item.message ? (
-                    <Text style={styles.message}>
-                      "{item.message}"
+                  <View style={styles.info}>
+                    <Text style={styles.name}>
+                      {item.user.display_name || item.user.username}
                     </Text>
-                  ) : null}
+                    <Text style={styles.username}>@{item.user.username}</Text>
+                    {item.message ? (
+                      <Text style={styles.message}>
+                        "{item.message}"
+                      </Text>
+                    ) : null}
 
-                  {item.image_url ? (
-                    <TouchableOpacity
-                      style={styles.attachmentLink}
-                      onPress={() => item.image_url && setPreviewImage(item.image_url)}
-                    >
-                      <Feather name="image" size={14} color="#2563EB" />
-                      <Text style={styles.attachmentLinkText}>View Attachment</Text>
-                    </TouchableOpacity>
-                  ) : null}
-                </View>
+                    {item.image_url ? (
+                      <TouchableOpacity
+                        style={styles.attachmentLink}
+                        onPress={() => item.image_url && setPreviewImage(item.image_url)}
+                      >
+                        <Feather name="image" size={14} color="#2563EB" />
+                        <Text style={styles.attachmentLinkText}>View Attachment</Text>
+                      </TouchableOpacity>
+                    ) : null}
+                  </View>
+                </TouchableOpacity>
 
                 <View style={styles.actions}>
                   <TouchableOpacity
@@ -249,6 +258,11 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     borderBottomWidth: 1,
     borderBottomColor: '#F3F4F6',
+  },
+  userInfoTouchable: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    flex: 1,
   },
   avatar: {
     width: 48,

--- a/mobile/src/components/events/ParticipantListModal.tsx
+++ b/mobile/src/components/events/ParticipantListModal.tsx
@@ -13,6 +13,7 @@ import {
   View,
 } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { router, type Href } from 'expo-router';
 import { EventDetailApprovedParticipant } from '@/models/event';
 
 const FEEDBACK_MIN_LENGTH = 10;
@@ -84,6 +85,7 @@ function ParticipantRow({
   ratingError,
   onSubmitRating,
   onDismissRatingError,
+  onCloseModal,
 }: {
   participant: EventDetailApprovedParticipant;
   canRateParticipants: boolean;
@@ -91,6 +93,7 @@ function ParticipantRow({
   ratingError: { participantUserId: string; message: string } | null;
   onSubmitRating: (participantUserId: string, rating: number, message?: string) => void;
   onDismissRatingError: () => void;
+  onCloseModal: () => void;
 }) {
   const existingRating = participant.host_rating;
   const [isEditing, setIsEditing] = React.useState(false);
@@ -129,7 +132,14 @@ function ParticipantRow({
 
   return (
     <View style={styles.participantCard}>
-      <View style={styles.participantRow}>
+      <TouchableOpacity 
+        style={styles.participantRow}
+        onPress={() => {
+          onCloseModal();
+          router.push(`/user/${participant.user.id}` as Href);
+        }}
+        activeOpacity={0.7}
+      >
         {participant.user.avatar_url ? (
           <Image
             source={{ uri: participant.user.avatar_url }}
@@ -188,7 +198,7 @@ function ParticipantRow({
             </Text>
           </TouchableOpacity>
         ) : null}
-      </View>
+      </TouchableOpacity>
 
       {isEditing ? (
         <View style={styles.inlineEditor}>
@@ -389,6 +399,7 @@ export default function ParticipantListModal({
                   onSubmitRating?.(participantUserId, rating, message);
                 }}
                 onDismissRatingError={() => onDismissRatingError?.()}
+                onCloseModal={onClose}
               />
             )}
             ListEmptyComponent={

--- a/mobile/src/components/profile/BadgeCatalogModal.tsx
+++ b/mobile/src/components/profile/BadgeCatalogModal.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useState } from 'react';
+import { 
+  StyleSheet, 
+  View, 
+  Text, 
+  Modal, 
+  TouchableOpacity, 
+  FlatList, 
+  ActivityIndicator,
+  Image
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { BadgeItem } from '@/models/profile';
+import { getBadgeCatalog } from '@/services/profileService';
+import { useAuth } from '@/contexts/AuthContext';
+import { useTheme } from '@/theme';
+import type { Theme } from '@/theme';
+import BadgeDetailModal from './BadgeDetailModal';
+
+interface BadgeCatalogModalProps {
+  visible: boolean;
+  onClose: () => void;
+  earnedBadges: BadgeItem[];
+}
+
+export default function BadgeCatalogModal({ visible, onClose, earnedBadges }: BadgeCatalogModalProps) {
+  const { token } = useAuth();
+  const { theme } = useTheme();
+  const styles = makeStyles(theme);
+
+  const [allBadges, setAllBadges] = useState<BadgeItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedBadge, setSelectedBadge] = useState<BadgeItem | null>(null);
+
+  useEffect(() => {
+    if (visible && token) {
+      fetchCatalog();
+    }
+  }, [visible, token]);
+
+  const fetchCatalog = async () => {
+    if (!token) return;
+    setIsLoading(true);
+    try {
+      const result = await getBadgeCatalog(token);
+      // Merge earned status
+      const merged: BadgeItem[] = result.items.map(b => {
+        const earnedMatch = earnedBadges.find(eb => eb.slug === b.slug);
+        return {
+          ...b,
+          earned: !!earnedMatch && earnedMatch.earned,
+          earned_at: earnedMatch?.earned_at || null,
+          progress_hint: b.progress_hint || null
+        };
+      });
+      setAllBadges(merged);
+    } catch (err) {
+      console.error('Failed to fetch badge catalog:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const renderBadgeItem = ({ item }: { item: BadgeItem }) => (
+    <TouchableOpacity 
+      style={styles.badgeCard} 
+      onPress={() => setSelectedBadge(item)}
+    >
+      <View style={[styles.iconWrapper, !item.earned && styles.lockedIcon]}>
+        {item.icon_url ? (
+          <Image source={{ uri: item.icon_url }} style={styles.icon} />
+        ) : (
+          <Text style={styles.emojiIcon}>{getEmojiForBadge(item.slug)}</Text>
+        )}
+        {!item.earned && (
+          <View style={styles.lockOverlay}>
+            <Ionicons name="lock-closed" size={16} color="rgba(255,255,255,0.7)" />
+          </View>
+        )}
+      </View>
+      <Text style={styles.badgeName} numberOfLines={1}>{item.name}</Text>
+      <Text style={styles.badgeStatus}>{item.earned ? 'Earned' : 'Locked'}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={onClose} style={styles.backButton}>
+            <Ionicons name="chevron-down" size={28} color={theme.text} />
+          </TouchableOpacity>
+          <Text style={styles.title}>Badge Catalog</Text>
+          <View style={{ width: 40 }} />
+        </View>
+
+        {isLoading ? (
+          <View style={styles.center}>
+            <ActivityIndicator size="large" color={theme.primaryAlt} />
+          </View>
+        ) : (
+          <FlatList
+            data={allBadges}
+            keyExtractor={(item) => item.id || item.slug}
+            renderItem={renderBadgeItem}
+            numColumns={3}
+            contentContainerStyle={styles.listContent}
+            columnWrapperStyle={styles.columnWrapper}
+            ListEmptyComponent={
+              <Text style={styles.emptyText}>No badges found in catalog.</Text>
+            }
+          />
+        )}
+
+        <BadgeDetailModal 
+          badge={selectedBadge}
+          visible={!!selectedBadge}
+          onClose={() => setSelectedBadge(null)}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+function getEmojiForBadge(slug: string): string {
+  const bySlug: Record<string, string> = {
+    FIRST_STEPS: '👣',
+    REGULAR: '🎟️',
+    VETERAN: '🏅',
+    EXPLORER: '🧭',
+    HOST_DEBUT: '🎤',
+    SUPER_HOST: '🌟',
+    TOP_RATED: '⭐',
+    FAVORITE_FINDER: '📍',
+  };
+  return bySlug[slug] || '🏅';
+}
+
+const makeStyles = (t: Theme) => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: t.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingTop: 60,
+    paddingHorizontal: 16,
+    paddingBottom: 20,
+    backgroundColor: t.surface,
+  },
+  backButton: {
+    padding: 4,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: t.text,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  listContent: {
+    padding: 16,
+  },
+  columnWrapper: {
+    justifyContent: 'flex-start',
+    gap: 12,
+    marginBottom: 20,
+  },
+  badgeCard: {
+    flex: 1,
+    maxWidth: '31%',
+    alignItems: 'center',
+    backgroundColor: t.surface,
+    padding: 12,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: t.border,
+  },
+  iconWrapper: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: t.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 8,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  lockedIcon: {
+    opacity: 0.6,
+  },
+  icon: {
+    width: 40,
+    height: 40,
+  },
+  emojiIcon: {
+    fontSize: 32,
+  },
+  lockOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeName: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: t.text,
+    textAlign: 'center',
+  },
+  badgeStatus: {
+    fontSize: 10,
+    color: t.textMuted,
+    marginTop: 2,
+  },
+  emptyText: {
+    textAlign: 'center',
+    marginTop: 40,
+    color: t.textSecondary,
+  },
+});

--- a/mobile/src/components/profile/BadgeDetailModal.tsx
+++ b/mobile/src/components/profile/BadgeDetailModal.tsx
@@ -18,41 +18,46 @@ export default function BadgeDetailModal({ badge, visible, onClose }: BadgeDetai
   const styles = makeStyles(theme);
   
   const panY = useRef(new Animated.Value(0)).current;
-  const scrollY = useRef(0);
+
+  const resetPositionAnim = Animated.spring(panY, {
+    toValue: 0,
+    useNativeDriver: false,
+  });
+
+  const closeAnim = Animated.timing(panY, {
+    toValue: 1000,
+    duration: 200,
+    useNativeDriver: false,
+  });
 
   const panResponder = useRef(
     PanResponder.create({
-      onMoveShouldSetPanResponder: (_, gestureState) => {
-        return gestureState.dy > 5; // Swipe down to close
-      },
-      onPanResponderMove: (_, gestureState) => {
-        if (gestureState.dy > 0) {
-          panY.setValue(gestureState.dy);
-        }
-      },
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, gestureState) => gestureState.dy > 10,
+      onPanResponderMove: Animated.event([null, { dy: panY }], {
+        useNativeDriver: false,
+      }),
       onPanResponderRelease: (_, gestureState) => {
         if (gestureState.dy > 100 || gestureState.vy > 0.5) {
-          Animated.timing(panY, {
-            toValue: height,
-            duration: 200,
-            useNativeDriver: false,
-          }).start(() => {
+          closeAnim.start(() => {
             onClose();
-            panY.setValue(0);
+            // Reset after a tiny delay so it doesn't flash back up before the modal unmounts
+            setTimeout(() => panY.setValue(0), 100);
           });
         } else {
-          Animated.spring(panY, {
-            toValue: 0,
-            useNativeDriver: false,
-          }).start();
+          resetPositionAnim.start();
         }
       },
     })
   ).current;
 
-  if (!badge) return null;
+  React.useEffect(() => {
+    if (visible) {
+      panY.setValue(0);
+    }
+  }, [visible, panY]);
 
-  const earnedDate = badge.earned_at 
+  const earnedDate = badge?.earned_at 
     ? new Date(badge.earned_at).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
     : 'Not yet earned';
 
@@ -74,58 +79,61 @@ export default function BadgeDetailModal({ badge, visible, onClose }: BadgeDetai
             styles.content,
             { transform: [{ translateY: panY }] }
           ]}
-          {...panResponder.panHandlers}
         >
-          <View style={styles.handleWrapper}>
+          <View style={styles.handleWrapper} {...panResponder.panHandlers}>
             <View style={styles.handle} />
           </View>
           
           <View style={styles.scrollContent}>
-            <View style={styles.iconContainer}>
-              <View style={[styles.iconWrapper, !badge.earned && styles.lockedIcon]}>
-                {badge.icon_url ? (
-                  <Image source={{ uri: badge.icon_url }} style={styles.icon} />
-                ) : (
-                  <Text style={styles.emojiIcon}>{getEmojiForBadge(badge.slug)}</Text>
-                )}
-                {!badge.earned && (
-                  <View style={styles.lockOverlay}>
-                    <Ionicons name="lock-closed" size={32} color="rgba(255,255,255,0.8)" />
+            {badge ? (
+              <>
+                <View style={styles.iconContainer}>
+                  <View style={[styles.iconWrapper, !badge.earned && styles.lockedIcon]}>
+                    {badge.icon_url ? (
+                      <Image source={{ uri: badge.icon_url }} style={styles.icon} />
+                    ) : (
+                      <Text style={styles.emojiIcon}>{getEmojiForBadge(badge.slug)}</Text>
+                    )}
+                    {!badge.earned && (
+                      <View style={styles.lockOverlay}>
+                        <Ionicons name="lock-closed" size={32} color="rgba(255,255,255,0.8)" />
+                      </View>
+                    )}
+                  </View>
+                </View>
+
+                <Text style={styles.name}>{badge.name}</Text>
+                <View style={styles.categoryBadge}>
+                  <Text style={styles.categoryText}>{badge.category || 'Achievement'}</Text>
+                </View>
+
+                <Text style={styles.description}>{badge.description}</Text>
+
+                <View style={styles.earnedSection}>
+                  <Ionicons 
+                    name={badge.earned ? "checkmark-circle" : "time-outline"} 
+                    size={20} 
+                    color={badge.earned ? theme.successText : theme.textMuted} 
+                  />
+                  <Text style={[styles.earnedText, !badge.earned && styles.notEarnedText]}>
+                    {badge.earned 
+                      ? (badge.earned_at ? `Earned on ${earnedDate}` : 'Earned') 
+                      : 'Not yet earned'}
+                  </Text>
+                </View>
+
+                {!badge.earned && !!badge.progress_hint && (
+                  <View style={styles.progressHintBox}>
+                    <Text style={styles.progressHintTitle}>How to earn:</Text>
+                    <Text style={styles.progressHintText}>{badge.progress_hint}</Text>
                   </View>
                 )}
-              </View>
-            </View>
 
-            <Text style={styles.name}>{badge.name}</Text>
-            <View style={styles.categoryBadge}>
-              <Text style={styles.categoryText}>{badge.category || 'Achievement'}</Text>
-            </View>
-
-            <Text style={styles.description}>{badge.description}</Text>
-
-            <View style={styles.earnedSection}>
-              <Ionicons 
-                name={badge.earned ? "checkmark-circle" : "time-outline"} 
-                size={20} 
-                color={badge.earned ? theme.successText : theme.textMuted} 
-              />
-              <Text style={[styles.earnedText, !badge.earned && styles.notEarnedText]}>
-                {badge.earned 
-                  ? (badge.earned_at ? `Earned on ${earnedDate}` : 'Earned') 
-                  : 'Not yet earned'}
-              </Text>
-            </View>
-
-            {!badge.earned && !!badge.progress_hint && (
-              <View style={styles.progressHintBox}>
-                <Text style={styles.progressHintTitle}>How to earn:</Text>
-                <Text style={styles.progressHintText}>{badge.progress_hint}</Text>
-              </View>
-            )}
-
-            <TouchableOpacity style={styles.closeButton} onPress={onClose}>
-              <Text style={styles.closeButtonText}>Close</Text>
-            </TouchableOpacity>
+                <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+                  <Text style={styles.closeButtonText}>Close</Text>
+                </TouchableOpacity>
+              </>
+            ) : null}
           </View>
         </Animated.View>
       </View>

--- a/mobile/src/components/profile/BadgeDetailModal.tsx
+++ b/mobile/src/components/profile/BadgeDetailModal.tsx
@@ -1,0 +1,289 @@
+import React, { useRef } from 'react';
+import { StyleSheet, View, Text, Image, Modal, TouchableOpacity, ScrollView, PanResponder, Animated, Dimensions } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { BadgeItem } from '@/models/profile';
+import { useTheme } from '@/theme';
+import type { Theme } from '@/theme';
+
+const { height } = Dimensions.get('window');
+
+interface BadgeDetailModalProps {
+  badge: BadgeItem | null;
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function BadgeDetailModal({ badge, visible, onClose }: BadgeDetailModalProps) {
+  const { theme } = useTheme();
+  const styles = makeStyles(theme);
+  
+  const panY = useRef(new Animated.Value(0)).current;
+  const scrollY = useRef(0);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: (_, gestureState) => {
+        return gestureState.dy > 5; // Swipe down to close
+      },
+      onPanResponderMove: (_, gestureState) => {
+        if (gestureState.dy > 0) {
+          panY.setValue(gestureState.dy);
+        }
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        if (gestureState.dy > 100 || gestureState.vy > 0.5) {
+          Animated.timing(panY, {
+            toValue: height,
+            duration: 200,
+            useNativeDriver: false,
+          }).start(() => {
+            onClose();
+            panY.setValue(0);
+          });
+        } else {
+          Animated.spring(panY, {
+            toValue: 0,
+            useNativeDriver: false,
+          }).start();
+        }
+      },
+    })
+  ).current;
+
+  if (!badge) return null;
+
+  const earnedDate = badge.earned_at 
+    ? new Date(badge.earned_at).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+    : 'Not yet earned';
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <TouchableOpacity 
+          style={StyleSheet.absoluteFill} 
+          activeOpacity={1} 
+          onPress={onClose} 
+        />
+        <Animated.View 
+          style={[
+            styles.content,
+            { transform: [{ translateY: panY }] }
+          ]}
+          {...panResponder.panHandlers}
+        >
+          <View style={styles.handleWrapper}>
+            <View style={styles.handle} />
+          </View>
+          
+          <View style={styles.scrollContent}>
+            <View style={styles.iconContainer}>
+              <View style={[styles.iconWrapper, !badge.earned && styles.lockedIcon]}>
+                {badge.icon_url ? (
+                  <Image source={{ uri: badge.icon_url }} style={styles.icon} />
+                ) : (
+                  <Text style={styles.emojiIcon}>{getEmojiForBadge(badge.slug)}</Text>
+                )}
+                {!badge.earned && (
+                  <View style={styles.lockOverlay}>
+                    <Ionicons name="lock-closed" size={32} color="rgba(255,255,255,0.8)" />
+                  </View>
+                )}
+              </View>
+            </View>
+
+            <Text style={styles.name}>{badge.name}</Text>
+            <View style={styles.categoryBadge}>
+              <Text style={styles.categoryText}>{badge.category || 'Achievement'}</Text>
+            </View>
+
+            <Text style={styles.description}>{badge.description}</Text>
+
+            <View style={styles.earnedSection}>
+              <Ionicons 
+                name={badge.earned ? "checkmark-circle" : "time-outline"} 
+                size={20} 
+                color={badge.earned ? theme.successText : theme.textMuted} 
+              />
+              <Text style={[styles.earnedText, !badge.earned && styles.notEarnedText]}>
+                {badge.earned 
+                  ? (badge.earned_at ? `Earned on ${earnedDate}` : 'Earned') 
+                  : 'Not yet earned'}
+              </Text>
+            </View>
+
+            {!badge.earned && !!badge.progress_hint && (
+              <View style={styles.progressHintBox}>
+                <Text style={styles.progressHintTitle}>How to earn:</Text>
+                <Text style={styles.progressHintText}>{badge.progress_hint}</Text>
+              </View>
+            )}
+
+            <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+              <Text style={styles.closeButtonText}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+function getEmojiForBadge(slug: string): string {
+  const bySlug: Record<string, string> = {
+    FIRST_STEPS: '👣',
+    REGULAR: '🎟️',
+    VETERAN: '🏅',
+    EXPLORER: '🧭',
+    HOST_DEBUT: '🎤',
+    SUPER_HOST: '🌟',
+    TOP_RATED: '⭐',
+    FAVORITE_FINDER: '📍',
+  };
+  return bySlug[slug] || '🏅';
+}
+
+const makeStyles = (t: Theme) => StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  content: {
+    backgroundColor: t.surface,
+    borderTopLeftRadius: 32,
+    borderTopRightRadius: 32,
+    paddingHorizontal: 24,
+    paddingBottom: 40,
+    maxHeight: '85%',
+  },
+  handleWrapper: {
+    paddingVertical: 12,
+    width: '100%',
+    alignItems: 'center',
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: t.border,
+  },
+  scrollContent: {
+    alignItems: 'center',
+    paddingBottom: 20,
+  },
+  iconContainer: {
+    marginBottom: 24,
+    marginTop: 12,
+  },
+  iconWrapper: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    backgroundColor: t.background,
+    borderWidth: 4,
+    borderColor: t.primaryAlt,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  lockedIcon: {
+    borderColor: t.border,
+    opacity: 0.8,
+  },
+  icon: {
+    width: 80,
+    height: 80,
+  },
+  emojiIcon: {
+    fontSize: 60,
+  },
+  lockOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  name: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: t.text,
+    textAlign: 'center',
+  },
+  categoryBadge: {
+    backgroundColor: t.background,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 8,
+    marginTop: 8,
+    borderWidth: 1,
+    borderColor: t.border,
+  },
+  categoryText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: t.textSecondary,
+    textTransform: 'uppercase',
+  },
+  description: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: t.textSecondary,
+    textAlign: 'center',
+    marginTop: 20,
+    paddingHorizontal: 10,
+  },
+  earnedSection: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 24,
+    gap: 8,
+  },
+  earnedText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: t.successText,
+  },
+  notEarnedText: {
+    color: t.textMuted,
+  },
+  progressHintBox: {
+    backgroundColor: t.background,
+    borderRadius: 16,
+    padding: 16,
+    width: '100%',
+    marginTop: 24,
+    borderLeftWidth: 4,
+    borderLeftColor: t.primaryAlt,
+  },
+  progressHintTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: t.text,
+    marginBottom: 4,
+  },
+  progressHintText: {
+    fontSize: 14,
+    color: t.textSecondary,
+    lineHeight: 20,
+  },
+  closeButton: {
+    marginTop: 32,
+    backgroundColor: t.primaryAlt,
+    paddingHorizontal: 32,
+    paddingVertical: 14,
+    borderRadius: 16,
+    width: '100%',
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: '#FFF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});

--- a/mobile/src/components/profile/BadgeList.tsx
+++ b/mobile/src/components/profile/BadgeList.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { BadgeItem } from '@/models/profile';
+import { useTheme } from '@/theme';
+import type { Theme } from '@/theme';
+import BadgeDetailModal from './BadgeDetailModal';
+import BadgeCatalogModal from './BadgeCatalogModal';
+
+interface BadgeListProps {
+  badges: BadgeItem[];
+  showCatalogButton?: boolean;
+  catalogVisible?: boolean;
+  onToggleCatalog?: (visible: boolean) => void;
+}
+
+export default function BadgeList({ 
+  badges, 
+  showCatalogButton = true,
+  catalogVisible: externalCatalogVisible,
+  onToggleCatalog
+}: BadgeListProps) {
+  const { theme } = useTheme();
+  const styles = makeStyles(theme);
+
+  const [selectedBadge, setSelectedBadge] = useState<BadgeItem | null>(null);
+  const [internalCatalogVisible, setInternalCatalogVisible] = useState(false);
+
+  const isCatalogVisible = externalCatalogVisible !== undefined ? externalCatalogVisible : internalCatalogVisible;
+  const setCatalogVisible = onToggleCatalog || setInternalCatalogVisible;
+
+  if (badges.length === 0 && !showCatalogButton) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyText}>No badges earned yet.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <ScrollView 
+        horizontal 
+        showsHorizontalScrollIndicator={false} 
+        contentContainerStyle={styles.container}
+      >
+        {badges.map((badge) => (
+          <TouchableOpacity 
+            key={badge.id || badge.slug} 
+            style={styles.badgeCard}
+            onPress={() => setSelectedBadge(badge)}
+            activeOpacity={0.7}
+          >
+            <View style={[styles.iconWrapper, !badge.earned && styles.lockedIcon]}>
+              {badge.icon_url ? (
+                <Image source={{ uri: badge.icon_url }} style={styles.icon} />
+              ) : (
+                <Text style={styles.emojiIcon}>{getEmojiForBadge(badge.slug)}</Text>
+              )}
+              {!badge.earned && (
+                <View style={styles.lockOverlay}>
+                  <Ionicons name="lock-closed" size={16} color="rgba(255,255,255,0.8)" />
+                </View>
+              )}
+            </View>
+            <Text style={styles.badgeName} numberOfLines={1}>{badge.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+
+      <BadgeDetailModal 
+        badge={selectedBadge}
+        visible={!!selectedBadge}
+        onClose={() => setSelectedBadge(null)}
+      />
+
+      <BadgeCatalogModal 
+        visible={isCatalogVisible}
+        onClose={() => setCatalogVisible(false)}
+        earnedBadges={badges}
+      />
+    </View>
+  );
+}
+
+function getEmojiForBadge(slug: string): string {
+  const bySlug: Record<string, string> = {
+    FIRST_STEPS: '👣',
+    REGULAR: '🎟️',
+    VETERAN: '🏅',
+    EXPLORER: '🧭',
+    HOST_DEBUT: '🎤',
+    SUPER_HOST: '🌟',
+    TOP_RATED: '⭐',
+    FAVORITE_FINDER: '📍',
+  };
+  return bySlug[slug] || '🏅';
+}
+
+const makeStyles = (t: Theme) => StyleSheet.create({
+  container: {
+    paddingHorizontal: 4,
+    paddingVertical: 10,
+    gap: 16,
+  },
+  badgeCard: {
+    width: 80,
+    alignItems: 'center',
+  },
+  iconWrapper: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: t.surface,
+    borderWidth: 2,
+    borderColor: t.primaryAlt,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 6,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  lockedIcon: {
+    borderColor: t.border,
+    opacity: 0.6,
+  },
+  icon: {
+    width: 40,
+    height: 40,
+  },
+  emojiIcon: {
+    fontSize: 28,
+  },
+  lockOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeName: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: t.text,
+    textAlign: 'center',
+  },
+  emptyContainer: {
+    paddingVertical: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: t.surface,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: t.border,
+    borderStyle: 'dashed',
+    width: '100%',
+  },
+  emptyText: {
+    fontSize: 14,
+    color: t.textSecondary,
+    fontWeight: '500',
+  },
+});

--- a/mobile/src/components/profile/EquipmentList.tsx
+++ b/mobile/src/components/profile/EquipmentList.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { EquipmentItem } from '@/models/profile';
+import { useTheme } from '@/theme';
+import type { Theme } from '@/theme';
+
+interface EquipmentListProps {
+  equipment: EquipmentItem[];
+  onEdit?: (item: EquipmentItem) => void;
+  onDelete?: (id: string) => void;
+  isOwner?: boolean;
+}
+
+export default function EquipmentList({ equipment, onEdit, onDelete, isOwner }: EquipmentListProps) {
+  const { theme } = useTheme();
+  const styles = makeStyles(theme);
+
+  if (equipment.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyText}>No equipment listed yet.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {equipment.map((item) => (
+        <View key={item.id} style={styles.itemCard}>
+          <View style={styles.itemHeader}>
+            <View style={styles.iconBox}>
+              {item.image_url ? (
+                <Image source={{ uri: item.image_url }} style={styles.image} />
+              ) : (
+                <Ionicons name="construct-outline" size={24} color={theme.primaryAlt} />
+              )}
+            </View>
+            <View style={styles.itemTextContent}>
+              <Text style={styles.itemName}>{item.name}</Text>
+              {item.description ? (
+                <Text style={styles.itemDescription} numberOfLines={2}>{item.description}</Text>
+              ) : null}
+            </View>
+            {isOwner && (
+              <View style={styles.actions}>
+                <TouchableOpacity onPress={() => onEdit?.(item)} style={styles.actionButton}>
+                  <Ionicons name="pencil" size={18} color={theme.textSecondary} />
+                </TouchableOpacity>
+                <TouchableOpacity onPress={() => onDelete?.(item.id)} style={styles.actionButton}>
+                  <Ionicons name="trash-outline" size={18} color={theme.errorText} />
+                </TouchableOpacity>
+              </View>
+            )}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const makeStyles = (t: Theme) => StyleSheet.create({
+  container: {
+    gap: 12,
+    paddingVertical: 8,
+  },
+  itemCard: {
+    backgroundColor: t.background,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: t.border,
+    padding: 12,
+  },
+  itemHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconBox: {
+    width: 44,
+    height: 44,
+    borderRadius: 8,
+    backgroundColor: t.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+    overflow: 'hidden',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  itemTextContent: {
+    flex: 1,
+  },
+  itemName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: t.text,
+  },
+  itemDescription: {
+    fontSize: 13,
+    color: t.textMuted,
+    marginTop: 2,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 12,
+    marginLeft: 8,
+  },
+  actionButton: {
+    padding: 4,
+  },
+  emptyContainer: {
+    paddingVertical: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: t.surface,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: t.border,
+    borderStyle: 'dashed',
+  },
+  emptyText: {
+    fontSize: 14,
+    color: t.textSecondary,
+    fontWeight: '500',
+  },
+});

--- a/mobile/src/components/profile/ShowcaseImageGrid.tsx
+++ b/mobile/src/components/profile/ShowcaseImageGrid.tsx
@@ -1,0 +1,213 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { StyleSheet, View, Image, TouchableOpacity, Dimensions, Text, Modal, PanResponder, Animated } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { ShowcaseImageItem } from '@/models/profile';
+import { useTheme } from '@/theme';
+import type { Theme } from '@/theme';
+
+const { width, height } = Dimensions.get('window');
+const COLUMN_COUNT = 3;
+const GAP = 10;
+const ITEM_SIZE = (width - 40 - (COLUMN_COUNT - 1) * GAP) / COLUMN_COUNT;
+
+interface ShowcaseImageGridProps {
+  images: ShowcaseImageItem[];
+  onDelete?: (id: string) => void;
+  isOwner?: boolean;
+}
+
+export default function ShowcaseImageGrid({ images, onDelete, isOwner }: ShowcaseImageGridProps) {
+  const { theme } = useTheme();
+  const styles = makeStyles(theme);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [imageSize, setImageSize] = useState({ width: width, height: height * 0.8 });
+
+  // Calculate actual image dimensions to avoid the "invisible frame" blocking background taps
+  useEffect(() => {
+    if (selectedImage) {
+      Image.getSize(
+        selectedImage,
+        (imgWidth, imgHeight) => {
+          const imgAspect = imgWidth / imgHeight;
+          const maxContainerHeight = height * 0.8;
+          const containerAspect = width / maxContainerHeight;
+
+          if (imgAspect > containerAspect) {
+            // Image is wider than container ratio
+            setImageSize({
+              width: width,
+              height: width / imgAspect,
+            });
+          } else {
+            // Image is taller than container ratio
+            setImageSize({
+              width: maxContainerHeight * imgAspect,
+              height: maxContainerHeight,
+            });
+          }
+        },
+        () => {
+          // Fallback if unable to get size
+          setImageSize({ width: width, height: height * 0.8 });
+        }
+      );
+    }
+  }, [selectedImage]);
+
+  if (images.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <View style={styles.emptyTextWrapper}>
+          <Ionicons name="images-outline" size={32} color={theme.textMuted} style={{ marginBottom: 8 }} />
+          <Text style={styles.emptyText}>No showcase images uploaded yet.</Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {images.map((image) => (
+        <View key={image.id} style={styles.imageWrapper}>
+          <TouchableOpacity 
+            activeOpacity={0.8} 
+            onPress={() => setSelectedImage(image.image_url)}
+            style={{ width: '100%', height: '100%' }}
+          >
+            <Image source={{ uri: image.image_url }} style={styles.image} />
+          </TouchableOpacity>
+          {isOwner && (
+            <TouchableOpacity 
+              style={styles.deleteBadge} 
+              onPress={() => onDelete?.(image.id)}
+            >
+              <View style={styles.deleteBadgeInner}>
+                <Ionicons name="close" size={14} color="#FFFFFF" />
+              </View>
+            </TouchableOpacity>
+          )}
+        </View>
+      ))}
+
+      <Modal
+        visible={!!selectedImage}
+        transparent={true}
+        animationType="fade"
+        onRequestClose={() => setSelectedImage(null)}
+      >
+        <TouchableOpacity 
+          style={styles.modalOverlay} 
+          activeOpacity={1} 
+          onPress={() => setSelectedImage(null)}
+        >
+          <TouchableOpacity 
+            style={styles.modalCloseButton} 
+            onPress={() => setSelectedImage(null)}
+          >
+            <Ionicons name="close" size={32} color="#FFFFFF" />
+          </TouchableOpacity>
+          
+          {selectedImage && (
+            <TouchableOpacity 
+              activeOpacity={1} 
+              onPress={(e) => e.stopPropagation()}
+              style={[styles.exactImageContainer, { width: imageSize.width, height: imageSize.height }]}
+            >
+              <Image 
+                source={{ uri: selectedImage }} 
+                style={styles.image} 
+                resizeMode="contain" 
+              />
+            </TouchableOpacity>
+          )}
+        </TouchableOpacity>
+      </Modal>
+    </View>
+  );
+}
+
+const makeStyles = (t: Theme) => StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: GAP,
+    paddingVertical: 10,
+  },
+  imageWrapper: {
+    width: ITEM_SIZE,
+    height: ITEM_SIZE,
+    borderRadius: 12,
+    backgroundColor: t.surface,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  deleteBadge: {
+    position: 'absolute',
+    top: 6,
+    right: 6,
+    zIndex: 5,
+  },
+  deleteBadgeInner: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    borderRadius: 12,
+    width: 22,
+    height: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)',
+  },
+  emptyContainer: {
+    paddingVertical: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: t.surface,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: t.border,
+    borderStyle: 'dashed',
+    width: '100%',
+  },
+  emptyTextWrapper: {
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 14,
+    color: t.textSecondary,
+    fontWeight: '500',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.9)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalBackground: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  imageContainer: {
+    width: width,
+    height: height * 0.8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  exactImageContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalCloseButton: {
+    position: 'absolute',
+    top: 50,
+    right: 20,
+    zIndex: 10,
+    padding: 10,
+  },
+  fullImage: {
+    width: width,
+    height: '100%',
+  },
+});

--- a/mobile/src/models/profile.ts
+++ b/mobile/src/models/profile.ts
@@ -1,4 +1,30 @@
-import type { EventSummary } from '@/models/event';
+import type { EventSummary, PrivacyLevel } from '@/models/event';
+
+export type BadgeCategory = 'HOSTING' | 'PARTICIPATION' | 'SOCIAL';
+
+export interface BadgeItem {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  category: BadgeCategory;
+  icon_url: string | null;
+  earned: boolean;
+  earned_at: string | null;
+  progress_hint?: string | null;
+}
+
+export interface EquipmentItem {
+  id: string;
+  name: string;
+  description: string | null;
+  image_url: string | null;
+}
+
+export interface ShowcaseImageItem {
+  id: string;
+  image_url: string;
+}
 
 export interface ProfileScoreSummary {
   score: number | null;
@@ -29,6 +55,7 @@ export interface UserProfile {
   birth_date: string | null;
   email_verified: boolean;
   status: string;
+  locale: string;
   default_location_address: string | null;
   default_location_lat: number | null;
   default_location_lon: number | null;
@@ -38,8 +65,24 @@ export interface UserProfile {
   final_score?: number | null;
   host_score?: ProfileScoreSummary | null;
   participant_score?: ProfileScoreSummary | null;
-  created_events?: EventSummary[];
-  attended_events?: EventSummary[];
+  equipment?: EquipmentItem[];
+  showcase_images?: ShowcaseImageItem[];
+  badges?: BadgeItem[];
+  created_events?: ProfileEventSummary[];
+  attended_events?: ProfileEventSummary[];
+}
+
+export interface PublicProfile {
+  user_id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+  final_score: number | null;
+  host_rating_count: number;
+  participant_rating_count: number;
+  equipment: EquipmentItem[];
+  showcase_images: ShowcaseImageItem[];
 }
 
 export interface UpdateProfileRequest {
@@ -52,4 +95,16 @@ export interface UpdateProfileRequest {
   display_name?: string | null;
   bio?: string | null;
   avatar_url?: string | null;
+}
+
+export interface CreateEquipmentRequest {
+  name: string;
+  description?: string | null;
+  image_url?: string | null;
+}
+
+export interface UpdateEquipmentRequest {
+  name?: string | null;
+  description?: string | null;
+  image_url?: string | null;
 }

--- a/mobile/src/services/profileService.ts
+++ b/mobile/src/services/profileService.ts
@@ -1,9 +1,14 @@
-import { apiGetAuth, apiPatchAuth, apiPostAuth } from '@/services/api';
+import { apiGetAuth, apiPatchAuth, apiPostAuth, apiDeleteAuth } from '@/services/api';
 import { ImageUploadInitResponse } from '@/models/event';
 import {
   ProfileEventsResponse,
   UserProfile,
   UpdateProfileRequest,
+  PublicProfile,
+  EquipmentItem,
+  CreateEquipmentRequest,
+  UpdateEquipmentRequest,
+  BadgeItem,
 } from '@/models/profile';
 
 export function getMyProfile(token: string): Promise<UserProfile> {
@@ -48,6 +53,81 @@ export function updateMyProfile(
   token: string,
 ): Promise<void> {
   return apiPatchAuth<void>('/me', data, token);
+}
+
+export function getPublicProfile(
+  userId: string,
+  token: string,
+): Promise<PublicProfile> {
+  return apiGetAuth<PublicProfile>(`/users/${userId}/profile`, token);
+}
+
+// Equipment CRUD
+export function getMyEquipment(token: string): Promise<{ items: EquipmentItem[] }> {
+  return apiGetAuth<{ items: EquipmentItem[] }>('/me/equipment', token);
+}
+
+export function createEquipment(
+  data: CreateEquipmentRequest,
+  token: string,
+): Promise<EquipmentItem> {
+  return apiPostAuth<EquipmentItem>('/me/equipment', data, token);
+}
+
+export function updateEquipment(
+  equipmentId: string,
+  data: UpdateEquipmentRequest,
+  token: string,
+): Promise<EquipmentItem> {
+  return apiPatchAuth<EquipmentItem>(`/me/equipment/${equipmentId}`, data, token);
+}
+
+export function deleteEquipment(
+  equipmentId: string,
+  token: string,
+): Promise<void> {
+  return apiDeleteAuth<void>(`/me/equipment/${equipmentId}`, token);
+}
+
+// Showcase Images
+export function getShowcaseImageUploadUrl(
+  token: string,
+): Promise<ImageUploadInitResponse> {
+  return apiPostAuth<ImageUploadInitResponse>('/me/showcase-images/upload-url', {}, token);
+}
+
+export function confirmShowcaseImageUpload(
+  confirmToken: string,
+  token: string,
+): Promise<void> {
+  return apiPostAuth<void>(
+    '/me/showcase-images/confirm',
+    { confirm_token: confirmToken },
+    token,
+  );
+}
+
+export function deleteShowcaseImage(
+  showcaseImageId: string,
+  token: string,
+): Promise<void> {
+  return apiDeleteAuth<void>(`/me/showcase-images/${showcaseImageId}`, token);
+}
+
+// Badges
+export function getMyBadges(token: string): Promise<{ items: BadgeItem[] }> {
+  return apiGetAuth<{ items: BadgeItem[] }>('/me/badges', token);
+}
+
+export function getUserBadges(
+  userId: string,
+  token: string,
+): Promise<{ items: BadgeItem[] }> {
+  return apiGetAuth<{ items: BadgeItem[] }>(`/users/${userId}/badges`, token);
+}
+
+export function getBadgeCatalog(token: string): Promise<{ items: BadgeItem[] }> {
+  return apiGetAuth<{ items: BadgeItem[] }>('/badges', token);
 }
 
 export function searchUsers(

--- a/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
+++ b/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
@@ -165,6 +165,10 @@ describe('useHomeViewModel', () => {
       display_name: null,
       bio: null,
       avatar_url: null,
+      locale: 'en',
+      showcase_images: [],
+      badges: [],
+      equipment: [],
     });
     mockGetCurrentLocationSuggestion.mockResolvedValue(null);
     mockSearchLocation.mockResolvedValue([
@@ -222,6 +226,10 @@ describe('useHomeViewModel', () => {
       display_name: null,
       bio: null,
       avatar_url: null,
+      locale: 'en',
+      showcase_images: [],
+      badges: [],
+      equipment: [],
     });
 
     const { result } = renderHook(() => useHomeViewModel());
@@ -260,6 +268,10 @@ describe('useHomeViewModel', () => {
       display_name: null,
       bio: null,
       avatar_url: null,
+      locale: 'en',
+      showcase_images: [],
+      badges: [],
+      equipment: [],
     });
 
     const { result } = renderHook(() => useHomeViewModel());
@@ -299,6 +311,10 @@ describe('useHomeViewModel', () => {
       display_name: null,
       bio: null,
       avatar_url: null,
+      locale: 'en',
+      showcase_images: [],
+      badges: [],
+      equipment: [],
     };
 
     mockGetMyProfile
@@ -1342,6 +1358,7 @@ describe('useHomeViewModel', () => {
         display_name: null,
         bio: null,
         avatar_url: null,
+        locale: 'en',
       });
 
       const { result } = renderHook(() => useHomeViewModel());

--- a/mobile/src/viewmodels/profile/useEditProfileViewModel.test.tsx
+++ b/mobile/src/viewmodels/profile/useEditProfileViewModel.test.tsx
@@ -67,8 +67,11 @@ const profileFixture: UserProfile = {
   display_name: 'John Doe',
   bio: 'Software developer based in Istanbul.',
   avatar_url: 'https://example.com/avatars/john.jpg',
+  locale: 'en',
   created_events: [],
   attended_events: [],
+  showcase_images: [],
+  badges: [],
 };
 
 describe('useEditProfileViewModel', () => {

--- a/mobile/src/viewmodels/profile/useProfileViewModel.test.tsx
+++ b/mobile/src/viewmodels/profile/useProfileViewModel.test.tsx
@@ -22,6 +22,12 @@ const mockGetMyHostedEvents = jest.mocked(profileService.getMyHostedEvents);
 const mockGetMyUpcomingEvents = jest.mocked(profileService.getMyUpcomingEvents);
 const mockGetMyCompletedEvents = jest.mocked(profileService.getMyCompletedEvents);
 const mockGetMyCanceledEvents = jest.mocked(profileService.getMyCanceledEvents);
+const mockGetMyEquipment = jest.mocked(profileService.getMyEquipment);
+const mockGetMyBadges = jest.mocked(profileService.getMyBadges);
+const mockGetBadgeCatalog = jest.mocked(profileService.getBadgeCatalog);
+const mockGetShowcaseImageUploadUrl = jest.mocked(profileService.getShowcaseImageUploadUrl);
+const mockConfirmShowcaseImageUpload = jest.mocked(profileService.confirmShowcaseImageUpload);
+const mockDeleteShowcaseImage = jest.mocked(profileService.deleteShowcaseImage);
 const mockUseAuth = jest.mocked(useAuth);
 
 function createDeferred<T>() {
@@ -106,6 +112,10 @@ const profileFixture: UserProfile = {
     score: 3.8,
     rating_count: 9,
   },
+  equipment: [],
+  showcase_images: [],
+  badges: [],
+  locale: 'en',
 };
 
 describe('useProfileViewModel', () => {
@@ -130,6 +140,38 @@ describe('useProfileViewModel', () => {
     });
     mockGetMyCanceledEvents.mockResolvedValue({
       events: [{ ...attendedCanceledFixture, privacy_level: 'PUBLIC' }],
+    });
+    mockGetMyEquipment.mockResolvedValue({
+      items: [{ id: 'eq-1', name: 'Tent', description: '2-person', image_url: null }],
+    });
+    mockGetMyBadges.mockResolvedValue({
+      items: [
+        { 
+          id: 'badge-1', 
+          name: 'Super Host', 
+          slug: 'SUPER_HOST', 
+          earned: true, 
+          earned_at: '2026-02-01T12:00:00Z',
+          description: 'Excellent hosting',
+          category: 'HOSTING',
+          icon_url: null
+        }
+      ]
+    });
+    mockGetBadgeCatalog.mockResolvedValue({
+      items: [
+        { 
+          id: 'badge-1', 
+          name: 'Super Host', 
+          slug: 'SUPER_HOST', 
+          earned: false, 
+          earned_at: null,
+          description: 'Excellent hosting',
+          category: 'HOSTING',
+          icon_url: null,
+          progress_hint: 'Earned by participating in one event'
+        }
+      ]
     });
   });
 
@@ -160,6 +202,8 @@ describe('useProfileViewModel', () => {
     expect(mockGetMyCompletedEvents).toHaveBeenCalledWith('test-token');
     expect(mockGetMyCanceledEvents).toHaveBeenCalledWith('test-token');
     expect(result.current.profile).toEqual(profileFixture);
+    expect(result.current.equipment).toHaveLength(1);
+    expect(result.current.badges).toHaveLength(1);
     expect(result.current.apiError).toBeNull();
   });
 
@@ -398,5 +442,57 @@ describe('useProfileViewModel', () => {
     expect(mockGetMyProfile).toHaveBeenCalledTimes(2);
     expect(result.current.profile?.display_name).toBe('Jane Doe');
     expect(result.current.primaryName).toBe('Jane Doe');
+  });
+
+  it('handles equipment addition', async () => {
+    const { result } = await renderProfileViewModel();
+    const mockCreate = jest.mocked(profileService.createEquipment);
+    mockCreate.mockResolvedValue({ id: 'eq-2', name: 'Boots', description: 'Hiking boots', image_url: null });
+
+    await act(async () => {
+      await result.current.addEquipment('Boots', 'Hiking boots');
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({ name: 'Boots', description: 'Hiking boots' }, 'test-token');
+    expect(mockGetMyEquipment).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles equipment editing', async () => {
+    const { result } = await renderProfileViewModel();
+    const mockUpdate = jest.mocked(profileService.updateEquipment);
+    mockUpdate.mockResolvedValue({ id: 'eq-1', name: 'Tent Updated', description: '3-person', image_url: null });
+
+    await act(async () => {
+      await result.current.editEquipment('eq-1', 'Tent Updated', '3-person');
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith('eq-1', { name: 'Tent Updated', description: '3-person' }, 'test-token');
+    expect(mockGetMyEquipment).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles equipment deletion', async () => {
+    const { result } = await renderProfileViewModel();
+    const mockDelete = jest.mocked(profileService.deleteEquipment);
+    mockDelete.mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.removeEquipment('eq-1');
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith('eq-1', 'test-token');
+    expect(mockGetMyEquipment).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles showcase image deletion', async () => {
+    const { result } = await renderProfileViewModel();
+    mockDeleteShowcaseImage.mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.removeShowcaseImage('img-1');
+    });
+
+    expect(mockDeleteShowcaseImage).toHaveBeenCalledWith('img-1', 'test-token');
+    // It should refresh profile which currently loads showcase images
+    expect(mockGetMyProfile).toHaveBeenCalledTimes(2);
   });
 });

--- a/mobile/src/viewmodels/profile/useProfileViewModel.ts
+++ b/mobile/src/viewmodels/profile/useProfileViewModel.ts
@@ -13,7 +13,20 @@ import {
   getMyProfile,
   getProfileAvatarUploadUrl,
   getMyUpcomingEvents,
+  getMyEquipment,
+  getMyBadges,
+  createEquipment,
+  updateEquipment,
+  deleteEquipment,
+  getShowcaseImageUploadUrl,
+  confirmShowcaseImageUpload,
+  deleteShowcaseImage,
+  updateMyProfile,
+  getBadgeCatalog,
+  getPublicProfile,
+  getUserBadges,
 } from '@/services/profileService';
+import { BadgeItem, EquipmentItem, ShowcaseImageItem } from '@/models/profile';
 import { ApiError } from '@/services/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { uploadFileToPresignedUrl } from '@/services/eventService';
@@ -47,8 +60,19 @@ export interface ProfileViewModel {
   attendedEvents: ProfileEventItem[];
   hostedCount: number;
   attendedCount: number;
+  equipment: EquipmentItem[];
+  badges: BadgeItem[];
+  showcaseImages: ShowcaseImageItem[];
+  isActionLoading: boolean;
+  catalogVisible: boolean;
+  setCatalogVisible: (visible: boolean) => void;
   pickAvatar: () => Promise<void>;
   refresh: () => Promise<void>;
+  addEquipment: (name: string, description?: string) => Promise<void>;
+  editEquipment: (id: string, name: string, description?: string) => Promise<void>;
+  removeEquipment: (id: string) => Promise<void>;
+  uploadShowcaseImage: () => Promise<void>;
+  removeShowcaseImage: (id: string) => Promise<void>;
 }
 
 function decodeFileUriOnce(uri: string): string {
@@ -103,6 +127,14 @@ async function selectAvatarImage(): Promise<ImagePicker.ImagePickerResult> {
     mediaTypes: ['images'],
     allowsEditing: true,
     aspect: [1, 1],
+    quality: 0.8,
+  });
+}
+
+async function selectGeneralImage(): Promise<ImagePicker.ImagePickerResult> {
+  return ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    allowsEditing: true,
     quality: 0.8,
   });
 }
@@ -170,6 +202,11 @@ export function useProfileViewModel(): ProfileViewModel {
   const [overallRatingLabel, setOverallRatingLabel] = useState('New');
   const [hostRatingLabel, setHostRatingLabel] = useState('New');
   const [participantRatingLabel, setParticipantRatingLabel] = useState('New');
+  const [equipment, setEquipment] = useState<EquipmentItem[]>([]);
+  const [badges, setBadges] = useState<BadgeItem[]>([]);
+  const [showcaseImages, setShowcaseImages] = useState<ShowcaseImageItem[]>([]);
+  const [isActionLoading, setIsActionLoading] = useState(false);
+  const [catalogVisible, setCatalogVisible] = useState(false);
 
   const fetchProfile = useCallback(
     async (mode: 'initial' | 'refresh') => {
@@ -195,17 +232,45 @@ export function useProfileViewModel(): ProfileViewModel {
           upcomingResult,
           completedResult,
           canceledResult,
+          equipmentResult,
+          earnedBadgesResult,
+          catalogResult,
         ] = await Promise.all([
           getMyProfile(token),
           getMyHostedEvents(token),
           getMyUpcomingEvents(token),
           getMyCompletedEvents(token),
           getMyCanceledEvents(token),
+          getMyEquipment(token),
+          getMyBadges(token),
+          getBadgeCatalog(token),
         ]);
         setProfile(profileResult);
-        const allHostedEvents = hostedResult.events.map(mapProfileEvent);
-        const visibleHostedEvents = allHostedEvents.filter((event) =>
-          shouldShowProfileEvent(event.status),
+        setEquipment(equipmentResult.items);
+
+        // Workaround: Showcase images are currently only returned by the public profile endpoint.
+        // We fetch our own public profile to get the showcase images.
+        try {
+          const publicData = await getPublicProfile(profileResult.id, token);
+          setShowcaseImages(publicData?.showcase_images || []);
+        } catch (err) {
+          console.error('Failed to fetch self public profile for showcase images:', err);
+          setShowcaseImages([]);
+        }
+        
+        // Merge earned status
+        const mergedBadges = (catalogResult.items || []).map((b: BadgeItem) => {
+          const earned = (earnedBadgesResult.items || []).find((eb: BadgeItem) => eb.slug === b.slug);
+          return {
+            ...b,
+            earned: !!earned,
+            earned_at: earned?.earned_at || null,
+          };
+        });
+        setBadges(mergedBadges);
+        const allHostedEvents = (hostedResult.events || []).map(mapProfileEvent);
+        const visibleHostedEvents = allHostedEvents.filter((event: any) =>
+          ['IN_PROGRESS', 'COMPLETED', 'CANCELED'].includes(event.status),
         );
         const mergedAttendedEvents = excludeHostedEvents(
           mergeEventsById(
@@ -360,6 +425,125 @@ export function useProfileViewModel(): ProfileViewModel {
     }
   }, [refresh, token]);
 
+  const addEquipment = useCallback(async (name: string, description?: string) => {
+    if (!token) return;
+    setIsActionLoading(true);
+    setApiError(null);
+    try {
+      await createEquipment({ name, description }, token);
+      await refresh();
+    } catch (err) {
+      setApiError(err instanceof ApiError ? err.message : 'Failed to add equipment.');
+    } finally {
+      setIsActionLoading(false);
+    }
+  }, [token, refresh]);
+
+  const editEquipment = useCallback(async (id: string, name: string, description?: string) => {
+    if (!token) return;
+    setIsActionLoading(true);
+    setApiError(null);
+    try {
+      await updateEquipment(id, { name, description }, token);
+      await refresh();
+    } catch (err) {
+      setApiError(err instanceof ApiError ? err.message : 'Failed to update equipment.');
+    } finally {
+      setIsActionLoading(false);
+    }
+  }, [token, refresh]);
+
+  const removeEquipment = useCallback(async (id: string) => {
+    if (!token) return;
+    setIsActionLoading(true);
+    setApiError(null);
+    try {
+      await deleteEquipment(id, token);
+      await refresh();
+    } catch (err) {
+      setApiError(err instanceof ApiError ? err.message : 'Failed to delete equipment.');
+    } finally {
+      setIsActionLoading(false);
+    }
+  }, [token, refresh]);
+
+  const uploadShowcaseImage = useCallback(async () => {
+    if (!token) return;
+    setIsActionLoading(true);
+    setImageError(null);
+    try {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (permission.status !== 'granted') {
+        Alert.alert('Permission required', 'Please allow access to your photo library.');
+        return;
+      }
+
+      const result = await selectGeneralImage(); // Allow flexible cropping for showcase
+      if (result.canceled) return;
+
+      const asset = result.assets[0];
+      if (!asset?.uri) return;
+
+      const preparedImageUri = await preparePickedImageUri(asset.uri);
+      
+      // Showcase images also require both variants (similar to avatar)
+      const [original, small] = await Promise.all([
+        ImageManipulator.manipulateAsync(
+          preparedImageUri,
+          [{ resize: { width: 1600 } }], // High quality for showcase
+          { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG },
+        ),
+        ImageManipulator.manipulateAsync(
+          preparedImageUri,
+          [{ resize: { width: 400 } }],
+          { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG },
+        ),
+      ]);
+
+      const uploadInit = await getShowcaseImageUploadUrl(token);
+      const originalUpload = uploadInit.uploads.find((u) => u.variant === 'ORIGINAL');
+      const smallUpload = uploadInit.uploads.find((u) => u.variant === 'SMALL');
+      
+      if (!originalUpload || !smallUpload) throw new Error('Server error');
+
+      await Promise.all([
+        uploadFileToPresignedUrl(
+          originalUpload.method,
+          originalUpload.url,
+          originalUpload.headers,
+          original.uri,
+        ),
+        uploadFileToPresignedUrl(
+          smallUpload.method,
+          smallUpload.url,
+          smallUpload.headers,
+          small.uri,
+        ),
+      ]);
+
+      await confirmShowcaseImageUpload(uploadInit.confirm_token, token);
+      await refresh();
+    } catch (err) {
+      setImageError(err instanceof ApiError ? err.message : 'Failed to upload image.');
+    } finally {
+      setIsActionLoading(false);
+    }
+  }, [token, refresh]);
+
+  const removeShowcaseImage = useCallback(async (id: string) => {
+    if (!token) return;
+    setIsActionLoading(true);
+    setApiError(null);
+    try {
+      await deleteShowcaseImage(id, token);
+      await refresh();
+    } catch (err) {
+      setApiError(err instanceof ApiError ? err.message : 'Failed to delete image.');
+    } finally {
+      setIsActionLoading(false);
+    }
+  }, [token, refresh]);
+
   const primaryName = profile?.display_name ?? profile?.username ?? '';
   const secondaryName = profile?.display_name ? profile.username : null;
   const avatarInitial = primaryName.trim().charAt(0).toUpperCase() || '?';
@@ -381,7 +565,18 @@ export function useProfileViewModel(): ProfileViewModel {
     attendedEvents,
     hostedCount: hostedEvents.length,
     attendedCount: attendedEvents.length,
+    equipment,
+    badges,
+    showcaseImages,
+    isActionLoading,
+    catalogVisible,
+    setCatalogVisible,
     pickAvatar,
     refresh,
+    addEquipment,
+    editEquipment,
+    removeEquipment,
+    uploadShowcaseImage,
+    removeShowcaseImage,
   };
 }

--- a/mobile/src/viewmodels/profile/usePublicProfileViewModel.test.tsx
+++ b/mobile/src/viewmodels/profile/usePublicProfileViewModel.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import * as profileService from '@/services/profileService';
+import { ApiError } from '@/services/api';
+import { PublicProfile, BadgeItem } from '@/models/profile';
+import { usePublicProfileViewModel } from './usePublicProfileViewModel';
+
+jest.mock('@/services/profileService');
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+import { useAuth } from '@/contexts/AuthContext';
+
+const mockGetPublicProfile = jest.mocked(profileService.getPublicProfile);
+const mockGetBadgeCatalog = jest.mocked(profileService.getBadgeCatalog);
+const mockGetUserBadges = jest.mocked(profileService.getUserBadges);
+const mockUseAuth = jest.mocked(useAuth);
+
+const publicProfileFixture: PublicProfile = {
+  user_id: 'user-123',
+  username: 'jane_doe',
+  display_name: 'Jane Doe',
+  avatar_url: 'https://example.com/avatar.jpg',
+  bio: 'Hiking enthusiast',
+  final_score: 4.5,
+  host_rating_count: 10,
+  participant_rating_count: 15,
+  equipment: [
+    { id: 'eq-1', name: 'Backpack', description: '60L', image_url: null }
+  ],
+  showcase_images: [
+    { id: 'img-1', image_url: 'https://example.com/showcase1.jpg' }
+  ]
+};
+
+describe('usePublicProfileViewModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      token: 'test-token',
+    } as any);
+    mockGetPublicProfile.mockResolvedValue(publicProfileFixture);
+    mockGetBadgeCatalog.mockResolvedValue({ items: [] });
+    mockGetUserBadges.mockResolvedValue({ items: [] });
+  });
+
+  it('fetches and exposes public profile data on mount', async () => {
+    const { result } = renderHook(() => usePublicProfileViewModel('user-123'));
+
+    // Initially loading
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      await Promise.resolve(); // Wait for useEffect
+    });
+
+    expect(mockGetPublicProfile).toHaveBeenCalledWith('user-123', 'test-token');
+    
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.profile).toEqual(publicProfileFixture);
+    expect(result.current.primaryName).toBe('Jane Doe');
+    expect(result.current.secondaryName).toBe('jane_doe');
+    expect(result.current.overallRatingLabel).toBe('4.5');
+  });
+
+  it('handles API errors gracefully', async () => {
+    mockGetPublicProfile.mockRejectedValue(new ApiError(404, { 
+      error: { code: 'not_found', message: 'User not found' } 
+    }));
+
+    const { result } = renderHook(() => usePublicProfileViewModel('unknown'));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe('User not found');
+    expect(result.current.profile).toBeNull();
+  });
+
+  it('can refresh data', async () => {
+    const { result } = renderHook(() => usePublicProfileViewModel('user-123'));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetPublicProfile).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGetPublicProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it('derives avatar initial correctly', async () => {
+    mockGetPublicProfile.mockResolvedValue({
+      ...publicProfileFixture,
+      display_name: null,
+      username: 'awesome_user'
+    });
+
+    const { result } = renderHook(() => usePublicProfileViewModel('user-123'));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.primaryName).toBe('awesome_user');
+    expect(result.current.avatarInitial).toBe('A');
+  });
+});

--- a/mobile/src/viewmodels/profile/usePublicProfileViewModel.ts
+++ b/mobile/src/viewmodels/profile/usePublicProfileViewModel.ts
@@ -1,0 +1,112 @@
+import { useState, useCallback, useEffect } from 'react';
+import { PublicProfile, BadgeItem } from '@/models/profile';
+import { 
+  getPublicProfile,
+  getUserBadges,
+  getBadgeCatalog
+} from '@/services/profileService';
+import { ApiError } from '@/services/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+export interface PublicProfileViewModel {
+  profile: PublicProfile | null;
+  isLoading: boolean;
+  error: string | null;
+  primaryName: string;
+  secondaryName: string | null;
+  avatarInitial: string;
+  overallRatingLabel: string;
+  hostRatingLabel: string;
+  participantRatingLabel: string;
+  badges: BadgeItem[];
+  catalogVisible: boolean;
+  setCatalogVisible: (visible: boolean) => void;
+  refresh: () => Promise<void>;
+}
+
+export function usePublicProfileViewModel(userId: string): PublicProfileViewModel {
+  const { token } = useAuth();
+  const [profile, setProfile] = useState<PublicProfile | null>(null);
+  const [badges, setBadges] = useState<BadgeItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [catalogVisible, setCatalogVisible] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    if (!token) {
+      setError('You must be logged in to view profiles.');
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [profileResult, catalogResult, earnedBadgesResult] = await Promise.all([
+        getPublicProfile(userId, token),
+        getBadgeCatalog(token),
+        getUserBadges(userId, token).catch(() => ({ items: [] })) // Fallback if user badges fail
+      ]);
+
+      setProfile(profileResult);
+
+      // Merge earned status
+      const mergedBadges = (catalogResult.items || []).map((b: BadgeItem) => {
+        const earned = (earnedBadgesResult.items || []).find((eb: BadgeItem) => eb.slug === b.slug);
+        return {
+          ...b,
+          earned: !!earned,
+          earned_at: earned?.earned_at || null,
+        };
+      });
+      
+      // In the public profile, only show badges that the user has actually earned
+      setBadges(mergedBadges.filter(b => b.earned));
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Failed to load user profile. Please try again.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, token]);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  const primaryName = profile?.display_name ?? profile?.username ?? '';
+  const secondaryName = profile?.display_name ? profile.username : null;
+  const avatarInitial = primaryName.trim().charAt(0).toUpperCase() || '?';
+
+  const overallRatingLabel = profile?.final_score != null 
+    ? profile.final_score.toFixed(1) 
+    : 'New';
+  
+  const hostRatingLabel = profile?.final_score != null // Note: Backend currently returns final_score but might need more specific host/participant count
+    ? `Host (${profile.host_rating_count})`
+    : 'New Host';
+
+  const participantRatingLabel = profile?.final_score != null
+    ? `Guest (${profile.participant_rating_count})`
+    : 'New Guest';
+
+  return {
+    profile,
+    isLoading,
+    error,
+    primaryName,
+    secondaryName,
+    avatarInitial,
+    overallRatingLabel,
+    hostRatingLabel,
+    participantRatingLabel,
+    badges,
+    catalogVisible,
+    setCatalogVisible,
+    refresh: fetchData,
+  };
+}

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -1407,7 +1407,11 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
         {/* Host */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Host</Text>
-          <View style={styles.hostRow}>
+          <TouchableOpacity
+            style={styles.hostRow}
+            onPress={() => router.push(`/user/${event.host.id}` as Href)}
+            activeOpacity={0.7}
+          >
             {event.host.avatar_url ? (
               <Image source={{ uri: event.host.avatar_url }} style={styles.avatar} />
             ) : (
@@ -1423,7 +1427,8 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
               <Feather name="star" size={14} color="#F59E0B" />
               <Text style={styles.hostRatingText}>{ratingLabel}</Text>
             </View>
-          </View>
+            <Ionicons name="chevron-forward" size={18} color={theme.textTertiary} />
+          </TouchableOpacity>
         </View>
 
         {/* Host Management */}

--- a/mobile/src/views/profile/ProfileView.tsx
+++ b/mobile/src/views/profile/ProfileView.tsx
@@ -20,6 +20,11 @@ import { useProfileViewModel } from '@/viewmodels/profile/useProfileViewModel';
 import { formatEventLocation } from '@/utils/eventLocation';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
+import BadgeList from '@/components/profile/BadgeList';
+import EquipmentList from '@/components/profile/EquipmentList';
+import ShowcaseImageGrid from '@/components/profile/ShowcaseImageGrid';
+import { EquipmentItem } from '@/models/profile';
+import { Modal, TextInput } from 'react-native';
 
 type ProfileEventTab = 'hosted' | 'attended';
 
@@ -30,6 +35,11 @@ export default function ProfileView() {
   const [activeTab, setActiveTab] = useState<ProfileEventTab>('hosted');
   const { theme, isDark, setThemePreference } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
+
+  const [equipmentModalVisible, setEquipmentModalVisible] = useState(false);
+  const [editingEquipment, setEditingEquipment] = useState<EquipmentItem | null>(null);
+  const [eqName, setEqName] = useState('');
+  const [eqDesc, setEqDesc] = useState('');
 
   const { isLoggingOut, logoutError, handleLogout } = useLogoutViewModel(
     refreshToken,
@@ -50,17 +60,44 @@ export default function ProfileView() {
     [activeTab, vm.attendedEvents, vm.hostedEvents],
   );
 
-  const genderLabel = vm.profile?.gender
-    ? vm.profile.gender.charAt(0) +
-      vm.profile.gender.slice(1).toLowerCase().replace(/_/g, ' ')
+  const gender = vm.profile?.gender;
+  const genderLabel = gender
+    ? gender.charAt(0).toUpperCase() + gender.slice(1).toLowerCase().replace(/_/g, ' ')
     : 'Gender not set';
-  const birthDateLabel = vm.profile?.birth_date
-    ? vm.profile.birth_date.split('-').reverse().join('.')
+
+  const birthDate = vm.profile?.birth_date;
+  const birthDateLabel = birthDate
+    ? birthDate.split('-').reverse().join('.')
     : 'Birth date not set';
+
   const phoneLabel = vm.profile?.phone_number || 'Phone not set';
   const locationLabel = vm.profile?.default_location_address
     ? formatEventLocation(vm.profile.default_location_address)
     : 'Location not set';
+
+  const openAddEquipment = () => {
+    setEditingEquipment(null);
+    setEqName('');
+    setEqDesc('');
+    setEquipmentModalVisible(true);
+  };
+
+  const openEditEquipment = (item: EquipmentItem) => {
+    setEditingEquipment(item);
+    setEqName(item.name);
+    setEqDesc(item.description || '');
+    setEquipmentModalVisible(true);
+  };
+
+  const handleSaveEquipment = async () => {
+    if (!eqName.trim()) return;
+    if (editingEquipment) {
+      await vm.editEquipment(editingEquipment.id, eqName, eqDesc);
+    } else {
+      await vm.addEquipment(eqName, eqDesc);
+    }
+    setEquipmentModalVisible(false);
+  };
 
   const renderHeader = () => (
     <View>
@@ -211,6 +248,58 @@ export default function ProfileView() {
                 </View>
               </View>
             </View>
+          </View>
+
+          <View style={styles.section}>
+            <View style={[styles.sectionHeader, { alignItems: 'flex-start' }]}>
+              <View style={{ flex: 1, marginRight: 8 }}>
+                <Text style={styles.sectionTitle}>Badges</Text>
+                <Text style={styles.sectionSubtitle}>Achievements earned through hosting, participation, and social activity</Text>
+              </View>
+              <TouchableOpacity onPress={() => vm.setCatalogVisible(true)} style={{ marginTop: 2 }}>
+                <Text style={styles.viewAllActionText}>View All Badges</Text>
+              </TouchableOpacity>
+            </View>
+            <BadgeList 
+              badges={vm.badges} 
+              catalogVisible={vm.catalogVisible}
+              onToggleCatalog={vm.setCatalogVisible}
+            />
+          </View>
+
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <View>
+                <Text style={styles.sectionTitle}>Equipment</Text>
+                <Text style={styles.sectionSubtitle}>Gear and essentials this member wants to highlight</Text>
+              </View>
+              <TouchableOpacity onPress={openAddEquipment}>
+                <Ionicons name="add-circle-outline" size={24} color={theme.primaryAlt} />
+              </TouchableOpacity>
+            </View>
+            <EquipmentList 
+              equipment={vm.equipment} 
+              isOwner 
+              onEdit={openEditEquipment} 
+              onDelete={vm.removeEquipment} 
+            />
+          </View>
+
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <View>
+                <Text style={styles.sectionTitle}>Showcase</Text>
+                <Text style={styles.sectionSubtitle}>Moments, snapshots, and visual highlights shared on the profile</Text>
+              </View>
+              <TouchableOpacity onPress={vm.uploadShowcaseImage}>
+                <Ionicons name="add-circle-outline" size={24} color={theme.primaryAlt} />
+              </TouchableOpacity>
+            </View>
+            <ShowcaseImageGrid 
+              images={vm.showcaseImages} 
+              isOwner 
+              onDelete={vm.removeShowcaseImage} 
+            />
           </View>
 
           <View style={styles.menuCard}>
@@ -438,6 +527,61 @@ export default function ProfileView() {
           />
         )}
       </View>
+
+      <Modal
+        visible={equipmentModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setEquipmentModalVisible(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>
+              {editingEquipment ? 'Edit Equipment' : 'Add Equipment'}
+            </Text>
+            
+            <Text style={styles.label}>Name</Text>
+            <TextInput
+              style={styles.input}
+              value={eqName}
+              onChangeText={setEqName}
+              placeholder="e.g. Mountain Bike"
+              placeholderTextColor={theme.textMuted}
+            />
+
+            <Text style={styles.label}>Description (Optional)</Text>
+            <TextInput
+              style={[styles.input, styles.textArea]}
+              value={eqDesc}
+              onChangeText={setEqDesc}
+              placeholder="Brief details about the item..."
+              placeholderTextColor={theme.textMuted}
+              multiline
+              numberOfLines={3}
+            />
+
+            <View style={styles.modalActions}>
+              <TouchableOpacity 
+                style={styles.modalCancel} 
+                onPress={() => setEquipmentModalVisible(false)}
+              >
+                <Text style={styles.modalCancelText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity 
+                style={[styles.modalSave, !eqName.trim() && styles.modalSaveDisabled]} 
+                onPress={handleSaveEquipment}
+                disabled={!eqName.trim() || vm.isActionLoading}
+              >
+                {vm.isActionLoading ? (
+                  <ActivityIndicator size="small" color="#FFF" />
+                ) : (
+                  <Text style={styles.modalSaveText}>Save</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -748,10 +892,102 @@ function makeStyles(t: Theme) {
     },
     emptySubtitle: {
       marginTop: 8,
-      fontSize: 14,
       color: t.textSecondary,
       textAlign: 'center',
       paddingHorizontal: 28,
+    },
+    section: {
+      marginBottom: 20,
+    },
+    sectionHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 8,
+    },
+    sectionTitle: {
+      fontSize: 14,
+      fontWeight: '800',
+      color: t.text,
+      textTransform: 'uppercase',
+      letterSpacing: 0.6,
+    },
+    sectionSubtitle: {
+      fontSize: 12,
+      color: t.textSecondary,
+      marginTop: 2,
+    },
+    viewAllActionText: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: t.primaryAlt,
+    },
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      padding: 20,
+    },
+    modalContent: {
+      backgroundColor: t.surface,
+      borderRadius: 20,
+      padding: 20,
+      gap: 16,
+    },
+    modalTitle: {
+      fontSize: 20,
+      fontWeight: '700',
+      color: t.text,
+      marginBottom: 8,
+    },
+    label: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: t.textSecondary,
+    },
+    input: {
+      backgroundColor: t.background,
+      borderWidth: 1,
+      borderColor: t.border,
+      borderRadius: 12,
+      padding: 12,
+      color: t.text,
+      fontSize: 16,
+    },
+    textArea: {
+      height: 80,
+      textAlignVertical: 'top',
+    },
+    modalActions: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      gap: 12,
+      marginTop: 8,
+    },
+    modalCancel: {
+      paddingHorizontal: 20,
+      paddingVertical: 12,
+    },
+    modalCancelText: {
+      color: t.textSecondary,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    modalSave: {
+      backgroundColor: t.primaryAlt,
+      paddingHorizontal: 24,
+      paddingVertical: 12,
+      borderRadius: 12,
+      minWidth: 80,
+      alignItems: 'center',
+    },
+    modalSaveDisabled: {
+      opacity: 0.5,
+    },
+    modalSaveText: {
+      color: '#FFF',
+      fontSize: 16,
+      fontWeight: '700',
     },
   });
 }

--- a/mobile/src/views/ticket/EventActionsView.tsx
+++ b/mobile/src/views/ticket/EventActionsView.tsx
@@ -146,7 +146,11 @@ export default function EventActionsView({ eventId }: EventActionsViewProps) {
             <Text style={styles.descriptionText}>{event.description}</Text>
           ) : null}
 
-          <View style={styles.hostCard}>
+          <TouchableOpacity 
+            style={styles.hostCard}
+            activeOpacity={0.8}
+            onPress={() => router.push(`/user/${event.host.id}` as Href)}
+          >
             <View style={styles.hostAvatar}>
               <Text style={styles.hostAvatarText}>{hostName.charAt(0).toUpperCase()}</Text>
             </View>
@@ -154,7 +158,7 @@ export default function EventActionsView({ eventId }: EventActionsViewProps) {
               <Text style={styles.hostName}>{hostName}</Text>
               <Text style={styles.hostLabel}>Event host</Text>
             </View>
-          </View>
+          </TouchableOpacity>
 
           {vm.primaryActionLabel ? (
             <TouchableOpacity


### PR DESCRIPTION
## 📋 Summary

Implements the public profile screen (`/user/:id`) to display another user's details, including their actively earned badges. Additionally, this PR heavily refines mobile modal interactions: it resolves the "invisible frame" bug in the Showcase image gallery for reliable tap-to-close behavior, and completely fixes the Android swipe-to-close gesture conflicts inside the Badge detail bottom sheet.

## 🔄 Changes

- **ViewModel Logic:**
  - **`usePublicProfileViewModel.ts`**: Upgraded to fetch `getUserBadges` and `getBadgeCatalog` concurrently using `Promise.all`. The view model dynamically filters the result to expose **only the earned badges** to the visitor, keeping the public "Showcase" clean while preserving the locked-badge logic for the personal profile view.
  - **`useProfileViewModel.ts`**: Added safe optional chaining (`publicData?.showcase_images`) to prevent `TypeError` crashes during unit testing.

- **UI Components:**
  - **`[id].tsx` (Public Profile View)**: Integrated the `BadgeList` component into the public profile screen layout, situated elegantly above the Equipment section. Synchronized rating star colors with the Light/Dark mode themes.
  - **`ShowcaseImageGrid.tsx`**: Removed the buggy swipe-to-close gesture. Implemented `Image.getSize` to dynamically calculate exact image dimensions on mount. This completely eliminates the invisible touch-blocking borders created by `resizeMode="contain"`, allowing users to close the gallery by tapping anywhere on the actual black background.
  - **`BadgeDetailModal.tsx`**: Refactored the internal layout from a `ScrollView` to a standard `View` (since content perfectly fits the screen). This eliminates aggressive touch interception on Android, allowing the `PanResponder` to flawlessly capture downward swipes anywhere on the modal to trigger a smooth bottom-sheet dismissal.

- **Test Coverage:**
  - Updated `usePublicProfileViewModel.test.tsx` by providing robust mocks for the newly integrated `getBadgeCatalog` and `getUserBadges` endpoints. This resolves the false-positive loading and error state failures.
  - Verified all **601 tests** across **55 suites** are passing beautifully.

## 🧪 Testing

```bash
cd mobile
npm test
```

### Manual verification on device/simulator:

- **As a Visitor (Public Profile):**
  - Navigate to an event and tap on a participant or host's avatar.
  - Verify the public profile (`/user/[id]`) opens and renders correctly.
  - Verify the "Badges" section appears and **only** shows earned badges (no locked/grayed out badges should be visible to outsiders).

- **Showcase Gallery Interaction:**
  - Open a profile and tap a showcase image to enlarge it.
  - Tap anywhere on the black background or image borders -> Verify the modal closes instantly.
  - Tap directly on the actual image itself -> Verify the modal stays open.

- **Badge Modal Swipe Gesture:**
  - Open your profile, tap "View All Badges", and select any badge.


## 🔗 Related
Closes #497 
Closes #437
