### PR TITLE
feat(frontend): let discover search events around the currently viewed map area 

### DIFF
--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -2337,3 +2337,30 @@
     }
   }
 }
+
+.dc-map-search-cta-wrapper {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 12px;
+  pointer-events: none;
+}
+
+.dc-map-search-cta {
+  pointer-events: auto;
+  padding: 10px 20px;
+  border-radius: 999px;
+  background-color: #111827;
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.1);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transition: transform 0.15s, background-color 0.15s;
+}
+
+.dc-map-search-cta:hover {
+  background-color: #1f2937;
+  transform: scale(1.03);
+}
+

--- a/frontend/src/viewmodels/discover/useDiscoverViewModel.ts
+++ b/frontend/src/viewmodels/discover/useDiscoverViewModel.ts
@@ -12,6 +12,21 @@ import type {
 import { ApiError } from '@/services/api';
 import { formatEventLocation } from '@/utils/eventLocation';
 
+function calculateDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371e3; // metres
+  const φ1 = (lat1 * Math.PI) / 180;
+  const φ2 = (lat2 * Math.PI) / 180;
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180;
+  const Δλ = ((lon2 - lon1) * Math.PI) / 180;
+
+  const a =
+    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
+}
+
 // Fallback when browser geolocation is unavailable and profile has no default (Beşiktaş, Istanbul)
 const DEFAULT_LAT = 41.0422;
 const DEFAULT_LON = 29.0083;
@@ -239,6 +254,10 @@ export function useDiscoverViewModel(token: string | null) {
 
   const searchTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
   const modalLocationTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const [showMapSearchCTA, setShowMapSearchCTA] = useState(false);
+  const [mapDraftCenter, setMapDraftCenter] = useState<{ lat: number; lon: number } | null>(null);
+  const [mapDraftRadius, setMapDraftRadius] = useState<number | null>(null);
 
   useEffect(() => {
     listCategories()
@@ -608,7 +627,54 @@ export function useDiscoverViewModel(token: string | null) {
     setSelectedLocation(defaultProfileLocation ?? browserLocation.current ?? null);
     setModalLocationQuery('');
     setModalLocationResults([]);
+    setShowMapSearchCTA(false);
   }, [defaultProfileLocation]);
+
+  const handleMapCameraChanged = useCallback(
+    (
+      center: { lat: number; lng: number },
+      bounds: { north: number; east: number; south: number; west: number } | null,
+    ) => {
+      const currentLat = selectedLocation ? Number(selectedLocation.lat) : DEFAULT_LAT;
+      const currentLon = selectedLocation ? Number(selectedLocation.lon) : DEFAULT_LON;
+
+      const dist = calculateDistance(currentLat, currentLon, center.lat, center.lng);
+
+      let radius = filters.radiusMeters;
+      if (bounds) {
+        radius = calculateDistance(center.lat, center.lng, bounds.north, bounds.east);
+      }
+
+      // If map moves more than 20% of current search radius, show CTA
+      const threshold = Math.max(filters.radiusMeters * 0.2, 500);
+
+      if (dist > threshold) {
+        setShowMapSearchCTA(true);
+        setMapDraftCenter({ lat: center.lat, lon: center.lng });
+        setMapDraftRadius(radius);
+      } else {
+        // If they pan back to the origin, hide it
+        setShowMapSearchCTA(false);
+      }
+    },
+    [selectedLocation, filters.radiusMeters],
+  );
+
+  const applyMapSearchArea = useCallback(() => {
+    if (!mapDraftCenter || !mapDraftRadius) return;
+
+    const snapRadius = RADIUS_OPTIONS.find((r) => r.value >= mapDraftRadius)?.value ?? 50000;
+
+    setSelectedLocation({
+      display_name: 'Map Area',
+      lat: String(mapDraftCenter.lat),
+      lon: String(mapDraftCenter.lon),
+    });
+    setFilters((prev) => ({ ...prev, radiusMeters: snapRadius }));
+    setShowMapSearchCTA(false);
+    setMapDraftCenter(null);
+    setMapDraftRadius(null);
+  }, [mapDraftCenter, mapDraftRadius]);
 
   const locationShortLabelText = locationShortLabel(selectedLocation);
   const hasCustomLocationFilter = isDiscoverLocationFilterActive(
@@ -663,5 +729,8 @@ export function useDiscoverViewModel(token: string | null) {
     browserLocationRequestPending,
     browserLocationError,
     mapCenter,
+    showMapSearchCTA,
+    handleMapCameraChanged,
+    applyMapSearchArea,
   };
 }

--- a/frontend/src/views/discover/DiscoverMapView.tsx
+++ b/frontend/src/views/discover/DiscoverMapView.tsx
@@ -18,6 +18,10 @@ interface DiscoverMapViewProps {
   selectedEventId: string | null;
   onSelectEvent: (eventId: string | null) => void;
   onRetry: () => void;
+  onCameraChanged?: (
+    center: { lat: number; lng: number },
+    bounds: { north: number; east: number; south: number; west: number } | null,
+  ) => void;
 }
 
 interface MappableEvent {
@@ -99,6 +103,7 @@ export default function DiscoverMapView({
   selectedEventId,
   onSelectEvent,
   onRetry,
+  onCameraChanged,
 }: DiscoverMapViewProps) {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
@@ -128,8 +133,10 @@ export default function DiscoverMapView({
           fullscreenControl={false}
           clickableIcons={false}
           onClick={() => onSelectEvent(null)}
-          onCameraChanged={(_e: MapCameraChangedEvent) => {
-            /* keep camera in user control */
+          onCameraChanged={(e: MapCameraChangedEvent) => {
+            if (onCameraChanged) {
+              onCameraChanged(e.detail.center, e.detail.bounds ?? null);
+            }
           }}
           className="dc-map-surface"
         >

--- a/frontend/src/views/discover/DiscoverPage.tsx
+++ b/frontend/src/views/discover/DiscoverPage.tsx
@@ -836,6 +836,7 @@ export default function DiscoverPage() {
           selectedEventId={selectedEventId}
           onSelectEvent={setSelectedEventId}
           onRetry={vm.refresh}
+          onCameraChanged={vm.handleMapCameraChanged}
         />
 
         <div
@@ -849,8 +850,21 @@ export default function DiscoverPage() {
           {!overlayCollapsed && eventsListUnderSearch}
         </div>
 
-        {categoriesBlock && (
-          <div className="dc-overlay dc-overlay-top-center">{categoriesBlock}</div>
+        {(categoriesBlock || vm.showMapSearchCTA) && (
+          <div className="dc-overlay dc-overlay-top-center">
+            {vm.showMapSearchCTA && (
+              <div className="dc-map-search-cta-wrapper">
+                <button
+                  type="button"
+                  className="dc-map-search-cta"
+                  onClick={vm.applyMapSearchArea}
+                >
+                  Search this area
+                </button>
+              </div>
+            )}
+            {categoriesBlock}
+          </div>
         )}
 
         <div className="dc-overlay dc-overlay-top-right">{locationButton}</div>


### PR DESCRIPTION

📋 Description
This PR addresses the issue where panning the discover map did not update event results unless the location filter was manually changed. It improves the map's connectivity to the discovery query by detecting significant camera movements and presenting a contextual "Search this area" action. When triggered, it automatically aligns the discovery origin and radius to the current map view.

🚀 Changes
- **ViewModels:**
  - `useDiscoverViewModel` now tracks camera pans via `handleMapCameraChanged`, calculating the distance moved from the original search origin.
  - Added a `showMapSearchCTA` state that becomes visible when the map has moved a significant distance (> 20% of the current radius or at least 500m).
  - Implemented `applyMapSearchArea` to automatically map the new center and visible radius to the `selectedLocation` and `radiusMeters` states, seamlessly fetching new events.
- **Views & Components:**
  - `DiscoverMapView` now passes `onCameraChanged` up from the Google Maps component.
  - `DiscoverPage` conditionally renders a new "Search this area" action overlaying the map when `showMapSearchCTA` is true.
- **Styling:**
  - Added `dc-map-search-cta` and `dc-map-search-cta-wrapper` CSS classes to `discover.css` for a sleek, responsive floating button that captures interactions.

✅ Acceptance Criteria
- [x] Panning or zooming the map can trigger a "Search this area" style action.
- [x] Triggering that action refreshes results around the currently viewed map area.
- [x] Events in a newly viewed city/region become discoverable without manually changing the location filter.
- [x] The updated search affects both map and list results consistently.
- [x] The UI avoids excessive automatic refetching while the user is still dragging the map (only shows CTA, user decides when to trigger).
- [x] Existing discover filters continue to work correctly with the new map-driven search behavior.
- [x] Behavior is implemented frontend-only using the current lat / lon / radius_meters backend contract.

🔗 References
Closes #617
