### PR TITLE
fix(frontend): improve event-detail join feedback and state handling

### DIFF
--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -163,7 +163,11 @@ export interface EventDetailEmbeddedRating {
 export interface EventDetailViewerContext {
   is_host: boolean;
   is_favorited: boolean;
-  participation_status: 'JOINED' | 'PENDING' | 'INVITED' | 'NONE' | 'LEAVED' | 'CANCELED';
+  participation_status: 'APPROVED' | 'JOINED' | 'PENDING' | 'INVITED' | 'NONE' | 'LEAVED' | 'CANCELED';
+}
+
+export function isActiveEventParticipantStatus(status: string | null | undefined): boolean {
+  return status === 'JOINED' || status === 'APPROVED';
 }
 
 export interface EventDetailHostContextUser {

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -1542,6 +1542,34 @@
   line-height: 1;
 }
 
+.ed-join-success {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background-color: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #15803d;
+  font-size: 14px;
+  margin-bottom: 10px;
+}
+
+.ed-join-success span:first-child {
+  flex: 1;
+}
+
+.ed-join-success-dismiss {
+  background: none;
+  border: none;
+  color: #15803d;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
 .ed-constraint-warning {
   padding: 10px 14px;
   border-radius: 10px;

--- a/frontend/src/utils/locationApproximation.test.ts
+++ b/frontend/src/utils/locationApproximation.test.ts
@@ -28,11 +28,19 @@ describe('shouldShowApproximateLocationIndicator', () => {
       expected: true,
     },
     {
-      name: 'protected approved participant with exact backend location',
+      name: 'protected joined participant with exact backend location',
       privacyLevel: 'PROTECTED' as const,
       isLocationApproximate: false,
       isHost: false,
       participationStatus: 'JOINED',
+      expected: false,
+    },
+    {
+      name: 'protected approved participant with exact backend location',
+      privacyLevel: 'PROTECTED' as const,
+      isLocationApproximate: false,
+      isHost: false,
+      participationStatus: 'APPROVED',
       expected: false,
     },
     {

--- a/frontend/src/utils/locationApproximation.ts
+++ b/frontend/src/utils/locationApproximation.ts
@@ -1,4 +1,4 @@
-import type { PrivacyLevel } from '@/models/event';
+import { isActiveEventParticipantStatus, type PrivacyLevel } from '@/models/event';
 
 interface ApproximateLocationContext {
   privacyLevel: PrivacyLevel;
@@ -18,7 +18,7 @@ export function shouldShowApproximateLocationIndicator({
   if (!isLocationApproximate) return false;
   if (privacyLevel !== 'PROTECTED') return false;
   if (isHost) return false;
-  return participationStatus !== 'JOINED';
+  return !isActiveEventParticipantStatus(participationStatus);
 }
 
 export function getApproximateLocationText(hasAddress: boolean): string {

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
@@ -8,6 +8,7 @@ const mockGetEventDetail = vi.fn();
 const mockGetEventHostContextSummary = vi.fn();
 const mockAddFavorite = vi.fn();
 const mockRemoveFavorite = vi.fn();
+const mockJoinEvent = vi.fn();
 const mockRequestJoinEvent = vi.fn();
 const mockCreateEventReport = vi.fn();
 
@@ -17,7 +18,7 @@ vi.mock('@/services/eventService', () => ({
   getEventImageUploadUrl: vi.fn(),
   getJoinRequestImageUploadUrl: vi.fn(),
   confirmEventImageUpload: vi.fn(),
-  joinEvent: vi.fn(),
+  joinEvent: (...args: unknown[]) => mockJoinEvent(...args),
   requestJoinEvent: (...args: unknown[]) => mockRequestJoinEvent(...args),
   listEventApprovedParticipants: vi.fn(),
   listEventPendingJoinRequests: vi.fn(),
@@ -99,6 +100,7 @@ describe('useEventDetailViewModel favorites', () => {
     });
     mockAddFavorite.mockResolvedValue(undefined);
     mockRemoveFavorite.mockResolvedValue(undefined);
+    mockJoinEvent.mockResolvedValue(undefined);
     mockRequestJoinEvent.mockResolvedValue({
       join_request_id: 'join-request-1',
       event_id: 'event-1',
@@ -205,6 +207,35 @@ describe('useEventDetailViewModel favorites', () => {
       image_confirm_token: undefined,
     });
     expect(result.current.event?.viewer_context.participation_status).toBe('PENDING');
+    expect(result.current.joinError).toBeNull();
+  });
+
+  it('marks the viewer as approved and shows success after a successful direct join', async () => {
+    mockGetEventDetail
+      .mockResolvedValueOnce(
+        makeEvent({
+          privacy_level: 'PUBLIC',
+          status: 'ACTIVE',
+          viewer_context: {
+            is_host: false,
+            is_favorited: false,
+            participation_status: 'NONE',
+          },
+        }),
+      )
+      .mockRejectedValueOnce(new Error('stale detail fetch'));
+
+    const { result } = renderHook(() => useEventDetailViewModel('event-1', 'token'));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      await result.current.handleJoin();
+    });
+
+    expect(mockJoinEvent).toHaveBeenCalledWith('event-1', 'token');
+    expect(result.current.event?.viewer_context.participation_status).toBe('APPROVED');
+    expect(result.current.joinSuccess).toBe('You joined the event successfully.');
     expect(result.current.joinError).toBeNull();
   });
 });

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -58,6 +58,8 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   const [invitationsHasNext, setInvitationsHasNext] = useState(false);
   const [joinLoading, setJoinLoading] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
+  const [joinSuccess, setJoinSuccess] = useState<string | null>(null);
+  const joinSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [leaveLoading, setLeaveLoading] = useState(false);
   const [leaveError, setLeaveError] = useState<string | null>(null);
   const [viewerRatingLoading, setViewerRatingLoading] = useState(false);
@@ -81,6 +83,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   useEffect(
     () => () => {
       if (coverImageSuccessTimerRef.current) clearTimeout(coverImageSuccessTimerRef.current);
+      if (joinSuccessTimerRef.current) clearTimeout(joinSuccessTimerRef.current);
     },
     [],
   );
@@ -282,10 +285,15 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   }, []);
 
   const handleRequestJoin = useCallback(
-    async (message?: string, imageFile?: File | null) => {
-      if (!eventId || !token) return;
+    async (message?: string, imageFile?: File | null): Promise<boolean> => {
+      if (!eventId || !token) return false;
       setJoinLoading(true);
       setJoinError(null);
+      if (joinSuccessTimerRef.current) {
+        clearTimeout(joinSuccessTimerRef.current);
+        joinSuccessTimerRef.current = null;
+      }
+      setJoinSuccess(null);
 
       try {
         let imageConfirmToken: string | undefined;
@@ -316,6 +324,12 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
         } catch {
           // Keep the optimistic pending state if the follow-up detail fetch is stale or fails.
         }
+        setJoinSuccess('Request sent successfully. The host will review it.');
+        joinSuccessTimerRef.current = setTimeout(() => {
+          setJoinSuccess(null);
+          joinSuccessTimerRef.current = null;
+        }, 5000);
+        return true;
       } catch (err) {
         if (err instanceof ApiError) {
           const errorMap: Record<string, string> = {
@@ -332,6 +346,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
         } else {
           setJoinError('Failed to send join request. Please try again.');
         }
+        return false;
       } finally {
         setJoinLoading(false);
       }
@@ -614,6 +629,13 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   }, [eventId, token, refreshEventDetail, mapRatingError, refreshApprovedParticipants]);
 
   const dismissJoinError = useCallback(() => setJoinError(null), []);
+  const dismissJoinSuccess = useCallback(() => {
+    if (joinSuccessTimerRef.current) {
+      clearTimeout(joinSuccessTimerRef.current);
+      joinSuccessTimerRef.current = null;
+    }
+    setJoinSuccess(null);
+  }, []);
   const dismissLeaveError = useCallback(() => setLeaveError(null), []);
   const dismissModerateError = useCallback(() => setModerateError(null), []);
   const dismissCancelError = useCallback(() => setCancelError(null), []);
@@ -795,6 +817,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     clearInviteResult,
     joinLoading,
     joinError,
+    joinSuccess,
     leaveLoading,
     leaveError,
     viewerRatingLoading,
@@ -828,6 +851,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     handleCancel,
     handleComplete,
     dismissJoinError,
+    dismissJoinSuccess,
     dismissLeaveError,
     dismissViewerRatingError,
     dismissParticipantRatingError,

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -30,6 +30,7 @@ import type {
   EventDetailPendingJoinRequest,
   EventDetailResponse,
   EventHostContextSummary,
+  EventDetailViewerContext,
 } from '@/models/event';
 import type { CreateEventInvitationsResponse } from '@/models/invitation';
 import { ApiError } from '@/services/api';
@@ -87,6 +88,23 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     },
     [],
   );
+
+  const clearJoinSuccess = useCallback(() => {
+    if (joinSuccessTimerRef.current) {
+      clearTimeout(joinSuccessTimerRef.current);
+      joinSuccessTimerRef.current = null;
+    }
+    setJoinSuccess(null);
+  }, []);
+
+  const showJoinSuccess = useCallback((message: string) => {
+    clearJoinSuccess();
+    setJoinSuccess(message);
+    joinSuccessTimerRef.current = setTimeout(() => {
+      setJoinSuccess(null);
+      joinSuccessTimerRef.current = null;
+    }, 5000);
+  }, [clearJoinSuccess]);
 
   const refreshEventDetail = useCallback(async () => {
     if (!eventId) {
@@ -230,10 +248,26 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     if (!eventId || !token) return;
     setJoinLoading(true);
     setJoinError(null);
+    clearJoinSuccess();
 
     try {
       await joinEvent(eventId, token);
-      await refreshEventDetail();
+      setEvent((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          viewer_context: {
+            ...prev.viewer_context,
+            participation_status: 'APPROVED' as EventDetailViewerContext['participation_status'],
+          },
+        };
+      });
+      try {
+        await refreshEventDetail();
+      } catch {
+        // Keep the optimistic approved state if the follow-up detail fetch is stale or fails.
+      }
+      showJoinSuccess('You joined the event successfully.');
     } catch (err) {
       if (err instanceof ApiError) {
         const errorMap: Record<string, string> = {
@@ -249,7 +283,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     } finally {
       setJoinLoading(false);
     }
-  }, [eventId, token, refreshEventDetail]);
+  }, [clearJoinSuccess, eventId, token, refreshEventDetail, showJoinSuccess]);
 
   const handleLeave = useCallback(async () => {
     if (!eventId || !token) return;
@@ -289,11 +323,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
       if (!eventId || !token) return false;
       setJoinLoading(true);
       setJoinError(null);
-      if (joinSuccessTimerRef.current) {
-        clearTimeout(joinSuccessTimerRef.current);
-        joinSuccessTimerRef.current = null;
-      }
-      setJoinSuccess(null);
+      clearJoinSuccess();
 
       try {
         let imageConfirmToken: string | undefined;
@@ -324,11 +354,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
         } catch {
           // Keep the optimistic pending state if the follow-up detail fetch is stale or fails.
         }
-        setJoinSuccess('Request sent successfully. The host will review it.');
-        joinSuccessTimerRef.current = setTimeout(() => {
-          setJoinSuccess(null);
-          joinSuccessTimerRef.current = null;
-        }, 5000);
+        showJoinSuccess('Request sent successfully. The host will review it.');
         return true;
       } catch (err) {
         if (err instanceof ApiError) {
@@ -351,7 +377,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
         setJoinLoading(false);
       }
     },
-    [eventId, token, markViewerPendingJoinRequest, refreshEventDetail],
+    [clearJoinSuccess, eventId, token, markViewerPendingJoinRequest, refreshEventDetail, showJoinSuccess],
   );
 
   const [cancelJoinRequestLoading, setCancelJoinRequestLoading] = useState(false);
@@ -629,13 +655,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   }, [eventId, token, refreshEventDetail, mapRatingError, refreshApprovedParticipants]);
 
   const dismissJoinError = useCallback(() => setJoinError(null), []);
-  const dismissJoinSuccess = useCallback(() => {
-    if (joinSuccessTimerRef.current) {
-      clearTimeout(joinSuccessTimerRef.current);
-      joinSuccessTimerRef.current = null;
-    }
-    setJoinSuccess(null);
-  }, []);
+  const dismissJoinSuccess = clearJoinSuccess;
   const dismissLeaveError = useCallback(() => setLeaveError(null), []);
   const dismissModerateError = useCallback(() => setModerateError(null), []);
   const dismissCancelError = useCallback(() => setCancelError(null), []);

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -485,6 +485,21 @@ describe('EventDetailPage ratings', () => {
     expect(screen.queryByRole('button', { name: /join event/i })).toBeNull();
   });
 
+  it('shows leave controls for approved participants as well as legacy joined participants', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PUBLIC';
+    event.viewer_context.participation_status = 'APPROVED';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByText(/you are participating in this event/i)).toBeDefined();
+    expect(screen.getByRole('button', { name: /leave event/i })).toBeDefined();
+    expect(screen.getByTestId('ed-view-ticket-cta')).toBeDefined();
+  });
+
   it('keeps the request form open when sending a join request fails', async () => {
     const event = makeBaseEvent();
     event.status = 'ACTIVE';
@@ -552,6 +567,23 @@ describe('EventDetailPage ratings', () => {
     renderPage();
 
     expect(screen.getByText(/request sent successfully\./i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss message/i }));
+    expect(vm.dismissJoinSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the join success message in the active participant state when provided by the view model', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PUBLIC';
+    event.viewer_context.participation_status = 'APPROVED';
+    const vm = makeReadyViewModel(event);
+    vm.joinSuccess = 'You joined the event successfully.';
+
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    expect(screen.getByText(/you joined the event successfully\./i)).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: /dismiss message/i }));
     expect(vm.dismissJoinSuccess).toHaveBeenCalledTimes(1);
   });
@@ -722,6 +754,19 @@ describe('EventDetailPage ratings', () => {
     event.status = 'ACTIVE';
     event.privacy_level = 'PUBLIC';
     event.viewer_context.participation_status = 'JOINED';
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByTestId('ed-view-ticket-cta')).toBeDefined();
+  });
+
+  it('shows the View Ticket CTA for approved participants on public events', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PUBLIC';
+    event.viewer_context.participation_status = 'APPROVED';
 
     mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
 

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -104,6 +104,7 @@ function makeReadyViewModel(event: EventDetailResponse) {
     invitationsHasNext: false,
     joinLoading: false,
     joinError: null,
+    joinSuccess: null,
     leaveLoading: false,
     leaveError: null,
     viewerRatingLoading: false,
@@ -133,6 +134,7 @@ function makeReadyViewModel(event: EventDetailResponse) {
     handleFavoriteToggle: vi.fn(),
     handleReportEvent: vi.fn(),
     dismissJoinError: vi.fn(),
+    dismissJoinSuccess: vi.fn(),
     dismissLeaveError: vi.fn(),
     dismissViewerRatingError: vi.fn(),
     dismissParticipantRatingError: vi.fn(),
@@ -477,8 +479,81 @@ describe('EventDetailPage ratings', () => {
     renderPage();
 
     expect(screen.getByText(/your join request is pending approval/i)).toBeDefined();
+    expect((screen.getByTestId('ed-request-pending-btn') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/request pending/i)).toBeDefined();
     expect(screen.queryByRole('button', { name: /request to join/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /join event/i })).toBeNull();
+  });
+
+  it('keeps the request form open when sending a join request fails', async () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'NONE';
+    const vm = makeReadyViewModel(event);
+    vm.handleRequestJoin.mockResolvedValue(false);
+
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /request to join/i }));
+    fireEvent.change(screen.getByPlaceholderText(/add a message \(optional\)\.\.\./i), {
+      target: { value: 'Please let me join.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send request/i }));
+
+    await waitFor(() => {
+      expect(vm.handleRequestJoin).toHaveBeenCalledWith('Please let me join.', null);
+    });
+
+    expect(screen.getByPlaceholderText(/add a message \(optional\)\.\.\./i)).toBeDefined();
+    expect(screen.getByDisplayValue('Please let me join.')).toBeDefined();
+  });
+
+  it('closes the request form after a successful join request submission', async () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'NONE';
+    const vm = makeReadyViewModel(event);
+    vm.handleRequestJoin.mockResolvedValue(true);
+
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /request to join/i }));
+    fireEvent.change(screen.getByPlaceholderText(/add a message \(optional\)\.\.\./i), {
+      target: { value: 'Please let me join.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send request/i }));
+
+    await waitFor(() => {
+      expect(vm.handleRequestJoin).toHaveBeenCalledWith('Please let me join.', null);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText(/add a message \(optional\)\.\.\./i)).toBeNull();
+    });
+    expect(screen.getByRole('button', { name: /request to join/i })).toBeDefined();
+  });
+
+  it('shows the join success message in the pending state when provided by the view model', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'PENDING';
+    const vm = makeReadyViewModel(event);
+    vm.joinSuccess = 'Request sent successfully. The host will review it.';
+
+    mockUseEventDetailViewModel.mockReturnValue(vm);
+
+    renderPage();
+
+    expect(screen.getByText(/request sent successfully\./i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss message/i }));
+    expect(vm.dismissJoinSuccess).toHaveBeenCalledTimes(1);
   });
 
   it('shows the proof image picker in the request form when expanded', () => {

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -11,6 +11,7 @@ import type {
   EventDetailResponse,
   EventHostContextSummary,
 } from '@/models/event';
+import { isActiveEventParticipantStatus } from '@/models/event';
 import type {
   CreateEventInvitationsResponse,
   EventInvitationFailure,
@@ -612,12 +613,13 @@ function JoinActionSection({
   const requestImageInputRef = useRef<HTMLInputElement>(null);
   const [showCancelRequestModal, setShowCancelRequestModal] = useState(false);
   const ctx = event.viewer_context;
+  const isActiveParticipant = isActiveEventParticipantStatus(ctx.participation_status);
 
   // Host doesn't see join actions
   if (ctx.is_host) return null;
 
   // Already participating states
-  if (ctx.participation_status === 'JOINED') {
+  if (isActiveParticipant) {
     const isCompletedOrCanceled = event.status === 'COMPLETED' || event.status === 'CANCELED';
     const joinedBannerClass = event.status === 'COMPLETED'
       ? 'ed-participation-attended'
@@ -628,6 +630,19 @@ function JoinActionSection({
 
     return (
       <div className="ed-section">
+        {joinSuccess && (
+          <div className="ed-join-success" role="status">
+            <span>{joinSuccess}</span>
+            <button
+              type="button"
+              className="ed-join-success-dismiss"
+              onClick={onDismissJoinSuccess}
+              aria-label="Dismiss message"
+            >
+              &times;
+            </button>
+          </div>
+        )}
         <div className={`ed-participation-banner ${joinedBannerClass}`}>
           {joinedBannerText}
         </div>
@@ -1042,7 +1057,7 @@ function ParticipantRatingSection({
   const trimmedLength = message.trim().length;
   const isEligibleParticipant = (
     !event.viewer_context.is_host
-    && event.viewer_context.participation_status === 'JOINED'
+    && isActiveEventParticipantStatus(event.viewer_context.participation_status)
     && event.status === 'COMPLETED'
     && event.rating_window.is_active
   );

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -570,12 +570,14 @@ function JoinActionSection({
   event,
   joinLoading,
   joinError,
+  joinSuccess,
   leaveLoading,
   leaveError,
   onJoin,
   onLeave,
   onRequestJoin,
   onDismissError,
+  onDismissJoinSuccess,
   onDismissLeaveError,
   isAuthenticated,
   cancelJoinRequestLoading,
@@ -586,12 +588,14 @@ function JoinActionSection({
   event: EventDetailResponse;
   joinLoading: boolean;
   joinError: string | null;
+  joinSuccess: string | null;
   leaveLoading: boolean;
   leaveError: string | null;
   onJoin: () => void;
   onLeave: () => void;
-  onRequestJoin: (message?: string, imageFile?: File | null) => void;
+  onRequestJoin: (message?: string, imageFile?: File | null) => Promise<boolean>;
   onDismissError: () => void;
+  onDismissJoinSuccess: () => void;
   onDismissLeaveError: () => void;
   isAuthenticated: boolean;
   cancelJoinRequestLoading: boolean;
@@ -678,6 +682,19 @@ function JoinActionSection({
   if (ctx.participation_status === 'PENDING') {
     return (
       <div className="ed-section">
+        {joinSuccess && (
+          <div className="ed-join-success" role="status">
+            <span>{joinSuccess}</span>
+            <button
+              type="button"
+              className="ed-join-success-dismiss"
+              onClick={onDismissJoinSuccess}
+              aria-label="Dismiss message"
+            >
+              &times;
+            </button>
+          </div>
+        )}
         <div className="ed-participation-banner ed-participation-pending">
           Your join request is pending approval
         </div>
@@ -695,6 +712,14 @@ function JoinActionSection({
           </div>
         )}
         <div className="ed-leave-action">
+          <button
+            type="button"
+            className="btn-primary ed-join-btn ed-join-btn-protected"
+            disabled
+            data-testid="ed-request-pending-btn"
+          >
+            Request Pending
+          </button>
           <button
             type="button"
             className="ed-leave-btn"
@@ -804,7 +829,11 @@ function JoinActionSection({
                 onClick={() => setShowRequestForm(true)}
                 disabled={!isAuthenticated || joinLoading}
               >
-                Request to Join
+                {joinLoading ? (
+                  <>
+                    <span className="spinner" /> Sending...
+                  </>
+                ) : 'Request to Join'}
               </button>
             </>
           ) : (
@@ -887,11 +916,12 @@ function JoinActionSection({
                 <button
                   type="button"
                   className="btn-primary ed-join-btn"
-                  onClick={() => {
-                    onRequestJoin(
+                  onClick={async () => {
+                    const ok = await onRequestJoin(
                       requestMessage.trim() || undefined,
                       requestImageFile,
                     );
+                    if (!ok) return;
                     setShowRequestForm(false);
                     setRequestMessage('');
                     setRequestImageFile(null);
@@ -901,7 +931,11 @@ function JoinActionSection({
                   }}
                   disabled={joinLoading}
                 >
-                  {joinLoading ? <span className="spinner" /> : 'Send Request'}
+                  {joinLoading ? (
+                    <>
+                      <span className="spinner" /> Sending...
+                    </>
+                  ) : 'Send Request'}
                 </button>
                 <button
                   type="button"
@@ -1590,6 +1624,7 @@ function EventContent({
   event,
   joinLoading,
   joinError,
+  joinSuccess,
   leaveLoading,
   leaveError,
   viewerRatingLoading,
@@ -1602,6 +1637,7 @@ function EventContent({
   onViewerRatingSubmit,
   onParticipantRatingSubmit,
   onDismissError,
+  onDismissJoinSuccess,
   onDismissLeaveError,
   onDismissViewerRatingError,
   onDismissParticipantRatingError,
@@ -1661,6 +1697,7 @@ function EventContent({
   event: EventDetailResponse;
   joinLoading: boolean;
   joinError: string | null;
+  joinSuccess: string | null;
   leaveLoading: boolean;
   leaveError: string | null;
   viewerRatingLoading: boolean;
@@ -1669,10 +1706,11 @@ function EventContent({
   participantRatingError: { participantUserId: string; message: string } | null;
   onJoin: () => void;
   onLeave: () => void;
-  onRequestJoin: (message?: string, imageFile?: File | null) => void;
+  onRequestJoin: (message?: string, imageFile?: File | null) => Promise<boolean>;
   onViewerRatingSubmit: (rating: number, message?: string) => void;
   onParticipantRatingSubmit: (participantUserId: string, rating: number, message?: string) => void;
   onDismissError: () => void;
+  onDismissJoinSuccess: () => void;
   onDismissLeaveError: () => void;
   onDismissViewerRatingError: () => void;
   onDismissParticipantRatingError: () => void;
@@ -1890,12 +1928,14 @@ function EventContent({
         event={event}
         joinLoading={joinLoading}
         joinError={joinError}
+        joinSuccess={joinSuccess}
         leaveLoading={leaveLoading}
         leaveError={leaveError}
         onJoin={onJoin}
         onLeave={onLeave}
         onRequestJoin={onRequestJoin}
         onDismissError={onDismissError}
+        onDismissJoinSuccess={onDismissJoinSuccess}
         onDismissLeaveError={onDismissLeaveError}
         isAuthenticated={isAuthenticated}
         cancelJoinRequestLoading={cancelJoinRequestLoading}
@@ -2327,6 +2367,7 @@ export default function EventDetailPage() {
       onDismissCancelJoinRequestError={vm.dismissCancelJoinRequestError}
       joinLoading={vm.joinLoading}
       joinError={vm.joinError}
+      joinSuccess={vm.joinSuccess}
       leaveLoading={vm.leaveLoading}
       leaveError={vm.leaveError}
       viewerRatingLoading={vm.viewerRatingLoading}
@@ -2339,6 +2380,7 @@ export default function EventDetailPage() {
       onViewerRatingSubmit={vm.handleViewerRatingSubmit}
       onParticipantRatingSubmit={vm.handleParticipantRatingSubmit}
       onDismissError={vm.dismissJoinError}
+      onDismissJoinSuccess={vm.dismissJoinSuccess}
       onDismissLeaveError={vm.dismissLeaveError}
       onDismissViewerRatingError={vm.dismissViewerRatingError}
       onDismissParticipantRatingError={vm.dismissParticipantRatingError}

--- a/frontend/src/views/events/EventInteractionPanel.tsx
+++ b/frontend/src/views/events/EventInteractionPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { UserAvatar } from '@/components/UserAvatar';
-import type { EventComment, EventDetailResponse } from '@/models/event';
+import { isActiveEventParticipantStatus, type EventComment, type EventDetailResponse } from '@/models/event';
 import { useEventCommentsViewModel } from '@/viewmodels/event/useEventCommentsViewModel';
 
 const COMMENT_MAX_LENGTH = 1000;
@@ -322,7 +322,8 @@ function DiscussionSection({ event, vm, isAuthenticated }: DiscussionSectionProp
     if (event.privacy_level === 'PRIVATE') return false;
     if (event.status === 'ACTIVE') return true;
     if (event.status === 'IN_PROGRESS') {
-      return event.viewer_context.is_host || event.viewer_context.participation_status === 'JOINED';
+      return event.viewer_context.is_host
+        || isActiveEventParticipantStatus(event.viewer_context.participation_status);
     }
     return false;
   })();
@@ -484,7 +485,7 @@ function ReviewSection({ event, vm, isAuthenticated }: ReviewSectionProps) {
 
   const isVerifiedAttendee =
     !event.viewer_context.is_host
-    && event.viewer_context.participation_status === 'JOINED'
+    && isActiveEventParticipantStatus(event.viewer_context.participation_status)
     && event.status === 'COMPLETED'
     && event.privacy_level !== 'PRIVATE';
 


### PR DESCRIPTION
## 📋 Summary
This PR improves event-detail join responsiveness on the web for both protected and public events. It fixes the protected request-to-join UX, adds missing success feedback for direct public joins, and aligns the frontend with the backend's active participation state so already-approved participants correctly see leave/ticket/participant-only UI.

## 🔄 Changes
- Improved the protected `Request to Join` flow on `EventDetailPage`
- Added explicit pending-state UI for protected requests:
  - disabled `Request Pending` button when the viewer already has a pending request
  - keeps the pending approval banner visible
- Added loading feedback for protected join requests:
  - spinner + `Sending...` while the request is in flight
- Added success feedback for join actions in the event detail view model:
  - auto-dismissed success state after 5 seconds
  - manual dismiss action from the UI
- Changed protected request form behavior:
  - form stays open on failure
  - form closes only after successful submission
- Added success feedback for public direct joins as well
- Optimistically updates public direct joins to active participant state before refresh completes
- Aligned frontend participant-state handling with backend event-detail semantics:
  - supports backend `APPROVED` as an active participation state
  - preserves compatibility with legacy `JOINED`
- Updated participant-only event-detail surfaces to respect active participant state consistently:
  - `Leave Event`
  - `View Ticket`
  - event interaction/discussion eligibility during active events
  - post-event participant review eligibility
  - protected approximate-location visibility logic
- Added/updated targeted tests covering:
  - pending-state rendering
  - failed protected request keeps form open
  - successful protected request closes form
  - join success message rendering and dismissal
  - public direct join success state
  - approved participant leave/ticket visibility
  - approximate-location logic for approved participants

## 🧪 Testing
- Ran targeted tests:
  - `cd frontend && npm test -- src/views/events/EventDetailPage.test.tsx`
  - `cd frontend && npm test -- src/viewmodels/event/useEventDetailViewModel.test.ts src/views/events/EventDetailPage.test.tsx src/utils/locationApproximation.test.ts`
- Ran frontend production build:
  - `cd frontend && npm run build`

## 🔗 Related
Closes #616
