### PR TITLE
feat(backend): close rating-count coverage gap on discovery card (#498)

### DIFF
--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -13,6 +13,7 @@ import (
 	invitationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/invitation"
 	joinrequestapp "github.com/bounswe/bounswe2026group11/backend/internal/application/join_request"
 	notificationapp "github.com/bounswe/bounswe2026group11/backend/internal/application/notification"
+	ratingapp "github.com/bounswe/bounswe2026group11/backend/internal/application/rating"
 	"github.com/bounswe/bounswe2026group11/backend/internal/domain"
 	"github.com/bounswe/bounswe2026group11/backend/tests_integration/common"
 	"github.com/google/uuid"
@@ -944,6 +945,136 @@ func TestDiscoverEventsReflectsFavoriteStateForCurrentUser(t *testing.T) {
 	}
 	if favoriteState[plainID.String()] {
 		t.Fatalf("expected event %s to not be favorited", plainID)
+	}
+}
+
+// TestDiscoverEventsHostScoreReflectsHostRatingCountAndScore proves that the
+// discovery card payload (DiscoverableEventItem.HostScore) surfaces the
+// host's cached aggregate from user_score with no drift as ratings accrue.
+// The other discovery tests cover routing/sorting/filtering shape; this one
+// is the per-issue value-assertion gap called out by #498.
+//
+// Setup: the host owns one ACTIVE event used as the discoverable card, plus
+// a parallel COMPLETED event that participants rate. Discovery must surface
+// the host's aggregated count on the ACTIVE card after each rating cycle:
+//
+//	0 ratings → HostedEventRatingCount = 0, FinalScore = nil
+//	1 rating  → HostedEventRatingCount = 1, FinalScore != nil
+//	3 ratings → HostedEventRatingCount = 3, FinalScore != nil
+func TestDiscoverEventsHostScoreReflectsHostRatingCountAndScore(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("host_for_count_assertion"))
+	rater1 := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("rater_one"))
+	rater2 := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("rater_two"))
+	rater3 := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("rater_three"))
+	categoryID := common.GivenEventCategory(t)
+	// Pick coordinates far from the other discovery tests' origins so the
+	// shared testcontainers DB does not bleed our seed events into their
+	// result sets when run with t.Parallel(). Izmir Konak square — well
+	// outside any other test's radius.
+	originLat := 38.4189
+	originLon := 27.1287
+
+	// Discoverable event: stays ACTIVE (not rateable, but rendered on the card).
+	discoverableID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Host Score Card Subject",
+		Description:  "active event whose card should reflect host_score updates",
+		CategoryID:   categoryID,
+		Lat:          38.4192,
+		Lon:          27.1290,
+		StartTime:    time.Now().UTC().Add(24 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+
+	// Rateable event: completed, hosted by the same host. Each rater submits
+	// against this one to drive the host's cached aggregate counts upward.
+	rateableID := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID:       host.ID,
+		Title:        "Completed Event for Rating",
+		Description:  "completed so participants can rate the host",
+		CategoryID:   categoryID,
+		Lat:          38.4195,
+		Lon:          27.1294,
+		StartTime:    time.Now().UTC().Add(-2 * time.Hour),
+		PrivacyLevel: domain.PrivacyPublic,
+	})
+	for _, rater := range []*domain.User{rater1, rater2, rater3} {
+		insertParticipation(t, rateableID, rater.ID, domain.ParticipationStatusApproved)
+	}
+	updateEventStatus(t, rateableID, string(domain.EventStatusCompleted))
+
+	// helper: discover and pluck the discoverable card so each phase can
+	// re-assert the host_score values without re-stating the input shape.
+	requireCard := func(t *testing.T, viewerID uuid.UUID) eventapp.DiscoverableEventItem {
+		t.Helper()
+		result, err := harness.Service.DiscoverEvents(context.Background(), viewerID, eventapp.DiscoverEventsInput{
+			Lat: &originLat,
+			Lon: &originLon,
+		})
+		if err != nil {
+			t.Fatalf("DiscoverEvents() error = %v", err)
+		}
+		for _, item := range result.Items {
+			if item.ID == discoverableID.String() {
+				return item
+			}
+		}
+		t.Fatalf("discoverable event %s not found in result (%d items)", discoverableID, len(result.Items))
+		return eventapp.DiscoverableEventItem{}
+	}
+
+	// when / then — phase 1: zero ratings
+	card := requireCard(t, rater1.ID)
+	if card.HostScore.HostedEventRatingCount != 0 {
+		t.Fatalf("phase 1: expected hosted_event_rating_count=0, got %d", card.HostScore.HostedEventRatingCount)
+	}
+	if card.HostScore.FinalScore != nil {
+		t.Fatalf("phase 1: expected final_score=nil with no ratings, got %v", *card.HostScore.FinalScore)
+	}
+
+	// when / then — phase 2: single rating
+	// Rating message validation enforces 10–100 chars when present; keep all
+	// strings comfortably above the lower bound.
+	rating1Msg := "Excellent host, recommended."
+	if _, err := harness.RatingService.UpsertEventRating(
+		context.Background(), rater1.ID, rateableID,
+		ratingapp.UpsertRatingInput{Rating: 5, Message: &rating1Msg},
+	); err != nil {
+		t.Fatalf("UpsertEventRating(rater1): %v", err)
+	}
+	card = requireCard(t, rater1.ID)
+	if card.HostScore.HostedEventRatingCount != 1 {
+		t.Fatalf("phase 2: expected hosted_event_rating_count=1, got %d", card.HostScore.HostedEventRatingCount)
+	}
+	if card.HostScore.FinalScore == nil {
+		t.Fatalf("phase 2: expected final_score!=nil after first rating")
+	}
+
+	// when / then — phase 3: three ratings
+	rating2Msg := "Solid hosting, would recommend."
+	rating3Msg := "Reasonable but had some issues."
+	if _, err := harness.RatingService.UpsertEventRating(
+		context.Background(), rater2.ID, rateableID,
+		ratingapp.UpsertRatingInput{Rating: 4, Message: &rating2Msg},
+	); err != nil {
+		t.Fatalf("UpsertEventRating(rater2): %v", err)
+	}
+	if _, err := harness.RatingService.UpsertEventRating(
+		context.Background(), rater3.ID, rateableID,
+		ratingapp.UpsertRatingInput{Rating: 3, Message: &rating3Msg},
+	); err != nil {
+		t.Fatalf("UpsertEventRating(rater3): %v", err)
+	}
+	card = requireCard(t, rater1.ID)
+	if card.HostScore.HostedEventRatingCount != 3 {
+		t.Fatalf("phase 3: expected hosted_event_rating_count=3, got %d", card.HostScore.HostedEventRatingCount)
+	}
+	if card.HostScore.FinalScore == nil {
+		t.Fatalf("phase 3: expected final_score!=nil with three ratings")
 	}
 }
 


### PR DESCRIPTION
Closes #498                                                                                          
   
  ## Summary                                                                                           
                                                         
  Closes the acceptance criterion of #498 — "every backend response that exposes a score must also
  expose its matching rating count" — by adding the missing **integration-test value assertion** on
  `DiscoverableEventItem.HostScore.HostedEventRatingCount`. The audit (below) shows every score field
  across DTOs and OpenAPI is **already paired with a count** thanks to PRs #332, #576, and #605; this
  PR is the last loose end (test coverage), plus a contract reference for the web (#499) and mobile
  (#500) sibling teams.

  **No production behavior changes.** No DTO additions, no OpenAPI edits, no migrations, no new
  endpoints.

  ---

  ## Audit findings (no DTO/OpenAPI changes required)

  Every aggregate score field is already paired with a count:

  | Response shape | Score field | Paired count field | Source |
  |---|---|---|---|
  | `DiscoverableEventItem.HostScore` (`GET /api/events`) | `final_score` | `hosted_event_rating_count`
   | `backend/internal/application/event/service_dto.go` (`EventHostScoreSummary`) |
  | `GetEventDetailResult.HostScore` (`GET /api/events/:id`) | `final_score` |
  `hosted_event_rating_count` | same `EventHostScoreSummary` |
  | `EventDetailHostContextUser` (host-context endpoint) | `final_score` | `rating_count` |
  `event/service_dto.go:218` |
  | `GetProfileResult` (`GET /api/me`) | `final_score` | `host_rating_count`,
  `participant_rating_count`, plus nested `host_score.rating_count`, `participant_score.rating_count` |
   `profile/service_dto.go:61-77` |
  | `PublicProfileResult` (`GET /api/users/:id`, shipped in #605) | `final_score` |
  `host_rating_count`, `participant_rating_count` | `profile/service_dto.go:68-79` |
  | `domain.UserScore` (cache row) | `participant_score`, `hosted_event_score`, `final_score` |
  `participant_rating_count`, `hosted_event_rating_count` | `domain/rating.go:41` |

  OpenAPI specs already match the Go types — `docs/openapi/event.yaml` defines `EventHostScoreSummary`
  and `EventDetailHostContextUserSummary` with the count fields; `docs/openapi/profile.yaml` defines
  `ScoreSummary`, `UserProfile`, and `PublicProfile` likewise.

  **The rating package** (`backend/internal/application/rating/`) is write-side only —
  `UpsertUserScoreParams` carries `ParticipantScore + ParticipantRatingCount` and `HostedEventScore +
  HostedEventRatingCount` together, so no DTO can return a score without its count.

  ---

  ## Contract for #499 (web) and #500 (mobile)

  This section is the source of truth for client developers. **Field names are stable; counts are
  guaranteed wherever scores are guaranteed.**

  ### Score → count mapping (copy-paste reference)

  ```json
  // GET /api/events/:id  (event detail)
  {
    "host_score": {
      "final_score": 4.2,
      "hosted_event_rating_count": 12
    }
  }
  ```

  ```json
  // GET /api/events  (discovery card, repeated per item)
  {
    "items": [
      {
        "host_score": {
          "final_score": 4.2,
          "hosted_event_rating_count": 12
        }
      }
    ]
  }
  ```

  ```json
  // GET /api/me  (profile)
  {
    "final_score": 4.0,
    "host_score":        { "score": 4.5, "rating_count": 8  },
    "participant_score": { "score": 3.8, "rating_count": 12 }
  }
  ```

  ```json
  // GET /api/users/:id  (public profile, shipped in PR #605)
  {
    "final_score": 4.0,
    "host_rating_count": 8,
    "participant_rating_count": 12
  }
  ```

  ### Field semantics (clients should rely on these)

  - **`*_rating_count`** = number of completed ratings; counts every non-soft-deleted rating row
  backing the score.
  - **`final_score` / `score` is `null` when the matching count is `0`.** Render "no ratings yet" in
  that case rather than `0.0`.
  - Counts and scores live in the `user_score` cache table, refreshed transactionally on rating
  create/update/delete by `RefreshHostedEventScore` / `refreshUserScore`
  (`backend/internal/application/rating/service.go`). Eventually consistent within a single
  transaction; no client-side polling needed.
  - Naming: snake_case wire format throughout. `rating_count` / `host_rating_count` /
  `participant_rating_count` / `hosted_event_rating_count` chosen for unambiguous binding to the
  matching score.

  ### Backward compatibility

  Purely additive coverage. **No field renames, no removals, no shape changes.** Existing clients that
  already consume score+count keep working unchanged.

  ---

  ## What this PR adds

  A single integration test in `backend/tests_integration/event_test.go`:

  `TestDiscoverEventsHostScoreReflectsHostRatingCountAndScore` walks the host's cached aggregate as
  ratings accrue — proves the discovery card's `host_score` block matches `user_score` for **0 / 1 /
  3** rating counts:

  ```
  0 ratings → HostedEventRatingCount = 0,  FinalScore = nil
  1 rating  → HostedEventRatingCount = 1,  FinalScore != nil
  3 ratings → HostedEventRatingCount = 3,  FinalScore != nil
  ```

  Setup uses two events on the same host: one ACTIVE (rendered on the discovery card, since discovery
  hides COMPLETED events) and one COMPLETED (so participants can rate). Geographic isolation chosen far
   from other discovery tests' origins (Izmir Konak) to prevent `t.Parallel`-driven test pollution
  against the shared testcontainers Postgres.

  ---

  ## References

  ### Sibling issues (frontend/mobile)
  - Web — #499
  - Mobile — #500

  ### Closed PRs that did the underlying DTO/OpenAPI work
  - #332 — exposed `host_score` on event detail
  - #576 — added audience attributes (introduced/normalized `EventHostScoreSummary` shape)
  - #605 — added public profile equipment/showcase APIs (introduced `PublicProfileResult` with paired
  counts)

  ### Contribution conventions
  - https://github.com/bounswe/bounswe2026group11/blob/main/docs/conventions.md

  ---

  ## Test plan

  - [x] `go test -count=1 -tags=integration ./tests_integration/... -run
  "TestDiscoverEventsHostScoreReflectsHostRatingCountAndScore"` — new test passes (≈14s with
  testcontainers Postgres bring-up)
  - [x] `go test -count=1 -tags=integration ./tests_integration/...` — full suite green, no regression
  (≈22s)
  - [x] `go test -race -count=1 ./internal/...` — 30 packages, 0 races
  - [x] `go vet`, `staticcheck`, `golangci-lint` (0 issues), `gosec` (no findings) — all clean
  - [x] `go build ./cmd/server`

  ---

  ## Out of scope

  - Frontend (#499) and mobile (#500) consumer updates — separate PRs once this lands.
  - Score recomputation logic changes (`refreshUserScore` is unchanged).
  - Single-rating record DTOs (`AdminEventRatingItem`, `AdminParticipantRatingItem`) — these are
  individual rating rows, not aggregates, so a count field would be meaningless.