### PR TITLE
Add frontend event edit and reconfirmation UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
 import DiscoverPage from './views/discover/DiscoverPage';
 import CreateEventPage from './views/events/CreateEventPage';
+import EditEventPage from './views/events/EditEventPage';
 import EventDetailPage from './views/events/EventDetailPage';
 import MyEventsPage from './views/events/MyEventsPage';
 import InvitationsPage from './views/invitations/InvitationsPage';
@@ -57,6 +58,7 @@ export default function App() {
 
             {/* Protected routes — require auth */}
             <Route path="/events/create" element={<ProtectedRoute><CreateEventPage /></ProtectedRoute>} />
+            <Route path="/events/:id/edit" element={<ProtectedRoute><EditEventPage /></ProtectedRoute>} />
             <Route path="/events/:id" element={<EventDetailPage />} />
             <Route path="/my-events" element={<ProtectedRoute><MyEventsPage /></ProtectedRoute>} />
             <Route path="/invitations" element={<ProtectedRoute><InvitationsPage /></ProtectedRoute>} />

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -47,6 +47,35 @@ export interface CreateEventResponse {
   created_at: string;
 }
 
+export interface UpdateEventRequest {
+  title?: string;
+  description?: string | null;
+  category_id?: number | null;
+  address?: string | null;
+  lat?: number;
+  lon?: number;
+  location_type?: LocationType;
+  route_points?: RoutePoint[];
+  start_time?: string;
+  end_time?: string | null;
+  capacity?: number | null;
+  constraints?: EventConstraint[];
+}
+
+export interface UpdateEventResponse {
+  id: string;
+  title: string;
+  privacy_level: PrivacyLevel;
+  status: 'ACTIVE';
+  start_time: string;
+  end_time?: string | null;
+  version_no: number;
+  reconfirmation_required: boolean;
+  reconfirmation_triggered_fields: string[];
+  participants_marked_pending: number;
+  updated_at: string;
+}
+
 export interface CategoryItem {
   id: number;
   name: string;
@@ -163,7 +192,26 @@ export interface EventDetailEmbeddedRating {
 export interface EventDetailViewerContext {
   is_host: boolean;
   is_favorited: boolean;
-  participation_status: 'JOINED' | 'PENDING' | 'INVITED' | 'NONE' | 'LEAVED' | 'CANCELED';
+  participation_status: 'APPROVED' | 'JOINED' | 'PENDING' | 'INVITED' | 'NONE' | 'LEAVED' | 'CANCELED' | null;
+  join_request_status?: 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELED' | null;
+  invitation_status?: string | null;
+  needs_reconfirmation?: boolean;
+  last_confirmed_event_version?: number | null;
+  latest_event_version?: number;
+  event_diff?: EventVersionDiff | null;
+}
+
+export interface EventVersionChange {
+  field: string;
+  old_value: unknown;
+  new_value: unknown;
+}
+
+export interface EventVersionDiff {
+  from_version_no: number;
+  to_version_no: number;
+  changed_fields: string[];
+  changes: EventVersionChange[];
 }
 
 export interface EventDetailHostContextUser {
@@ -223,6 +271,7 @@ export interface EventCollectionPageInfo {
 
 export interface EventDetailResponse {
   id: string;
+  version_no?: number;
   title: string;
   description: string | null;
   image_url: string | null;
@@ -309,6 +358,15 @@ export interface RejectJoinRequestResponse {
   status: string;
   updated_at: string;
   cooldown_ends_at: string;
+}
+
+export interface ReconfirmParticipationResponse {
+  participation_id: string;
+  event_id: string;
+  status: string;
+  reconfirmed_at: string;
+  last_confirmed_event_version: number;
+  latest_event_version: number;
 }
 
 export interface FavoriteEventItem {

--- a/frontend/src/models/profile.ts
+++ b/frontend/src/models/profile.ts
@@ -10,6 +10,7 @@ export interface EventSummary {
   location_address?: string | null;
   privacy_level?: 'PUBLIC' | 'PROTECTED' | 'PRIVATE';
   approved_participant_count?: number;
+  participants_count?: number;
   host_score?: {
     final_score: number | null;
     hosted_event_rating_count: number;

--- a/frontend/src/services/eventService.test.ts
+++ b/frontend/src/services/eventService.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { reverseGeocode, searchLocation, createEventReport } from './eventService';
+import {
+  createEventReport,
+  listEventApprovedParticipants,
+  reconfirmEventParticipation,
+  reverseGeocode,
+  searchLocation,
+  updateEvent,
+} from './eventService';
 
 vi.mock('@/config/api', () => ({
   API_BASE_URL: 'http://api.test',
@@ -300,5 +307,102 @@ describe('eventService.createEventReport', () => {
         message: 'This looks suspicious.',
       }),
     }));
+  });
+});
+
+describe('eventService.updateEvent', () => {
+  it('patches event updates through the versioned update endpoint', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        id: 'event-1',
+        title: 'Updated event title',
+        privacy_level: 'PROTECTED',
+        status: 'ACTIVE',
+        start_time: '2026-05-10T10:00:00Z',
+        end_time: null,
+        version_no: 4,
+        reconfirmation_required: true,
+        reconfirmation_triggered_fields: ['title'],
+        participants_marked_pending: 2,
+        updated_at: '2026-05-09T10:00:00Z',
+      }),
+    );
+
+    const result = await updateEvent(
+      'event-1',
+      { title: 'Updated event title' },
+      'access-token',
+    );
+
+    expect(fetch).toHaveBeenCalledWith('http://api.test/events/event-1', expect.objectContaining({
+      method: 'PATCH',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({ title: 'Updated event title' }),
+    }));
+    expect(result.version_no).toBe(4);
+    expect(result.reconfirmation_required).toBe(true);
+  });
+});
+
+describe('eventService.listEventApprovedParticipants', () => {
+  it('passes participant status filters to the backend', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        items: [],
+        page_info: {
+          next_cursor: null,
+          has_next: false,
+        },
+      }),
+    );
+
+    await listEventApprovedParticipants('event-1', 'access-token', {
+      limit: 25,
+      cursor: 'next-page',
+      status: 'PENDING',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://api.test/events/event-1/participants?limit=25&cursor=next-page&status=PENDING',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer access-token',
+        }),
+      }),
+    );
+  });
+});
+
+describe('eventService.reconfirmEventParticipation', () => {
+  it('posts to the reconfirm endpoint with bearer auth', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        participation_id: 'participation-1',
+        event_id: 'event-1',
+        status: 'APPROVED',
+        reconfirmed_at: '2026-05-10T10:00:00Z',
+        last_confirmed_event_version: 5,
+        latest_event_version: 5,
+      }),
+    );
+
+    const result = await reconfirmEventParticipation('event-1', 'access-token');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://api.test/events/event-1/participation/reconfirm',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer access-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(result.latest_event_version).toBe(5);
   });
 });

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -7,6 +7,8 @@ import type {
 import {
   CreateEventRequest,
   CreateEventResponse,
+  UpdateEventRequest,
+  UpdateEventResponse,
   ListCategoriesResponse,
   LocationSuggestion,
   DiscoverEventsParams,
@@ -18,6 +20,7 @@ import {
   RequestJoinRequestBody,
   ApproveJoinRequestResponse,
   RejectJoinRequestResponse,
+  ReconfirmParticipationResponse,
   FavoriteEventsResponse,
   FavoriteEventItem,
   EventApprovedParticipantsResponse,
@@ -91,6 +94,14 @@ export function createEvent(
   return apiPostAuth<CreateEventResponse>('/events/', request, token);
 }
 
+export function updateEvent(
+  eventId: string,
+  request: UpdateEventRequest,
+  token: string,
+): Promise<UpdateEventResponse> {
+  return apiPatchAuth<UpdateEventResponse>(`/events/${eventId}`, request, token);
+}
+
 export function listCategories(): Promise<ListCategoriesResponse> {
   return apiGet<ListCategoriesResponse>('/categories/');
 }
@@ -138,6 +149,18 @@ function buildCollectionPath(eventId: string, resource: string, limit?: number, 
   return query === '' ? `/events/${eventId}/${resource}` : `/events/${eventId}/${resource}?${query}`;
 }
 
+function buildParticipantsPath(
+  eventId: string,
+  options: { limit?: number; cursor?: string | null; status?: 'APPROVED' | 'PENDING' } = {},
+) {
+  const qs = new URLSearchParams();
+  if (options.limit != null) qs.set('limit', String(options.limit));
+  if (options.cursor) qs.set('cursor', options.cursor);
+  if (options.status) qs.set('status', options.status);
+  const query = qs.toString();
+  return query === '' ? `/events/${eventId}/participants` : `/events/${eventId}/participants?${query}`;
+}
+
 export function getEventHostContextSummary(
   eventId: string,
   token: string,
@@ -148,10 +171,10 @@ export function getEventHostContextSummary(
 export function listEventApprovedParticipants(
   eventId: string,
   token: string,
-  options: { limit?: number; cursor?: string | null } = {},
+  options: { limit?: number; cursor?: string | null; status?: 'APPROVED' | 'PENDING' } = {},
 ): Promise<EventApprovedParticipantsResponse> {
   return apiGetAuth<EventApprovedParticipantsResponse>(
-    buildCollectionPath(eventId, 'participants', options.limit, options.cursor),
+    buildParticipantsPath(eventId, options),
     token,
   );
 }
@@ -217,6 +240,17 @@ export function leaveEvent(
   token: string,
 ): Promise<void> {
   return apiPatchAuth<void>(`/events/${eventId}/leave`, {}, token);
+}
+
+export function reconfirmEventParticipation(
+  eventId: string,
+  token: string,
+): Promise<ReconfirmParticipationResponse> {
+  return apiPostAuth<ReconfirmParticipationResponse>(
+    `/events/${eventId}/participation/reconfirm`,
+    {},
+    token,
+  );
 }
 
 export function requestJoinEvent(

--- a/frontend/src/styles/create-event.css
+++ b/frontend/src/styles/create-event.css
@@ -540,8 +540,140 @@
   min-width: 120px;
 }
 
+.ce-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.edit-event-page {
+  max-width: 680px;
+}
+
+.edit-event-page .create-event-subtitle {
+  margin-bottom: 32px;
+}
+
+.edit-event-form {
+  gap: 0;
+}
+
+.edit-event-form > .ce-row {
+  display: flex;
+}
+
+.edit-event-form > .ce-row .field-group {
+  margin-bottom: 20px;
+}
+
+.edit-event-form .field-textarea {
+  min-height: 130px;
+}
+
+.ce-edit-back-link {
+  display: inline-flex;
+  width: fit-content;
+  margin-bottom: 18px;
+  color: #4b5563;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ce-edit-back-link:hover {
+  color: #111827;
+  text-decoration: underline;
+}
+
+.ce-edit-warning {
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  color: #92400e;
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+
+.ce-edit-critical-list {
+  margin: -8px 0 20px;
+  padding-left: 20px;
+  text-align: left;
+  color: #92400e;
+  font-size: 14px;
+}
+
+.ce-edit-modal-actions,
+.ce-edit-form-actions,
+.ce-edit-constraint-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.ce-edit-modal-actions,
+.ce-edit-form-actions {
+  justify-content: flex-end;
+  padding: 16px 0 0;
+}
+
+.ce-edit-constraint-row {
+  align-items: flex-start;
+}
+
+.ce-edit-constraint-list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ce-edit-constraint-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #f9fafb;
+  font-size: 14px;
+  color: #374151;
+}
+
+.ce-chip-remove {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #fecaca;
+  border-radius: 50%;
+  background: #fff;
+  color: #b91c1c;
+  cursor: pointer;
+}
+
+.ce-chip-remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Responsive */
 @media (max-width: 600px) {
+  .ce-header,
+  .ce-edit-modal-actions,
+  .ce-edit-form-actions,
+  .ce-edit-constraint-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .edit-event-form > .ce-row {
+    grid-template-columns: 1fr;
+  }
+
   .create-event-title {
     font-size: 22px;
   }

--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -1483,8 +1483,8 @@
   position: absolute;
   right: 16px;
   top: 86px;
-  bottom: 16px;
   width: clamp(300px, 23vw, 360px);
+  max-height: calc(100vh - 102px);
   background: #ffffff;
   border: 1px solid rgba(15, 23, 42, 0.06);
   border-radius: 18px;
@@ -1492,7 +1492,8 @@
   z-index: 20;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   animation: dc-side-panel-enter 0.22s ease-out;
 }
 
@@ -1539,17 +1540,6 @@
   flex-shrink: 0;
 }
 
-.dc-side-panel-image-badges {
-  position: absolute;
-  bottom: 10px;
-  left: 12px;
-  right: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-
 .dc-side-panel-image-img,
 .dc-side-panel-image > div {
   width: 100%;
@@ -1564,6 +1554,9 @@
 }
 
 .dc-side-panel-category {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
   display: inline-flex;
   align-items: center;
   gap: 5px;
@@ -1584,8 +1577,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  overflow-y: auto;
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 .dc-side-panel-head {
@@ -1651,7 +1643,6 @@
 }
 
 .dc-side-panel-cta {
-  margin-top: auto;
   display: block;
   width: 100%;
   padding: 10px 14px;
@@ -1674,6 +1665,9 @@
 }
 
 .dc-side-panel-lifecycle {
+  position: absolute;
+  top: 14px;
+  left: 12px;
   padding: 3px 9px;
   border-radius: 999px;
   font-size: 10px;
@@ -1715,10 +1709,6 @@
   color: #334155;
   line-height: 1.5;
   white-space: pre-wrap;
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 
 .dc-side-panel-tags {

--- a/frontend/src/styles/event-detail.css
+++ b/frontend/src/styles/event-detail.css
@@ -958,6 +958,12 @@
   margin-bottom: 16px;
 }
 
+.ed-host-action-group {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
 .ed-mgmt-group:last-child {
   margin-bottom: 0;
 }
@@ -1042,6 +1048,27 @@
   flex-wrap: wrap;
 }
 
+.ed-mgmt-item-pending-reconfirmation {
+  align-items: center;
+  background-color: #fffbeb;
+  border-color: #fde68a;
+}
+
+.ed-reconfirm-status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background-color: #fef3c7;
+  border: 1px solid #fcd34d;
+  color: #92400e;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
 .ed-mgmt-user-score {
   font-size: 12px;
   color: #f59e0b;
@@ -1101,7 +1128,8 @@
 /* Cancel event button */
 .ed-cancel-event-btn {
   width: 100%;
-  padding: 12px 24px;
+  min-height: 44px;
+  padding: 0 18px;
   border-radius: 10px;
   border: 1px solid #dc2626;
   background: none;
@@ -1141,6 +1169,33 @@
 .ed-complete-event-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.ed-reconfirmation-mgmt-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid #fde68a;
+  background: #fffbeb;
+  color: #92400e;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.ed-reconfirmation-mgmt-card strong {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #f59e0b;
+  color: #ffffff;
+  font-size: 16px;
 }
 
 /* Confirmation modal */
@@ -1512,6 +1567,260 @@
 .ed-expiry-warning strong {
   font-weight: 700;
   color: #78350f;
+}
+
+.ed-reconfirm-panel {
+  margin-bottom: 20px;
+  padding: 16px;
+  border: 1px solid #fde68a;
+  background: #fffbeb;
+  border-radius: 12px;
+  color: #92400e;
+}
+
+.ed-reconfirm-panel h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  color: #78350f;
+}
+
+.ed-reconfirm-panel p {
+  margin: 0 0 12px;
+  color: #92400e;
+}
+
+.ed-reconfirm-diff {
+  margin: 14px 0;
+  padding: 12px;
+  border-radius: 10px;
+  background: #ffffff;
+  border: 1px solid #fde68a;
+}
+
+.ed-reconfirm-diff-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+  color: #78350f;
+}
+
+.ed-reconfirm-diff-header strong {
+  font-size: 14px;
+}
+
+.ed-reconfirm-diff-header span {
+  font-size: 12px;
+  font-weight: 700;
+  color: #92400e;
+}
+
+.ed-reconfirm-summary-row {
+  margin-bottom: 12px;
+}
+
+.ed-reconfirm-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.ed-reconfirm-btn,
+.ed-reconfirm-secondary-btn,
+.ed-edit-event-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 18px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.ed-reconfirm-btn,
+.ed-edit-event-link {
+  border: 1px solid #111827;
+  background: #111827;
+  color: #ffffff;
+}
+
+.ed-reconfirm-secondary-btn {
+  border: 1px solid #d97706;
+  background: #ffffff;
+  color: #92400e;
+}
+
+.ed-reconfirm-btn:disabled,
+.ed-reconfirm-secondary-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ed-version-history {
+  gap: 14px;
+}
+
+.ed-version-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ed-version-pill,
+.ed-version-summary-pill,
+.ed-version-change-title span {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.ed-version-pill {
+  padding: 4px 10px;
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+.ed-version-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 14px;
+  background: #ffffff;
+}
+
+.ed-version-attention {
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  color: #92400e;
+  font-size: 14px;
+}
+
+.ed-version-range {
+  margin: 0 0 12px;
+  color: #475569;
+  font-size: 14px;
+}
+
+.ed-version-summary-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.ed-version-summary-pill {
+  padding: 4px 10px;
+  background: #f1f5f9;
+  color: #334155;
+}
+
+.ed-version-change-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ed-version-change-list-compact {
+  gap: 10px;
+}
+
+.ed-version-change {
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.ed-version-change-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.ed-version-change-title strong {
+  color: #0f172a;
+}
+
+.ed-version-change-title span {
+  padding: 3px 8px;
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.ed-version-values {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: stretch;
+  gap: 10px;
+}
+
+.ed-version-values div {
+  padding: 10px;
+  border-radius: 8px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+}
+
+.ed-version-flow-arrow {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  border: 1px solid #fde68a;
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.ed-version-flow-arrow svg {
+  display: block;
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transform: translateY(1.5px);
+}
+
+.ed-version-values span {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.ed-version-values p {
+  margin: 0;
+  color: #1f2937;
+  font-size: 14px;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.ed-version-values-constraints p {
+  color: #374151;
 }
 
 .ed-join-error {
@@ -2724,6 +3033,19 @@
 }
 
 @media (max-width: 600px) {
+  .ed-host-action-group {
+    grid-template-columns: 1fr;
+  }
+
+  .ed-version-values {
+    grid-template-columns: 1fr;
+  }
+
+  .ed-version-flow-arrow {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+
   .ed-comments-replies {
     margin-left: 18px;
     padding-left: 10px;

--- a/frontend/src/viewmodels/event/useEditEventViewModel.ts
+++ b/frontend/src/viewmodels/event/useEditEventViewModel.ts
@@ -1,0 +1,633 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { ApiError } from '@/services/api';
+import {
+  getEventDetail,
+  listCategories,
+  searchLocation,
+  updateEvent,
+} from '@/services/eventService';
+import {
+  MAX_CONSTRAINTS,
+  ROUTE_MAX_POINTS,
+  ROUTE_MIN_POINTS,
+  deriveRouteAddress,
+  type RouteWaypoint,
+} from '@/viewmodels/event/useCreateEventViewModel';
+import type {
+  CategoryItem,
+  EventConstraint,
+  EventDetailResponse,
+  LocationSuggestion,
+  LocationType,
+  UpdateEventRequest,
+  UpdateEventResponse,
+} from '@/models/event';
+
+const TITLE_MIN = 10;
+const TITLE_MAX = 60;
+const DESC_MIN = 20;
+const DESC_MAX = 600;
+const CAPACITY_MIN = 2;
+
+export interface EditEventFormData {
+  title: string;
+  description: string;
+  categoryId: number | null;
+  locationType: LocationType;
+  locationQuery: string;
+  address: string;
+  lat: number | null;
+  lon: number | null;
+  routePoints: RouteWaypoint[];
+  startDate: string;
+  startTime: string;
+  endDate: string;
+  endTime: string;
+  capacity: string;
+  constraints: EventConstraint[];
+  constraintType: string;
+  constraintInfo: string;
+}
+
+export interface EditEventFormErrors {
+  title?: string | null;
+  description?: string | null;
+  categoryId?: string | null;
+  location?: string | null;
+  startDate?: string | null;
+  startTime?: string | null;
+  endDate?: string | null;
+  endTime?: string | null;
+  capacity?: string | null;
+  constraints?: string | null;
+}
+
+export interface EditEventChangePreview {
+  request: UpdateEventRequest;
+  changedFields: string[];
+  criticalChangeLabels: string[];
+}
+
+const INITIAL_FORM: EditEventFormData = {
+  title: '',
+  description: '',
+  categoryId: null,
+  locationType: 'POINT',
+  locationQuery: '',
+  address: '',
+  lat: null,
+  lon: null,
+  routePoints: [],
+  startDate: '',
+  startTime: '',
+  endDate: '',
+  endTime: '',
+  capacity: '',
+  constraints: [],
+  constraintType: '',
+  constraintInfo: '',
+};
+
+function toDatePart(iso?: string | null): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
+function toTimePart(iso?: string | null): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+function toISODateTime(date: string, time: string): string | null {
+  if (!date || !time) return null;
+  const parsed = new Date(`${date}T${time}`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function sameInstant(a?: string | null, b?: string | null): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  const left = new Date(a).getTime();
+  const right = new Date(b).getTime();
+  return Number.isFinite(left) && Number.isFinite(right) && left === right;
+}
+
+function normalizeOptionalString(value: string | null | undefined): string | null {
+  const trimmed = (value ?? '').trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeConstraints(constraints: EventConstraint[]): EventConstraint[] {
+  return constraints
+    .map((constraint) => ({
+      type: constraint.type.trim(),
+      info: constraint.info.trim(),
+    }))
+    .filter((constraint) => constraint.type.length > 0 && constraint.info.length > 0);
+}
+
+function constraintsEqual(a: EventConstraint[], b: EventConstraint[]): boolean {
+  const left = normalizeConstraints(a);
+  const right = normalizeConstraints(b);
+  if (left.length !== right.length) return false;
+  return left.every((constraint, index) => (
+    constraint.type === right[index].type && constraint.info === right[index].info
+  ));
+}
+
+function hasAddedConstraint(previous: EventConstraint[], next: EventConstraint[]): boolean {
+  const previousKeys = new Set(
+    normalizeConstraints(previous).map((constraint) => `${constraint.type}\u0000${constraint.info}`),
+  );
+  return normalizeConstraints(next).some(
+    (constraint) => !previousKeys.has(`${constraint.type}\u0000${constraint.info}`),
+  );
+}
+
+function routePointsFromEvent(event: EventDetailResponse): RouteWaypoint[] {
+  return event.location.route_points.map((point) => ({
+    lat: point.lat,
+    lon: point.lon,
+    label: null,
+  }));
+}
+
+function routePointsEqual(a: RouteWaypoint[], b: RouteWaypoint[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((point, index) => (
+    point.lat === b[index].lat && point.lon === b[index].lon
+  ));
+}
+
+function formFromEvent(event: EventDetailResponse): EditEventFormData {
+  const isRoute = event.location.type === 'ROUTE';
+  return {
+    ...INITIAL_FORM,
+    title: event.title,
+    description: event.description ?? '',
+    categoryId: event.category?.id ?? null,
+    locationType: event.location.type,
+    locationQuery: event.location.address ?? '',
+    address: event.location.address ?? '',
+    lat: isRoute ? null : event.location.point?.lat ?? null,
+    lon: isRoute ? null : event.location.point?.lon ?? null,
+    routePoints: isRoute ? routePointsFromEvent(event) : [],
+    startDate: toDatePart(event.start_time),
+    startTime: toTimePart(event.start_time),
+    endDate: toDatePart(event.end_time),
+    endTime: toTimePart(event.end_time),
+    capacity: event.capacity != null ? String(event.capacity) : '',
+    constraints: event.constraints ?? [],
+  };
+}
+
+function addField(
+  changedFields: string[],
+  criticalLabels: string[],
+  field: string,
+  label: string,
+  critical = true,
+) {
+  if (!changedFields.includes(field)) changedFields.push(field);
+  if (critical && !criticalLabels.includes(label)) criticalLabels.push(label);
+}
+
+function buildUpdateRequest(
+  form: EditEventFormData,
+  event: EventDetailResponse,
+): EditEventChangePreview {
+  const request: UpdateEventRequest = {};
+  const changedFields: string[] = [];
+  const criticalChangeLabels: string[] = [];
+
+  const title = form.title.trim();
+  if (title !== event.title) {
+    request.title = title;
+    addField(changedFields, criticalChangeLabels, 'title', 'Title');
+  }
+
+  const description = normalizeOptionalString(form.description);
+  if (description !== normalizeOptionalString(event.description)) {
+    request.description = description;
+    addField(changedFields, criticalChangeLabels, 'description', 'Description');
+  }
+
+  if (form.categoryId !== (event.category?.id ?? null)) {
+    request.category_id = form.categoryId;
+    addField(changedFields, criticalChangeLabels, 'category_id', 'Category');
+  }
+
+  const startTime = toISODateTime(form.startDate, form.startTime);
+  if (startTime && !sameInstant(startTime, event.start_time)) {
+    request.start_time = startTime;
+    addField(changedFields, criticalChangeLabels, 'start_time', 'Start time');
+  }
+
+  const endTime = form.endDate || form.endTime ? toISODateTime(form.endDate, form.endTime) : null;
+  if (!sameInstant(endTime, event.end_time)) {
+    request.end_time = endTime;
+    addField(changedFields, criticalChangeLabels, 'end_time', 'End time');
+  }
+
+  const capacity = form.capacity.trim() ? Number.parseInt(form.capacity.trim(), 10) : null;
+  if (capacity !== (event.capacity ?? null)) {
+    request.capacity = capacity;
+    addField(changedFields, criticalChangeLabels, 'capacity', 'Capacity', false);
+  }
+
+  const previousAddress = normalizeOptionalString(event.location.address);
+  const nextAddress = form.locationType === 'ROUTE'
+    ? normalizeOptionalString(form.address) ?? normalizeOptionalString(deriveRouteAddress(form.routePoints))
+    : normalizeOptionalString(form.address);
+  const locationChanged =
+    form.locationType !== event.location.type ||
+    nextAddress !== previousAddress ||
+    (form.locationType === 'POINT' &&
+      (form.lat !== event.location.point?.lat || form.lon !== event.location.point?.lon)) ||
+    (form.locationType === 'ROUTE' &&
+      !routePointsEqual(form.routePoints, routePointsFromEvent(event)));
+
+  if (locationChanged) {
+    request.location_type = form.locationType;
+    request.address = nextAddress;
+    if (form.locationType === 'POINT') {
+      request.lat = form.lat ?? undefined;
+      request.lon = form.lon ?? undefined;
+    } else {
+      request.route_points = form.routePoints.map((point) => ({ lat: point.lat, lon: point.lon }));
+    }
+    addField(changedFields, criticalChangeLabels, 'location', 'Location or route');
+  }
+
+  const constraints = normalizeConstraints(form.constraints);
+  if (!constraintsEqual(constraints, event.constraints ?? [])) {
+    request.constraints = constraints;
+    addField(
+      changedFields,
+      criticalChangeLabels,
+      'constraints',
+      'Participation requirements',
+      hasAddedConstraint(event.constraints ?? [], constraints),
+    );
+  }
+
+  return { request, changedFields, criticalChangeLabels };
+}
+
+function validateForm(form: EditEventFormData, event: EventDetailResponse | null): EditEventFormErrors {
+  const errors: EditEventFormErrors = {};
+  const title = form.title.trim();
+  const description = form.description.trim();
+
+  if (!title) errors.title = 'Title is required.';
+  else if (title.length < TITLE_MIN) errors.title = `Title must be at least ${TITLE_MIN} characters.`;
+  else if (title.length > TITLE_MAX) errors.title = `Title must be at most ${TITLE_MAX} characters.`;
+
+  if (description && description.length < DESC_MIN) {
+    errors.description = `Description must be at least ${DESC_MIN} characters.`;
+  } else if (description.length > DESC_MAX) {
+    errors.description = `Description must be at most ${DESC_MAX} characters.`;
+  }
+
+  if (form.categoryId == null) errors.categoryId = 'Please select a category.';
+
+  if (form.locationType === 'POINT') {
+    if (form.lat == null || form.lon == null) errors.location = 'Please search and select a location.';
+  } else if (form.routePoints.length < ROUTE_MIN_POINTS) {
+    errors.location = `Add at least ${ROUTE_MIN_POINTS} waypoints to create a route.`;
+  } else if (form.routePoints.length > ROUTE_MAX_POINTS) {
+    errors.location = `A route can have at most ${ROUTE_MAX_POINTS} waypoints.`;
+  }
+
+  if (!form.startDate) errors.startDate = 'Start date is required.';
+  if (!form.startTime) errors.startTime = 'Start time is required.';
+  const startIso = toISODateTime(form.startDate, form.startTime);
+  if (!errors.startDate && !errors.startTime) {
+    if (!startIso) errors.startDate = 'Invalid start date.';
+    else if (new Date(startIso).getTime() <= Date.now()) errors.startDate = 'Start date must be in the future.';
+  }
+
+  if (form.endDate || form.endTime) {
+    if (!form.endDate) errors.endDate = 'End date is required if end time is set.';
+    if (!form.endTime) errors.endTime = 'End time is required if end date is set.';
+    const endIso = toISODateTime(form.endDate, form.endTime);
+    if (!errors.endDate && !errors.endTime) {
+      if (!endIso) errors.endDate = 'Invalid end date.';
+      else if (startIso && new Date(endIso).getTime() <= new Date(startIso).getTime()) {
+        errors.endTime = 'End time must be after start time.';
+      }
+    }
+  }
+
+  if (form.capacity.trim()) {
+    const capacity = Number.parseInt(form.capacity.trim(), 10);
+    if (!Number.isFinite(capacity) || String(capacity) !== form.capacity.trim()) {
+      errors.capacity = 'Capacity must be a whole number.';
+    } else if (capacity < CAPACITY_MIN) {
+      errors.capacity = `Capacity must be at least ${CAPACITY_MIN}.`;
+    } else if (event && capacity < event.approved_participant_count + event.pending_participant_count) {
+      errors.capacity = 'Capacity cannot be below current approved plus pending participants.';
+    }
+  }
+
+  if (normalizeConstraints(form.constraints).length !== form.constraints.length) {
+    errors.constraints = 'Every requirement needs a type and details.';
+  }
+
+  return errors;
+}
+
+function mapApiValidationErrors(err: ApiError): EditEventFormErrors {
+  const errors: EditEventFormErrors = {};
+  if (!err.details) return errors;
+  for (const [key, message] of Object.entries(err.details)) {
+    if (key === 'title') errors.title = message;
+    else if (key === 'description') errors.description = message;
+    else if (key === 'category_id') errors.categoryId = message;
+    else if (['address', 'lat', 'lon', 'location_type', 'route_points'].includes(key) || key.startsWith('route_points')) {
+      errors.location = message;
+    } else if (key === 'start_time') errors.startDate = message;
+    else if (key === 'end_time') errors.endDate = message;
+    else if (key === 'capacity') errors.capacity = message;
+    else if (key.startsWith('constraints')) errors.constraints = message;
+  }
+  return errors;
+}
+
+export function useEditEventViewModel(eventId: string | undefined) {
+  const { token } = useAuth();
+  const [event, setEvent] = useState<EventDetailResponse | null>(null);
+  const [form, setForm] = useState<EditEventFormData>(INITIAL_FORM);
+  const [errors, setErrors] = useState<EditEventFormErrors>({});
+  const [categories, setCategories] = useState<CategoryItem[]>([]);
+  const [locationResults, setLocationResults] = useState<LocationSuggestion[]>([]);
+  const [locationSearching, setLocationSearching] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [updateResult, setUpdateResult] = useState<UpdateEventResponse | null>(null);
+  const searchTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const canEdit = Boolean(
+    event?.viewer_context.is_host &&
+    event.status === 'ACTIVE' &&
+    new Date(event.start_time).getTime() > Date.now(),
+  );
+
+  const load = useCallback(async () => {
+    if (!eventId) {
+      setApiError('Event not found.');
+      setIsLoading(false);
+      return;
+    }
+    if (!token) {
+      setApiError('You must be logged in to edit this event.');
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    setApiError(null);
+    try {
+      const [eventData, categoryData] = await Promise.all([
+        getEventDetail(eventId, token),
+        listCategories().catch(() => ({ items: [] as CategoryItem[] })),
+      ]);
+      setEvent(eventData);
+      setForm(formFromEvent(eventData));
+      setCategories(categoryData.items);
+      setErrors({});
+      setSuccessMessage(null);
+      setUpdateResult(null);
+    } catch (err) {
+      setEvent(null);
+      setApiError(err instanceof ApiError ? err.message : 'Failed to load event details. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [eventId, token]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const updateField = useCallback(<K extends keyof EditEventFormData>(field: K, value: EditEventFormData[K]) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: null }));
+    setApiError(null);
+    setSuccessMessage(null);
+    setUpdateResult(null);
+  }, []);
+
+  const previewChanges = useCallback((): EditEventChangePreview | null => {
+    if (!event) return null;
+    if (!canEdit) {
+      setApiError('Only active events that have not started can be edited.');
+      return null;
+    }
+    const nextErrors = validateForm(form, event);
+    if (Object.values(nextErrors).some(Boolean)) {
+      setErrors(nextErrors);
+      return null;
+    }
+    const preview = buildUpdateRequest(form, event);
+    if (preview.changedFields.length === 0) {
+      setApiError('No changes to save.');
+      return null;
+    }
+    setErrors({});
+    setApiError(null);
+    return preview;
+  }, [canEdit, event, form]);
+
+  const handleSubmit = useCallback(async (request?: UpdateEventRequest) => {
+    if (!event || !token) return null;
+    const prepared = request ?? previewChanges()?.request;
+    if (!prepared) return null;
+    setIsSaving(true);
+    setApiError(null);
+    setSuccessMessage(null);
+    setUpdateResult(null);
+    try {
+      const result = await updateEvent(event.id, prepared, token);
+      const refreshed = await getEventDetail(event.id, token);
+      setEvent(refreshed);
+      setForm(formFromEvent(refreshed));
+      setUpdateResult(result);
+      const pendingReconfirmationCount = Math.max(
+        refreshed.pending_participant_count,
+        result.participants_marked_pending,
+      );
+      setSuccessMessage(
+        result.reconfirmation_required
+          ? `Event updated. ${pendingReconfirmationCount} participant${pendingReconfirmationCount === 1 ? '' : 's'} must reconfirm.`
+          : 'Event updated successfully.',
+      );
+      return result;
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setErrors(mapApiValidationErrors(err));
+        setApiError(err.message);
+      } else {
+        setApiError('Failed to update event. Please try again.');
+      }
+      return null;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [event, previewChanges, token]);
+
+  const handleLocationSearch = useCallback((query: string) => {
+    updateField('locationQuery', query);
+    updateField('lat', null);
+    updateField('lon', null);
+    updateField('address', '');
+    setLocationResults([]);
+    if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    if (query.trim().length < 3) return;
+    searchTimeout.current = setTimeout(async () => {
+      setLocationSearching(true);
+      try {
+        setLocationResults(await searchLocation(query));
+      } catch {
+        setLocationResults([]);
+      } finally {
+        setLocationSearching(false);
+      }
+    }, 400);
+  }, [updateField]);
+
+  const selectLocation = useCallback((suggestion: LocationSuggestion) => {
+    setForm((prev) => ({
+      ...prev,
+      locationQuery: suggestion.display_name,
+      address: suggestion.display_name,
+      lat: Number.parseFloat(suggestion.lat),
+      lon: Number.parseFloat(suggestion.lon),
+    }));
+    setLocationResults([]);
+    setErrors((prev) => ({ ...prev, location: null }));
+  }, []);
+
+  const setLocationType = useCallback((type: LocationType) => {
+    setForm((prev) => (
+      prev.locationType === type
+        ? prev
+        : {
+            ...prev,
+            locationType: type,
+            locationQuery: '',
+            address: '',
+            lat: null,
+            lon: null,
+            routePoints: type === 'ROUTE' ? prev.routePoints : [],
+          }
+    ));
+    setLocationResults([]);
+    setErrors((prev) => ({ ...prev, location: null }));
+  }, []);
+
+  const addRoutePointFromSuggestion = useCallback((suggestion: LocationSuggestion) => {
+    const lat = Number.parseFloat(suggestion.lat);
+    const lon = Number.parseFloat(suggestion.lon);
+    if (Number.isNaN(lat) || Number.isNaN(lon)) return;
+    setForm((prev) => {
+      if (prev.routePoints.length >= ROUTE_MAX_POINTS) return prev;
+      return {
+        ...prev,
+        locationQuery: '',
+        routePoints: [...prev.routePoints, { lat, lon, label: suggestion.display_name }],
+      };
+    });
+    setLocationResults([]);
+    setErrors((prev) => ({ ...prev, location: null }));
+  }, []);
+
+  const addRoutePointFromCoordinate = useCallback((lat: number, lon: number, label?: string | null) => {
+    setForm((prev) => {
+      if (prev.routePoints.length >= ROUTE_MAX_POINTS) return prev;
+      return { ...prev, routePoints: [...prev.routePoints, { lat, lon, label: label ?? null }] };
+    });
+    setErrors((prev) => ({ ...prev, location: null }));
+  }, []);
+
+  const removeRoutePoint = useCallback((index: number) => {
+    setForm((prev) => ({ ...prev, routePoints: prev.routePoints.filter((_, i) => i !== index) }));
+  }, []);
+
+  const moveRoutePoint = useCallback((index: number, direction: -1 | 1) => {
+    setForm((prev) => {
+      const target = index + direction;
+      if (target < 0 || target >= prev.routePoints.length) return prev;
+      const next = [...prev.routePoints];
+      [next[index], next[target]] = [next[target], next[index]];
+      return { ...prev, routePoints: next };
+    });
+  }, []);
+
+  const updateRoutePointLabel = useCallback((index: number, label: string) => {
+    setForm((prev) => {
+      if (index < 0 || index >= prev.routePoints.length) return prev;
+      const next = [...prev.routePoints];
+      next[index] = { ...next[index], label };
+      return { ...prev, routePoints: next };
+    });
+  }, []);
+
+  const addConstraint = useCallback(() => {
+    setForm((prev) => {
+      if (prev.constraints.length >= MAX_CONSTRAINTS) return prev;
+      const type = prev.constraintType.trim();
+      const info = prev.constraintInfo.trim();
+      if (!type || !info) return prev;
+      return {
+        ...prev,
+        constraints: [...prev.constraints, { type, info }],
+        constraintType: '',
+        constraintInfo: '',
+      };
+    });
+  }, []);
+
+  const removeConstraint = useCallback((index: number) => {
+    setForm((prev) => ({ ...prev, constraints: prev.constraints.filter((_, i) => i !== index) }));
+  }, []);
+
+  return {
+    event,
+    form,
+    errors,
+    categories,
+    locationResults,
+    locationSearching,
+    isLoading,
+    isSaving,
+    apiError,
+    successMessage,
+    updateResult,
+    canEdit,
+    retry: load,
+    updateField,
+    previewChanges,
+    handleSubmit,
+    handleLocationSearch,
+    selectLocation,
+    setLocationType,
+    addRoutePointFromSuggestion,
+    addRoutePointFromCoordinate,
+    removeRoutePoint,
+    moveRoutePoint,
+    updateRoutePointLabel,
+    addConstraint,
+    removeConstraint,
+  };
+}

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
@@ -204,7 +204,8 @@ describe('useEventDetailViewModel favorites', () => {
       message: undefined,
       image_confirm_token: undefined,
     });
-    expect(result.current.event?.viewer_context.participation_status).toBe('PENDING');
+    expect(result.current.event?.viewer_context.participation_status).toBe('NONE');
+    expect(result.current.event?.viewer_context.join_request_status).toBe('PENDING');
     expect(result.current.joinError).toBeNull();
   });
 });

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.test.ts
@@ -8,6 +8,7 @@ const mockGetEventDetail = vi.fn();
 const mockGetEventHostContextSummary = vi.fn();
 const mockAddFavorite = vi.fn();
 const mockRemoveFavorite = vi.fn();
+const mockJoinEvent = vi.fn();
 const mockRequestJoinEvent = vi.fn();
 const mockCreateEventReport = vi.fn();
 
@@ -17,7 +18,7 @@ vi.mock('@/services/eventService', () => ({
   getEventImageUploadUrl: vi.fn(),
   getJoinRequestImageUploadUrl: vi.fn(),
   confirmEventImageUpload: vi.fn(),
-  joinEvent: vi.fn(),
+  joinEvent: (...args: unknown[]) => mockJoinEvent(...args),
   requestJoinEvent: (...args: unknown[]) => mockRequestJoinEvent(...args),
   listEventApprovedParticipants: vi.fn(),
   listEventPendingJoinRequests: vi.fn(),
@@ -99,6 +100,12 @@ describe('useEventDetailViewModel favorites', () => {
     });
     mockAddFavorite.mockResolvedValue(undefined);
     mockRemoveFavorite.mockResolvedValue(undefined);
+    mockJoinEvent.mockResolvedValue({
+      participation_id: 'participation-1',
+      event_id: 'event-1',
+      status: 'APPROVED',
+      joined_at: '2026-04-02T10:00:00Z',
+    });
     mockRequestJoinEvent.mockResolvedValue({
       join_request_id: 'join-request-1',
       event_id: 'event-1',
@@ -206,6 +213,37 @@ describe('useEventDetailViewModel favorites', () => {
     });
     expect(result.current.event?.viewer_context.participation_status).toBe('NONE');
     expect(result.current.event?.viewer_context.join_request_status).toBe('PENDING');
+    expect(result.current.joinError).toBeNull();
+  });
+
+  it('marks the viewer as joined immediately after a successful public join', async () => {
+    mockGetEventDetail
+      .mockResolvedValueOnce(
+        makeEvent({
+          privacy_level: 'PUBLIC',
+          status: 'ACTIVE',
+          approved_participant_count: 8,
+          viewer_context: {
+            is_host: false,
+            is_favorited: false,
+            participation_status: 'NONE',
+          },
+        }),
+      )
+      .mockRejectedValueOnce(new Error('stale detail fetch'));
+
+    const { result } = renderHook(() => useEventDetailViewModel('event-1', 'token'));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await act(async () => {
+      await result.current.handleJoin();
+    });
+
+    expect(mockJoinEvent).toHaveBeenCalledWith('event-1', 'token');
+    expect(result.current.event?.viewer_context.participation_status).toBe('JOINED');
+    expect(result.current.event?.viewer_context.join_request_status).toBeNull();
+    expect(result.current.event?.approved_participant_count).toBe(9);
     expect(result.current.joinError).toBeNull();
   });
 });

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -21,6 +21,7 @@ import {
   upsertEventRating,
   upsertParticipantRating,
   leaveEvent,
+  reconfirmEventParticipation,
   createEventReport,
 } from '@/services/eventService';
 import type {
@@ -48,6 +49,10 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   const [approvedParticipantsLoading, setApprovedParticipantsLoading] = useState(false);
   const [approvedParticipantsNextCursor, setApprovedParticipantsNextCursor] = useState<string | null>(null);
   const [approvedParticipantsHasNext, setApprovedParticipantsHasNext] = useState(false);
+  const [pendingParticipants, setPendingParticipants] = useState<EventDetailApprovedParticipant[]>([]);
+  const [pendingParticipantsLoading, setPendingParticipantsLoading] = useState(false);
+  const [pendingParticipantsNextCursor, setPendingParticipantsNextCursor] = useState<string | null>(null);
+  const [pendingParticipantsHasNext, setPendingParticipantsHasNext] = useState(false);
   const [pendingJoinRequests, setPendingJoinRequests] = useState<EventDetailPendingJoinRequest[]>([]);
   const [pendingJoinRequestsLoading, setPendingJoinRequestsLoading] = useState(false);
   const [pendingJoinRequestsNextCursor, setPendingJoinRequestsNextCursor] = useState<string | null>(null);
@@ -77,6 +82,9 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
   const [reportLoading, setReportLoading] = useState(false);
   const [reportError, setReportError] = useState<string | null>(null);
   const [reportSuccessMessage, setReportSuccessMessage] = useState<string | null>(null);
+  const [reconfirmLoading, setReconfirmLoading] = useState(false);
+  const [reconfirmError, setReconfirmError] = useState<string | null>(null);
+  const [reconfirmSuccessMessage, setReconfirmSuccessMessage] = useState<string | null>(null);
 
   useEffect(
     () => () => {
@@ -100,6 +108,9 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     setApprovedParticipants([]);
     setApprovedParticipantsNextCursor(null);
     setApprovedParticipantsHasNext(false);
+    setPendingParticipants([]);
+    setPendingParticipantsNextCursor(null);
+    setPendingParticipantsHasNext(false);
     setPendingJoinRequests([]);
     setPendingJoinRequestsNextCursor(null);
     setPendingJoinRequestsHasNext(false);
@@ -133,6 +144,23 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
       setApprovedParticipantsHasNext(response.page_info.has_next);
     } finally {
       setApprovedParticipantsLoading(false);
+    }
+  }, [eventId, token]);
+
+  const refreshPendingParticipants = useCallback(async (cursor?: string | null, append = false) => {
+    if (!eventId || !token) return;
+    setPendingParticipantsLoading(true);
+    try {
+      const response = await listEventApprovedParticipants(eventId, token, {
+        limit: hostCollectionPageSize,
+        cursor,
+        status: 'PENDING',
+      });
+      setPendingParticipants((prev) => append ? [...prev, ...response.items] : response.items);
+      setPendingParticipantsNextCursor(response.page_info.next_cursor);
+      setPendingParticipantsHasNext(response.page_info.has_next);
+    } finally {
+      setPendingParticipantsLoading(false);
     }
   }, [eventId, token]);
 
@@ -172,6 +200,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     await Promise.all([
       refreshHostContextSummary(),
       refreshApprovedParticipants(undefined, false),
+      refreshPendingParticipants(undefined, false),
       refreshPendingJoinRequests(undefined, false),
       refreshInvitations(undefined, false),
     ]);
@@ -179,6 +208,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     refreshApprovedParticipants,
     refreshHostContextSummary,
     refreshInvitations,
+    refreshPendingParticipants,
     refreshPendingJoinRequests,
   ]);
 
@@ -267,6 +297,47 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     }
   }, [eventId, token, refreshEventDetail]);
 
+  const handleReconfirmParticipation = useCallback(async () => {
+    if (!eventId || !token) return;
+    setReconfirmLoading(true);
+    setReconfirmError(null);
+    setReconfirmSuccessMessage(null);
+
+    try {
+      const response = await reconfirmEventParticipation(eventId, token);
+      await refreshEventDetail();
+      setEvent((prev) => prev
+        ? {
+            ...prev,
+            viewer_context: {
+              ...prev.viewer_context,
+              participation_status: 'JOINED',
+              join_request_status: null,
+              needs_reconfirmation: false,
+              last_confirmed_event_version: response.last_confirmed_event_version,
+              latest_event_version: response.latest_event_version,
+              event_diff: null,
+            },
+          }
+        : prev);
+      setReconfirmSuccessMessage('Attendance reconfirmed.');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const errorMap: Record<string, string> = {
+          participation_reconfirm_not_allowed:
+            'This attendance update can no longer be reconfirmed. Please review the latest event status.',
+          event_not_joinable: 'This event is no longer accepting attendance reconfirmations.',
+          host_cannot_join: 'Hosts do not need to reconfirm their own event.',
+        };
+        setReconfirmError(errorMap[err.code] ?? err.message);
+      } else {
+        setReconfirmError('Failed to reconfirm your attendance. Please try again.');
+      }
+    } finally {
+      setReconfirmLoading(false);
+    }
+  }, [eventId, token, refreshEventDetail]);
+
   const markViewerPendingJoinRequest = useCallback(() => {
     setEvent((prev) => {
       if (!prev) return prev;
@@ -275,7 +346,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
         ...prev,
         viewer_context: {
           ...prev.viewer_context,
-          participation_status: 'PENDING',
+          join_request_status: 'PENDING',
         },
       };
     });
@@ -310,12 +381,12 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
           message,
           image_confirm_token: imageConfirmToken,
         });
-        markViewerPendingJoinRequest();
         try {
           await refreshEventDetail();
         } catch {
           // Keep the optimistic pending state if the follow-up detail fetch is stale or fails.
         }
+        markViewerPendingJoinRequest();
       } catch (err) {
         if (err instanceof ApiError) {
           const errorMap: Record<string, string> = {
@@ -351,23 +422,22 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
 
     try {
       await cancelMyJoinRequest(eventId, token);
-      // Optimistically flip viewer state back to NONE so the join CTA reappears.
-      setEvent((prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          viewer_context: {
-            ...prev.viewer_context,
-            participation_status: 'NONE',
-          },
-        };
-      });
       // Best-effort refresh — server is authoritative for any drift.
       try {
         await refreshEventDetail();
       } catch {
         // Keep optimistic NONE state if the follow-up fetch fails.
       }
+      setEvent((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          viewer_context: {
+            ...prev.viewer_context,
+            join_request_status: null,
+          },
+        };
+      });
     } catch (err) {
       if (err instanceof ApiError) {
         // 409 typically means the request was already handled (approved/rejected) — refetch
@@ -721,6 +791,16 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     refreshApprovedParticipants,
   ]);
 
+  const loadMorePendingParticipants = useCallback(async () => {
+    if (!pendingParticipantsHasNext || !pendingParticipantsNextCursor || pendingParticipantsLoading) return;
+    await refreshPendingParticipants(pendingParticipantsNextCursor, true);
+  }, [
+    pendingParticipantsHasNext,
+    pendingParticipantsLoading,
+    pendingParticipantsNextCursor,
+    refreshPendingParticipants,
+  ]);
+
   const loadMorePendingJoinRequests = useCallback(async () => {
     if (!pendingJoinRequestsHasNext || !pendingJoinRequestsNextCursor || pendingJoinRequestsLoading) return;
     await refreshPendingJoinRequests(pendingJoinRequestsNextCursor, true);
@@ -781,6 +861,9 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     approvedParticipants,
     approvedParticipantsLoading,
     approvedParticipantsHasNext,
+    pendingParticipants,
+    pendingParticipantsLoading,
+    pendingParticipantsHasNext,
     pendingJoinRequests,
     pendingJoinRequestsLoading,
     pendingJoinRequestsHasNext,
@@ -811,11 +894,15 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     reportLoading,
     reportError,
     reportSuccessMessage,
+    reconfirmLoading,
+    reconfirmError,
+    reconfirmSuccessMessage,
     handleFavoriteToggle,
     handleReportEvent,
     retry: fetchDetail,
     handleJoin,
     handleLeave,
+    handleReconfirmParticipation,
     handleRequestJoin,
     cancelJoinRequestLoading,
     cancelJoinRequestError,
@@ -829,6 +916,8 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     handleComplete,
     dismissJoinError,
     dismissLeaveError,
+    dismissReconfirmError: () => setReconfirmError(null),
+    dismissReconfirmSuccess: () => setReconfirmSuccessMessage(null),
     dismissViewerRatingError,
     dismissParticipantRatingError,
     dismissModerateError,
@@ -843,6 +932,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     dismissReportError,
     dismissReportSuccess,
     loadMoreApprovedParticipants,
+    loadMorePendingParticipants,
     loadMorePendingJoinRequests,
     loadMoreInvitations,
   };

--- a/frontend/src/viewmodels/event/useEventDetailViewModel.ts
+++ b/frontend/src/viewmodels/event/useEventDetailViewModel.ts
@@ -253,6 +253,27 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     fetchDetail();
   }, [fetchDetail]);
 
+  const markViewerJoined = useCallback(() => {
+    setEvent((prev) => {
+      if (!prev) return prev;
+
+      const wasJoined = prev.viewer_context.participation_status === 'JOINED' ||
+        prev.viewer_context.participation_status === 'APPROVED';
+
+      return {
+        ...prev,
+        approved_participant_count: wasJoined
+          ? prev.approved_participant_count
+          : prev.approved_participant_count + 1,
+        viewer_context: {
+          ...prev.viewer_context,
+          participation_status: 'JOINED',
+          join_request_status: null,
+        },
+      };
+    });
+  }, []);
+
   const handleJoin = useCallback(async () => {
     if (!eventId || !token) return;
     setJoinLoading(true);
@@ -260,7 +281,12 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
 
     try {
       await joinEvent(eventId, token);
-      await refreshEventDetail();
+      try {
+        await refreshEventDetail();
+      } catch {
+        // Keep the optimistic joined state if the follow-up detail fetch is stale or fails.
+      }
+      markViewerJoined();
     } catch (err) {
       if (err instanceof ApiError) {
         const errorMap: Record<string, string> = {
@@ -276,7 +302,7 @@ export function useEventDetailViewModel(eventId: string | undefined, token: stri
     } finally {
       setJoinLoading(false);
     }
-  }, [eventId, token, refreshEventDetail]);
+  }, [eventId, token, markViewerJoined, refreshEventDetail]);
 
   const handleLeave = useCallback(async () => {
     if (!eventId || !token) return;

--- a/frontend/src/views/discover/DiscoverEventSidePanel.tsx
+++ b/frontend/src/views/discover/DiscoverEventSidePanel.tsx
@@ -145,26 +145,24 @@ export default function DiscoverEventSidePanel({
           imgClassName="dc-side-panel-image-img"
           variant="card"
         />
-        <div className="dc-side-panel-image-badges">
+        <span
+          className="dc-side-panel-category"
+          style={{ background: presentation.color, color: presentation.textColor }}
+        >
+          <span aria-hidden>{presentation.emoji}</span>
+          <span>{presentation.label}</span>
+        </span>
+        {lifecycle && (
           <span
-            className="dc-side-panel-category"
-            style={{ background: presentation.color, color: presentation.textColor }}
+            className={`dc-side-panel-lifecycle ${
+              lifecycle.variant === 'upcoming'
+                ? 'dc-side-panel-lifecycle-upcoming'
+                : 'dc-side-panel-lifecycle-in-progress'
+            }`}
           >
-            <span aria-hidden>{presentation.emoji}</span>
-            <span>{presentation.label}</span>
+            {lifecycle.label}
           </span>
-          {lifecycle && (
-            <span
-              className={`dc-side-panel-lifecycle ${
-                lifecycle.variant === 'upcoming'
-                  ? 'dc-side-panel-lifecycle-upcoming'
-                  : 'dc-side-panel-lifecycle-in-progress'
-              }`}
-            >
-              {lifecycle.label}
-            </span>
-          )}
-        </div>
+        )}
       </div>
 
       <div className="dc-side-panel-body">
@@ -247,7 +245,7 @@ export default function DiscoverEventSidePanel({
 
         {tags.length > 0 && (
           <div className="dc-side-panel-tags">
-            {tags.slice(0, 8).map((tag) => (
+            {tags.map((tag) => (
               <span key={tag} className="dc-side-panel-tag">
                 #{tag}
               </span>

--- a/frontend/src/views/events/EditEventPage.tsx
+++ b/frontend/src/views/events/EditEventPage.tsx
@@ -1,0 +1,399 @@
+import { useState, type FormEvent } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import RoutePointsEditor from '@/components/RoutePointsEditor';
+import { MAX_CONSTRAINTS } from '@/viewmodels/event/useCreateEventViewModel';
+import {
+  type EditEventChangePreview,
+  useEditEventViewModel,
+} from '@/viewmodels/event/useEditEventViewModel';
+import type { LocationType } from '@/models/event';
+import '@/styles/create-event.css';
+
+function RequiredMark() {
+  return <span className="ce-required-mark" aria-hidden>*</span>;
+}
+
+function CriticalChangeModal({
+  preview,
+  loading,
+  onCancel,
+  onConfirm,
+}: {
+  preview: EditEventChangePreview;
+  loading: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="ce-popup-overlay" role="presentation">
+      <div className="ce-popup ce-edit-confirm-modal" role="dialog" aria-modal="true" aria-labelledby="edit-confirm-title">
+        <div className="ce-popup-icon">!</div>
+        <h2 id="edit-confirm-title" className="ce-popup-title">Confirm event update</h2>
+        {preview.criticalChangeLabels.length > 0 ? (
+          <>
+            <p className="ce-popup-message">
+              These changes can require approved participants to reconfirm attendance:
+            </p>
+            <ul className="ce-edit-critical-list">
+              {preview.criticalChangeLabels.map((label) => (
+                <li key={label}>{label}</li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p className="ce-popup-message">
+            This update creates a new event version. Participants will see the latest event details.
+          </p>
+        )}
+        <div className="ce-edit-modal-actions">
+          <button type="button" className="btn-secondary" onClick={onCancel} disabled={loading}>
+            Review Again
+          </button>
+          <button type="button" className="btn-primary" onClick={onConfirm} disabled={loading}>
+            {loading ? 'Saving...' : 'Save Update'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function EditEventPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const vm = useEditEventViewModel(id);
+  const [pendingPreview, setPendingPreview] = useState<EditEventChangePreview | null>(null);
+  const busy = vm.isLoading || vm.isSaving;
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const preview = vm.previewChanges();
+    if (!preview) return;
+    setPendingPreview(preview);
+  };
+
+  const confirmSubmit = async () => {
+    if (!pendingPreview) return;
+    const result = await vm.handleSubmit(pendingPreview.request);
+    if (result) setPendingPreview(null);
+  };
+
+  if (vm.isLoading) {
+    return (
+      <div className="create-event-page edit-event-page">
+        <h1 className="create-event-title">Loading event...</h1>
+      </div>
+    );
+  }
+
+  if (vm.apiError && !vm.event) {
+    return (
+      <div className="create-event-page edit-event-page">
+        <h1 className="create-event-title">Edit Event</h1>
+        <p className="create-event-subtitle">{vm.apiError}</p>
+        <button type="button" className="btn-secondary" onClick={() => navigate(-1)}>
+          Go Back
+        </button>
+      </div>
+    );
+  }
+
+  if (!vm.event) return null;
+
+  return (
+    <div className="create-event-page edit-event-page">
+      {pendingPreview && (
+        <CriticalChangeModal
+          preview={pendingPreview}
+          loading={vm.isSaving}
+          onCancel={() => setPendingPreview(null)}
+          onConfirm={confirmSubmit}
+        />
+      )}
+
+      <Link className="ce-edit-back-link" to={`/events/${vm.event.id}`}>
+        &larr; Back to Event
+      </Link>
+      <h1 className="create-event-title">Edit Event</h1>
+      <p className="create-event-subtitle">Update event details through the versioned event contract.</p>
+
+      {vm.successMessage && (
+        <div className="success-banner" role="status">
+          {vm.successMessage}
+        </div>
+      )}
+      {vm.apiError && <div className="error-banner">{vm.apiError}</div>}
+
+      {!vm.canEdit && (
+        <div className="error-banner">
+          Only active events that have not started can be edited.
+        </div>
+      )}
+
+      <form className="create-event-form edit-event-form" onSubmit={handleSubmit}>
+        <div className="ce-host-info">
+          <span className="ce-host-label">Current version:</span>
+          <span className="ce-host-name">
+            v{vm.event.version_no ?? vm.event.viewer_context.latest_event_version ?? 1}
+          </span>
+        </div>
+
+        <div className="field-group">
+          <label className="field-label" htmlFor="edit-title">
+            Title <RequiredMark />
+          </label>
+          <input
+            id="edit-title"
+            className={`field-input ${vm.errors.title ? 'has-error' : ''}`}
+            value={vm.form.title}
+            disabled={busy || !vm.canEdit}
+            onChange={(e) => vm.updateField('title', e.target.value)}
+          />
+          {vm.errors.title && <p className="field-error">{vm.errors.title}</p>}
+        </div>
+
+        <div className="field-group">
+          <label className="field-label" htmlFor="edit-description">Description</label>
+          <textarea
+            id="edit-description"
+            className={`field-input field-textarea ${vm.errors.description ? 'has-error' : ''}`}
+            value={vm.form.description}
+            disabled={busy || !vm.canEdit}
+            onChange={(e) => vm.updateField('description', e.target.value)}
+          />
+          {vm.errors.description && <p className="field-error">{vm.errors.description}</p>}
+        </div>
+
+        <div className="field-group">
+          <label className="field-label" htmlFor="edit-category">
+            Category <RequiredMark />
+          </label>
+          <select
+            id="edit-category"
+            className={`field-input ${vm.errors.categoryId ? 'has-error' : ''}`}
+            value={vm.form.categoryId ?? ''}
+            disabled={busy || !vm.canEdit}
+            onChange={(e) => vm.updateField('categoryId', e.target.value ? Number(e.target.value) : null)}
+          >
+            <option value="">Select category</option>
+            {vm.categories.map((category) => (
+              <option key={category.id} value={category.id}>{category.name}</option>
+            ))}
+          </select>
+          {vm.errors.categoryId && <p className="field-error">{vm.errors.categoryId}</p>}
+        </div>
+
+        <div className="field-group">
+          <span className="field-label">
+            Location <RequiredMark />
+          </span>
+          <div className="ce-location-type-row">
+            {(['POINT', 'ROUTE'] as LocationType[]).map((type) => (
+              <button
+                key={type}
+                type="button"
+                className={`ce-location-type-chip ${vm.form.locationType === type ? 'selected' : ''}`}
+                disabled={busy || !vm.canEdit}
+                onClick={() => vm.setLocationType(type)}
+              >
+                {type === 'POINT' ? 'Point' : 'Route'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {vm.form.locationType === 'POINT' ? (
+          <div className="field-group">
+            <label className="field-label" htmlFor="edit-location-search">
+              Search location <RequiredMark />
+            </label>
+            <input
+              id="edit-location-search"
+              className={`field-input ${vm.errors.location ? 'has-error' : ''}`}
+              value={vm.form.locationQuery}
+              disabled={busy || !vm.canEdit}
+              onChange={(e) => vm.handleLocationSearch(e.target.value)}
+              placeholder="Search a place"
+            />
+            {vm.locationSearching && <p className="field-hint">Searching...</p>}
+            {vm.locationResults.length > 0 && (
+              <ul className="ce-location-results">
+                {vm.locationResults.map((suggestion, index) => (
+                  <li key={`${suggestion.lat}-${suggestion.lon}-${index}`}>
+                    <button type="button" className="ce-location-item" onClick={() => vm.selectLocation(suggestion)}>
+                      {suggestion.display_name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {vm.form.lat != null && vm.form.lon != null && (
+              <p className="field-hint">
+                Selected: {vm.form.lat.toFixed(5)}, {vm.form.lon.toFixed(5)}
+              </p>
+            )}
+            {vm.errors.location && <p className="field-error">{vm.errors.location}</p>}
+          </div>
+        ) : (
+          <div className="field-group">
+            <label className="field-label" htmlFor="edit-route-address">Route label</label>
+            <input
+              id="edit-route-address"
+              className="field-input"
+              value={vm.form.address}
+              disabled={busy || !vm.canEdit}
+              onChange={(e) => vm.updateField('address', e.target.value)}
+              placeholder="Optional route label"
+            />
+            <RoutePointsEditor
+              routePoints={vm.form.routePoints}
+              locationQuery={vm.form.locationQuery}
+              isSearching={vm.locationSearching}
+              suggestions={vm.locationResults}
+              errorText={vm.errors.location}
+              disabled={busy || !vm.canEdit}
+              onSearch={vm.handleLocationSearch}
+              onAddFromSuggestion={vm.addRoutePointFromSuggestion}
+              onAddFromCoordinate={vm.addRoutePointFromCoordinate}
+              onRemove={vm.removeRoutePoint}
+              onMove={vm.moveRoutePoint}
+              onUpdateLabel={vm.updateRoutePointLabel}
+            />
+          </div>
+        )}
+
+        <div className="ce-row">
+          <div className="field-group">
+            <label className="field-label" htmlFor="edit-start-date">
+              Start date <RequiredMark />
+            </label>
+            <input
+              id="edit-start-date"
+              type="date"
+              className={`field-input ${vm.errors.startDate ? 'has-error' : ''}`}
+              value={vm.form.startDate}
+              disabled={busy || !vm.canEdit}
+              onChange={(e) => vm.updateField('startDate', e.target.value)}
+            />
+            {vm.errors.startDate && <p className="field-error">{vm.errors.startDate}</p>}
+          </div>
+          <div className="field-group">
+            <label className="field-label" htmlFor="edit-start-time">
+              Start time <RequiredMark />
+            </label>
+            <input
+              id="edit-start-time"
+              type="time"
+              className={`field-input ${vm.errors.startTime ? 'has-error' : ''}`}
+              value={vm.form.startTime}
+              disabled={busy || !vm.canEdit}
+              onChange={(e) => vm.updateField('startTime', e.target.value)}
+            />
+            {vm.errors.startTime && <p className="field-error">{vm.errors.startTime}</p>}
+          </div>
+        </div>
+
+        <div className="ce-row">
+          <div className="field-group">
+            <label className="field-label" htmlFor="edit-end-date">End date</label>
+            <input
+              id="edit-end-date"
+              type="date"
+              className={`field-input ${vm.errors.endDate ? 'has-error' : ''}`}
+              value={vm.form.endDate}
+              disabled={busy || !vm.canEdit}
+              onChange={(e) => vm.updateField('endDate', e.target.value)}
+            />
+            {vm.errors.endDate && <p className="field-error">{vm.errors.endDate}</p>}
+          </div>
+          <div className="field-group">
+            <label className="field-label" htmlFor="edit-end-time">End time</label>
+            <input
+              id="edit-end-time"
+              type="time"
+              className={`field-input ${vm.errors.endTime ? 'has-error' : ''}`}
+              value={vm.form.endTime}
+              disabled={busy || !vm.canEdit}
+              onChange={(e) => vm.updateField('endTime', e.target.value)}
+            />
+            {vm.errors.endTime && <p className="field-error">{vm.errors.endTime}</p>}
+          </div>
+        </div>
+
+        <div className="field-group">
+          <label className="field-label" htmlFor="edit-capacity">Capacity</label>
+          <input
+            id="edit-capacity"
+            type="number"
+            min={2}
+            className={`field-input ${vm.errors.capacity ? 'has-error' : ''}`}
+            value={vm.form.capacity}
+            disabled={busy || !vm.canEdit}
+            onChange={(e) => vm.updateField('capacity', e.target.value)}
+            placeholder="Unlimited"
+          />
+          {vm.errors.capacity && <p className="field-error">{vm.errors.capacity}</p>}
+        </div>
+
+        <div className="field-group">
+          <label className="field-label">Participation requirements</label>
+          {vm.form.constraints.length > 0 && (
+            <ul className="ce-edit-constraint-list">
+              {vm.form.constraints.map((constraint, index) => (
+                <li key={`${constraint.type}-${index}`}>
+                  <span>{constraint.type}: {constraint.info}</span>
+                  <button
+                    type="button"
+                    className="ce-chip-remove"
+                    disabled={busy || !vm.canEdit}
+                    onClick={() => vm.removeConstraint(index)}
+                  >
+                    &times;
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="ce-edit-constraint-row">
+            <input
+              className="field-input"
+              value={vm.form.constraintType}
+              disabled={busy || !vm.canEdit || vm.form.constraints.length >= MAX_CONSTRAINTS}
+              onChange={(e) => vm.updateField('constraintType', e.target.value)}
+              placeholder="Type"
+            />
+            <input
+              className="field-input"
+              value={vm.form.constraintInfo}
+              disabled={busy || !vm.canEdit || vm.form.constraints.length >= MAX_CONSTRAINTS}
+              onChange={(e) => vm.updateField('constraintInfo', e.target.value)}
+              placeholder="Details"
+            />
+            <button type="button" className="btn-secondary" disabled={busy || !vm.canEdit} onClick={vm.addConstraint}>
+              Add
+            </button>
+          </div>
+          {vm.errors.constraints && <p className="field-error">{vm.errors.constraints}</p>}
+        </div>
+
+        {vm.updateResult?.reconfirmation_required && (
+          <div className="ce-edit-warning" role="status">
+            Reconfirmation needed: {Math.max(
+              vm.event?.pending_participant_count ?? 0,
+              vm.updateResult.participants_marked_pending,
+            )}
+          </div>
+        )}
+
+        <div className="ce-edit-form-actions">
+          <button type="button" className="btn-secondary" onClick={() => navigate(`/events/${vm.event?.id}`)} disabled={busy}>
+            Cancel
+          </button>
+          <button type="submit" className="btn-primary" disabled={busy || !vm.canEdit}>
+            {vm.isSaving ? 'Saving...' : 'Preview & Save'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/views/events/EventDetailPage.test.tsx
+++ b/frontend/src/views/events/EventDetailPage.test.tsx
@@ -120,9 +120,13 @@ function makeReadyViewModel(event: EventDetailResponse) {
     reportLoading: false,
     reportError: null,
     reportSuccessMessage: null,
+    reconfirmLoading: false,
+    reconfirmError: null,
+    reconfirmSuccessMessage: null,
     retry: vi.fn(),
     handleJoin: vi.fn(),
     handleLeave: vi.fn(),
+    handleReconfirmParticipation: vi.fn(),
     handleRequestJoin: vi.fn(),
     handleViewerRatingSubmit: vi.fn(),
     handleParticipantRatingSubmit: vi.fn(),
@@ -141,6 +145,8 @@ function makeReadyViewModel(event: EventDetailResponse) {
     dismissCompleteError: vi.fn(),
     dismissReportError: vi.fn(),
     dismissReportSuccess: vi.fn(),
+    dismissReconfirmError: vi.fn(),
+    dismissReconfirmSuccess: vi.fn(),
     coverImageUploading: false,
     coverImageError: null,
     coverImageSuccessMessage: null,
@@ -148,6 +154,10 @@ function makeReadyViewModel(event: EventDetailResponse) {
     dismissCoverImageError: vi.fn(),
     dismissCoverImageSuccess: vi.fn(),
     loadMoreApprovedParticipants: vi.fn(),
+    pendingParticipants: [],
+    pendingParticipantsLoading: false,
+    pendingParticipantsHasNext: false,
+    loadMorePendingParticipants: vi.fn(),
     loadMorePendingJoinRequests: vi.fn(),
     loadMoreInvitations: vi.fn(),
     inviteLoading: false,
@@ -380,6 +390,27 @@ describe('EventDetailPage ratings', () => {
     expect(screen.queryByTestId('ed-directions-link')).toBeNull();
   });
 
+  it('shows the approximate district and province when protected location address is available', () => {
+    const event = makeBaseEvent();
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'NONE';
+    event.location = {
+      type: 'POINT',
+      address: 'Kadikoy, Istanbul, Turkiye',
+      point: { lat: 40.981, lon: 29.032 },
+      route_points: [],
+      is_location_approximate: true,
+    };
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByText('Kadikoy, Istanbul')).toBeDefined();
+    expect(screen.queryByText(/^approximate area$/i)).toBeNull();
+    expect(screen.queryByTestId('ed-directions-link')).toBeNull();
+  });
+
   it('shows the map fallback and hides the directions link when coordinates are missing', () => {
     const event = makeBaseEvent();
     event.location = {
@@ -602,6 +633,33 @@ describe('EventDetailPage ratings', () => {
 
     renderPage();
 
+    expect(screen.queryByTestId('ed-cancel-request-btn')).toBeNull();
+  });
+
+  it('does not show a Cancel Request button when attendance needs reconfirmation', () => {
+    const event = makeBaseEvent();
+    event.status = 'ACTIVE';
+    event.privacy_level = 'PROTECTED';
+    event.viewer_context.participation_status = 'PENDING';
+    event.viewer_context.needs_reconfirmation = true;
+    event.viewer_context.event_diff = {
+      from_version_no: 1,
+      to_version_no: 2,
+      changed_fields: ['start_time'],
+      changes: [
+        {
+          field: 'start_time',
+          old_value: '2026-04-01T17:00:00Z',
+          new_value: '2026-04-01T18:00:00Z',
+        },
+      ],
+    };
+
+    mockUseEventDetailViewModel.mockReturnValue(makeReadyViewModel(event));
+
+    renderPage();
+
+    expect(screen.getByTestId('ed-reconfirmation-banner')).toBeDefined();
     expect(screen.queryByTestId('ed-cancel-request-btn')).toBeNull();
   });
 

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -10,6 +10,7 @@ import type {
   EventDetailPendingJoinRequest,
   EventDetailResponse,
   EventHostContextSummary,
+  EventVersionChange,
 } from '@/models/event';
 import type {
   CreateEventInvitationsResponse,
@@ -20,6 +21,7 @@ import { EventCoverImage } from '@/components/EventCoverImage';
 import { UserAvatar } from '@/components/UserAvatar';
 import { getEventLifecyclePresentation, getEventStatusPresentation } from '@/utils/eventStatus';
 import { getApproximateLocationText } from '@/utils/locationApproximation';
+import { formatEventLocation } from '@/utils/eventLocation';
 import NotFoundView from '../fallback/NotFoundView';
 import AccessDeniedView from '../fallback/AccessDeniedView';
 import EventInteractionPanel from './EventInteractionPanel';
@@ -77,6 +79,209 @@ function formatShortDate(iso: string): string {
     month: 'short',
     day: 'numeric',
   });
+}
+
+const ATTENDANCE_CRITICAL_FIELDS = new Set([
+  'title',
+  'description',
+  'category',
+  'category_id',
+  'location',
+  'start_time',
+  'end_time',
+  'privacy_level',
+  'capacity',
+  'minimum_age',
+  'maximum_age',
+  'preferred_gender',
+  'constraints',
+]);
+
+function formatTitleCaseValue(value: string): string {
+  return value
+    .toLowerCase()
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function formatConstraintType(value: unknown): string {
+  if (typeof value !== 'string' || value.trim() === '') return 'Requirement';
+  const normalized = value.trim().toUpperCase();
+  const labels: Record<string, string> = {
+    AGE: 'Age',
+    MINIMUM_AGE: 'Minimum age',
+    MAXIMUM_AGE: 'Maximum age',
+    GENDER: 'Gender',
+    PREFERRED_GENDER: 'Preferred gender',
+    CAPACITY: 'Capacity',
+    EQUIPMENT: 'Equipment',
+    EXPERIENCE: 'Experience',
+    SKILL: 'Skill',
+    ACCESSIBILITY: 'Accessibility',
+    CUSTOM: 'Other',
+    OTHER: 'Other',
+  };
+  return labels[normalized] ?? formatTitleCaseValue(normalized);
+}
+
+function formatConstraintList(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) return 'None';
+  return value
+    .map((item) => {
+      if (isRecord(item)) {
+        const type = formatConstraintType(item.type);
+        const info = typeof item.info === 'string' ? item.info.trim() : '';
+        return info ? `${type}: ${info}` : type;
+      }
+      return String(item);
+    })
+    .join(' · ');
+}
+
+function formatHistoryLocation(value: unknown): string {
+  if (!isRecord(value)) return value == null ? 'Not set' : String(value);
+  const type = typeof value.type === 'string' ? value.type : null;
+  const address = typeof value.address === 'string' && value.address.trim() ? value.address : null;
+  if (type === 'ROUTE') {
+    const routePoints = Array.isArray(value.route_points) ? value.route_points.length : 0;
+    return [address, routePoints ? `${routePoints} route point${routePoints === 1 ? '' : 's'}` : null]
+      .filter(Boolean)
+      .join(' · ') || 'Route';
+  }
+  const point = isRecord(value.point) ? value.point : null;
+  const lat = typeof point?.lat === 'number' ? point.lat : null;
+  const lon = typeof point?.lon === 'number' ? point.lon : null;
+  return [address, lat != null && lon != null ? `${lat.toFixed(4)}, ${lon.toFixed(4)}` : null]
+    .filter(Boolean)
+    .join(' · ') || 'Point location';
+}
+
+function formatDiffValue(field: string, value: unknown): string {
+  if (value == null) return field === 'capacity' ? 'Unlimited' : 'Not set';
+  if (field === 'start_time' || field === 'end_time') {
+    return typeof value === 'string' ? formatDateTime(value) : String(value);
+  }
+  if (field === 'location') return formatHistoryLocation(value);
+  if (field === 'constraints') return formatConstraintList(value);
+  if (field === 'privacy_level' || field === 'preferred_gender' || field === 'status') {
+    return typeof value === 'string' ? formatTitleCaseValue(value) : String(value);
+  }
+  if (field === 'capacity') return typeof value === 'number' ? `${value} participants` : String(value);
+  if (field === 'minimum_age') return typeof value === 'number' ? `${value}+` : String(value);
+  if (field === 'maximum_age') return typeof value === 'number' ? `Up to ${value}` : String(value);
+  if (field === 'category' || field === 'category_id') {
+    if (isRecord(value) && typeof value.name === 'string') return value.name;
+    return String(value);
+  }
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'string') return value.trim() || 'Not set';
+  if (typeof value === 'number') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getChangeFieldLabel(field: string): string {
+  const labels: Record<string, string> = {
+    title: 'Title',
+    description: 'Description',
+    category: 'Category',
+    category_id: 'Category',
+    location: 'Location or route',
+    start_time: 'Start time',
+    end_time: 'End time',
+    privacy_level: 'Privacy',
+    capacity: 'Capacity',
+    minimum_age: 'Minimum age',
+    maximum_age: 'Maximum age',
+    preferred_gender: 'Preferred gender',
+    constraints: 'Participation requirements',
+  };
+  return labels[field] ?? formatTitleCaseValue(field);
+}
+
+function VersionChangeValues({ change }: { change: EventVersionChange }) {
+  const isConstraintField = change.field === 'constraints';
+  const beforeValue = formatDiffValue(change.field, change.old_value);
+  const nowValue = formatDiffValue(change.field, change.new_value);
+
+  return (
+    <div className={`ed-version-values ${isConstraintField ? 'ed-version-values-constraints' : ''}`}>
+      <div>
+        <span>Before</span>
+        <p>{beforeValue}</p>
+      </div>
+      <span className="ed-version-flow-arrow" aria-hidden>
+        <svg viewBox="0 0 24 24" focusable="false">
+          <path d="M5 12h14" />
+          <path d="m13 6 6 6-6 6" />
+        </svg>
+      </span>
+      <div>
+        <span>Now</span>
+        <p>{nowValue}</p>
+      </div>
+    </div>
+  );
+}
+
+function VersionChangeList({ changes, compact = false }: { changes: EventVersionChange[]; compact?: boolean }) {
+  return (
+    <ul className={compact ? 'ed-version-change-list ed-version-change-list-compact' : 'ed-version-change-list'}>
+      {changes.map((change: EventVersionChange, index) => {
+        const isCritical = ATTENDANCE_CRITICAL_FIELDS.has(change.field);
+        return (
+          <li key={`${change.field}-${index}`} className="ed-version-change">
+            <div className="ed-version-change-title">
+              <strong>{getChangeFieldLabel(change.field)}</strong>
+              {isCritical && <span>Attendance impact</span>}
+            </div>
+            <VersionChangeValues change={change} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function summarizeChangedFields(changedFields: string[]): string[] {
+  const summaries: string[] = [];
+  const add = (summary: string) => {
+    if (!summaries.includes(summary)) summaries.push(summary);
+  };
+  if (changedFields.includes('start_time') || changedFields.includes('end_time')) add('Time changed');
+  if (changedFields.includes('location')) add('Location or route changed');
+  if (changedFields.includes('privacy_level')) add('Privacy changed');
+  if (
+    changedFields.includes('capacity') ||
+    changedFields.includes('minimum_age') ||
+    changedFields.includes('maximum_age') ||
+    changedFields.includes('preferred_gender') ||
+    changedFields.includes('constraints')
+  ) {
+    add('Participation rules changed');
+  }
+  changedFields.forEach((field) => {
+    if (!ATTENDANCE_CRITICAL_FIELDS.has(field)) add(`${getChangeFieldLabel(field)} changed`);
+  });
+  return summaries.length > 0 ? summaries : ['Event details changed'];
+}
+
+function getViewerParticipationState(event: EventDetailResponse): 'JOINED' | 'PENDING' | 'INVITED' | 'NONE' | 'LEAVED' | 'CANCELED' {
+  const status = event.viewer_context.participation_status;
+  if (status === 'APPROVED' || status === 'JOINED') return 'JOINED';
+  if (status === 'PENDING' || event.viewer_context.join_request_status === 'PENDING') return 'PENDING';
+  if (status === 'INVITED' || event.viewer_context.invitation_status === 'PENDING') return 'INVITED';
+  if (status === 'LEAVED') return 'LEAVED';
+  if (status === 'CANCELED') return 'CANCELED';
+  return 'NONE';
 }
 
 function getDisplayName(user: { display_name: string | null; username: string }): string {
@@ -146,6 +351,137 @@ function ExpiryWarningBanner({ event }: { event: EventDetailResponse }) {
   );
 }
 
+function ReconfirmationBanner({
+  event,
+  loading,
+  error,
+  successMessage,
+  onReconfirm,
+  onLeave,
+  onDismissError,
+  onDismissSuccess,
+}: {
+  event: EventDetailResponse;
+  loading: boolean;
+  error: string | null;
+  successMessage: string | null;
+  onReconfirm: () => void;
+  onLeave: () => void;
+  onDismissError: () => void;
+  onDismissSuccess: () => void;
+}) {
+  if (!event.viewer_context.needs_reconfirmation && !successMessage) return null;
+
+  const diff = event.viewer_context.event_diff ?? null;
+  const changes = diff?.changes ?? [];
+  const summaries = summarizeChangedFields(
+    diff?.changed_fields ?? changes.map((change) => change.field),
+  );
+
+  return (
+    <div className="ed-reconfirm-panel" data-testid="ed-reconfirmation-banner">
+      {event.viewer_context.needs_reconfirmation ? (
+        <>
+          <div>
+            <h2>Attendance needs reconfirmation</h2>
+            <p>
+              Event details changed since the version you last confirmed. Review what changed and reconfirm if you can still attend.
+            </p>
+          </div>
+          {diff && (
+            <div className="ed-reconfirm-diff" data-testid="ed-reconfirmation-diff">
+              <div className="ed-reconfirm-diff-header">
+                <strong>Changes since your last confirmation</strong>
+                <span>v{diff.from_version_no} to v{diff.to_version_no}</span>
+              </div>
+              <div className="ed-version-summary-row ed-reconfirm-summary-row">
+                {summaries.map((summary) => (
+                  <span key={summary} className="ed-version-summary-pill">{summary}</span>
+                ))}
+              </div>
+              {changes.length > 0 ? (
+                <VersionChangeList changes={changes} compact />
+              ) : (
+                <p className="ed-mgmt-empty">No detailed changes are available for this update.</p>
+              )}
+            </div>
+          )}
+          {error && (
+            <div className="ed-join-error">
+              <span>{error}</span>
+              <button type="button" className="ed-join-error-dismiss" onClick={onDismissError}>&times;</button>
+            </div>
+          )}
+          <div className="ed-reconfirm-actions">
+            <button type="button" className="ed-reconfirm-btn" onClick={onReconfirm} disabled={loading}>
+              {loading ? 'Reconfirming...' : 'Reconfirm Attendance'}
+            </button>
+            <button type="button" className="ed-reconfirm-secondary-btn" onClick={onLeave} disabled={loading}>
+              Leave Event
+            </button>
+          </div>
+        </>
+      ) : (
+        <div className="ed-cover-upload-success" role="status">
+          <span>{successMessage}</span>
+          <button type="button" className="ed-join-error-dismiss" onClick={onDismissSuccess}>&times;</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EventVersionHistorySection({ event }: { event: EventDetailResponse }) {
+  const diff = event.viewer_context.event_diff ?? null;
+  const changes = diff?.changes ?? [];
+  const versionNo =
+    event.version_no ??
+    event.viewer_context.latest_event_version ??
+    diff?.to_version_no ??
+    null;
+  const status = getViewerParticipationState(event);
+  const canViewHistory = event.viewer_context.is_host || status === 'JOINED' || status === 'PENDING';
+
+  if (!canViewHistory || (!diff && versionNo == null)) return null;
+
+  const summaries = summarizeChangedFields(
+    diff?.changed_fields ?? changes.map((change) => change.field),
+  );
+
+  return (
+    <div className="ed-section ed-version-history" data-testid="ed-version-history">
+      <div className="ed-version-header">
+        <h2 className="ed-section-title">Version History</h2>
+        {versionNo != null && <span className="ed-version-pill">v{versionNo}</span>}
+      </div>
+      <div className="ed-version-card">
+        {event.viewer_context.needs_reconfirmation && (
+          <div className="ed-version-attention">
+            Review these changes before confirming that you can still attend.
+          </div>
+        )}
+        {diff ? (
+          <p className="ed-version-range">
+            Changes from version {diff.from_version_no} to {diff.to_version_no}
+          </p>
+        ) : (
+          <p className="ed-version-range">Current event version{versionNo != null ? ` ${versionNo}` : ''}</p>
+        )}
+        <div className="ed-version-summary-row">
+          {summaries.map((summary) => (
+            <span key={summary} className="ed-version-summary-pill">{summary}</span>
+          ))}
+        </div>
+        {changes.length > 0 ? (
+          <VersionChangeList changes={changes} />
+        ) : (
+          <p className="ed-mgmt-empty">No changes need review right now.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function PencilCoverIcon() {
   return (
     <svg
@@ -207,6 +543,9 @@ function LocationSection({ location }: { location: EventDetailResponse['location
 
   const hasMap = anchor !== null;
   const isApproximate = location.is_location_approximate;
+  const approximateAreaLabel = location.address
+    ? formatEventLocation(location.address)
+    : 'Approximate area';
 
   return (
     <div className="ed-section">
@@ -225,7 +564,7 @@ function LocationSection({ location }: { location: EventDetailResponse['location
           {location.address && !isApproximate ? (
             <p className="ed-info-primary">{location.address}</p>
           ) : isApproximate ? (
-            <p className="ed-info-primary">Approximate area</p>
+            <p className="ed-info-primary">{approximateAreaLabel}</p>
           ) : (
             <p className="ed-info-secondary">No address provided</p>
           )}
@@ -608,12 +947,15 @@ function JoinActionSection({
   const requestImageInputRef = useRef<HTMLInputElement>(null);
   const [showCancelRequestModal, setShowCancelRequestModal] = useState(false);
   const ctx = event.viewer_context;
+  const viewerState = getViewerParticipationState(event);
 
   // Host doesn't see join actions
   if (ctx.is_host) return null;
 
+  if (ctx.needs_reconfirmation) return null;
+
   // Already participating states
-  if (ctx.participation_status === 'JOINED') {
+  if (viewerState === 'JOINED') {
     const isCompletedOrCanceled = event.status === 'COMPLETED' || event.status === 'CANCELED';
     const joinedBannerClass = event.status === 'COMPLETED'
       ? 'ed-participation-attended'
@@ -675,7 +1017,7 @@ function JoinActionSection({
     );
   }
 
-  if (ctx.participation_status === 'PENDING') {
+  if (viewerState === 'PENDING') {
     return (
       <div className="ed-section">
         <div className="ed-participation-banner ed-participation-pending">
@@ -721,7 +1063,7 @@ function JoinActionSection({
     );
   }
 
-  if (ctx.participation_status === 'INVITED') {
+  if (viewerState === 'INVITED') {
     return (
       <div className="ed-section">
         <div className="ed-participation-banner ed-participation-invited">
@@ -1008,7 +1350,7 @@ function ParticipantRatingSection({
   const trimmedLength = message.trim().length;
   const isEligibleParticipant = (
     !event.viewer_context.is_host
-    && event.viewer_context.participation_status === 'JOINED'
+    && getViewerParticipationState(event) === 'JOINED'
     && event.status === 'COMPLETED'
     && event.rating_window.is_active
   );
@@ -1498,6 +1840,41 @@ function ReportEventModal({
   );
 }
 
+function HostPendingReconfirmationItem({ participant }: { participant: EventDetailApprovedParticipant }) {
+  return (
+    <li className="ed-mgmt-item ed-mgmt-item-pending-reconfirmation">
+      <Link
+        to={`/users/${participant.user.id}`}
+        className="ed-mgmt-avatar-link"
+        aria-label={`View ${getDisplayName(participant.user)}'s profile`}
+      >
+        <UserAvatar
+          username={participant.user.username}
+          displayName={participant.user.display_name}
+          avatarUrl={participant.user.avatar_url}
+          size="sm"
+          variant="muted"
+        />
+      </Link>
+      <Link to={`/users/${participant.user.id}`} className="ed-mgmt-user-link">
+        <div className="ed-mgmt-user-info">
+          <div className="ed-mgmt-user-topline">
+            <span className="ed-mgmt-name">{getDisplayName(participant.user)}</span>
+            {participant.user.final_score != null && (
+              <span className="ed-mgmt-user-score">
+                {'★'} {participant.user.final_score.toFixed(1)} ({participant.user.rating_count})
+              </span>
+            )}
+          </div>
+          <span className="ed-mgmt-username">@{participant.user.username}</span>
+          <span className="ed-mgmt-message">Waiting since {formatShortDate(participant.updated_at)}</span>
+        </div>
+      </Link>
+      <span className="ed-reconfirm-status-pill">Needs reconfirmation</span>
+    </li>
+  );
+}
+
 function LeaveConfirmModal({
   onConfirm,
   onClose,
@@ -1626,12 +2003,21 @@ function EventContent({
   onReportEvent,
   onDismissReportError,
   onDismissReportSuccess,
+  reconfirmLoading,
+  reconfirmError,
+  reconfirmSuccessMessage,
+  onReconfirmParticipation,
+  onDismissReconfirmError,
+  onDismissReconfirmSuccess,
   isAuthenticated,
   token,
   hostContextSummary,
   approvedParticipants,
   approvedParticipantsLoading,
   approvedParticipantsHasNext,
+  pendingParticipants,
+  pendingParticipantsLoading,
+  pendingParticipantsHasNext,
   pendingJoinRequests,
   pendingJoinRequestsLoading,
   pendingJoinRequestsHasNext,
@@ -1639,6 +2025,7 @@ function EventContent({
   invitationsLoading,
   invitationsHasNext,
   onLoadMoreApprovedParticipants,
+  onLoadMorePendingParticipants,
   onLoadMorePendingJoinRequests,
   onLoadMoreInvitations,
   inviteLoading,
@@ -1697,12 +2084,21 @@ function EventContent({
   onReportEvent: (category: EventReportCategory, message?: string) => Promise<boolean>;
   onDismissReportError: () => void;
   onDismissReportSuccess: () => void;
+  reconfirmLoading: boolean;
+  reconfirmError: string | null;
+  reconfirmSuccessMessage: string | null;
+  onReconfirmParticipation: () => void;
+  onDismissReconfirmError: () => void;
+  onDismissReconfirmSuccess: () => void;
   isAuthenticated: boolean;
   token: string | null;
   hostContextSummary: EventHostContextSummary | null;
   approvedParticipants: EventDetailApprovedParticipant[];
   approvedParticipantsLoading: boolean;
   approvedParticipantsHasNext: boolean;
+  pendingParticipants: EventDetailApprovedParticipant[];
+  pendingParticipantsLoading: boolean;
+  pendingParticipantsHasNext: boolean;
   pendingJoinRequests: EventDetailPendingJoinRequest[];
   pendingJoinRequestsLoading: boolean;
   pendingJoinRequestsHasNext: boolean;
@@ -1710,6 +2106,7 @@ function EventContent({
   invitationsLoading: boolean;
   invitationsHasNext: boolean;
   onLoadMoreApprovedParticipants: () => void;
+  onLoadMorePendingParticipants: () => void;
   onLoadMorePendingJoinRequests: () => void;
   onLoadMoreInvitations: () => void;
   inviteLoading: boolean;
@@ -1739,6 +2136,10 @@ function EventContent({
     event.viewer_context.is_host
     && event.status === 'COMPLETED'
     && event.rating_window.is_active
+  );
+  const pendingReconfirmationCount = Math.max(
+    event.pending_participant_count,
+    pendingParticipants.length,
   );
 
   const showCoverImageEdit = isAuthenticated && event.viewer_context.is_host;
@@ -1885,6 +2286,17 @@ function EventContent({
       {/* Expiry warning — shown in last 7 days before auto-completion */}
       <ExpiryWarningBanner event={event} />
 
+      <ReconfirmationBanner
+        event={event}
+        loading={reconfirmLoading}
+        error={reconfirmError}
+        successMessage={reconfirmSuccessMessage}
+        onReconfirm={onReconfirmParticipation}
+        onLeave={onLeave}
+        onDismissError={onDismissReconfirmError}
+        onDismissSuccess={onDismissReconfirmSuccess}
+      />
+
       {/* Join action — prominent position */}
       <JoinActionSection
         event={event}
@@ -2028,6 +2440,8 @@ function EventContent({
           </div>
         )}
 
+        <EventVersionHistorySection event={event} />
+
         {/* Host management section — only visible to host */}
         {event.viewer_context.is_host && (
           <div className="ed-section">
@@ -2035,7 +2449,14 @@ function EventContent({
 
             {/* Cancel event button */}
             {event.status === 'ACTIVE' && (
-              <div className="ed-mgmt-group">
+              <div className="ed-mgmt-group ed-host-action-group">
+                <Link
+                  to={`/events/${event.id}/edit`}
+                  className="ed-edit-event-link"
+                  data-testid="ed-edit-event-link"
+                >
+                  Edit Event
+                </Link>
                 {cancelError && (
                   <div className="ed-join-error" style={{ marginBottom: 10 }}>
                     <span>{cancelError}</span>
@@ -2071,6 +2492,45 @@ function EventContent({
                 </button>
               </div>
             )}
+
+            <div className="ed-mgmt-group ed-reconfirmation-mgmt-group">
+              <h3 className="ed-mgmt-title">
+                Reconfirmation Needed ({pendingReconfirmationCount})
+              </h3>
+              {pendingReconfirmationCount > 0 ? (
+                <>
+                  <div className="ed-reconfirmation-mgmt-card">
+                    <strong>{pendingReconfirmationCount}</strong>
+                    <span>
+                      Participant{pendingReconfirmationCount === 1 ? '' : 's'} must approve the latest event version before they are fully confirmed again.
+                    </span>
+                  </div>
+                  {pendingParticipantsLoading && pendingParticipants.length === 0 ? (
+                    <p className="ed-mgmt-empty">Loading participants awaiting reconfirmation...</p>
+                  ) : pendingParticipants.length === 0 ? (
+                    <p className="ed-mgmt-empty">No participant details are available yet.</p>
+                  ) : (
+                    <ul className="ed-mgmt-list">
+                      {pendingParticipants.map((p) => (
+                        <HostPendingReconfirmationItem key={p.participation_id} participant={p} />
+                      ))}
+                    </ul>
+                  )}
+                  {pendingParticipantsHasNext && (
+                    <button
+                      type="button"
+                      className="ed-secondary-btn"
+                      onClick={onLoadMorePendingParticipants}
+                      disabled={pendingParticipantsLoading}
+                    >
+                      {pendingParticipantsLoading ? 'Loading...' : 'Load More Reconfirmations'}
+                    </button>
+                  )}
+                </>
+              ) : (
+                <p className="ed-mgmt-empty">No participants need reconfirmation.</p>
+              )}
+            </div>
 
             {/* Approved participants */}
             <div className="ed-mgmt-group">
@@ -2363,10 +2823,19 @@ export default function EventDetailPage() {
       onReportEvent={vm.handleReportEvent}
       onDismissReportError={vm.dismissReportError}
       onDismissReportSuccess={vm.dismissReportSuccess}
+      reconfirmLoading={vm.reconfirmLoading}
+      reconfirmError={vm.reconfirmError}
+      reconfirmSuccessMessage={vm.reconfirmSuccessMessage}
+      onReconfirmParticipation={vm.handleReconfirmParticipation}
+      onDismissReconfirmError={vm.dismissReconfirmError}
+      onDismissReconfirmSuccess={vm.dismissReconfirmSuccess}
       hostContextSummary={vm.hostContextSummary}
       approvedParticipants={vm.approvedParticipants}
       approvedParticipantsLoading={vm.approvedParticipantsLoading}
       approvedParticipantsHasNext={vm.approvedParticipantsHasNext}
+      pendingParticipants={vm.pendingParticipants}
+      pendingParticipantsLoading={vm.pendingParticipantsLoading}
+      pendingParticipantsHasNext={vm.pendingParticipantsHasNext}
       pendingJoinRequests={vm.pendingJoinRequests}
       pendingJoinRequestsLoading={vm.pendingJoinRequestsLoading}
       pendingJoinRequestsHasNext={vm.pendingJoinRequestsHasNext}
@@ -2374,6 +2843,7 @@ export default function EventDetailPage() {
       invitationsLoading={vm.invitationsLoading}
       invitationsHasNext={vm.invitationsHasNext}
       onLoadMoreApprovedParticipants={vm.loadMoreApprovedParticipants}
+      onLoadMorePendingParticipants={vm.loadMorePendingParticipants}
       onLoadMorePendingJoinRequests={vm.loadMorePendingJoinRequests}
       onLoadMoreInvitations={vm.loadMoreInvitations}
       inviteLoading={vm.inviteLoading}

--- a/frontend/src/views/events/MyEventsPage.tsx
+++ b/frontend/src/views/events/MyEventsPage.tsx
@@ -28,6 +28,7 @@ function formatTime(iso: string): string {
 function EventCard({ event }: { event: EventSummary }) {
   const badge = getEventCardBadgePresentation(event.status);
   const category = event.category_name ?? event.category;
+  const participantCount = event.approved_participant_count ?? event.participants_count ?? 0;
 
   return (
     <Link to={`/events/${event.id}`} className="dc-card">
@@ -72,7 +73,7 @@ function EventCard({ event }: { event: EventSummary }) {
         )}
         <div className="dc-card-footer">
           <span className="dc-card-participants">
-            {event.approved_participant_count ?? 0} participant{event.approved_participant_count === 1 ? '' : 's'}
+            {participantCount} participant{participantCount === 1 ? '' : 's'}
           </span>
           {event.host_score?.final_score != null && (
             <span className="dc-card-score">


### PR DESCRIPTION
## 📋 Summary
Adds the frontend event edit and versioning/reconfirmation experience for web hosts and participants. Hosts can edit active events, participants can review changes and reconfirm attendance, and event/detail/discovery UI now better reflects updated backend event state.

## 🔄 Changes
- Added an event edit page and route for hosts with prefilled event data
- Connected event updates to the backend versioned update endpoint
- Added critical-change preview and reconfirmation messaging after edits
- Added participant-facing reconfirmation banner with before/now change comparison
- Added version history/change summary UI on event detail
- Added host management UI for participants who still need reconfirmation
- Improved protected-event join/reconfirmation state handling
- Improved Discover map event preview card layout and scrolling behavior
- Improved approximate protected location display on event detail
- Fixed My Events participant counts to support backend `participants_count`
- Added/updated frontend tests for event service and event detail behavior

## 🧪 Testing
- Ran `npm run build`
- Ran `npm test -- eventService.test.ts`

## 🔗 Related
Related to #451 , #452 , #616
