### PR TITLE
feat(backend): finish multi-select category filter on event discovery (#483)

### DIFF
--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler.go
@@ -1113,6 +1113,22 @@ func parseDiscoverEventsInput(c *fiber.Ctx) (event.DiscoverEventsInput, map[stri
 		input.CategoryIDs = categoryIDs
 	}
 
+	// Backward-compat: the discovery endpoint historically accepted a
+	// singular `category_id=N` parameter. We keep it as an alias for a
+	// one-element `category_ids`. When both are present, the richer
+	// plural form wins so clients that adopted the new contract are
+	// unaffected by stray legacy params.
+	if len(input.CategoryIDs) == 0 {
+		if rawSingle := strings.TrimSpace(c.Query("category_id")); rawSingle != "" {
+			value, err := strconv.Atoi(rawSingle)
+			if err != nil {
+				errs["category_id"] = "category_id must be an integer"
+			} else {
+				input.CategoryIDs = []int{value}
+			}
+		}
+	}
+
 	tagNames := parseListQueryValues(values, "tag_names")
 	if len(tagNames) > 0 {
 		input.TagNames = tagNames

--- a/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
+++ b/backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go
@@ -588,6 +588,121 @@ func TestDiscoverEventsIgnoresEmptyOptionalListParams(t *testing.T) {
 	}
 }
 
+// TestDiscoverEventsAcceptsSingularCategoryIDAlias proves the legacy
+// `?category_id=N` form still works as a one-element category_ids list,
+// fulfilling the backward-compat acceptance criterion of #483.
+func TestDiscoverEventsAcceptsSingularCategoryIDAlias(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/?lat=41.01&lon=29.02&category_id=5", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.discoverCallCount != 1 {
+		t.Fatalf("expected discover service to be called once, got %d", svc.discoverCallCount)
+	}
+	if len(svc.lastDiscoverInput.CategoryIDs) != 1 || svc.lastDiscoverInput.CategoryIDs[0] != 5 {
+		t.Fatalf("expected singular alias to land as [5], got %v", svc.lastDiscoverInput.CategoryIDs)
+	}
+}
+
+// TestDiscoverEventsCategoryIdsInvalidReturns400 pins the 400 contract
+// for non-integer values in the plural form (#483 acceptance criterion).
+func TestDiscoverEventsCategoryIdsInvalidReturns400(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/?lat=41.01&lon=29.02&category_ids=foo", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+	if svc.discoverCallCount != 0 {
+		t.Fatalf("expected discover service not to be called, got %d", svc.discoverCallCount)
+	}
+}
+
+// TestDiscoverEventsSingularCategoryIDInvalidReturns400 mirrors the
+// invalid-input check for the legacy alias path. Same 400 contract.
+func TestDiscoverEventsSingularCategoryIDInvalidReturns400(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/?lat=41.01&lon=29.02&category_id=foo", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
+	}
+	if svc.discoverCallCount != 0 {
+		t.Fatalf("expected discover service not to be called, got %d", svc.discoverCallCount)
+	}
+}
+
+// TestDiscoverEventsBothCategoryIDAndCategoryIDsPrefersPlural defends the
+// precedence rule documented in OpenAPI: when a stale client sends both
+// the legacy alias and the new plural form, the richer plural value wins
+// and the singular one is silently dropped (no 400 noise).
+func TestDiscoverEventsBothCategoryIDAndCategoryIDsPrefersPlural(t *testing.T) {
+	// given
+	svc := &stubEventService{}
+	app := newEventTestApp(svc, authedVerifier())
+
+	req := httptest.NewRequest(fiber.MethodGet, "/events/?lat=41.01&lon=29.02&category_ids=1,2&category_id=99", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Bearer valid.token")
+
+	// when
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("application.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	if svc.discoverCallCount != 1 {
+		t.Fatalf("expected discover service to be called once, got %d", svc.discoverCallCount)
+	}
+	if len(svc.lastDiscoverInput.CategoryIDs) != 2 ||
+		svc.lastDiscoverInput.CategoryIDs[0] != 1 ||
+		svc.lastDiscoverInput.CategoryIDs[1] != 2 {
+		t.Fatalf("expected plural to win with [1 2], got %v", svc.lastDiscoverInput.CategoryIDs)
+	}
+}
+
 func TestGetEventDetailReturns200(t *testing.T) {
 	// given
 	svc := &stubEventService{}

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -2359,7 +2359,18 @@ paths:
             items:
               type: integer
               minimum: 1
-          description: Optional comma-separated category ids. Matches events whose `category_id` is in the provided set.
+          description: |
+            Optional comma-separated category ids. Matches events whose `category_id` is in the provided set.
+
+            For backward compatibility with the legacy single-category contract, the `category_id` (singular, integer) query parameter is also accepted and treated as a one-element list. When both `category_ids` and `category_id` are present, `category_ids` takes precedence and the singular value is ignored. Non-integer values in either parameter return `400` with the offending field name in `error.details`.
+        - name: category_id
+          in: query
+          required: false
+          deprecated: true
+          schema:
+            type: integer
+            minimum: 1
+          description: Legacy alias for a one-element `category_ids`. Prefer `category_ids` for new clients.
         - name: start_from
           in: query
           required: false


### PR DESCRIPTION
Closes #483

  ## Summary

  Closes the remaining acceptance criteria of #483. The multi-select form (`category_ids=1,2,3`) was
  already wired end-to-end in earlier PRs — handler parser, `ANY()` SQL filter, OpenAPI spec, and HTTP
   tests for the comma-separated and empty cases all shipped quietly. This PR fills the two loose
  ends:

  1. **Backward-compatibility with the legacy singular `category_id=N`** form (acceptance criterion
  2). The discovery handler now accepts `category_id` as a one-element alias for `category_ids`. When
  both are present, the richer plural form wins and the singular value is silently dropped so stale
  clients with stray params don't trip a 400.
  2. **HTTP-layer 400 assertion for invalid (non-integer) inputs** on both the plural and the legacy
  singular paths (acceptance criterion 3 / 4).

  OpenAPI documents the alias, marks the singular form `deprecated: true`, and pins the precedence
  rule. **No DTO, SQL, or migration changes.**

  ---

  ## Audit findings (already shipped, no action needed)

  | Item | Where | Status |
  |---|---|---|
  | `CategoryIDs []int` on `DiscoverEventsInput` | `backend/internal/application/event/service_dto.go`
   | ✅ |
  | `category_ids` comma-separated parser |
  `backend/internal/adapter/out/httpapi/event_handler/event_handler.go` (`parseCategoryIDs`) | ✅ |
  | SQL `ANY($N::bigint[])` filter | `backend/internal/adapter/in/postgres/event_repo.go`
  (`ListDiscoverableEvents`) | ✅ |
  | OpenAPI `category_ids` parameter (array, comma-separated, integer items) |
  `docs/openapi/event.yaml` | ✅ |
  | HTTP test: `category_ids=1,3` returns 200 | `event_handler_test.go`
  (`TestDiscoverEventsParsesQueryParamsBeforeCallingService`) | ✅ |
  | HTTP test: `category_ids=` (empty) returns 200 | same file
  (`TestDiscoverEventsIgnoresEmptyOptionalListParams`) | ✅ |
  | Service-level test with `CategoryIDs: []int{X}` | `tests_integration/event_test.go` | ✅ |

  ---

  ## Wire-format reference for #484 (web) and #485 (mobile)

  ### Preferred (multi-select)

  ```bash
  curl 'https://api.example.com/api/events?lat=41.01&lon=29.02&category_ids=1,3,5'
  ```

  - `category_ids` accepts a comma-separated list of category ids (or repeated query params, both
  supported by the underlying parser).
  - Empty (`category_ids=`) is a **no-op filter** — returns 200 with no category restriction. Not a
  400.

  ### Legacy alias (single category)

  ```bash
  curl 'https://api.example.com/api/events?lat=41.01&lon=29.02&category_id=5'
  ```

  - Treated as `category_ids=5` (one-element list).
  - Marked **deprecated** in the OpenAPI spec; new clients should use `category_ids`.
  - Kept indefinitely for backward compatibility — existing mobile builds with the legacy contract
  continue to work.

  ### Precedence when both present

  ```bash
  curl '...?category_ids=1,2&category_id=99'   # CategoryIDs = [1, 2]; the 99 is silently dropped
  ```

  The richer plural form wins. This protects clients that adopted the new contract from breakage if a
  stale legacy param leaks into the request (e.g. cached query string).

  ### Invalid input

  ```bash
  curl '...?category_ids=foo'   # → 400,
  {"error":{"code":"validation_error","details":{"category_ids":"category_ids must contain only
  integers"}}}
  curl '...?category_id=foo'    # → 400,
  {"error":{"code":"validation_error","details":{"category_id":"category_id must be an integer"}}}
  ```

  The offending field name (`category_ids` vs `category_id`) is reflected in `error.details` so the
  client can highlight the right input control.

  ---

  ## Field semantics (clients should rely on these)

  - **`category_ids`** — preferred. Comma-separated list (`?category_ids=1,3,5`) OR repeated params
  (`?category_ids=1&category_ids=3`). Both forms parse identically.
  - **`category_id`** — legacy alias for a one-element list. Accepted indefinitely, deprecated in
  OpenAPI.
  - **Empty values** — `category_ids=` / no parameter → no filter. Discovery returns events from all
  categories.
  - **Invalid values** — non-integer in either form → 400 with field-specific `error.details`.
  - **OR semantics across the list** — events whose `category_id` is `IN (provided ids)`.

  ### Backward compatibility

  Purely additive. **No field renames, no removals, no shape changes.** Existing clients on either
  form keep working.

  ---

  ## What this PR adds

  ### Code (`backend/internal/adapter/out/httpapi/event_handler/event_handler.go`)

  8-line block in `parseDiscoverEventsInput` after the existing `category_ids` parsing:

  ```go
  if len(input.CategoryIDs) == 0 {
      if rawSingle := strings.TrimSpace(c.Query("category_id")); rawSingle != "" {
          value, err := strconv.Atoi(rawSingle)
          if err != nil {
              errs["category_id"] = "category_id must be an integer"
          } else {
              input.CategoryIDs = []int{value}
          }
      }
  }
  ```

  ### Tests (`backend/internal/adapter/out/httpapi/event_handler/event_handler_test.go`)

  Four new HTTP-layer tests, given/when/then style:

  - `TestDiscoverEventsAcceptsSingularCategoryIDAlias` — `?category_id=5` → 200, fake service receives
   `CategoryIDs: []int{5}`.
  - `TestDiscoverEventsCategoryIdsInvalidReturns400` — `?category_ids=foo` → 400, service not called.
  - `TestDiscoverEventsSingularCategoryIDInvalidReturns400` — `?category_id=foo` → 400, service not
  called.
  - `TestDiscoverEventsBothCategoryIDAndCategoryIDsPrefersPlural` — both present → 200, service
  receives `[1, 2]` (singular dropped).

  ### OpenAPI (`docs/openapi/event.yaml`)

  - `category_ids` description extended to document the alias and precedence.
  - Separate `category_id` parameter entry with `deprecated: true`.

  ---

  ## References

  ### Sibling issues (frontend/mobile)
  - Web — #484
  - Mobile — #485

  ### Code entry points
  - Handler: `backend/internal/adapter/out/httpapi/event_handler/event_handler.go`
  (`parseDiscoverEventsInput`)
  - Repository: `backend/internal/adapter/in/postgres/event_repo.go` (`ListDiscoverableEvents`)
  - DTO: `backend/internal/application/event/service_dto.go` (`DiscoverEventsInput.CategoryIDs`)
  - OpenAPI: `docs/openapi/event.yaml` — search for `name: category_ids`

  ### Contribution conventions
  - https://github.com/bounswe/bounswe2026group11/blob/main/docs/conventions.md

  ---

  ## Notable design decisions

  - **Precedence (`category_ids` wins when both present)** — protects new-contract adopters from
  accidental breakage by stale legacy params; silently drops singular instead of erroring on conflict
  (less noise, clearer intent).
  - **Empty `category_ids=` returns 200, not 400** — REST convention: empty query value means absence
  of the filter, not a malformed request. This is a deliberate read of acceptance criterion 3; trivial
   to flip if reviewers prefer strict 400.
  - **Singular alias is `deprecated: true` in OpenAPI but not removed** — gives mobile/web a
  deprecation runway without breaking existing builds.

  ---

  ## Test plan

  - [x] `go test ./internal/adapter/out/httpapi/event_handler/...` — new tests pass + existing
  discovery tests green
  - [x] `go test ./internal/...` — no regression
  - [x] `go test -race -count=1 ./internal/...` — 0 races across 30 packages
  - [x] `go test -tags=integration ./tests_integration/...` — full suite green (≈41s)
  - [x] `go vet`, `golangci-lint` (0 issues), `gosec` (no findings) — all clean
  - [x] `go build ./cmd/server`
  - [x] Coverage on the added 8-line block: **100%** (verified with `go tool cover -html`)

  ---

  ## Out of scope

  - Frontend (#484) and mobile (#485) consumer updates — separate PRs once this lands.
  - Removing `category_id` singular form — keep indefinitely or deprecate in a future PR with a
  release-cycle warning.
  - Validating `category_id` / `category_ids` values against `minimum: 1` (OpenAPI spec) —
  pre-existing parser gap, applies equally to plural form, scope of a separate small PR.
  - Multi-category support on event create / update endpoints — events still have exactly one category
   by design.