### PR TITLE
feat(mobile): improved the ui and ux

### DIFF
--- a/mobile/src/components/events/InvitationsModal.tsx
+++ b/mobile/src/components/events/InvitationsModal.tsx
@@ -18,6 +18,7 @@ import {
 import { Feather, MaterialIcons } from '@expo/vector-icons';
 import { EventDetailInvitation } from '@/models/event';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTheme, type Theme } from '@/theme';
 
 interface InvitationsModalProps {
   visible: boolean;
@@ -51,6 +52,8 @@ export default function InvitationsModal({
   isSearchingUsers,
 }: InvitationsModalProps) {
   const { user } = useAuth();
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => makeStyles(theme), [theme]);
   const [error, setError] = useState<string | null>(null);
   const [inviteMessage, setInviteMessage] = useState('');
 
@@ -131,13 +134,13 @@ export default function InvitationsModal({
   const getStatusStyle = (status: string) => {
     switch (status) {
       case 'ACCEPTED':
-        return { bg: '#DCFCE7', text: '#16A34A', label: 'Accepted' };
+        return { bg: theme.successBg, text: theme.successText, label: 'Accepted' };
       case 'DECLINED':
-        return { bg: '#FEE2E2', text: '#DC2626', label: 'Declined' };
+        return { bg: theme.errorBg, text: theme.errorText, label: 'Declined' };
       case 'CANCELED':
-        return { bg: '#F3F4F6', text: '#6B7280', label: 'Revoked' };
+        return { bg: theme.surfaceAlt, text: theme.textSecondary, label: 'Revoked' };
       default:
-        return { bg: '#FEF3C7', text: '#D97706', label: 'Pending' };
+        return { bg: theme.warningBg, text: theme.warningText, label: 'Pending' };
     }
   };
 
@@ -170,7 +173,7 @@ export default function InvitationsModal({
             <View style={styles.header}>
               <Text style={styles.title}>Manage Invitations</Text>
               <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
-                <Feather name="x" size={24} color="#111827" />
+                <Feather name="x" size={24} color={theme.text} />
               </TouchableOpacity>
             </View>
 
@@ -184,7 +187,7 @@ export default function InvitationsModal({
                   <TextInput
                     style={[styles.input, !!error && styles.inputError]}
                     placeholder="e.g. janesmith, bob"
-                    placeholderTextColor="#9CA3AF"
+                    placeholderTextColor={theme.placeholder}
                     value={userSearchQuery}
                     onChangeText={(val) => {
                       setUserSearchQuery(val);
@@ -217,7 +220,7 @@ export default function InvitationsModal({
                   disabled={selectedUsers.length === 0 && !userSearchQuery.trim() || isInviting}
                 >
                   {isInviting ? (
-                    <ActivityIndicator size="small" color="#FFFFFF" />
+                    <ActivityIndicator size="small" color={theme.textOnPrimary} />
                   ) : (
                     <Text style={styles.inviteBtnText}>Invite</Text>
                   )}
@@ -233,7 +236,7 @@ export default function InvitationsModal({
                         style={styles.chipRemoveBtn}
                         onPress={() => removeSelectedUser(username)}
                       >
-                        <MaterialIcons name="close" size={14} color="#6B7280" />
+                        <MaterialIcons name="close" size={14} color={theme.textSecondary} />
                       </TouchableOpacity>
                     </View>
                   ))}
@@ -247,7 +250,7 @@ export default function InvitationsModal({
                 <TextInput
                   style={styles.messageInput}
                   placeholder="e.g. Hope to see you there!"
-                  placeholderTextColor="#9CA3AF"
+                  placeholderTextColor={theme.placeholder}
                   value={inviteMessage}
                   onChangeText={setInviteMessage}
                   multiline
@@ -279,7 +282,7 @@ export default function InvitationsModal({
                       />
                     ) : (
                       <View style={styles.avatarFallback}>
-                        <Feather name="user" size={20} color="#9CA3AF" />
+                        <Feather name="user" size={20} color={theme.textTertiary} />
                       </View>
                     )}
 
@@ -314,7 +317,7 @@ export default function InvitationsModal({
                           );
                         }}
                       >
-                        <Feather name="trash-2" size={18} color="#DC2626" />
+                        <Feather name="trash-2" size={18} color={theme.errorText} />
                       </TouchableOpacity>
                     )}
                   </View>
@@ -322,7 +325,7 @@ export default function InvitationsModal({
               }}
               ListEmptyComponent={
                 <View style={styles.emptyContainer}>
-                  <MaterialIcons name="mail-outline" size={40} color="#D1D5DB" />
+                  <MaterialIcons name="mail-outline" size={40} color={theme.textTertiary} />
                   <Text style={styles.emptyText}>
                     {loading ? 'Loading invitations...' : 'No invitations sent yet.'}
                   </Text>
@@ -332,7 +335,7 @@ export default function InvitationsModal({
                 hasMore ? (
                   <TouchableOpacity style={styles.loadMoreBtn} onPress={onLoadMore}>
                     {loading ? (
-                      <ActivityIndicator size="small" color="#6366F1" />
+                      <ActivityIndicator size="small" color={theme.infoText} />
                     ) : (
                       <Text style={styles.loadMoreText}>Load more</Text>
                     )}
@@ -347,14 +350,15 @@ export default function InvitationsModal({
   );
 }
 
-const styles = StyleSheet.create({
+function makeStyles(t: Theme) {
+  return StyleSheet.create({
   overlay: {
     flex: 1,
-    backgroundColor: 'rgba(15, 23, 42, 0.5)',
+    backgroundColor: t.overlay,
     justifyContent: 'flex-end',
   },
   container: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: t.surface,
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
     paddingHorizontal: 20,
@@ -366,7 +370,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 4,
     borderRadius: 2,
-    backgroundColor: '#D1D5DB',
+    backgroundColor: t.borderStrong,
     alignSelf: 'center',
     marginBottom: 20,
   },
@@ -379,12 +383,12 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 22,
     fontWeight: '700',
-    color: '#111827',
+    color: t.text,
   },
   sectionTitle: {
     fontSize: 18,
     fontWeight: '600',
-    color: '#374151',
+    color: t.text,
     marginBottom: 12,
   },
   closeBtn: {
@@ -396,7 +400,7 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#374151',
+    color: t.textSecondary,
     marginBottom: 8,
   },
   labelRow: {
@@ -419,13 +423,13 @@ const styles = StyleSheet.create({
     paddingRight: 6,
     paddingVertical: 6,
     borderRadius: 16,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceAlt,
     borderWidth: 1,
-    borderColor: '#D1D5DB',
+    borderColor: t.borderStrong,
   },
   userChipText: {
     fontSize: 13,
-    color: '#111827',
+    color: t.text,
   },
   chipRemoveBtn: {
     padding: 2,
@@ -437,20 +441,20 @@ const styles = StyleSheet.create({
   input: {
     flex: 1,
     height: 56,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceVariant,
     borderRadius: 16,
     paddingHorizontal: 16,
     fontSize: 16,
-    color: '#111827',
+    color: t.text,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: t.border,
   },
   inputError: {
-    borderColor: '#EF4444',
-    backgroundColor: '#FEF2F2',
+    borderColor: t.errorBorder,
+    backgroundColor: t.errorBg,
   },
   inviteBtn: {
-    backgroundColor: '#111827',
+    backgroundColor: t.primary,
     borderRadius: 16,
     paddingHorizontal: 24,
     height: 56,
@@ -458,30 +462,30 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   inviteBtnDisabled: {
-    backgroundColor: '#9CA3AF',
+    opacity: 0.55,
   },
   inviteBtnText: {
-    color: '#FFFFFF',
+    color: t.textOnPrimary,
     fontWeight: '600',
     fontSize: 16,
   },
   hint: {
     fontSize: 12,
-    color: '#6B7280',
+    color: t.textMuted,
     marginTop: 8,
   },
   messageInputContainer: {
     marginTop: 16,
   },
   messageInput: {
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceVariant,
     borderRadius: 16,
     paddingHorizontal: 16,
     paddingVertical: 12,
     fontSize: 15,
-    color: '#111827',
+    color: t.text,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: t.border,
     textAlignVertical: 'top',
     minHeight: 60,
   },
@@ -490,10 +494,10 @@ const styles = StyleSheet.create({
     top: 60,
     left: 0,
     right: 0,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: t.surface,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: t.border,
     zIndex: 1000,
     elevation: 5,
     maxHeight: 200,
@@ -503,7 +507,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     borderBottomWidth: 1,
-    borderBottomColor: '#F3F4F6',
+    borderBottomColor: t.border,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
@@ -511,20 +515,20 @@ const styles = StyleSheet.create({
   suggestionText: {
     fontSize: 15,
     fontWeight: '600',
-    color: '#111827',
+    color: t.text,
   },
   suggestionSubtext: {
     fontSize: 13,
-    color: '#6B7280',
+    color: t.textSecondary,
   },
   errorText: {
     fontSize: 13,
-    color: '#DC2626',
+    color: t.errorText,
     marginTop: 6,
   },
   divider: {
     height: 1,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.border,
     marginBottom: 10,
   },
   list: {
@@ -535,19 +539,19 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 14,
     borderBottomWidth: 1,
-    borderBottomColor: '#F3F4F6',
+    borderBottomColor: t.border,
   },
   avatar: {
     width: 44,
     height: 44,
     borderRadius: 22,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceVariant,
   },
   avatarFallback: {
     width: 44,
     height: 44,
     borderRadius: 22,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceVariant,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -558,11 +562,11 @@ const styles = StyleSheet.create({
   name: {
     fontSize: 15,
     fontWeight: '600',
-    color: '#111827',
+    color: t.text,
   },
   username: {
     fontSize: 13,
-    color: '#6B7280',
+    color: t.textSecondary,
     marginTop: 1,
   },
   statusBadge: {
@@ -580,7 +584,7 @@ const styles = StyleSheet.create({
   },
   emptyText: {
     textAlign: 'center',
-    color: '#6B7280',
+    color: t.textSecondary,
     marginTop: 12,
     fontSize: 15,
   },
@@ -590,10 +594,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 10,
     borderRadius: 999,
-    backgroundColor: '#F5F3FF',
+    backgroundColor: t.infoBg,
   },
   loadMoreText: {
-    color: '#7C3AED',
+    color: t.infoText,
     fontWeight: '600',
   },
   revokeBtn: {
@@ -601,8 +605,9 @@ const styles = StyleSheet.create({
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: '#FEF2F2',
+    backgroundColor: t.errorBg,
     alignItems: 'center',
     justifyContent: 'center',
   },
-});
+  });
+}

--- a/mobile/src/components/events/JoinRequestsModal.tsx
+++ b/mobile/src/components/events/JoinRequestsModal.tsx
@@ -15,6 +15,7 @@ import {
 import { Feather } from '@expo/vector-icons';
 import { router, type Href } from 'expo-router';
 import { EventDetailPendingJoinRequest } from '@/models/event';
+import { useTheme, type Theme } from '@/theme';
 
 interface JoinRequestsModalProps {
   visible: boolean;
@@ -39,6 +40,8 @@ export default function JoinRequestsModal({
   onApprove,
   onReject,
 }: JoinRequestsModalProps) {
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => makeStyles(theme), [theme]);
   const [previewImage, setPreviewImage] = React.useState<string | null>(null);
   const panY = React.useRef(new Animated.Value(0)).current;
 
@@ -98,7 +101,7 @@ export default function JoinRequestsModal({
           <View style={styles.header}>
             <Text style={styles.title}>Pending Requests ({requests.length})</Text>
             <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
-              <Feather name="x" size={24} color="#111827" />
+              <Feather name="x" size={24} color={theme.text} />
             </TouchableOpacity>
           </View>
 
@@ -122,7 +125,7 @@ export default function JoinRequestsModal({
                     />
                   ) : (
                     <View style={styles.avatarFallback}>
-                      <Feather name="user" size={20} color="#9CA3AF" />
+                      <Feather name="user" size={20} color={theme.textTertiary} />
                     </View>
                   )}
 
@@ -142,7 +145,7 @@ export default function JoinRequestsModal({
                         style={styles.attachmentLink}
                         onPress={() => item.image_url && setPreviewImage(item.image_url)}
                       >
-                        <Feather name="image" size={14} color="#2563EB" />
+                        <Feather name="image" size={14} color={theme.infoText} />
                         <Text style={styles.attachmentLinkText}>View Attachment</Text>
                       </TouchableOpacity>
                     ) : null}
@@ -154,14 +157,14 @@ export default function JoinRequestsModal({
                     style={[styles.actionBtn, styles.rejectBtn]}
                     onPress={() => onReject(item.join_request_id)}
                   >
-                    <Feather name="x" size={20} color="#DC2626" />
+                    <Feather name="x" size={20} color={theme.errorText} />
                   </TouchableOpacity>
 
                   <TouchableOpacity
                     style={[styles.actionBtn, styles.approveBtn]}
                     onPress={() => onApprove(item.join_request_id)}
                   >
-                    <Feather name="check" size={20} color="#16A34A" />
+                    <Feather name="check" size={20} color={theme.successText} />
                   </TouchableOpacity>
                 </View>
               </View>
@@ -212,14 +215,15 @@ export default function JoinRequestsModal({
   );
 }
 
-const styles = StyleSheet.create({
+function makeStyles(t: Theme) {
+  return StyleSheet.create({
   overlay: {
     flex: 1,
-    backgroundColor: 'rgba(15, 23, 42, 0.5)',
+    backgroundColor: t.overlay,
     justifyContent: 'flex-end',
   },
   container: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: t.surface,
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
     paddingHorizontal: 20,
@@ -231,7 +235,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 4,
     borderRadius: 2,
-    backgroundColor: '#D1D5DB',
+    backgroundColor: t.borderStrong,
     alignSelf: 'center',
     marginBottom: 20,
   },
@@ -244,7 +248,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 20,
     fontWeight: '700',
-    color: '#111827',
+    color: t.text,
   },
   closeBtn: {
     padding: 4,
@@ -257,7 +261,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     paddingVertical: 14,
     borderBottomWidth: 1,
-    borderBottomColor: '#F3F4F6',
+    borderBottomColor: t.border,
   },
   userInfoTouchable: {
     flexDirection: 'row',
@@ -268,13 +272,13 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceVariant,
   },
   avatarFallback: {
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceVariant,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -285,16 +289,17 @@ const styles = StyleSheet.create({
   name: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#111827',
+    color: t.text,
   },
   username: {
     fontSize: 14,
-    color: '#6B7280',
+    color: t.textSecondary,
     marginTop: 2,
   },
   message: {
     marginTop: 4,
     fontStyle: 'italic',
+    color: t.textSecondary,
   },
   attachmentLink: {
     flexDirection: 'row',
@@ -303,14 +308,14 @@ const styles = StyleSheet.create({
     marginTop: 8,
     paddingVertical: 4,
     paddingHorizontal: 8,
-    backgroundColor: '#EFF6FF',
+    backgroundColor: t.infoBg,
     borderRadius: 6,
     alignSelf: 'flex-start',
   },
   attachmentLinkText: {
     fontSize: 12,
     fontWeight: '600',
-    color: '#2563EB',
+    color: t.infoText,
   },
   actions: {
     flexDirection: 'row',
@@ -325,14 +330,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   rejectBtn: {
-    backgroundColor: '#FEE2E2',
+    backgroundColor: t.errorBg,
   },
   approveBtn: {
-    backgroundColor: '#DCFCE7',
+    backgroundColor: t.successBg,
   },
   empty: {
     textAlign: 'center',
-    color: '#6B7280',
+    color: t.textSecondary,
     marginTop: 32,
     fontSize: 15,
   },
@@ -342,10 +347,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 10,
     borderRadius: 999,
-    backgroundColor: '#EFF6FF',
+    backgroundColor: t.infoBg,
   },
   loadMoreText: {
-    color: '#2563EB',
+    color: t.infoText,
     fontWeight: '600',
   },
   previewOverlay: {
@@ -375,4 +380,5 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-});
+  });
+}

--- a/mobile/src/components/events/ParticipantListModal.tsx
+++ b/mobile/src/components/events/ParticipantListModal.tsx
@@ -15,6 +15,7 @@ import {
 import { Feather } from '@expo/vector-icons';
 import { router, type Href } from 'expo-router';
 import { EventDetailApprovedParticipant } from '@/models/event';
+import { useTheme, type Theme } from '@/theme';
 
 const FEEDBACK_MIN_LENGTH = 10;
 const FEEDBACK_MAX_LENGTH = 100;
@@ -53,10 +54,12 @@ function StarRatingInput({
   value,
   onChange,
   disabled,
+  styles,
 }: {
   value: number;
   onChange: (value: number) => void;
   disabled?: boolean;
+  styles: ReturnType<typeof makeStyles>;
 }) {
   return (
     <View style={styles.starRow}>
@@ -86,6 +89,8 @@ function ParticipantRow({
   onSubmitRating,
   onDismissRatingError,
   onCloseModal,
+  theme,
+  styles,
 }: {
   participant: EventDetailApprovedParticipant;
   canRateParticipants: boolean;
@@ -94,6 +99,8 @@ function ParticipantRow({
   onSubmitRating: (participantUserId: string, rating: number, message?: string) => void;
   onDismissRatingError: () => void;
   onCloseModal: () => void;
+  theme: Theme;
+  styles: ReturnType<typeof makeStyles>;
 }) {
   const existingRating = participant.host_rating;
   const [isEditing, setIsEditing] = React.useState(false);
@@ -147,7 +154,7 @@ function ParticipantRow({
           />
         ) : (
           <View style={styles.avatarFallback}>
-            <Feather name="user" size={20} color="#9CA3AF" />
+            <Feather name="user" size={20} color={theme.textTertiary} />
           </View>
         )}
 
@@ -207,7 +214,12 @@ function ParticipantRow({
           </Text>
           <Text style={styles.inlineEditorSubtitle}>1 to 5 stars</Text>
 
-          <StarRatingInput value={rating} onChange={setRating} disabled={isLoading} />
+          <StarRatingInput
+            value={rating}
+            onChange={setRating}
+            disabled={isLoading}
+            styles={styles}
+          />
 
           <TextInput
             style={[
@@ -218,7 +230,7 @@ function ParticipantRow({
             value={message}
             onChangeText={setMessage}
             placeholder="Optional note about reliability, communication, or overall experience."
-            placeholderTextColor="#9CA3AF"
+            placeholderTextColor={theme.placeholder}
             maxLength={FEEDBACK_MAX_LENGTH}
             multiline
             numberOfLines={3}
@@ -256,7 +268,7 @@ function ParticipantRow({
               activeOpacity={0.85}
             >
               {isLoading ? (
-                <ActivityIndicator size="small" color="#FFFFFF" />
+                <ActivityIndicator size="small" color={theme.textOnPrimary} />
               ) : (
                 <Text style={styles.submitButtonText}>
                   {existingRating ? 'Save Changes' : 'Submit Rating'}
@@ -312,6 +324,8 @@ export default function ParticipantListModal({
   onDismissRatingError,
   onClose,
 }: ParticipantListModalProps) {
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => makeStyles(theme), [theme]);
   const panY = React.useRef(new Animated.Value(0)).current;
 
   const resetPositionAnim = Animated.spring(panY, {
@@ -381,7 +395,7 @@ export default function ParticipantListModal({
             </View>
 
             <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
-              <Feather name="x" size={24} color="#111827" />
+              <Feather name="x" size={24} color={theme.text} />
             </TouchableOpacity>
           </View>
 
@@ -400,6 +414,8 @@ export default function ParticipantListModal({
                 }}
                 onDismissRatingError={() => onDismissRatingError?.()}
                 onCloseModal={onClose}
+                theme={theme}
+                styles={styles}
               />
             )}
             ListEmptyComponent={
@@ -419,14 +435,15 @@ export default function ParticipantListModal({
   );
 }
 
-const styles = StyleSheet.create({
+function makeStyles(t: Theme) {
+  return StyleSheet.create({
   overlay: {
     flex: 1,
-    backgroundColor: 'rgba(15, 23, 42, 0.5)',
+    backgroundColor: t.overlay,
     justifyContent: 'flex-end',
   },
   container: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: t.surface,
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
     paddingHorizontal: 20,
@@ -438,7 +455,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 4,
     borderRadius: 2,
-    backgroundColor: '#D1D5DB',
+    backgroundColor: t.borderStrong,
     alignSelf: 'center',
     marginBottom: 20,
   },
@@ -452,13 +469,13 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 20,
     fontWeight: '700',
-    color: '#111827',
+    color: t.text,
   },
   subtitle: {
     marginTop: 4,
     fontSize: 13,
     lineHeight: 18,
-    color: '#6B7280',
+    color: t.textSecondary,
     maxWidth: 280,
   },
   closeBtn: {
@@ -470,7 +487,7 @@ const styles = StyleSheet.create({
   participantCard: {
     paddingVertical: 12,
     borderBottomWidth: 1,
-    borderBottomColor: '#F3F4F6',
+    borderBottomColor: t.border,
   },
   participantRow: {
     flexDirection: 'row',
@@ -480,13 +497,13 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceVariant,
   },
   avatarFallback: {
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: '#F3F4F6',
+    backgroundColor: t.surfaceVariant,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -503,16 +520,16 @@ const styles = StyleSheet.create({
   name: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#111827',
+    color: t.text,
   },
   userScore: {
     fontSize: 12,
-    color: '#F59E0B',
+    color: t.warningText,
     fontWeight: '500',
   },
   username: {
     fontSize: 14,
-    color: '#6B7280',
+    color: t.textSecondary,
     marginTop: 2,
   },
   ratingSummaryBlock: {
@@ -524,10 +541,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 6,
     borderRadius: 999,
-    backgroundColor: '#FFFBEB',
+    backgroundColor: t.warningBg,
     borderWidth: 1,
-    borderColor: '#FDE68A',
-    color: '#A16207',
+    borderColor: t.warningBorder,
+    color: t.warningText,
     fontSize: 12,
     fontWeight: '700',
     overflow: 'hidden',
@@ -537,21 +554,21 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 6,
     borderRadius: 999,
-    backgroundColor: '#F8FAFC',
+    backgroundColor: t.surfaceAlt,
     borderWidth: 1,
-    borderColor: '#E2E8F0',
-    color: '#64748B',
+    borderColor: t.border,
+    color: t.textMuted,
     fontSize: 12,
     fontWeight: '700',
     overflow: 'hidden',
   },
   ratingMessage: {
-    color: '#475569',
+    color: t.textSecondary,
     fontSize: 13,
     lineHeight: 20,
   },
   ratingUpdatedAt: {
-    color: '#9CA3AF',
+    color: t.textTertiary,
     fontSize: 12,
   },
   rateButton: {
@@ -561,11 +578,11 @@ const styles = StyleSheet.create({
     paddingVertical: 9,
     borderRadius: 10,
     borderWidth: 1,
-    borderColor: '#111827',
-    backgroundColor: '#FFFFFF',
+    borderColor: t.borderStrong,
+    backgroundColor: t.surface,
   },
   rateButtonText: {
-    color: '#111827',
+    color: t.text,
     fontSize: 13,
     fontWeight: '700',
   },
@@ -574,19 +591,19 @@ const styles = StyleSheet.create({
     marginLeft: 60,
     padding: 14,
     borderRadius: 16,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: t.surfaceAlt,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: t.border,
     gap: 12,
   },
   inlineEditorTitle: {
     fontSize: 15,
     fontWeight: '700',
-    color: '#0F172A',
+    color: t.text,
   },
   inlineEditorSubtitle: {
     fontSize: 13,
-    color: '#475569',
+    color: t.textSecondary,
   },
   starRow: {
     flexDirection: 'row',
@@ -599,18 +616,18 @@ const styles = StyleSheet.create({
   },
   starIcon: {
     fontSize: 28,
-    color: '#D1D5DB',
+    color: t.borderStrong,
   },
   starIconActive: {
-    color: '#F59E0B',
+    color: t.warningText,
   },
   ratingTextArea: {
     borderWidth: 1,
-    borderColor: '#D1D5DB',
+    borderColor: t.borderStrong,
     borderRadius: 12,
     padding: 12,
-    backgroundColor: '#FFFFFF',
-    color: '#111827',
+    backgroundColor: t.surface,
+    color: t.text,
     fontSize: 14,
     lineHeight: 22,
   },
@@ -618,7 +635,7 @@ const styles = StyleSheet.create({
     minHeight: 84,
   },
   ratingTextAreaError: {
-    borderColor: '#FCA5A5',
+    borderColor: t.errorBorder,
   },
   ratingMeta: {
     flexDirection: 'row',
@@ -629,28 +646,28 @@ const styles = StyleSheet.create({
   ratingCharCount: {
     fontSize: 12,
     fontWeight: '700',
-    color: '#64748B',
+    color: t.textMuted,
   },
   ratingHelper: {
     fontSize: 12,
     lineHeight: 18,
-    color: '#64748B',
+    color: t.textMuted,
     flex: 1,
   },
   ratingValidationText: {
     fontSize: 13,
-    color: '#DC2626',
+    color: t.errorText,
   },
   errorBanner: {
-    backgroundColor: '#FEF2F2',
+    backgroundColor: t.errorBg,
     borderWidth: 1,
-    borderColor: '#FECACA',
+    borderColor: t.errorBorder,
     borderRadius: 10,
     padding: 12,
     marginTop: 12,
   },
   errorBannerText: {
-    color: '#DC2626',
+    color: t.errorText,
     fontSize: 14,
   },
   inlineActions: {
@@ -666,13 +683,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     borderRadius: 12,
-    backgroundColor: '#111827',
+    backgroundColor: t.primary,
   },
   submitButtonDisabled: {
     opacity: 0.55,
   },
   submitButtonText: {
-    color: '#FFFFFF',
+    color: t.textOnPrimary,
     fontSize: 14,
     fontWeight: '700',
   },
@@ -681,17 +698,17 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 10,
     borderWidth: 1,
-    borderColor: '#CBD5E1',
+    borderColor: t.borderStrong,
     backgroundColor: 'transparent',
   },
   cancelInlineButtonText: {
-    color: '#475569',
+    color: t.textSecondary,
     fontSize: 14,
     fontWeight: '600',
   },
   empty: {
     textAlign: 'center',
-    color: '#6B7280',
+    color: t.textSecondary,
     marginTop: 32,
     fontSize: 15,
   },
@@ -701,10 +718,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 10,
     borderRadius: 999,
-    backgroundColor: '#EFF6FF',
+    backgroundColor: t.infoBg,
   },
   loadMoreText: {
-    color: '#2563EB',
+    color: t.infoText,
     fontWeight: '600',
   },
-});
+  });
+}

--- a/mobile/src/components/home/SearchSection.tsx
+++ b/mobile/src/components/home/SearchSection.tsx
@@ -9,6 +9,7 @@ interface SearchSectionProps {
   onChangeQuery: (value: string) => void;
   onSubmitSearch: () => void;
   onPressFilter: () => void;
+  onPressMapView?: () => void;
 }
 
 export default function SearchSection({
@@ -16,6 +17,7 @@ export default function SearchSection({
   onChangeQuery,
   onSubmitSearch,
   onPressFilter,
+  onPressMapView,
 }: SearchSectionProps) {
   const { theme } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
@@ -51,6 +53,19 @@ export default function SearchSection({
       >
         <Feather name="sliders" size={22} color={theme.textOnPrimary} />
       </TouchableOpacity>
+
+      {onPressMapView ? (
+        <TouchableOpacity
+          style={styles.mapButton}
+          onPress={onPressMapView}
+          activeOpacity={0.85}
+          accessibilityRole="button"
+          accessibilityLabel="Switch to map view"
+          testID="toggle-map"
+        >
+          <Feather name="map" size={22} color={theme.text} />
+        </TouchableOpacity>
+      ) : null}
     </View>
   );
 }
@@ -60,6 +75,7 @@ function makeStyles(t: Theme) {
     row: {
       flexDirection: 'row',
       alignItems: 'center',
+      gap: 10,
       marginBottom: 14,
     },
     searchContainer: {
@@ -72,7 +88,6 @@ function makeStyles(t: Theme) {
       flexDirection: 'row',
       alignItems: 'center',
       paddingHorizontal: 16,
-      marginRight: 12,
     },
     searchIcon: {
       marginRight: 10,
@@ -88,6 +103,16 @@ function makeStyles(t: Theme) {
       height: 56,
       borderRadius: 18,
       backgroundColor: t.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    mapButton: {
+      width: 56,
+      height: 56,
+      borderRadius: 18,
+      backgroundColor: t.surface,
+      borderWidth: 1,
+      borderColor: t.border,
       alignItems: 'center',
       justifyContent: 'center',
     },

--- a/mobile/src/views/event/CreateEventView.test.tsx
+++ b/mobile/src/views/event/CreateEventView.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Platform } from 'react-native';
 import CreateEventView from './CreateEventView';
+import { jest } from '@jest/globals';
 import {
   formatDateForForm,
   type CreateEventViewModel,
@@ -44,6 +45,9 @@ jest.mock('@react-native-community/datetimepicker', () => {
   return function MockDateTimePicker(props: {
     mode: 'date' | 'time';
     minimumDate?: Date;
+    themeVariant?: 'dark' | 'light';
+    textColor?: string;
+    accentColor?: string;
     onChange?: unknown;
     onValueChange?: unknown;
     onDismiss?: unknown;
@@ -51,6 +55,9 @@ jest.mock('@react-native-community/datetimepicker', () => {
     return ReactLocal.createElement('div', {
       'data-testid': `datetimepicker-${props.mode}`,
       'data-minimum-date': props.minimumDate?.toISOString() ?? '',
+      'data-theme-variant': props.themeVariant ?? '',
+      'data-text-color': props.textColor ?? '',
+      'data-accent-color': props.accentColor ?? '',
       'data-has-on-change': String(Boolean(props.onChange)),
       'data-has-on-value-change': String(Boolean(props.onValueChange)),
       'data-has-on-dismiss': String(Boolean(props.onDismiss)),
@@ -73,7 +80,7 @@ jest.mock('@/contexts/AuthContext', () => ({
 }));
 
 jest.mock('@/viewmodels/event/useCreateEventViewModel', () => {
-  const actual = jest.requireActual('@/viewmodels/event/useCreateEventViewModel');
+  const actual = jest.requireActual('@/viewmodels/event/useCreateEventViewModel') as Record<string, unknown>;
   return {
     ...actual,
     useCreateEventViewModel: jest.fn(),
@@ -143,7 +150,7 @@ function buildViewModel(
     addGenderConstraint: jest.fn(),
     addConstraint: jest.fn(),
     removeConstraint: jest.fn(),
-    pickImage: jest.fn(),
+    pickImage: jest.fn<CreateEventViewModel['pickImage']>().mockResolvedValue(undefined),
     removeImage: jest.fn(),
     invitedUsers: [],
     userSearchQuery: '',
@@ -152,8 +159,10 @@ function buildViewModel(
     addInvitedUser: jest.fn(),
     removeInvitedUser: jest.fn(),
     handleUserSearch: jest.fn(),
-    pickAndParseUserFile: jest.fn(),
-    handleSubmit: jest.fn(),
+    pickAndParseUserFile: jest
+      .fn<CreateEventViewModel['pickAndParseUserFile']>()
+      .mockResolvedValue(undefined),
+    handleSubmit: jest.fn<CreateEventViewModel['handleSubmit']>().mockResolvedValue(null),
     ...partial,
   };
 }
@@ -215,6 +224,9 @@ describe('CreateEventView', () => {
     expected.setHours(0, 0, 0, 0);
 
     expect(minimumDate.getTime()).toBe(expected.getTime());
+    expect(datePicker.getAttribute('data-theme-variant')).toBe('light');
+    expect(datePicker.getAttribute('data-text-color')).toBe('#0F172A');
+    expect(datePicker.getAttribute('data-accent-color')).toBe('#2563EB');
     expect(datePicker.getAttribute('data-has-on-change')).toBe('true');
     expect(datePicker.getAttribute('data-has-on-value-change')).toBe('false');
     expect(datePicker.getAttribute('data-has-on-dismiss')).toBe('false');

--- a/mobile/src/views/event/CreateEventView.tsx
+++ b/mobile/src/views/event/CreateEventView.tsx
@@ -36,8 +36,9 @@ import type { Theme } from '@/theme';
 export default function CreateEventView() {
   const vm = useCreateEventViewModel();
   const { token } = useAuth();
-  const { theme } = useTheme();
+  const { theme, isDark } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
+  const pickerThemeVariant = isDark ? 'dark' : 'light';
 
   const handleCreate = async () => {
     await vm.handleSubmit(token ?? '');
@@ -542,6 +543,10 @@ export default function CreateEventView() {
                 mode="date"
                 display={Platform.OS === 'ios' ? 'inline' : 'default'}
                 minimumDate={getMinimumDatePickerDate()}
+                themeVariant={pickerThemeVariant}
+                textColor={theme.text}
+                accentColor={theme.infoText}
+                style={styles.dateTimePicker}
                 onChange={handleDateValueChange}
               />
             </View>
@@ -553,6 +558,10 @@ export default function CreateEventView() {
                 mode="time"
                 display={Platform.OS === 'ios' ? 'spinner' : 'default'}
                 is24Hour={true}
+                themeVariant={pickerThemeVariant}
+                textColor={theme.text}
+                accentColor={theme.infoText}
+                style={styles.dateTimePicker}
                 onChange={handleTimeValueChange}
               />
             </View>
@@ -629,6 +638,10 @@ export default function CreateEventView() {
                 mode="date"
                 display={Platform.OS === 'ios' ? 'inline' : 'default'}
                 minimumDate={getMinimumDatePickerDate()}
+                themeVariant={pickerThemeVariant}
+                textColor={theme.text}
+                accentColor={theme.infoText}
+                style={styles.dateTimePicker}
                 onChange={handleDateValueChange}
               />
             </View>
@@ -640,6 +653,10 @@ export default function CreateEventView() {
                 mode="time"
                 display={Platform.OS === 'ios' ? 'spinner' : 'default'}
                 is24Hour={true}
+                themeVariant={pickerThemeVariant}
+                textColor={theme.text}
+                accentColor={theme.infoText}
+                style={styles.dateTimePicker}
                 onChange={handleTimeValueChange}
               />
             </View>
@@ -1336,6 +1353,13 @@ function makeStyles(t: Theme) {
       marginTop: 12,
       backgroundColor: t.surface,
       borderRadius: 12,
+      borderWidth: 1,
+      borderColor: t.border,
+      overflow: 'hidden',
+    },
+    dateTimePicker: {
+      width: '100%',
+      backgroundColor: t.surface,
     },
     privacyRow: {
       flexDirection: 'row',

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -94,27 +94,12 @@ export default function HomeView() {
 
           {/* Floating overlay — search, location and list toggle above the map */}
           <View
-            style={[styles.mapOverlay, { top: insets.top + 12 }]}
+            style={[styles.mapOverlay, { top: insets.top + 8 }]}
             pointerEvents="box-none"
           >
-            {/* Row 1: logo + location pill + bell + theme toggle + list toggle */}
+            {/* Row 1: logo + bell + theme toggle */}
             <View style={styles.mapOverlayRow}>
-              <SemLogo height={36} color={theme.text} />
-
-              <View ref={locationButtonRef} collapsable={false}>
-                <TouchableOpacity
-                  style={styles.mapLocationPill}
-                  onPress={handleOpenLocationPicker}
-                  accessibilityRole="button"
-                  accessibilityLabel="Select location"
-                >
-                  <Feather name="map-pin" size={14} color={styles.mapLocationIconColor.color} />
-                  <Text style={styles.mapLocationText} numberOfLines={1}>
-                    {vm.locationLabel}
-                  </Text>
-                  <Feather name="chevron-down" size={14} color={styles.mapLocationIconColor.color} />
-                </TouchableOpacity>
-              </View>
+              <SemLogo height={46} color={theme.text} />
 
               <View style={styles.mapOverlayRowSpacer} />
 
@@ -136,19 +121,24 @@ export default function HomeView() {
               >
                 <Feather name={isDark ? 'sun' : 'moon'} size={18} color={theme.text} />
               </TouchableOpacity>
+            </View>
 
+            <View ref={locationButtonRef} collapsable={false}>
               <TouchableOpacity
-                style={styles.mapIconBtn}
-                onPress={vm.toggleViewMode}
+                style={styles.mapLocationPill}
+                onPress={handleOpenLocationPicker}
                 accessibilityRole="button"
-                accessibilityLabel="Switch to list view"
-                testID="toggle-list"
+                accessibilityLabel="Select location"
               >
-                <Feather name="list" size={20} color={theme.text} />
+                <Feather name="map-pin" size={16} color={styles.mapLocationIconColor.color} />
+                <Text style={styles.mapLocationText} numberOfLines={1}>
+                  {vm.locationLabel}
+                </Text>
+                <Feather name="chevron-down" size={16} color={styles.mapLocationIconColor.color} />
               </TouchableOpacity>
             </View>
 
-            {/* Row 2: search bar + filter button */}
+            {/* Row 2: search bar + filter + list button */}
             <View style={styles.mapSearchRow}>
               <View style={styles.mapSearchContainer}>
                 <Feather
@@ -177,7 +167,17 @@ export default function HomeView() {
                 accessibilityLabel="Open filters"
                 testID="map-filter-btn"
               >
-                <Feather name="sliders" size={20} color={styles.mapLocationIconColor.color} />
+                <Feather name="sliders" size={19} color={styles.mapLocationIconColor.color} />
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.mapFilterBtn}
+                onPress={vm.toggleViewMode}
+                accessibilityRole="button"
+                accessibilityLabel="Switch to list view"
+                testID="toggle-list"
+              >
+                <Feather name="list" size={20} color={styles.mapLocationIconColor.color} />
               </TouchableOpacity>
             </View>
           </View>
@@ -201,11 +201,11 @@ export default function HomeView() {
                 accessibilityRole="button"
                 accessibilityLabel="Select location"
               >
-                <Feather name="map-pin" size={14} color={isDark ? theme.text : theme.textOnPrimary} />
+                <Feather name="map-pin" size={18} color={isDark ? theme.text : theme.textOnPrimary} />
                 <Text style={styles.locationPillText} numberOfLines={1}>
                   {vm.locationLabel}
                 </Text>
-                <Feather name="chevron-down" size={14} color={isDark ? theme.text : theme.textOnPrimary} />
+                <Feather name="chevron-down" size={18} color={isDark ? theme.text : theme.textOnPrimary} />
               </TouchableOpacity>
             </View>
 
@@ -214,53 +214,10 @@ export default function HomeView() {
               onChangeQuery={vm.updateSearchText}
               onSubmitSearch={vm.submitSearch}
               onPressFilter={vm.openFilterModal}
+              onPressMapView={() => {
+                if (vm.viewMode !== 'MAP') vm.toggleViewMode();
+              }}
             />
-
-            <View style={styles.viewToggleRow}>
-              <TouchableOpacity
-                style={[
-                  styles.viewToggleButton,
-                  styles.viewToggleLeft,
-                  vm.viewMode === 'LIST' && styles.viewToggleActive,
-                ]}
-                onPress={() => vm.viewMode !== 'LIST' && vm.toggleViewMode()}
-                accessibilityRole="button"
-                accessibilityLabel="List view"
-                accessibilityState={{ selected: vm.viewMode === 'LIST' }}
-                testID="toggle-list"
-              >
-                <Text
-                  style={[
-                    styles.viewToggleText,
-                    vm.viewMode === 'LIST' && styles.viewToggleTextActive,
-                  ]}
-                >
-                  List
-                </Text>
-              </TouchableOpacity>
-
-              <TouchableOpacity
-                style={[
-                  styles.viewToggleButton,
-                  styles.viewToggleRight,
-                  vm.viewMode === 'MAP' && styles.viewToggleActive,
-                ]}
-                onPress={() => vm.viewMode !== 'MAP' && vm.toggleViewMode()}
-                accessibilityRole="button"
-                accessibilityLabel="Map view"
-                accessibilityState={{ selected: vm.viewMode === 'MAP' }}
-                testID="toggle-map"
-              >
-                <Text
-                  style={[
-                    styles.viewToggleText,
-                    vm.viewMode === 'MAP' && styles.viewToggleTextActive,
-                  ]}
-                >
-                  Map
-                </Text>
-              </TouchableOpacity>
-            </View>
 
             {vm.apiError ? (
               <View style={styles.errorBanner}>
@@ -355,27 +312,28 @@ function makeStyles(t: Theme, isDark: boolean) {
       paddingTop: 8,
     },
     locationRow: {
-      marginBottom: 10,
+      marginBottom: 14,
     },
     locationPill: {
-      alignSelf: 'flex-start',
+      alignSelf: 'stretch',
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 6,
-      paddingHorizontal: 14,
-      paddingVertical: 8,
-      borderRadius: 999,
+      gap: 10,
+      minHeight: 52,
+      paddingHorizontal: 18,
+      paddingVertical: 12,
+      borderRadius: 26,
       backgroundColor: isDark ? t.surface : t.primary,
-      borderWidth: isDark ? 1 : 0,
+      borderWidth: 1,
       borderColor: t.border,
-      maxWidth: '80%',
+      width: '100%',
     },
     locationPillText: {
       color: isDark ? t.text : t.textOnPrimary,
-      fontSize: 13,
+      fontSize: 16,
       fontWeight: '700',
       fontStyle: 'italic',
-      flexShrink: 1,
+      flex: 1,
     },
     listWrapper: {
       flex: 1,
@@ -400,47 +358,13 @@ function makeStyles(t: Theme, isDark: boolean) {
       color: t.errorText,
       fontSize: 14,
     },
-    viewToggleRow: {
-      flexDirection: 'row',
-      marginTop: 10,
-      marginBottom: 2,
-      alignSelf: 'center',
-      borderRadius: 999,
-      borderWidth: 1,
-      borderColor: t.border,
-      overflow: 'hidden',
-    },
-    viewToggleButton: {
-      paddingHorizontal: 24,
-      paddingVertical: 8,
-      backgroundColor: t.surface,
-    },
-    viewToggleLeft: {
-      borderTopLeftRadius: 999,
-      borderBottomLeftRadius: 999,
-    },
-    viewToggleRight: {
-      borderTopRightRadius: 999,
-      borderBottomRightRadius: 999,
-    },
-    viewToggleActive: {
-      backgroundColor: t.primary,
-    },
-    viewToggleText: {
-      fontSize: 13,
-      fontWeight: '600',
-      color: t.textSecondary,
-    },
-    viewToggleTextActive: {
-      color: t.textOnPrimary,
-    },
     // ── full-screen map floating overlay ─────────────────────────────────────
     mapOverlay: {
       position: 'absolute',
       left: 14,
       right: 14,
       zIndex: 20,
-      gap: 8,
+      gap: 6,
     },
     mapOverlayRow: {
       flexDirection: 'row',
@@ -453,25 +377,27 @@ function makeStyles(t: Theme, isDark: boolean) {
     mapLocationPill: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 6,
-      paddingHorizontal: 14,
+      gap: 8,
+      minHeight: 46,
+      paddingHorizontal: 16,
       paddingVertical: 9,
-      borderRadius: 999,
+      borderRadius: 23,
       backgroundColor: isDark ? t.surface : t.primary,
-      borderWidth: isDark ? 1 : 0,
+      borderWidth: 1,
       borderColor: t.border,
-      maxWidth: 150,
+      width: '100%',
       shadowColor: '#000',
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.18,
-      shadowRadius: 6,
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: 0.15,
+      shadowRadius: 5,
       elevation: 4,
     },
     mapLocationText: {
       color: isDark ? t.text : t.textOnPrimary,
-      fontSize: 13,
+      fontSize: 15,
       fontWeight: '700',
-      flexShrink: 1,
+      fontStyle: 'italic',
+      flex: 1,
     },
     mapLocationIconColor: {
       color: isDark ? t.text : t.textOnPrimary,
@@ -500,27 +426,6 @@ function makeStyles(t: Theme, isDark: boolean) {
       borderRadius: 4,
       backgroundColor: t.notificationBadge,
     },
-    mapFloatingBtn: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: 6,
-      paddingHorizontal: 14,
-      paddingVertical: 9,
-      borderRadius: 999,
-      backgroundColor: t.surface,
-      borderWidth: 1,
-      borderColor: t.border,
-      shadowColor: '#000',
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.15,
-      shadowRadius: 6,
-      elevation: 4,
-    },
-    mapFloatingBtnText: {
-      fontSize: 13,
-      fontWeight: '600',
-      color: t.text,
-    },
     mapSearchRow: {
       flexDirection: 'row',
       alignItems: 'center',
@@ -528,18 +433,18 @@ function makeStyles(t: Theme, isDark: boolean) {
     },
     mapSearchContainer: {
       flex: 1,
-      height: 50,
+      height: 46,
       flexDirection: 'row',
       alignItems: 'center',
-      paddingHorizontal: 14,
-      borderRadius: 16,
+      paddingHorizontal: 13,
+      borderRadius: 15,
       backgroundColor: t.surface,
       borderWidth: 1,
       borderColor: t.border,
       shadowColor: '#000',
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.12,
-      shadowRadius: 6,
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: 0.11,
+      shadowRadius: 5,
       elevation: 4,
     },
     mapSearchIcon: {
@@ -547,23 +452,23 @@ function makeStyles(t: Theme, isDark: boolean) {
     },
     mapSearchInput: {
       flex: 1,
-      fontSize: 15,
+      fontSize: 14,
       color: t.text,
       paddingVertical: 0,
     },
     mapFilterBtn: {
-      width: 50,
-      height: 50,
-      borderRadius: 16,
+      width: 46,
+      height: 46,
+      borderRadius: 15,
       backgroundColor: isDark ? t.surface : t.primary,
       borderWidth: isDark ? 1 : 0,
       borderColor: t.border,
       alignItems: 'center',
       justifyContent: 'center',
       shadowColor: '#000',
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.18,
-      shadowRadius: 6,
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: 0.15,
+      shadowRadius: 5,
       elevation: 4,
     },
   });

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "types": ["jest", "node"],
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
## 📋 Summary

Polishes several mobile UI/UX surfaces, with a focus on dark theme consistency and a cleaner Explore map/list experience.

Event management modals now respect the active theme, Create Event date/time pickers are readable in dark mode, and the Explore screen has a less awkward map/list switcher with improved location banner sizing.

## 🔄 Changes

- Updated event host modals to align with the active theme:
  - `InvitationsModal`
  - `JoinRequestsModal`
  - `ParticipantListModal`
  - Replaced hardcoded white backgrounds/text colors with theme tokens.
  - Fixed theme inconsistency in private-event invite/manage, attendees, and pending request popups.

- Improved Create Event date/time picker visibility:
  - Added dark/light `themeVariant` handling.
  - Passed themed `textColor` and `accentColor` to date/time pickers.
  - Added themed picker wrapper styling so inline iOS pickers remain readable in dark mode.
  - Updated tests/mocks for picker theme props.

- Refined Explore list/map controls:
  - Removed the centered `List / Map` segmented toggle from list view.
  - Added a compact map button next to the filter button.
  - Enlarged the list-view location banner so addresses are easier to read.
  - In map view, moved the list button next to filters.
  - Widened but compacted the map-view location banner.
  - Adjusted map-view logo/control sizing so the overlay blocks less of the map.

- Fixed mobile TypeScript test environment issues:
  - Added Jest/Node types to `mobile/tsconfig.json`.
  - Tightened async mock typings in `CreateEventView.test.tsx`.

## 🧪 Testing

```bash
cd mobile
npx tsc --noEmit
```


Manual verification on simulator:

- Open Explore in list view:
  - Location banner is larger and easier to read.
  - Map switch appears beside the filter button.
  - Old centered `List / Map` toggle is gone.

- Open Explore in map view:
  - Location banner is wider but compact.
  - List switch appears beside the filter button.
  - Overlay no longer blocks as much of the map.

- Open Create Event in dark mode:
  - Date and time pickers are readable.

- Open private event host modals in dark mode:
  - Invite/manage, attendees, and pending request popups match the theme.