### PR TITLE
feat(backend): filter discovery by viewer age and gender eligibility (#501)

### DIFF
--- a/backend/internal/adapter/in/postgres/event_repo.go
+++ b/backend/internal/adapter/in/postgres/event_repo.go
@@ -889,6 +889,39 @@ func (r *EventRepository) ListDiscoverableEvents(
 		filters = append(filters, "e.family_oriented = true")
 	}
 
+	// Eligibility filter (issue #501).
+	//
+	// Anonymous viewer: strict — only events with NO age/gender restriction
+	// are returned. We don't know who the caller is, so we cannot claim
+	// they satisfy any restriction.
+	//
+	// Authenticated viewer: generous — events whose restriction the viewer
+	// satisfies are returned, AND events whose restriction is on a
+	// dimension the viewer hasn't filled in (e.g. event requires age 18+
+	// but viewer's birth_date is NULL) are still returned. Joining will
+	// reject with profile_incomplete (existing #467 behavior); we don't
+	// silently hide the event from incomplete profiles. The age check uses
+	// EXTRACT(YEAR FROM AGE($now, viewer.birth_date)) which matches the
+	// year-floor + month/day adjustment of domain.HasMinimumAge so SQL and
+	// the join-flow Go path can never drift apart.
+	viewerJoinClause := ""
+	if params.AnonymousViewer {
+		filters = append(filters,
+			"e.minimum_age IS NULL",
+			"e.preferred_gender IS NULL",
+		)
+	} else {
+		viewerJoinClause = fmt.Sprintf("LEFT JOIN app_user viewer ON viewer.id = %s", userPlaceholder)
+		nowPlaceholder := addArg(params.Now)
+		filters = append(filters, fmt.Sprintf(
+			"(e.minimum_age IS NULL OR viewer.birth_date IS NULL OR EXTRACT(YEAR FROM AGE(%s, viewer.birth_date)) >= e.minimum_age)",
+			nowPlaceholder,
+		))
+		filters = append(filters,
+			"(e.preferred_gender IS NULL OR viewer.gender IS NULL OR e.preferred_gender = viewer.gender)",
+		)
+	}
+
 	paginationClause, orderByClause := buildDiscoverEventsPagination(params, addArg)
 	limitPlaceholder := addArg(params.RepositoryFetchLimit)
 
@@ -919,6 +952,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 			LEFT JOIN event_category ec ON ec.id = e.category_id
 			LEFT JOIN favorite_event fav ON fav.event_id = e.id AND fav.user_id = %s
 			LEFT JOIN user_score us ON us.user_id = e.host_id
+			%s
 			WHERE %s
 		)
 		SELECT
@@ -945,7 +979,7 @@ func (r *EventRepository) ListDiscoverableEvents(
 		%s
 		ORDER BY %s
 		LIMIT %s
-	`, distanceExpr, relevanceExpr, userPlaceholder, strings.Join(filters, "\n			AND "), paginationClause, orderByClause, limitPlaceholder)
+	`, distanceExpr, relevanceExpr, userPlaceholder, viewerJoinClause, strings.Join(filters, "\n			AND "), paginationClause, orderByClause, limitPlaceholder)
 
 	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {

--- a/backend/internal/application/event/repository_dto.go
+++ b/backend/internal/application/event/repository_dto.go
@@ -138,6 +138,16 @@ type DiscoverEventsParams struct {
 	FilterFingerprint    string
 	DecodedCursor        *DiscoverEventsCursor
 	RepositoryFetchLimit int
+	// AnonymousViewer is true when the discovery request has no
+	// authenticated user. The repo uses this to skip the viewer JOIN and
+	// apply a strict eligibility filter (only events with no age/gender
+	// restriction are returned for anonymous callers).
+	AnonymousViewer bool
+	// Now is the reference timestamp used to compute the viewer's age in
+	// the eligibility WHERE clause. Set by the service so query results are
+	// deterministic with respect to the service's clock (also useful for
+	// tests that override `service.now`).
+	Now time.Time
 }
 
 // DiscoverableEventRecord is the repository-level projection used for discovery responses.

--- a/backend/internal/application/event/service.go
+++ b/backend/internal/application/event/service.go
@@ -242,6 +242,12 @@ func (s *Service) DiscoverEvents(ctx context.Context, userID uuid.UUID, input Di
 	}
 	params.FilterFingerprint = fingerprint
 	params.RepositoryFetchLimit = params.Limit + 1
+	// Eligibility filtering is derived from the viewer (anonymous vs auth'd
+	// + their stored age/gender), not from query input, so it deliberately
+	// does NOT enter FilterFingerprint. Two viewers with different profiles
+	// see different result sets but each one paginates consistently.
+	params.AnonymousViewer = userID == uuid.Nil
+	params.Now = s.now().UTC()
 
 	if params.CursorToken != "" {
 		cursor, err := decodeDiscoverEventsCursor(params.CursorToken)

--- a/backend/tests_integration/event_test.go
+++ b/backend/tests_integration/event_test.go
@@ -2964,16 +2964,320 @@ func TestRequestJoinReactivatesRejectedRequestAfterCooldown(t *testing.T) {
 	}
 }
 
+// genderPtr returns a heap-allocated EventParticipantGender for use in test
+// fixtures that take *domain.EventParticipantGender pointers.
+func genderPtr(g domain.EventParticipantGender) *domain.EventParticipantGender { return &g }
+
+// TestDiscoverEventsAnonymousHidesAgeRestrictedEvents asserts the anonymous
+// (uuid.Nil) discovery path applies the strict eligibility policy from #501:
+// only events with no age/gender restriction at all are returned.
+func TestDiscoverEventsAnonymousHidesAgeRestrictedEvents(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("host_eli_anon_age"))
+	categoryID := common.GivenEventCategory(t)
+	originLat := 36.8969 // Antalya Konyaalti
+	originLon := 30.7133
+
+	openEvent := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli Anon Age Open", Description: "no age restriction",
+		CategoryID: categoryID, Lat: 36.8975, Lon: 30.7140,
+		StartTime: time.Now().UTC().Add(24 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+	})
+	restrictedEvent := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli Anon Age 21+", Description: "age 21 restriction",
+		CategoryID: categoryID, Lat: 36.8980, Lon: 30.7145,
+		StartTime: time.Now().UTC().Add(25 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+		MinimumAge: common.IntPtr(21),
+	})
+
+	// when — anonymous discovery (uuid.Nil)
+	result, err := harness.Service.DiscoverEvents(context.Background(), uuid.Nil, eventapp.DiscoverEventsInput{
+		Lat: &originLat, Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	gotIDs := discoverEventIDs(result.Items)
+	if !contains(gotIDs, openEvent.String()) {
+		t.Errorf("expected open event %s in anonymous result, got %v", openEvent, gotIDs)
+	}
+	if contains(gotIDs, restrictedEvent.String()) {
+		t.Errorf("anonymous result should hide age-restricted event %s, got %v", restrictedEvent, gotIDs)
+	}
+}
+
+// TestDiscoverEventsAnonymousHidesGenderRestrictedEvents mirrors the age
+// case for preferred_gender — same strict policy.
+func TestDiscoverEventsAnonymousHidesGenderRestrictedEvents(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("host_eli_anon_gender"))
+	categoryID := common.GivenEventCategory(t)
+	originLat := 36.8969
+	originLon := 30.7250
+
+	openEvent := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli Anon Gender Open", Description: "no gender restriction",
+		CategoryID: categoryID, Lat: 36.8975, Lon: 30.7258,
+		StartTime: time.Now().UTC().Add(24 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+	})
+	restrictedEvent := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli Anon Female Only", Description: "female-only",
+		CategoryID: categoryID, Lat: 36.8980, Lon: 30.7265,
+		StartTime: time.Now().UTC().Add(25 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+		PreferredGender: genderPtr(domain.GenderFemale),
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), uuid.Nil, eventapp.DiscoverEventsInput{
+		Lat: &originLat, Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	gotIDs := discoverEventIDs(result.Items)
+	if !contains(gotIDs, openEvent.String()) {
+		t.Errorf("expected open event %s in anonymous result, got %v", openEvent, gotIDs)
+	}
+	if contains(gotIDs, restrictedEvent.String()) {
+		t.Errorf("anonymous result should hide gender-restricted event %s, got %v", restrictedEvent, gotIDs)
+	}
+}
+
+// TestDiscoverEventsAuthedAdultSeesAgeRestrictedEvent verifies that an
+// authenticated viewer who satisfies the minimum age sees the restricted
+// event in their result set.
+func TestDiscoverEventsAuthedAdultSeesAgeRestrictedEvent(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("host_eli_adult"))
+	adult := common.GivenUser(t, harness.AuthRepo,
+		common.WithUserUsername("viewer_adult"),
+		common.WithUserBirthDate(time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)),
+	)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 40.1885 // Bursa Osmangazi
+	originLon := 29.0610
+
+	restrictedEvent := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli Adult 21+", Description: "age 21 restriction",
+		CategoryID: categoryID, Lat: 40.1890, Lon: 29.0615,
+		StartTime: time.Now().UTC().Add(24 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+		MinimumAge: common.IntPtr(21),
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), adult.ID, eventapp.DiscoverEventsInput{
+		Lat: &originLat, Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	if !contains(discoverEventIDs(result.Items), restrictedEvent.String()) {
+		t.Errorf("adult viewer should see age-restricted event %s, got %v", restrictedEvent, discoverEventIDs(result.Items))
+	}
+}
+
+// TestDiscoverEventsAuthedMinorHidesAgeRestrictedEvent verifies that an
+// authenticated viewer who does NOT meet minimum_age has the event hidden.
+func TestDiscoverEventsAuthedMinorHidesAgeRestrictedEvent(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("host_eli_minor"))
+	minor := common.GivenUser(t, harness.AuthRepo,
+		common.WithUserUsername("viewer_minor"),
+		common.WithUserBirthDate(time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)),
+	)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 40.1885
+	originLon := 29.0750
+
+	restrictedEvent := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli Minor 21+", Description: "age 21 restriction",
+		CategoryID: categoryID, Lat: 40.1890, Lon: 29.0755,
+		StartTime: time.Now().UTC().Add(24 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+		MinimumAge: common.IntPtr(21),
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), minor.ID, eventapp.DiscoverEventsInput{
+		Lat: &originLat, Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	if contains(discoverEventIDs(result.Items), restrictedEvent.String()) {
+		t.Errorf("minor viewer should NOT see age-restricted event %s, got %v", restrictedEvent, discoverEventIDs(result.Items))
+	}
+}
+
+// TestDiscoverEventsAuthedGenderMatchSeesAndMismatchHides covers the two
+// gender outcomes in one fixture: a FEMALE viewer sees the female-only
+// event and not the male-only event.
+func TestDiscoverEventsAuthedGenderMatchSeesAndMismatchHides(t *testing.T) {
+	t.Parallel()
+
+	// given
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("host_eli_gender_match"))
+	female := common.GivenUser(t, harness.AuthRepo,
+		common.WithUserUsername("viewer_female"),
+		common.WithUserGender("FEMALE"),
+	)
+	categoryID := common.GivenEventCategory(t)
+	originLat := 40.1885
+	originLon := 29.0900
+
+	femaleOnly := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli Female Only", Description: "female only",
+		CategoryID: categoryID, Lat: 40.1890, Lon: 29.0905,
+		StartTime: time.Now().UTC().Add(24 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+		PreferredGender: genderPtr(domain.GenderFemale),
+	})
+	maleOnly := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli Male Only", Description: "male only",
+		CategoryID: categoryID, Lat: 40.1895, Lon: 29.0910,
+		StartTime: time.Now().UTC().Add(25 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+		PreferredGender: genderPtr(domain.GenderMale),
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), female.ID, eventapp.DiscoverEventsInput{
+		Lat: &originLat, Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	gotIDs := discoverEventIDs(result.Items)
+	if !contains(gotIDs, femaleOnly.String()) {
+		t.Errorf("FEMALE viewer should see female-only event %s, got %v", femaleOnly, gotIDs)
+	}
+	if contains(gotIDs, maleOnly.String()) {
+		t.Errorf("FEMALE viewer should NOT see male-only event %s, got %v", maleOnly, gotIDs)
+	}
+}
+
+// TestDiscoverEventsAuthedMissingBirthDateSeesAgeRestrictedEvent documents
+// the generous policy for incomplete profiles: events whose restriction is
+// on a dimension the viewer hasn't filled in are still returned. The user
+// will hit profile_incomplete on join attempt — better UX than silent hide.
+func TestDiscoverEventsAuthedMissingBirthDateSeesAgeRestrictedEvent(t *testing.T) {
+	t.Parallel()
+
+	// given — viewer has no birth_date
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("host_eli_no_dob"))
+	viewer := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("viewer_no_dob"))
+	categoryID := common.GivenEventCategory(t)
+	originLat := 40.1885
+	originLon := 29.1050
+
+	restrictedEvent := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli No DOB 21+", Description: "age 21 restriction",
+		CategoryID: categoryID, Lat: 40.1890, Lon: 29.1055,
+		StartTime: time.Now().UTC().Add(24 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+		MinimumAge: common.IntPtr(21),
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat: &originLat, Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	if !contains(discoverEventIDs(result.Items), restrictedEvent.String()) {
+		t.Errorf("viewer with no birth_date should still see age-restricted event %s (generous policy), got %v", restrictedEvent, discoverEventIDs(result.Items))
+	}
+}
+
+// TestDiscoverEventsAuthedMissingGenderSeesGenderRestrictedEvent — same
+// generous policy for viewers without a stored gender.
+func TestDiscoverEventsAuthedMissingGenderSeesGenderRestrictedEvent(t *testing.T) {
+	t.Parallel()
+
+	// given — viewer has no gender
+	harness := common.NewEventHarness(t)
+	host := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("host_eli_no_gender"))
+	viewer := common.GivenUser(t, harness.AuthRepo, common.WithUserUsername("viewer_no_gender"))
+	categoryID := common.GivenEventCategory(t)
+	originLat := 40.1885
+	originLon := 29.1200
+
+	restrictedEvent := createDiscoveryEvent(t, harness, discoveryEventSeed{
+		HostID: host.ID, Title: "Eli No Gender Female Only", Description: "female only",
+		CategoryID: categoryID, Lat: 40.1890, Lon: 29.1205,
+		StartTime: time.Now().UTC().Add(24 * time.Hour), PrivacyLevel: domain.PrivacyPublic,
+		PreferredGender: genderPtr(domain.GenderFemale),
+	})
+
+	// when
+	result, err := harness.Service.DiscoverEvents(context.Background(), viewer.ID, eventapp.DiscoverEventsInput{
+		Lat: &originLat, Lon: &originLon,
+	})
+
+	// then
+	if err != nil {
+		t.Fatalf("DiscoverEvents() error = %v", err)
+	}
+	if !contains(discoverEventIDs(result.Items), restrictedEvent.String()) {
+		t.Errorf("viewer with no gender should still see gender-restricted event %s (generous policy), got %v", restrictedEvent, discoverEventIDs(result.Items))
+	}
+}
+
+// discoverEventIDs and contains are tiny helpers used by the eligibility
+// tests above to assert presence/absence of specific event ids in a
+// discovery result without caring about ordering or other items.
+func discoverEventIDs(items []eventapp.DiscoverableEventItem) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.ID
+	}
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
 type discoveryEventSeed struct {
-	HostID       uuid.UUID
-	Title        string
-	Description  string
-	CategoryID   int
-	Lat          float64
-	Lon          float64
-	StartTime    time.Time
-	PrivacyLevel domain.EventPrivacyLevel
-	Tags         []string
+	HostID          uuid.UUID
+	Title           string
+	Description     string
+	CategoryID      int
+	Lat             float64
+	Lon             float64
+	StartTime       time.Time
+	PrivacyLevel    domain.EventPrivacyLevel
+	Tags            []string
+	MinimumAge      *int
+	PreferredGender *domain.EventParticipantGender
 }
 
 type routeDiscoveryEventSeed struct {
@@ -2996,15 +3300,17 @@ func createDiscoveryEvent(t *testing.T, harness *common.EventHarness, seed disco
 	}
 
 	result, err := harness.Service.CreateEvent(context.Background(), seed.HostID, eventapp.CreateEventInput{
-		Title:        seed.Title,
-		Description:  common.StringPtr(seed.Description),
-		CategoryID:   &seed.CategoryID,
-		LocationType: domain.LocationPoint,
-		Lat:          &seed.Lat,
-		Lon:          &seed.Lon,
-		StartTime:    createStartTime,
-		PrivacyLevel: seed.PrivacyLevel,
-		Tags:         seed.Tags,
+		Title:           seed.Title,
+		Description:     common.StringPtr(seed.Description),
+		CategoryID:      &seed.CategoryID,
+		LocationType:    domain.LocationPoint,
+		Lat:             &seed.Lat,
+		Lon:             &seed.Lon,
+		StartTime:       createStartTime,
+		PrivacyLevel:    seed.PrivacyLevel,
+		Tags:            seed.Tags,
+		MinimumAge:      seed.MinimumAge,
+		PreferredGender: seed.PreferredGender,
 	})
 	if err != nil {
 		t.Fatalf("CreateEvent() discovery seed error = %v", err)

--- a/docs/openapi/event.yaml
+++ b/docs/openapi/event.yaml
@@ -2290,6 +2290,16 @@ paths:
         - `is_favorited` is resolved for the authenticated caller; unauthenticated callers always
           receive `is_favorited: false`.
 
+        Eligibility filtering (issue #501):
+        - **Anonymous callers** see only events with no `minimum_age` or `preferred_gender` restriction.
+          Events with any audience restriction are completely hidden until the caller authenticates.
+        - **Authenticated callers** see events whose restrictions they satisfy (age computed from
+          `birth_date`; gender matched directly), AND — generously — events whose restriction is on a
+          dimension the viewer hasn't filled in (e.g. `minimum_age=21` with `birth_date IS NULL`). The
+          join attempt for those events will then return `400 profile_incomplete`, surfacing the gap to
+          the user instead of silently hiding the event.
+        - Filtering happens in SQL before pagination, so cursors and page sizes remain consistent.
+
         Sorting defaults:
         - If `q` is omitted and `sort_by` is omitted, sorting defaults to `START_TIME`.
         - If `q` is present and `sort_by` is omitted, sorting defaults to `RELEVANCE`.


### PR DESCRIPTION
Closes #501

  ## Summary

  `GET /api/events` discovery now filters out events the viewer is ineligible to join based on the
  event's `minimum_age` and `preferred_gender` — mirroring the join-flow rejection added by PR #467,
  but at the **SQL layer** so cursors and page sizes stay consistent. Two policies, both encoded in
  the WHERE clause and documented in OpenAPI:

  - **Anonymous viewer** (`uuid.Nil`, public discovery from #322) → **strict**: only events with no
  `minimum_age` and no `preferred_gender` are returned. We don't know who they are; we cannot claim
  eligibility.
  - **Authenticated viewer** → **generous**: events whose restriction the viewer satisfies are
  returned, AND events whose restriction is on a dimension the viewer hasn't filled in (e.g.
  `minimum_age=21` with `birth_date IS NULL`) are still returned. The user can attempt to join and
  will get `400 profile_incomplete` (existing #467 behavior). Better UX than silently hiding events
  from incomplete profiles.

  No request/response shape change. Eligibility is derived from the viewer (not query input), so it
  deliberately does NOT enter `FilterFingerprint` — different viewers see different result sets but
  each one paginates consistently.

  ---

  ## Audit findings (what already existed vs what was missing)

  | Item | State | Where |
  |---|---|---|
  | `Event.MinimumAge *int`, `Event.PreferredGender *EventParticipantGender` | ✅ exists |
  `backend/internal/domain/event.go` |
  | `User.Gender *string`, `User.BirthDate *time.Time` | ✅ exists | `backend/internal/domain/user.go`
   |
  | `domain.CheckParticipationEligibility(user, event, now) *AppError` | ✅ exists, used by join flows
   | `backend/internal/domain/join_eligibility.go:14` |
  | `domain.HasMinimumAge(birthDate, minAge, now) bool` | ✅ exists, year-floor + month/day adjustment
   | `backend/internal/domain/join_eligibility.go:52` |
  | Discovery SQL — viewer's `app_user` row joined? | ❌ → ✅ this PR (LEFT JOIN for authed) |
  `backend/internal/adapter/in/postgres/event_repo.go` `ListDiscoverableEvents` |
  | Discovery SQL — `minimum_age` / `preferred_gender` filtered? | ❌ → ✅ this PR | same file |
  | Anonymous handling | ✅ `callerID(c)` returns `uuid.Nil`; service derives `AnonymousViewer` flag |
   `event_handler.go`, `event/service.go` |

  ---

  ## Wire format & contract for #502 (web) and #503 (mobile)

  ### No shape change

  The `DiscoverableEventItem` payload is identical to before. The behavioral change is that ineligible
   events **disappear from the result list entirely** — they don't return as cards with a "you can't
  join" flag.

  ```bash
  curl 'https://api.example.com/api/events?lat=41.01&lon=29.02'
  # Response shape unchanged. Ineligible events simply absent from `items`.
  ```

  ### Anonymous vs authenticated

  ```bash
  # Anonymous: only events without ANY age/gender restriction
  curl '/api/events?lat=...&lon=...'

  # Authenticated: events the viewer satisfies, OR events restricting on a
  # dimension the viewer hasn't filled in (generous policy)
  curl -H 'Authorization: Bearer ...' '/api/events?lat=...&lon=...'
  ```

  ### Decision matrix (clients can use this to predict behavior)

  | Viewer state | Event has `minimum_age=21` | Event has `preferred_gender=FEMALE` |
  |---|---|---|
  | Anonymous | hidden | hidden |
  | Authed, age 25 | visible | depends on viewer.gender |
  | Authed, age 16 | hidden | depends on viewer.gender |
  | Authed, no `birth_date` set | **visible** (generous) | depends on viewer.gender |
  | Authed FEMALE | depends on age | visible |
  | Authed MALE | depends on age | hidden |
  | Authed, no `gender` set | depends on age | **visible** (generous) |

  ### Edge cases clients should know

  1. **User updates profile mid-session** (e.g. adds `birth_date`) — next page may return a different
  set. Cursor invalidation is **not auto-triggered**; clients can refresh the discovery list
  themselves if needed. This is acceptable since the cursor's `FilterFingerprint` deliberately
  excludes viewer-derived filters.
  2. **Anonymous → login transition** — the same query returns more (or different) events after
  authentication. Clients should refetch on auth change.
  3. **Authed user with incomplete profile sees a restricted event but join fails** — backend returns
  `400 profile_incomplete` from #467. Frontend should redirect to profile-complete flow with a clear
  hint.
  4. **Server clock determines age** — viewers turning 18/21 mid-flight start seeing events on the
  next page after their birthday rolls. No client-side recompute needed.

  ### Backward compatibility

  Purely additive **behavior** (filter rule). **No field renames, no removals, no shape changes.**
  Existing clients that didn't filter eligibility on the client (most of them) get correctness for
  free; clients that did filter still work — the backend now just guarantees the same outcome.

  ---

  ## What this PR adds

  ### SQL change (`backend/internal/adapter/in/postgres/event_repo.go`)

  Two branches in `ListDiscoverableEvents`:

  ```go
  // Anonymous: strict
  if params.AnonymousViewer {
      filters = append(filters,
          "e.minimum_age IS NULL",
          "e.preferred_gender IS NULL",
      )
  } else {
      // Authenticated: generous
      viewerJoinClause = fmt.Sprintf("LEFT JOIN app_user viewer ON viewer.id = %s", userPlaceholder)
      nowPlaceholder := addArg(params.Now)
      filters = append(filters, fmt.Sprintf(
          "(e.minimum_age IS NULL OR viewer.birth_date IS NULL OR EXTRACT(YEAR FROM AGE(%s,
  viewer.birth_date)) >= e.minimum_age)",
          nowPlaceholder,
      ))
      filters = append(filters,
          "(e.preferred_gender IS NULL OR viewer.gender IS NULL OR e.preferred_gender =
  viewer.gender)",
      )
  }
  ```

  `EXTRACT(YEAR FROM AGE($now, viewer.birth_date))` matches `domain.HasMinimumAge` Go semantics (year
  floor + month/day adjustment). SQL and the join-flow Go path can never drift apart — same calc.

  ### Service change (`backend/internal/application/event/service.go`)

  ```go
  params.AnonymousViewer = userID == uuid.Nil
  params.Now = s.now().UTC()
  ```

  `Now` is set by the service so tests can override the clock; eligibility is therefore deterministic
  per `service.now()`.

  ### Tests (`backend/tests_integration/event_test.go`)

  `discoveryEventSeed` extended with `MinimumAge *int` + `PreferredGender
  *domain.EventParticipantGender`. Seven new integration tests pin every branch:

  | Test | Asserts |
  |---|---|
  | `TestDiscoverEventsAnonymousHidesAgeRestrictedEvents` | anon viewer doesn't see `minimum_age=21`
  event |
  | `TestDiscoverEventsAnonymousHidesGenderRestrictedEvents` | anon viewer doesn't see
  `preferred_gender=FEMALE` event |
  | `TestDiscoverEventsAuthedAdultSeesAgeRestrictedEvent` | adult (born 1990) sees `minimum_age=21`
  event |
  | `TestDiscoverEventsAuthedMinorHidesAgeRestrictedEvent` | minor (born 2010) doesn't see
  `minimum_age=21` event |
  | `TestDiscoverEventsAuthedGenderMatchSeesAndMismatchHides` | FEMALE viewer sees female-only, hides
  male-only (one fixture, two assertions) |
  | `TestDiscoverEventsAuthedMissingBirthDateSeesAgeRestrictedEvent` | viewer with no `birth_date`
  still sees age-restricted event (generous policy) |
  | `TestDiscoverEventsAuthedMissingGenderSeesGenderRestrictedEvent` | viewer with no `gender` still
  sees gender-restricted event (generous policy) |

  Coordinates isolated by city (Antalya, Bursa) to avoid `t.Parallel`-driven pollution against the
  shared testcontainers Postgres.

  ### OpenAPI (`docs/openapi/event.yaml`)

  `GET /events` description gets a 7-line "Eligibility filtering (issue #501)" section explaining
  anonymous-strict, authed-generous, and the SQL-pagination guarantee. No schema changes.

  ---

  ## References

  ### Sibling issues (frontend/mobile)
  - Web — #502
  - Mobile — #503

  ### Code entry points
  - Service: `backend/internal/application/event/service.go` (`DiscoverEvents`, lines ~245)
  - Repo SQL: `backend/internal/adapter/in/postgres/event_repo.go` (`ListDiscoverableEvents`,
  eligibility block ~line 892)
  - DTO: `backend/internal/application/event/repository_dto.go`
  (`DiscoverEventsParams.AnonymousViewer`, `Now`)
  - Go-level join eligibility (kept as-is for join flows):
  `backend/internal/domain/join_eligibility.go`
  - OpenAPI: `docs/openapi/event.yaml` — `/events` operation description

  ### Closed PRs that prepared the ground
  - #225 — added `gender` and `birth_date` to user
  - #322 — public/anonymous event discovery
  - #467 — Go-level eligibility helper + join-flow enforcement (this PR pushes the same predicate into
   discovery SQL)
  - #576 — audience attributes (parallel work; informed the discoveryEventSeed extension pattern)

  ### Contribution conventions
  - https://github.com/bounswe/bounswe2026group11/blob/main/docs/conventions.md

  ---

  ## Notable design decisions

  - **SQL filter, not Go post-filter.** Per-row Go evaluation breaks SQL keyset pagination — pages
  would arrive with fewer items than requested. SQL pushes the predicate down so cursor-stable
  pagination holds.
  - **Don't reuse `domain.CheckParticipationEligibility` in discovery.** That helper is shaped for
  join flows (returns `*AppError` with reason). Discovery doesn't need a reason — it just needs a
  yes/no SQL predicate. Same logical rules, different evaluation surface; comments in service + repo
  cross-reference for parity.
  - **Generous missing-attribute policy.** The dark-pattern alternative (silently hide events from
  users with incomplete profiles) is worse: users would never know events existed. Surfacing them and
  letting the join fail with `profile_incomplete` puts the gap in the user's face where they can fix
  it.
  - **Eligibility excluded from `FilterFingerprint`.** Two viewers paginating the same query
  independently is correct. A viewer fixing their profile mid-session sees a slightly different next
  page, which is acceptable (and expected — they just unlocked content).

  ---

  ## Test plan

  - [x] `go test ./internal/...` — all packages green; service `DiscoverEvents` coverage 86.1%
  - [x] `go test -race -count=1 ./internal/...` — 30 packages, 0 races
  - [x] `go test -tags=integration ./tests_integration/...` — full suite green (≈25s); new 7 tests
  pass (≈14s subset)
  - [x] `go vet`, `golangci-lint` (0 issues), `gosec` (no findings) — all clean
  - [x] `go build ./cmd/server`
  - [x] HTML coverage on the new SQL block: **100%** (every `if`/`else` branch hit; `cov8` on every
  added line)
  - [x] `ListDiscoverableEvents` repo function coverage via `-coverpkg`: **90.5%** (remaining 9.5% are
   pre-existing DB-error paths)

  ---

  ## Out of scope

  - Frontend (#502) and mobile (#503) consumer updates — separate PRs once this lands.
  - Pushing eligibility filter into other event endpoints — the event detail page is intentionally NOT
   filtered. A user following a deep link to a restricted event should see the page with a clear
  "you're not eligible to join" banner from the join attempt, not a 404.
  - Per-event eligibility breakdown in the discovery card payload (e.g. "this event requires age 21+")
   — frontend doesn't need it because such events are filtered out for ineligible viewers.
  - Changing `domain.CheckParticipationEligibility` or join-flow rejection logic — kept as-is.
  - DB error path coverage in `ListDiscoverableEvents` — pre-existing gap, not specific to #501.