### PR TITLE
feat(mobile): move invitations to profile and improve create flow

### DIFF
--- a/mobile/jest/mocks/expo-router.js
+++ b/mobile/jest/mocks/expo-router.js
@@ -3,6 +3,7 @@ module.exports = {
     push: jest.fn(),
     replace: jest.fn(),
     back: jest.fn(),
+    canGoBack: jest.fn(() => true),
   },
   useFocusEffect: jest.fn(),
   Href: {},

--- a/mobile/jest/mocks/react-native.js
+++ b/mobile/jest/mocks/react-native.js
@@ -25,6 +25,8 @@ const REACT_NATIVE_ONLY_PROPS = new Set([
   'showsHorizontalScrollIndicator',
   'showsVerticalScrollIndicator',
   'textAlignVertical',
+  'thumbColor',
+  'trackColor',
   'underlineColorAndroid',
   'adjustsFontSizeToFit',
   'clearButtonMode',
@@ -35,6 +37,7 @@ const REACT_NATIVE_ONLY_PROPS = new Set([
   'delayPressOut',
   'hitSlop',
   'horizontal',
+  'ios_backgroundColor',
   'keyboardType',
   'nestedScrollEnabled',
   'onRequestClose',
@@ -168,6 +171,35 @@ const TouchableOpacity = React.forwardRef(function MockTouchableOpacity(
   );
 });
 
+const Pressable = React.forwardRef(function MockPressable(
+  {
+    children,
+    onPress,
+    accessibilityLabel,
+    accessibilityRole,
+    testID,
+    style,
+    disabled,
+    ...props
+  },
+  ref,
+) {
+  return React.createElement(
+    'div',
+    {
+      ref,
+      role: accessibilityRole,
+      'aria-label': accessibilityLabel,
+      'data-testid': testID,
+      style: mergeStyle(style),
+      disabled,
+      onClick: disabled ? undefined : (event) => onPress?.(event),
+      ...stripReactNativeOnlyProps(props),
+    },
+    children,
+  );
+});
+
 const TextInput = React.forwardRef(function MockTextInput(
   {
     value,
@@ -256,21 +288,32 @@ const Switch = React.forwardRef(function MockSwitch(
   });
 });
 
+function renderListPart(part) {
+  if (!part) return null;
+  return typeof part === 'function' ? React.createElement(part) : part;
+}
+
 const FlatList = React.forwardRef(function MockFlatList(
   { data, renderItem, ListEmptyComponent, ListHeaderComponent, ListFooterComponent, keyExtractor },
   ref,
 ) {
   if (!data || data.length === 0) {
-    return React.createElement('div', { ref }, ListEmptyComponent);
+    return React.createElement(
+      'div',
+      { ref },
+      renderListPart(ListHeaderComponent),
+      renderListPart(ListEmptyComponent),
+      renderListPart(ListFooterComponent),
+    );
   }
   return React.createElement(
     'div',
     { ref },
-    ListHeaderComponent,
+    renderListPart(ListHeaderComponent),
     data.map((item, index) =>
       React.createElement('div', { key: keyExtractor ? keyExtractor(item, index) : index }, renderItem({ item, index })),
     ),
-    ListFooterComponent,
+    renderListPart(ListFooterComponent),
   );
 });
 
@@ -279,12 +322,18 @@ const SectionList = React.forwardRef(function MockSectionList(
   ref,
 ) {
   if (!sections || sections.length === 0) {
-    return React.createElement('div', { ref }, ListEmptyComponent);
+    return React.createElement(
+      'div',
+      { ref },
+      renderListPart(ListHeaderComponent),
+      renderListPart(ListEmptyComponent),
+      renderListPart(ListFooterComponent),
+    );
   }
   return React.createElement(
     'div',
     { ref },
-    ListHeaderComponent,
+    renderListPart(ListHeaderComponent),
     sections.map((section, idx) =>
       React.createElement(
         'div',
@@ -295,13 +344,16 @@ const SectionList = React.forwardRef(function MockSectionList(
         ),
       ),
     ),
-    ListFooterComponent,
+    renderListPart(ListFooterComponent),
   );
 });
 
 module.exports = {
   Alert: {
     alert: jest.fn(),
+  },
+  Keyboard: {
+    dismiss: jest.fn(),
   },
   Platform: {
     OS: 'ios',
@@ -321,6 +373,7 @@ module.exports = {
   Text,
   TextInput,
   TouchableOpacity,
+  Pressable,
   StyleSheet: {
     create: (styles) => styles,
   },

--- a/mobile/src/components/invitation/InvitationCard.tsx
+++ b/mobile/src/components/invitation/InvitationCard.tsx
@@ -12,6 +12,7 @@ interface InvitationCardProps {
   onDecline: (id: string) => void;
   onPress?: (eventId: string) => void;
   isActionLoading?: boolean;
+  compact?: boolean;
 }
 
 export default function InvitationCard({
@@ -20,6 +21,7 @@ export default function InvitationCard({
   onDecline,
   onPress,
   isActionLoading,
+  compact = false,
 }: InvitationCardProps) {
   const { theme } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
@@ -27,13 +29,13 @@ export default function InvitationCard({
   const { event, host, message } = invitation;
 
   return (
-    <View style={styles.card}>
+    <View style={[styles.card, compact && styles.compactCard]}>
       <TouchableOpacity
         activeOpacity={0.92}
-        style={styles.mainContent}
+        style={[styles.mainContent, compact && styles.compactMainContent]}
         onPress={() => onPress?.(event.id)}
       >
-        <View style={styles.imageWrapper}>
+        <View style={[styles.imageWrapper, compact && styles.compactImageWrapper]}>
           {event.image_url ? (
             <Image
               source={{ uri: event.image_url }}
@@ -42,7 +44,7 @@ export default function InvitationCard({
             />
           ) : (
             <View style={styles.imagePlaceholder}>
-              <Feather name="calendar" size={28} color={theme.textTertiary} />
+              <Feather name="calendar" size={compact ? 22 : 28} color={theme.textTertiary} />
             </View>
           )}
         </View>
@@ -72,21 +74,21 @@ export default function InvitationCard({
             </View>
           </View>
 
-          <Text style={styles.title} numberOfLines={2}>
+          <Text style={[styles.title, compact && styles.compactTitle]} numberOfLines={compact ? 1 : 2}>
             {event.title}
           </Text>
 
           <View style={styles.metaGroup}>
             <View style={styles.metaRow}>
               <Feather name="clock" size={16} color={theme.textMuted} />
-              <Text style={styles.metaText}>
+              <Text style={styles.metaText} numberOfLines={compact ? 1 : undefined}>
                 {formatEventDateLabel(event.start_time)}
               </Text>
             </View>
 
             <View style={styles.metaRow}>
               <Feather name="map-pin" size={16} color={theme.textMuted} />
-              <Text style={styles.metaText}>
+              <Text style={styles.metaText} numberOfLines={compact ? 1 : undefined}>
                 Location available on event page
               </Text>
             </View>
@@ -95,15 +97,17 @@ export default function InvitationCard({
       </TouchableOpacity>
 
       {message && (
-        <View style={styles.messageBox}>
+        <View style={[styles.messageBox, compact && styles.compactMessageBox]}>
           <Text style={styles.messageLabel}>Note from host:</Text>
-          <Text style={styles.messageText}>"{message}"</Text>
+          <Text style={styles.messageText} numberOfLines={compact ? 2 : undefined}>
+            "{message}"
+          </Text>
         </View>
       )}
 
-      <View style={styles.actions}>
+      <View style={[styles.actions, compact && styles.compactActions]}>
         <TouchableOpacity
-          style={[styles.actionButton, styles.declineButton]}
+          style={[styles.actionButton, compact && styles.compactActionButton, styles.declineButton]}
           onPress={() => onDecline(invitation.invitation_id)}
           disabled={isActionLoading}
         >
@@ -111,7 +115,7 @@ export default function InvitationCard({
         </TouchableOpacity>
 
         <TouchableOpacity
-          style={[styles.actionButton, styles.acceptButton]}
+          style={[styles.actionButton, compact && styles.compactActionButton, styles.acceptButton]}
           onPress={() => onAccept(invitation.invitation_id)}
           disabled={isActionLoading}
         >
@@ -139,9 +143,20 @@ function makeStyles(t: Theme) {
       shadowOffset: { width: 0, height: 8 },
       elevation: 3,
     },
+    compactCard: {
+      borderRadius: 18,
+      padding: 12,
+      marginBottom: 10,
+      shadowOpacity: 0.04,
+      shadowRadius: 10,
+      shadowOffset: { width: 0, height: 4 },
+    },
     mainContent: {
       flexDirection: 'row',
       gap: 14,
+    },
+    compactMainContent: {
+      gap: 12,
     },
     imageWrapper: {
       width: 108,
@@ -149,6 +164,11 @@ function makeStyles(t: Theme) {
       borderRadius: 18,
       overflow: 'hidden',
       backgroundColor: t.imagePlaceholder,
+    },
+    compactImageWrapper: {
+      width: 76,
+      height: 92,
+      borderRadius: 14,
     },
     image: {
       width: '100%',
@@ -162,18 +182,21 @@ function makeStyles(t: Theme) {
     },
     content: {
       flex: 1,
+      minWidth: 0,
       justifyContent: 'space-between',
     },
     topRow: {
       flexDirection: 'row',
-      alignItems: 'center',
+      alignItems: 'flex-start',
       justifyContent: 'space-between',
       gap: 10,
+      flexWrap: 'wrap',
     },
     statusBadgeRow: {
       flexDirection: 'row',
       alignItems: 'center',
       gap: 8,
+      flexShrink: 0,
     },
     statusBadge: {
       paddingHorizontal: 10,
@@ -204,12 +227,16 @@ function makeStyles(t: Theme) {
       borderRadius: 999,
       paddingHorizontal: 10,
       paddingVertical: 6,
+      maxWidth: '100%',
+      minWidth: 0,
+      flexShrink: 1,
     },
     hostPillText: {
       color: t.textMuted,
       fontSize: 11,
       fontWeight: '700',
-      maxWidth: 70,
+      minWidth: 0,
+      flexShrink: 1,
     },
     title: {
       marginTop: 10,
@@ -217,6 +244,11 @@ function makeStyles(t: Theme) {
       lineHeight: 22,
       fontWeight: '800',
       color: t.text,
+    },
+    compactTitle: {
+      marginTop: 8,
+      fontSize: 16,
+      lineHeight: 20,
     },
     metaGroup: {
       marginTop: 12,
@@ -242,6 +274,11 @@ function makeStyles(t: Theme) {
       borderWidth: 1,
       borderColor: t.border,
     },
+    compactMessageBox: {
+      borderRadius: 12,
+      padding: 10,
+      marginTop: 10,
+    },
     messageLabel: {
       fontSize: 10,
       fontWeight: '700',
@@ -261,12 +298,20 @@ function makeStyles(t: Theme) {
       gap: 12,
       marginTop: 14,
     },
+    compactActions: {
+      gap: 10,
+      marginTop: 10,
+    },
     actionButton: {
       flex: 1,
       height: 44,
       borderRadius: 14,
       alignItems: 'center',
       justifyContent: 'center',
+    },
+    compactActionButton: {
+      height: 40,
+      borderRadius: 12,
     },
     declineButton: {
       backgroundColor: t.errorBg,

--- a/mobile/src/viewmodels/event/useMyEventsViewModel.test.tsx
+++ b/mobile/src/viewmodels/event/useMyEventsViewModel.test.tsx
@@ -3,21 +3,18 @@
  */
 import { act, renderHook, waitFor } from '@testing-library/react';
 import * as eventService from '@/services/eventService';
-import * as invitationService from '@/services/invitationService';
 import * as ticketService from '@/services/ticketService';
 import type { MyEventsResponse, MyEventSummary } from '@/models/event';
 import { useMyEventsViewModel } from './useMyEventsViewModel';
 import { useAuth } from '@/contexts/AuthContext';
 
 jest.mock('@/services/eventService');
-jest.mock('@/services/invitationService');
 jest.mock('@/services/ticketService');
 jest.mock('@/contexts/AuthContext', () => ({
   useAuth: jest.fn(),
 }));
 
 const mockListMyEvents = jest.mocked(eventService.listMyEvents);
-const mockListMyInvitations = jest.mocked(invitationService.listMyInvitations);
 const mockListMyTickets = jest.mocked(ticketService.listMyTickets);
 const mockUseAuth = jest.mocked(useAuth);
 
@@ -68,22 +65,6 @@ const myEventsResponse: MyEventsResponse = {
   ],
 };
 
-const myInvitationsResponse = {
-  pending: [
-    {
-      invitation_id: 'inv-1',
-      status: 'PENDING',
-      event: { id: 'event-1', title: 'Private Event 1', start_time: '2026-05-10T10:00:00Z' },
-      host: { username: 'host1', display_name: 'Host One' },
-      message: 'Join us!',
-    },
-  ],
-  past: {
-    items: [],
-    page_info: { next_cursor: null, has_next: false },
-  },
-};
-
 const myTicketsResponse = {
   items: [
     {
@@ -119,77 +100,41 @@ describe('useMyEventsViewModel', () => {
       clearAuth: jest.fn(),
     });
     mockListMyEvents.mockResolvedValue(myEventsResponse);
-    mockListMyInvitations.mockResolvedValue(myInvitationsResponse as any);
     mockListMyTickets.mockResolvedValue(myTicketsResponse as any);
   });
 
-  it('loads my events and invitations on mount', async () => {
+  it('loads my events on mount and decorates attended ticket data', async () => {
     const { result } = renderHook(() => useMyEventsViewModel());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(mockListMyEvents).toHaveBeenCalledWith('mock-token');
-    expect(mockListMyInvitations).toHaveBeenCalledWith('mock-token');
     expect(mockListMyTickets).toHaveBeenCalledWith('mock-token');
     
-    expect(result.current.invitations.length).toBe(1);
-    expect(result.current.statusTabs.find(t => t.value === 'INVITATIONS')?.count).toBe(1);
+    expect(result.current.statusTabs.map((tab) => tab.value)).toEqual([
+      'ACTIVE',
+      'IN_PROGRESS',
+      'COMPLETED',
+      'CANCELED',
+    ]);
     expect(result.current.attendedEvents[0].ticket_id).toBe('ticket-1');
     expect(result.current.attendedEvents[0].ticket_status).toBe('USED');
     expect(result.current.attendedEvents[0].badges).toEqual([{ type: 'TICKET', label: 'Ticket' }]);
   });
 
-  it('filters events when the selected status changes, including INVITATIONS', async () => {
+  it('filters events when the selected status changes', async () => {
     const { result } = renderHook(() => useMyEventsViewModel());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     act(() => {
-      result.current.setActiveStatus('INVITATIONS');
+      result.current.setActiveStatus('COMPLETED');
     });
 
-    expect(result.current.activeStatus).toBe('INVITATIONS');
-    expect(result.current.emptyTitle).toBe('No invitations yet');
-  });
-
-  it('handles accepting an invitation', async () => {
-    const mockAccept = jest.mocked(invitationService.acceptInvitation);
-    mockAccept.mockResolvedValue({} as any);
-    
-    // First call returns 1, second (after reload) returns 0
-    mockListMyInvitations
-      .mockResolvedValueOnce(myInvitationsResponse as any)
-      .mockResolvedValueOnce({
-        pending: [],
-        past: { items: [], page_info: { next_cursor: null, has_next: false } },
-      } as any);
-
-    const { result } = renderHook(() => useMyEventsViewModel());
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    await act(async () => {
-      await result.current.handleAccept('inv-1');
-    });
-
-    expect(mockAccept).toHaveBeenCalledWith('inv-1', 'mock-token');
-    // After reload, it should be 0
-    await waitFor(() => expect(result.current.invitations.length).toBe(0));
-    await waitFor(() => expect(mockListMyEvents).toHaveBeenCalledTimes(2));
-  });
-
-  it('handles declining an invitation', async () => {
-    const mockDecline = jest.mocked(invitationService.declineInvitation);
-    mockDecline.mockResolvedValue({} as any);
-
-    const { result } = renderHook(() => useMyEventsViewModel());
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    await act(async () => {
-      await result.current.handleDecline('inv-1');
-    });
-
-    expect(mockDecline).toHaveBeenCalledWith('inv-1', 'mock-token');
-    expect(result.current.invitations.length).toBe(0);
+    expect(result.current.activeStatus).toBe('COMPLETED');
+    expect(result.current.visibleEvents.map((event) => event.id)).toEqual([
+      'host-completed',
+    ]);
   });
 
   it('shows an auth-specific error when the user is logged out', async () => {
@@ -226,15 +171,4 @@ describe('useMyEventsViewModel', () => {
     }
   });
 
-  it('treats a missing invitations items array as empty instead of crashing', async () => {
-    mockListMyInvitations.mockResolvedValueOnce({ total: 0 } as any);
-
-    const { result } = renderHook(() => useMyEventsViewModel());
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    expect(result.current.errorMessage).toBeNull();
-    expect(result.current.invitations).toEqual([]);
-    expect(result.current.invitationCount).toBe(0);
-  });
 });

--- a/mobile/src/viewmodels/event/useMyEventsViewModel.ts
+++ b/mobile/src/viewmodels/event/useMyEventsViewModel.ts
@@ -1,23 +1,18 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   MyEventStatus,
   MyEventSummary,
 } from '@/models/event';
 import { useAuth } from '@/contexts/AuthContext';
 import { listMyEvents } from '@/services/eventService';
-import { listMyInvitations, acceptInvitation, declineInvitation } from '@/services/invitationService';
-import { ReceivedInvitation } from '@/models/invitation';
 import { ApiError } from '@/services/api';
 import { listMyTickets } from '@/services/ticketService';
 import type { TicketListItem } from '@/models/ticket';
 
-type ExtendedStatus = MyEventStatus | 'INVITATIONS';
-
-const STATUS_OPTIONS: Array<{ value: ExtendedStatus; label: string }> = [
+const STATUS_OPTIONS: Array<{ value: MyEventStatus; label: string }> = [
   { value: 'ACTIVE', label: 'Active' },
   { value: 'IN_PROGRESS', label: 'In Progress' },
   { value: 'COMPLETED', label: 'Completed' },
-  { value: 'INVITATIONS', label: 'Invites' },
   { value: 'CANCELED', label: 'Canceled' },
 ];
 
@@ -44,7 +39,7 @@ const EMPTY_STATE_COPY: Record<
 };
 
 export interface MyEventsStatusTab {
-  value: ExtendedStatus;
+  value: MyEventStatus;
   label: string;
   count: number;
 }
@@ -52,25 +47,20 @@ export interface MyEventsStatusTab {
 
 
 export interface MyEventsViewModel {
-  activeStatus: ExtendedStatus;
+  activeStatus: MyEventStatus;
   statusTabs: MyEventsStatusTab[];
   hostedEvents: MyEventSummary[];
   attendedEvents: MyEventSummary[];
-  invitations: ReceivedInvitation[];
   visibleEvents: MyEventSummary[];
   hostedCount: number;
   attendedCount: number;
-  invitationCount: number;
   isLoading: boolean;
-  isActionLoading: string | null;
   errorMessage: string | null;
   canRetry: boolean;
   emptyTitle: string;
   emptySubtitle: string;
-  setActiveStatus: (status: ExtendedStatus) => void;
+  setActiveStatus: (status: MyEventStatus) => void;
   reload: () => Promise<void>;
-  handleAccept: (invitationId: string) => Promise<void>;
-  handleDecline: (invitationId: string) => Promise<void>;
 }
 
 function getTimeValue(value: string) {
@@ -104,32 +94,19 @@ function sortVisibleEvents(
   return sorted;
 }
 
-function normalizeInvitationsResponse(
-  response: { pending?: ReceivedInvitation[]; items?: ReceivedInvitation[] } | null | undefined,
-): ReceivedInvitation[] {
-  if (Array.isArray(response?.pending)) return response.pending;
-  if (Array.isArray(response?.items)) return response.items;
-  return [];
-}
-
 export function useMyEventsViewModel(): MyEventsViewModel {
   const { token } = useAuth();
 
-  const [activeStatus, setActiveStatus] = useState<ExtendedStatus>('ACTIVE');
+  const [activeStatus, setActiveStatus] = useState<MyEventStatus>('ACTIVE');
   const [hostedEvents, setHostedEvents] = useState<MyEventSummary[]>([]);
   const [attendedEvents, setAttendedEvents] = useState<MyEventSummary[]>([]);
-  const [invitations, setInvitations] = useState<ReceivedInvitation[]>([]);
-  const [invitationCount, setInvitationCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
-  const [isActionLoading, setIsActionLoading] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const reload = React.useCallback(async () => {
     if (!token) {
       setHostedEvents([]);
       setAttendedEvents([]);
-      setInvitations([]);
-      setInvitationCount(0);
       setErrorMessage('You must be logged in to manage your events.');
       setIsLoading(false);
       return;
@@ -148,9 +125,8 @@ export function useMyEventsViewModel(): MyEventsViewModel {
     };
 
     try {
-      const [eventsResponse, invitationsResponse, ticketsResponse] = await Promise.all([
+      const [eventsResponse, ticketsResponse] = await Promise.all([
         withTimeout(listMyEvents(token)),
-        withTimeout(listMyInvitations(token)).catch(() => ({ pending: [] })),
         withTimeout(listMyTickets(token)).catch(() => ({ items: [] })),
       ]);
 
@@ -178,18 +154,13 @@ export function useMyEventsViewModel(): MyEventsViewModel {
       });
 
       const nextHostedEvents = eventsResponse?.hosted_events ?? [];
-      const nextInvitations = normalizeInvitationsResponse(invitationsResponse);
 
       setHostedEvents(nextHostedEvents);
       setAttendedEvents(decoratedAttendedEvents);
-      setInvitations(nextInvitations);
-      setInvitationCount(nextInvitations.length);
     } catch (error) {
       console.error('Failed to load events:', error);
       setHostedEvents([]);
       setAttendedEvents([]);
-      setInvitations([]);
-      setInvitationCount(0);
       
       const message = error instanceof ApiError ? error.message : 
                      error instanceof Error ? error.message : 
@@ -200,73 +171,28 @@ export function useMyEventsViewModel(): MyEventsViewModel {
     }
   }, [token]);
 
-  const handleAccept = useCallback(
-    async (invitationId: string) => {
-      if (!token) return;
-      setIsActionLoading(invitationId);
-      try {
-        await acceptInvitation(invitationId, token);
-        setInvitations((prev) => prev.filter((i) => i.invitation_id !== invitationId));
-        setInvitationCount((prev) => prev - 1);
-        await reload();
-      } catch (err) {
-        setErrorMessage(err instanceof ApiError ? err.message : 'Failed to accept invitation');
-      } finally {
-        setIsActionLoading(null);
-      }
-    },
-    [token],
-  );
-
-  const handleDecline = useCallback(
-    async (invitationId: string) => {
-      if (!token) return;
-      setIsActionLoading(invitationId);
-      try {
-        await declineInvitation(invitationId, token);
-        setInvitations((prev) => prev.filter((i) => i.invitation_id !== invitationId));
-        setInvitationCount((prev) => prev - 1);
-      } catch (err) {
-        setErrorMessage(err instanceof ApiError ? err.message : 'Failed to decline invitation');
-      } finally {
-        setIsActionLoading(null);
-      }
-    },
-    [token],
-  );
-
   useEffect(() => {
     void reload();
   }, [token]);
 
   const allEvents = [...hostedEvents, ...attendedEvents];
-  const visibleEvents = activeStatus !== 'INVITATIONS'
-    ? sortVisibleEvents(
-      allEvents.filter((event) => event.status === activeStatus),
-      activeStatus as MyEventStatus,
-    )
-    : [];
+  const visibleEvents = sortVisibleEvents(
+    allEvents.filter((event) => event.status === activeStatus),
+    activeStatus,
+  );
 
   const statusTabs = STATUS_OPTIONS.map((statusOption) => {
-    let count = 0;
-    if (statusOption.value === 'INVITATIONS') {
-      count = invitationCount;
-    } else {
-      count = allEvents.filter((event) => event.status === statusOption.value).length;
-    }
+    const count = allEvents.filter((event) => event.status === statusOption.value).length;
     return { ...statusOption, count };
   });
 
-  const hasAnyEvents = allEvents.length > 0 || invitations.length > 0;
+  const hasAnyEvents = allEvents.length > 0;
 
   let emptyTitle = 'No events to manage yet';
   let emptySubtitle = 'Events you host or join will appear here once your plans start coming together.';
 
-  if (activeStatus === 'INVITATIONS') {
-    emptyTitle = 'No invitations yet';
-    emptySubtitle = 'Private event invites from your friends and hosts will appear here.';
-  } else if (hasAnyEvents) {
-    const currentStatus = activeStatus as MyEventStatus;
+  if (hasAnyEvents) {
+    const currentStatus = activeStatus;
     emptyTitle = EMPTY_STATE_COPY[currentStatus].title;
     emptySubtitle = EMPTY_STATE_COPY[currentStatus].subtitle;
   }
@@ -276,20 +202,15 @@ export function useMyEventsViewModel(): MyEventsViewModel {
     statusTabs,
     hostedEvents,
     attendedEvents,
-    invitations,
     visibleEvents,
     hostedCount: hostedEvents.length,
     attendedCount: attendedEvents.length,
-    invitationCount,
     isLoading,
-    isActionLoading,
     errorMessage,
     canRetry: Boolean(token),
     emptyTitle,
     emptySubtitle,
     setActiveStatus,
     reload,
-    handleAccept,
-    handleDecline,
   };
 }

--- a/mobile/src/viewmodels/profile/useProfileViewModel.test.tsx
+++ b/mobile/src/viewmodels/profile/useProfileViewModel.test.tsx
@@ -3,6 +3,7 @@
  */
 import { renderHook, act } from '@testing-library/react';
 import * as profileService from '@/services/profileService';
+import * as invitationService from '@/services/invitationService';
 import { ApiError } from '@/services/api';
 import type {
   ProfileEventSummary,
@@ -11,6 +12,7 @@ import type {
 import { useProfileViewModel } from './useProfileViewModel';
 
 jest.mock('@/services/profileService');
+jest.mock('@/services/invitationService');
 jest.mock('@/contexts/AuthContext', () => ({
   useAuth: jest.fn(),
 }));
@@ -28,6 +30,9 @@ const mockGetBadgeCatalog = jest.mocked(profileService.getBadgeCatalog);
 const mockGetShowcaseImageUploadUrl = jest.mocked(profileService.getShowcaseImageUploadUrl);
 const mockConfirmShowcaseImageUpload = jest.mocked(profileService.confirmShowcaseImageUpload);
 const mockDeleteShowcaseImage = jest.mocked(profileService.deleteShowcaseImage);
+const mockListMyInvitations = jest.mocked(invitationService.listMyInvitations);
+const mockAcceptInvitation = jest.mocked(invitationService.acceptInvitation);
+const mockDeclineInvitation = jest.mocked(invitationService.declineInvitation);
 const mockUseAuth = jest.mocked(useAuth);
 
 function createDeferred<T>() {
@@ -118,6 +123,33 @@ const profileFixture: UserProfile = {
   locale: 'en',
 };
 
+const invitationFixture = {
+  invitation_id: 'inv-1',
+  status: 'PENDING' as const,
+  event: {
+    id: 'event-1',
+    title: 'Private Picnic',
+    start_time: '2026-05-10T10:00:00Z',
+    image_url: null,
+  },
+  host: {
+    username: 'host_user',
+    display_name: 'Host User',
+    profile_image_url: null,
+  },
+  message: 'Join us!',
+  created_at: '2026-05-01T10:00:00Z',
+  updated_at: '2026-05-01T10:00:00Z',
+};
+
+const invitationsResponse = {
+  pending: [invitationFixture],
+  past: {
+    items: [],
+    page_info: { next_cursor: null, has_next: false },
+  },
+};
+
 describe('useProfileViewModel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -173,6 +205,9 @@ describe('useProfileViewModel', () => {
         }
       ]
     });
+    mockListMyInvitations.mockResolvedValue(invitationsResponse as any);
+    mockAcceptInvitation.mockResolvedValue({} as any);
+    mockDeclineInvitation.mockResolvedValue({} as any);
   });
 
   it('starts in loading state', () => {
@@ -201,8 +236,11 @@ describe('useProfileViewModel', () => {
     expect(mockGetMyUpcomingEvents).toHaveBeenCalledWith('test-token');
     expect(mockGetMyCompletedEvents).toHaveBeenCalledWith('test-token');
     expect(mockGetMyCanceledEvents).toHaveBeenCalledWith('test-token');
+    expect(mockListMyInvitations).toHaveBeenCalledWith('test-token');
     expect(result.current.profile).toEqual(profileFixture);
     expect(result.current.equipment).toHaveLength(1);
+    expect(result.current.invitations).toEqual([invitationFixture]);
+    expect(result.current.invitationCount).toBe(1);
     expect(result.current.badges).toHaveLength(1);
     expect(result.current.apiError).toBeNull();
   });
@@ -420,6 +458,7 @@ describe('useProfileViewModel', () => {
     expect(mockGetMyUpcomingEvents).not.toHaveBeenCalled();
     expect(mockGetMyCompletedEvents).not.toHaveBeenCalled();
     expect(mockGetMyCanceledEvents).not.toHaveBeenCalled();
+    expect(mockListMyInvitations).not.toHaveBeenCalled();
   });
 
   it('can refresh profile data', async () => {
@@ -442,6 +481,54 @@ describe('useProfileViewModel', () => {
     expect(mockGetMyProfile).toHaveBeenCalledTimes(2);
     expect(result.current.profile?.display_name).toBe('Jane Doe');
     expect(result.current.primaryName).toBe('Jane Doe');
+  });
+
+  it('keeps profile usable when invitations fail to load', async () => {
+    mockListMyInvitations.mockRejectedValueOnce(
+      new ApiError(500, {
+        error: {
+          code: 'internal_error',
+          message: 'Invitations unavailable.',
+        },
+      }),
+    );
+
+    const { result } = await renderProfileViewModel();
+
+    expect(result.current.profile).toEqual(profileFixture);
+    expect(result.current.invitations).toEqual([]);
+    expect(result.current.invitationError).toBe('Invitations unavailable.');
+    expect(result.current.apiError).toBeNull();
+  });
+
+  it('handles accepting an invitation from profile', async () => {
+    mockListMyInvitations
+      .mockResolvedValueOnce(invitationsResponse as any)
+      .mockResolvedValueOnce({
+        pending: [],
+        past: { items: [], page_info: { next_cursor: null, has_next: false } },
+      } as any);
+
+    const { result } = await renderProfileViewModel();
+
+    await act(async () => {
+      await result.current.handleAcceptInvitation('inv-1');
+    });
+
+    expect(mockAcceptInvitation).toHaveBeenCalledWith('inv-1', 'test-token');
+    expect(result.current.invitations).toEqual([]);
+    expect(mockGetMyProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles declining an invitation from profile', async () => {
+    const { result } = await renderProfileViewModel();
+
+    await act(async () => {
+      await result.current.handleDeclineInvitation('inv-1');
+    });
+
+    expect(mockDeclineInvitation).toHaveBeenCalledWith('inv-1', 'test-token');
+    expect(result.current.invitations).toEqual([]);
   });
 
   it('handles equipment addition', async () => {

--- a/mobile/src/viewmodels/profile/useProfileViewModel.ts
+++ b/mobile/src/viewmodels/profile/useProfileViewModel.ts
@@ -30,6 +30,8 @@ import { BadgeItem, EquipmentItem, ShowcaseImageItem } from '@/models/profile';
 import { ApiError } from '@/services/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { uploadFileToPresignedUrl } from '@/services/eventService';
+import { acceptInvitation, declineInvitation, listMyInvitations } from '@/services/invitationService';
+import type { ReceivedInvitation } from '@/models/invitation';
 import { shouldShowProfileEvent } from '@/utils/eventStatus';
 
 export interface ProfileEventItem {
@@ -61,13 +63,19 @@ export interface ProfileViewModel {
   hostedCount: number;
   attendedCount: number;
   equipment: EquipmentItem[];
+  invitations: ReceivedInvitation[];
+  invitationCount: number;
   badges: BadgeItem[];
   showcaseImages: ShowcaseImageItem[];
   isActionLoading: boolean;
+  isInvitationActionLoading: string | null;
+  invitationError: string | null;
   catalogVisible: boolean;
   setCatalogVisible: (visible: boolean) => void;
   pickAvatar: () => Promise<void>;
   refresh: () => Promise<void>;
+  handleAcceptInvitation: (invitationId: string) => Promise<void>;
+  handleDeclineInvitation: (invitationId: string) => Promise<void>;
   addEquipment: (name: string, description?: string) => Promise<void>;
   editEquipment: (id: string, name: string, description?: string) => Promise<void>;
   removeEquipment: (id: string) => Promise<void>;
@@ -187,6 +195,18 @@ function excludeHostedEvents(
   return events.filter((event) => !hostedIds.has(event.id));
 }
 
+function normalizeInvitationsResponse(
+  response: { pending?: ReceivedInvitation[]; items?: ReceivedInvitation[] } | null | undefined,
+): ReceivedInvitation[] {
+  if (Array.isArray(response?.pending)) return response.pending;
+  if (Array.isArray(response?.items)) return response.items;
+  return [];
+}
+
+function getInvitationErrorMessage(error: unknown): string {
+  return error instanceof ApiError ? error.message : 'Failed to load invitations.';
+}
+
 export function useProfileViewModel(): ProfileViewModel {
   const { token } = useAuth();
 
@@ -203,9 +223,12 @@ export function useProfileViewModel(): ProfileViewModel {
   const [hostRatingLabel, setHostRatingLabel] = useState('New');
   const [participantRatingLabel, setParticipantRatingLabel] = useState('New');
   const [equipment, setEquipment] = useState<EquipmentItem[]>([]);
+  const [invitations, setInvitations] = useState<ReceivedInvitation[]>([]);
   const [badges, setBadges] = useState<BadgeItem[]>([]);
   const [showcaseImages, setShowcaseImages] = useState<ShowcaseImageItem[]>([]);
   const [isActionLoading, setIsActionLoading] = useState(false);
+  const [isInvitationActionLoading, setIsInvitationActionLoading] = useState<string | null>(null);
+  const [invitationError, setInvitationError] = useState<string | null>(null);
   const [catalogVisible, setCatalogVisible] = useState(false);
 
   const fetchProfile = useCallback(
@@ -217,6 +240,8 @@ export function useProfileViewModel(): ProfileViewModel {
         setOverallRatingLabel('New');
         setHostRatingLabel('New');
         setParticipantRatingLabel('New');
+        setInvitations([]);
+        setInvitationError(null);
         setApiError('You must be logged in to view your profile.');
         setIsLoading(false);
         return;
@@ -224,8 +249,10 @@ export function useProfileViewModel(): ProfileViewModel {
 
       if (mode === 'initial') setIsLoading(true);
       setApiError(null);
+      setInvitationError(null);
 
       try {
+        let nextInvitationError: string | null = null;
         const [
           profileResult,
           hostedResult,
@@ -235,6 +262,7 @@ export function useProfileViewModel(): ProfileViewModel {
           equipmentResult,
           earnedBadgesResult,
           catalogResult,
+          invitationsResult,
         ] = await Promise.all([
           getMyProfile(token),
           getMyHostedEvents(token),
@@ -244,9 +272,15 @@ export function useProfileViewModel(): ProfileViewModel {
           getMyEquipment(token),
           getMyBadges(token),
           getBadgeCatalog(token),
+          listMyInvitations(token).catch((err) => {
+            nextInvitationError = getInvitationErrorMessage(err);
+            return null;
+          }),
         ]);
         setProfile(profileResult);
         setEquipment(equipmentResult.items);
+        setInvitations(normalizeInvitationsResponse(invitationsResult));
+        setInvitationError(nextInvitationError);
 
         // Workaround: Showcase images are currently only returned by the public profile endpoint.
         // We fetch our own public profile to get the showcase images.
@@ -300,6 +334,8 @@ export function useProfileViewModel(): ProfileViewModel {
       } catch (err) {
         setHostedEvents([]);
         setAttendedEvents([]);
+        setInvitations([]);
+        setInvitationError(null);
         setOverallRatingLabel('New');
         setHostRatingLabel('New');
         setParticipantRatingLabel('New');
@@ -329,6 +365,35 @@ export function useProfileViewModel(): ProfileViewModel {
   const refresh = useCallback(async () => {
     await fetchProfile('refresh');
   }, [fetchProfile]);
+
+  const handleAcceptInvitation = useCallback(async (invitationId: string) => {
+    if (!token) return;
+    setIsInvitationActionLoading(invitationId);
+    setInvitationError(null);
+    try {
+      await acceptInvitation(invitationId, token);
+      setInvitations((prev) => prev.filter((invitation) => invitation.invitation_id !== invitationId));
+      await refresh();
+    } catch (err) {
+      setInvitationError(err instanceof ApiError ? err.message : 'Failed to accept invitation.');
+    } finally {
+      setIsInvitationActionLoading(null);
+    }
+  }, [refresh, token]);
+
+  const handleDeclineInvitation = useCallback(async (invitationId: string) => {
+    if (!token) return;
+    setIsInvitationActionLoading(invitationId);
+    setInvitationError(null);
+    try {
+      await declineInvitation(invitationId, token);
+      setInvitations((prev) => prev.filter((invitation) => invitation.invitation_id !== invitationId));
+    } catch (err) {
+      setInvitationError(err instanceof ApiError ? err.message : 'Failed to decline invitation.');
+    } finally {
+      setIsInvitationActionLoading(null);
+    }
+  }, [token]);
 
   const pickAvatar = useCallback(async () => {
     if (!token) {
@@ -566,13 +631,19 @@ export function useProfileViewModel(): ProfileViewModel {
     hostedCount: hostedEvents.length,
     attendedCount: attendedEvents.length,
     equipment,
+    invitations,
+    invitationCount: invitations.length,
     badges,
     showcaseImages,
     isActionLoading,
+    isInvitationActionLoading,
+    invitationError,
     catalogVisible,
     setCatalogVisible,
     pickAvatar,
     refresh,
+    handleAcceptInvitation,
+    handleDeclineInvitation,
     addEquipment,
     editEquipment,
     removeEquipment,

--- a/mobile/src/views/event/CreateEventView.test.tsx
+++ b/mobile/src/views/event/CreateEventView.test.tsx
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Platform } from 'react-native';
+import { router } from 'expo-router';
 import CreateEventView from './CreateEventView';
 import { jest } from '@jest/globals';
 import {
@@ -33,6 +34,7 @@ jest.mock('expo-router', () => ({
   router: {
     back: jest.fn(),
     replace: jest.fn(),
+    canGoBack: jest.fn(() => true),
   },
 }));
 
@@ -105,6 +107,15 @@ jest.mock('@/viewmodels/event/useCreateEventViewModel', () => {
 
 const mockUseAuth = jest.mocked(useAuth);
 const mockUseCreateEventViewModel = jest.mocked(useCreateEventViewModel);
+
+const createdEventResponse = {
+  id: 'event-1',
+  title: 'Created Event',
+  privacy_level: 'PUBLIC',
+  status: 'ACTIVE',
+  start_time: '2027-05-10T10:00:00Z',
+  created_at: '2026-05-01T10:00:00Z',
+};
 
 function buildViewModel(
   partial: Partial<CreateEventViewModel> = {},
@@ -189,6 +200,7 @@ describe('CreateEventView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (Platform as any).OS = 'ios';
+    (router.canGoBack as jest.Mock).mockReturnValue(true);
     mockUseAuth.mockReturnValue({
       token: 'token',
       login: jest.fn(),
@@ -351,5 +363,37 @@ describe('CreateEventView', () => {
 
     fireEvent.click(familyOrientedToggle);
     expect(updateField).toHaveBeenCalledWith('familyOriented', true);
+  });
+
+  it('returns to the previous screen after creating an event successfully', async () => {
+    const handleSubmit = jest
+      .fn<CreateEventViewModel['handleSubmit']>()
+      .mockResolvedValue(createdEventResponse as any);
+    (router.canGoBack as jest.Mock).mockReturnValue(true);
+    mockUseCreateEventViewModel.mockReturnValue(buildViewModel({ handleSubmit }));
+
+    render(<CreateEventView />);
+
+    fireEvent.click(screen.getByLabelText('Create event'));
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledWith('token'));
+    await waitFor(() => expect(router.back).toHaveBeenCalledTimes(1));
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('falls back to home after creation when there is no previous screen', async () => {
+    const handleSubmit = jest
+      .fn<CreateEventViewModel['handleSubmit']>()
+      .mockResolvedValue(createdEventResponse as any);
+    (router.canGoBack as jest.Mock).mockReturnValue(false);
+    mockUseCreateEventViewModel.mockReturnValue(buildViewModel({ handleSubmit }));
+
+    render(<CreateEventView />);
+
+    fireEvent.click(screen.getByLabelText('Create event'));
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledWith('token'));
+    await waitFor(() => expect(router.replace).toHaveBeenCalledWith('/(tabs)/home'));
+    expect(router.back).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/views/event/CreateEventView.tsx
+++ b/mobile/src/views/event/CreateEventView.tsx
@@ -14,7 +14,7 @@ import {
   Switch,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import { router, type Href } from 'expo-router';
 import { MaterialIcons, Feather } from '@expo/vector-icons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useAuth } from '@/contexts/AuthContext';
@@ -42,7 +42,14 @@ export default function CreateEventView() {
   const pickerThemeVariant = isDark ? 'dark' : 'light';
 
   const handleCreate = async () => {
-    await vm.handleSubmit(token ?? '');
+    const createdEvent = await vm.handleSubmit(token ?? '');
+    if (!createdEvent) return;
+
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace('/(tabs)/home' as Href);
+    }
   };
 
   const [activeDatePicker, setActiveDatePicker] = useState<'start' | 'end' | null>(null);
@@ -1072,6 +1079,8 @@ export default function CreateEventView() {
           onPress={handleCreate}
           disabled={vm.isLoading}
           activeOpacity={0.8}
+          accessibilityRole="button"
+          accessibilityLabel="Create event"
         >
           {vm.isLoading ? (
             <ActivityIndicator color={theme.textOnPrimary} />

--- a/mobile/src/views/events/MyEventsView.tsx
+++ b/mobile/src/views/events/MyEventsView.tsx
@@ -11,7 +11,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Feather } from '@expo/vector-icons';
 import { router, useFocusEffect, type Href } from 'expo-router';
 import MyEventCard from '@/components/events/MyEventCard';
-import InvitationCard from '@/components/invitation/InvitationCard';
 import { useMyEventsViewModel } from '@/viewmodels/event/useMyEventsViewModel';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
@@ -124,15 +123,7 @@ export default function MyEventsView() {
               theme={theme}
               styles={styles}
             />
-          ) : vm.activeStatus === 'INVITATIONS' && vm.invitations.length === 0 ? (
-            <StatePanel
-              icon="mail"
-              title={vm.emptyTitle}
-              subtitle={vm.emptySubtitle}
-              theme={theme}
-              styles={styles}
-            />
-          ) : vm.activeStatus !== 'INVITATIONS' && vm.visibleEvents.length === 0 ? (
+          ) : vm.visibleEvents.length === 0 ? (
             <StatePanel
               icon="calendar"
               title={vm.emptyTitle}
@@ -145,26 +136,13 @@ export default function MyEventsView() {
               showsVerticalScrollIndicator={false}
               contentContainerStyle={styles.listContent}
             >
-              {vm.activeStatus === 'INVITATIONS' ? (
-                vm.invitations.map((invitation) => (
-                  <InvitationCard
-                    key={invitation.invitation_id}
-                    invitation={invitation}
-                    onAccept={() => vm.handleAccept(invitation.invitation_id)}
-                    onDecline={() => vm.handleDecline(invitation.invitation_id)}
-                    onPress={(eventId) => router.push(`/event/${eventId}` as Href)}
-                    isActionLoading={vm.isActionLoading === invitation.invitation_id}
-                  />
-                ))
-              ) : (
-                vm.visibleEvents.map((event) => (
-                  <MyEventCard
-                    key={event.id}
-                    event={event}
-                    onPress={(eventId) => router.push(`/event-actions/${eventId}` as Href)}
-                  />
-                ))
-              )}
+              {vm.visibleEvents.map((event) => (
+                <MyEventCard
+                  key={event.id}
+                  event={event}
+                  onPress={(eventId) => router.push(`/event-actions/${eventId}` as Href)}
+                />
+              ))}
             </ScrollView>
           )}
         </View>

--- a/mobile/src/views/profile/ProfileView.test.tsx
+++ b/mobile/src/views/profile/ProfileView.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Keyboard } from 'react-native';
+import { router } from 'expo-router';
+import ProfileView from './ProfileView';
+import { useAuth } from '@/contexts/AuthContext';
+import { useLogoutViewModel } from '@/viewmodels/auth/useLogoutViewModel';
+import { usePushNotificationPreference } from '@/viewmodels/notifications/usePushNotificationPreference';
+import { useProfileViewModel, type ProfileViewModel } from '@/viewmodels/profile/useProfileViewModel';
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/viewmodels/auth/useLogoutViewModel', () => ({
+  useLogoutViewModel: jest.fn(),
+}));
+
+jest.mock('@/viewmodels/notifications/usePushNotificationPreference', () => ({
+  usePushNotificationPreference: jest.fn(),
+}));
+
+jest.mock('@/viewmodels/profile/useProfileViewModel', () => ({
+  useProfileViewModel: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactLocal = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) =>
+      ReactLocal.createElement('div', null, children),
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const ReactLocal = require('react');
+  return {
+    Ionicons: ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', { 'data-icon': name }),
+  };
+});
+
+jest.mock('@/components/invitation/InvitationCard', () => {
+  const ReactLocal = require('react');
+  return ({ invitation, onAccept, onDecline, compact }: any) =>
+    ReactLocal.createElement('div', { 'data-testid': 'profile-invitation-card', 'data-compact': String(Boolean(compact)) }, [
+      ReactLocal.createElement('span', { key: 'title' }, invitation.event.title),
+      ReactLocal.createElement(
+        'button',
+        { key: 'accept', onClick: () => onAccept(invitation.invitation_id) },
+        'Accept invitation',
+      ),
+      ReactLocal.createElement(
+        'button',
+        { key: 'decline', onClick: () => onDecline(invitation.invitation_id) },
+        'Decline invitation',
+      ),
+    ]);
+});
+
+jest.mock('@/components/profile/BadgeList', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', null, 'Badges mock');
+});
+
+jest.mock('@/components/profile/EquipmentList', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', null, 'Equipment mock');
+});
+
+jest.mock('@/components/profile/ShowcaseImageGrid', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', null, 'Showcase mock');
+});
+
+jest.mock('@/components/profile/ProfileEventCard', () => {
+  const ReactLocal = require('react');
+  return ({ title }: { title: string }) => ReactLocal.createElement('div', null, title);
+});
+
+const mockUseAuth = jest.mocked(useAuth);
+const mockUseLogoutViewModel = jest.mocked(useLogoutViewModel);
+const mockUsePushNotificationPreference = jest.mocked(usePushNotificationPreference);
+const mockUseProfileViewModel = jest.mocked(useProfileViewModel);
+
+function buildViewModel(overrides: Partial<ProfileViewModel> = {}): ProfileViewModel {
+  return {
+    profile: {
+      id: 'user-1',
+      username: 'john_doe',
+      email: 'john@example.com',
+      phone_number: '+905551112233',
+      gender: 'MALE',
+      birth_date: '1998-05-14',
+      email_verified: true,
+      status: 'active',
+      default_location_address: 'Istanbul, Turkey',
+      default_location_lat: 41.0082,
+      default_location_lon: 28.9784,
+      display_name: 'John Doe',
+      bio: null,
+      avatar_url: null,
+      final_score: 4.2,
+      host_score: null,
+      participant_score: null,
+      equipment: [],
+      showcase_images: [],
+      badges: [],
+      locale: 'en',
+    },
+    isLoading: false,
+    isUploadingAvatar: false,
+    apiError: null,
+    imageError: null,
+    imageUploadSuccessMessage: null,
+    primaryName: 'John Doe',
+    secondaryName: 'john_doe',
+    avatarInitial: 'J',
+    overallRatingLabel: '4.2',
+    hostRatingLabel: 'New',
+    participantRatingLabel: 'New',
+    hostedEvents: [
+      {
+        id: 'hosted-1',
+        title: 'Hosted Event',
+        start_time: '2026-05-10T10:00:00Z',
+        end_time: null,
+        image_url: null,
+        category_label: 'Social',
+        status: 'IN_PROGRESS',
+        privacy_level: 'PUBLIC',
+      },
+    ],
+    attendedEvents: [],
+    hostedCount: 1,
+    attendedCount: 0,
+    equipment: [],
+    invitations: [
+      {
+        invitation_id: 'inv-1',
+        status: 'PENDING',
+        event: {
+          id: 'event-1',
+          title: 'Private Picnic',
+          start_time: '2026-05-12T10:00:00Z',
+          image_url: null,
+        },
+        host: {
+          username: 'host_user',
+          display_name: 'Host User',
+          profile_image_url: null,
+        },
+        message: null,
+        created_at: '2026-05-01T10:00:00Z',
+        updated_at: '2026-05-01T10:00:00Z',
+      },
+    ],
+    invitationCount: 1,
+    badges: [],
+    showcaseImages: [],
+    isActionLoading: false,
+    isInvitationActionLoading: null,
+    invitationError: null,
+    catalogVisible: false,
+    setCatalogVisible: jest.fn(),
+    pickAvatar: jest.fn(),
+    refresh: jest.fn().mockResolvedValue(undefined),
+    handleAcceptInvitation: jest.fn().mockResolvedValue(undefined),
+    handleDeclineInvitation: jest.fn().mockResolvedValue(undefined),
+    addEquipment: jest.fn().mockResolvedValue(undefined),
+    editEquipment: jest.fn().mockResolvedValue(undefined),
+    removeEquipment: jest.fn().mockResolvedValue(undefined),
+    uploadShowcaseImage: jest.fn().mockResolvedValue(undefined),
+    removeShowcaseImage: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('ProfileView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      token: 'token',
+      refreshToken: 'refresh',
+      user: null,
+      setSession: jest.fn(),
+      clearAuth: jest.fn(),
+    } as any);
+    mockUseLogoutViewModel.mockReturnValue({
+      isLoggingOut: false,
+      logoutError: null,
+      handleLogout: jest.fn(),
+    });
+    mockUsePushNotificationPreference.mockReturnValue({
+      pushNotificationsEnabled: true,
+      isHydrating: false,
+      isSaving: false,
+      errorMessage: null,
+      setPushNotificationsEnabled: jest.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it('renders invitations as a profile section with actions', () => {
+    const handleAcceptInvitation = jest.fn().mockResolvedValue(undefined);
+    const handleDeclineInvitation = jest.fn().mockResolvedValue(undefined);
+    mockUseProfileViewModel.mockReturnValue(
+      buildViewModel({ handleAcceptInvitation, handleDeclineInvitation }),
+    );
+
+    render(<ProfileView />);
+
+    expect(screen.getByText('Invitations')).toBeTruthy();
+    expect(screen.getByText('Private Picnic')).toBeTruthy();
+    expect(screen.getByTestId('profile-invitation-card').getAttribute('data-compact')).toBe('true');
+
+    fireEvent.click(screen.getByText('Accept invitation'));
+    expect(handleAcceptInvitation).toHaveBeenCalledWith('inv-1');
+
+    fireEvent.click(screen.getByText('Decline invitation'));
+    expect(handleDeclineInvitation).toHaveBeenCalledWith('inv-1');
+  });
+
+  it('previews only one invitation on profile and links to the full invitations page', () => {
+    const secondInvitation = {
+      ...buildViewModel().invitations[0],
+      invitation_id: 'inv-2',
+      event: {
+        id: 'event-2',
+        title: 'Second Private Event',
+        start_time: '2026-05-13T10:00:00Z',
+        image_url: null,
+      },
+    };
+    mockUseProfileViewModel.mockReturnValue(
+      buildViewModel({
+        invitations: [...buildViewModel().invitations, secondInvitation],
+        invitationCount: 2,
+      }),
+    );
+
+    render(<ProfileView />);
+
+    expect(screen.getByText('Private Picnic')).toBeTruthy();
+    expect(screen.queryByText('Second Private Event')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('View all invitations'));
+    expect(router.push).toHaveBeenCalledWith('/profile/invitations');
+  });
+
+  it('dismisses the keyboard when tapping the equipment modal surface', () => {
+    mockUseProfileViewModel.mockReturnValue(buildViewModel());
+
+    render(<ProfileView />);
+
+    fireEvent.click(screen.getByLabelText('Add equipment'));
+    fireEvent.click(screen.getByTestId('equipment-modal-dismiss-layer'));
+
+    expect(Keyboard.dismiss).toHaveBeenCalled();
+  });
+});

--- a/mobile/src/views/profile/ProfileView.tsx
+++ b/mobile/src/views/profile/ProfileView.tsx
@@ -19,6 +19,7 @@ import { router, type Href, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import ProfileEventCard from '@/components/profile/ProfileEventCard';
+import InvitationCard from '@/components/invitation/InvitationCard';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLogoutViewModel } from '@/viewmodels/auth/useLogoutViewModel';
 import { usePushNotificationPreference } from '@/viewmodels/notifications/usePushNotificationPreference';
@@ -32,6 +33,7 @@ import ShowcaseImageGrid from '@/components/profile/ShowcaseImageGrid';
 import { EquipmentItem } from '@/models/profile';
 
 type ProfileEventTab = 'hosted' | 'attended';
+const INVITATION_PROFILE_PREVIEW_LIMIT = 1;
 
 export default function ProfileView() {
   const { refreshToken, clearAuth } = useAuth();
@@ -94,8 +96,14 @@ export default function ProfileView() {
     setEquipmentModalVisible(true);
   };
 
+  const closeEquipmentModal = () => {
+    Keyboard.dismiss();
+    setEquipmentModalVisible(false);
+  };
+
   const handleSaveEquipment = async () => {
     if (!eqName.trim()) return;
+    Keyboard.dismiss();
     if (editingEquipment) {
       await vm.editEquipment(editingEquipment.id, eqName, eqDesc);
     } else {
@@ -104,8 +112,12 @@ export default function ProfileView() {
     setEquipmentModalVisible(false);
   };
 
-  const renderHeader = () => (
-    <View>
+  const renderHeader = () => {
+    const previewInvitations = vm.invitations.slice(0, INVITATION_PROFILE_PREVIEW_LIMIT);
+    const hasMoreInvitations = vm.invitationCount > INVITATION_PROFILE_PREVIEW_LIMIT;
+
+    return (
+      <View>
       <Text style={styles.screenTitle}>Profile</Text>
 
       {vm.apiError ? (
@@ -274,11 +286,75 @@ export default function ProfileView() {
 
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
+              <View style={{ flex: 1, marginRight: 8 }}>
+                <Text style={styles.sectionTitle}>Invitations</Text>
+                <Text style={styles.sectionSubtitle}>Private event invites awaiting your response</Text>
+              </View>
+              {vm.invitationCount > 0 ? (
+                <View style={styles.sectionCountBadge}>
+                  <Text style={styles.sectionCountText}>{vm.invitationCount}</Text>
+                </View>
+              ) : null}
+            </View>
+
+            {vm.invitationError ? (
+              <View style={styles.sectionMessageCard}>
+                <Text style={styles.sectionErrorText}>{vm.invitationError}</Text>
+                <TouchableOpacity
+                  onPress={vm.refresh}
+                  style={styles.sectionRetryButton}
+                  accessibilityRole="button"
+                  accessibilityLabel="Retry loading invitations"
+                >
+                  <Text style={styles.sectionRetryButtonText}>Retry</Text>
+                </TouchableOpacity>
+              </View>
+            ) : previewInvitations.length > 0 ? (
+              <>
+                {previewInvitations.map((invitation) => (
+                  <InvitationCard
+                    key={invitation.invitation_id}
+                    invitation={invitation}
+                    onAccept={vm.handleAcceptInvitation}
+                    onDecline={vm.handleDeclineInvitation}
+                    onPress={(eventId) => router.push(`/event/${eventId}` as Href)}
+                    isActionLoading={vm.isInvitationActionLoading === invitation.invitation_id}
+                    compact
+                  />
+                ))}
+
+                {hasMoreInvitations ? (
+                  <TouchableOpacity
+                    style={styles.viewAllInvitationsButton}
+                    onPress={() => router.push('/profile/invitations' as Href)}
+                    accessibilityRole="button"
+                    accessibilityLabel="View all invitations"
+                  >
+                    <Text style={styles.viewAllInvitationsText}>
+                      View all {vm.invitationCount} invitations
+                    </Text>
+                    <Ionicons name="chevron-forward" size={18} color={theme.primaryAlt} />
+                  </TouchableOpacity>
+                ) : null}
+              </>
+            ) : (
+              <View style={styles.sectionMessageCard}>
+                <Text style={styles.sectionMessageText}>No pending invitations.</Text>
+              </View>
+            )}
+          </View>
+
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
               <View>
                 <Text style={styles.sectionTitle}>Equipment</Text>
                 <Text style={styles.sectionSubtitle}>Gear and essentials this member wants to highlight</Text>
               </View>
-              <TouchableOpacity onPress={openAddEquipment}>
+              <TouchableOpacity
+                onPress={openAddEquipment}
+                accessibilityRole="button"
+                accessibilityLabel="Add equipment"
+              >
                 <Ionicons name="add-circle-outline" size={24} color={theme.primaryAlt} />
               </TouchableOpacity>
             </View>
@@ -486,7 +562,8 @@ export default function ProfileView() {
         </>
       ) : null}
     </View>
-  );
+    );
+  };
 
   return (
     <SafeAreaView edges={['top', 'left', 'right']} style={styles.safeArea}>
@@ -537,59 +614,65 @@ export default function ProfileView() {
         visible={equipmentModalVisible}
         transparent
         animationType="fade"
-        onRequestClose={() => setEquipmentModalVisible(false)}
+        onRequestClose={closeEquipmentModal}
       >
-        <Pressable 
-          style={styles.modalOverlay} 
-          onPress={Keyboard.dismiss}
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.modalOverlay}
         >
-          <View style={styles.modalContent} onStartShouldSetResponder={() => true}>
-            <Text style={styles.modalTitle}>
-              {editingEquipment ? 'Edit Equipment' : 'Add Equipment'}
-            </Text>
-            
-            <Text style={styles.label}>Name</Text>
-            <TextInput
-              style={styles.input}
-              value={eqName}
-              onChangeText={setEqName}
-              placeholder="e.g. Mountain Bike"
-              placeholderTextColor={theme.textMuted}
-            />
+          <Pressable
+            testID="equipment-modal-dismiss-layer"
+            style={styles.modalDismissLayer}
+            onPress={Keyboard.dismiss}
+          >
+            <Pressable style={styles.modalContent} onPress={Keyboard.dismiss}>
+              <Text style={styles.modalTitle}>
+                {editingEquipment ? 'Edit Equipment' : 'Add Equipment'}
+              </Text>
 
-            <Text style={styles.label}>Description (Optional)</Text>
-            <TextInput
-              style={[styles.input, styles.textArea]}
-              value={eqDesc}
-              onChangeText={setEqDesc}
-              placeholder="Brief details about the item..."
-              placeholderTextColor={theme.textMuted}
-              multiline
-              numberOfLines={3}
-              textAlignVertical="top"
-            />
+              <Text style={styles.label}>Name</Text>
+              <TextInput
+                style={styles.input}
+                value={eqName}
+                onChangeText={setEqName}
+                placeholder="e.g. Mountain Bike"
+                placeholderTextColor={theme.textMuted}
+              />
 
-            <View style={styles.modalActions}>
-              <TouchableOpacity 
-                style={styles.modalCancel} 
-                onPress={() => setEquipmentModalVisible(false)}
-              >
-                <Text style={styles.modalCancelText}>Cancel</Text>
-              </TouchableOpacity>
-              <TouchableOpacity 
-                style={[styles.modalSave, !eqName.trim() && styles.modalSaveDisabled]} 
-                onPress={handleSaveEquipment}
-                disabled={!eqName.trim() || vm.isActionLoading}
-              >
-                {vm.isActionLoading ? (
-                  <ActivityIndicator size="small" color={theme.textOnPrimary} />
-                ) : (
-                  <Text style={styles.modalSaveText}>Save</Text>
-                )}
-              </TouchableOpacity>
-            </View>
-          </View>
-        </Pressable>
+              <Text style={styles.label}>Description (Optional)</Text>
+              <TextInput
+                style={[styles.input, styles.textArea]}
+                value={eqDesc}
+                onChangeText={setEqDesc}
+                placeholder="Brief details about the item..."
+                placeholderTextColor={theme.textMuted}
+                multiline
+                numberOfLines={3}
+                textAlignVertical="top"
+              />
+
+              <View style={styles.modalActions}>
+                <TouchableOpacity
+                  style={styles.modalCancel}
+                  onPress={closeEquipmentModal}
+                >
+                  <Text style={styles.modalCancelText}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.modalSave, !eqName.trim() && styles.modalSaveDisabled]}
+                  onPress={handleSaveEquipment}
+                  disabled={!eqName.trim() || vm.isActionLoading}
+                >
+                  {vm.isActionLoading ? (
+                    <ActivityIndicator size="small" color={theme.textOnPrimary} />
+                  ) : (
+                    <Text style={styles.modalSaveText}>Save</Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+            </Pressable>
+          </Pressable>
+        </KeyboardAvoidingView>
       </Modal>
     </SafeAreaView>
   );
@@ -931,11 +1014,80 @@ function makeStyles(t: Theme) {
       fontWeight: '700',
       color: t.primaryAlt,
     },
+    viewAllInvitationsButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 6,
+      backgroundColor: t.surface,
+      borderRadius: 14,
+      borderWidth: 1,
+      borderColor: t.border,
+      paddingVertical: 12,
+      marginTop: 2,
+    },
+    viewAllInvitationsText: {
+      color: t.primaryAlt,
+      fontSize: 14,
+      fontWeight: '800',
+    },
+    sectionCountBadge: {
+      minWidth: 28,
+      height: 28,
+      borderRadius: 14,
+      paddingHorizontal: 8,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: t.primaryAlt,
+    },
+    sectionCountText: {
+      color: t.textOnPrimary,
+      fontSize: 13,
+      fontWeight: '800',
+    },
+    sectionMessageCard: {
+      backgroundColor: t.surface,
+      borderRadius: 16,
+      borderWidth: 1,
+      borderColor: t.border,
+      paddingHorizontal: 16,
+      paddingVertical: 18,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 12,
+    },
+    sectionMessageText: {
+      fontSize: 14,
+      color: t.textSecondary,
+      fontWeight: '500',
+      textAlign: 'center',
+    },
+    sectionErrorText: {
+      fontSize: 14,
+      color: t.errorText,
+      fontWeight: '500',
+      textAlign: 'center',
+    },
+    sectionRetryButton: {
+      backgroundColor: t.errorBorder,
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      borderRadius: 10,
+    },
+    sectionRetryButtonText: {
+      color: t.errorText,
+      fontSize: 14,
+      fontWeight: '700',
+    },
     modalOverlay: {
       flex: 1,
       backgroundColor: 'rgba(0,0,0,0.5)',
       justifyContent: 'center',
       padding: 20,
+    },
+    modalDismissLayer: {
+      flex: 1,
+      justifyContent: 'center',
     },
     modalContent: {
       backgroundColor: t.surface,


### PR DESCRIPTION
## 📋 Summary

Moves mobile invitations out of My Events and into Profile, with a compact Profile preview and a full invitations page for longer lists. Also fixes invitation card layout so the inviter name no longer gets cut off awkwardly.

Improves two related mobile UX issues: the equipment modal now dismisses the keyboard when tapping the modal surface, canceling, or saving, and successful event creation now immediately navigates back to the previous screen, falling back to Home when no previous screen exists.

## 🔄 Changes

### Profile Invitations

- **Moved Invitations:** Removed invitations from the My Events tab flow.
- **Profile Section:** Added pending invitations as a Profile section.
- **Preview Limit:** Profile shows only the first pending invitation to avoid taking too much vertical space.
- **View All:** Added `View all N invitations` button linking to `/profile/invitations`.
- **States:** Added empty and error states for Profile invitations.
- **Actions:** Accept/decline actions work directly from the Profile preview.

### Invitation Card Layout

- **Host Name Fix:** Removed the small fixed host-name width that caused inviter names to be cut off.
- **Responsive Header:** Host pill now shrinks/wraps within available space.
- **Compact Mode:** Added compact `InvitationCard` rendering for Profile previews.

### My Events

- **Removed Invite Tab:** My Events now only handles event statuses.
- **ViewModel Cleanup:** Removed invitation fetching/action state from `useMyEventsViewModel`.

### Equipment Modal

- **Keyboard Dismissal:** Tapping the equipment modal surface dismisses the keyboard.
- **Cancel/Save:** Cancel and save also dismiss the keyboard cleanly.

### Create Event Navigation

- **Success Navigation:** After successful event creation, navigates back when possible.
- **Fallback:** If there is no previous screen, replaces to `/(tabs)/home`.

### Test Mocks

- Added `router.canGoBack()` to the Expo Router Jest mock.
- Extended the React Native Jest mock for `Pressable` and `Keyboard.dismiss`.

## 🧪 Testing

### Automated

```bash
cd mobile

npm test -- --runTestsByPath src/viewmodels/event/useMyEventsViewModel.test.tsx src/viewmodels/profile/useProfileViewModel.test.tsx src/views/events/MyEventsView.test.tsx src/views/profile/ProfileView.test.tsx

npm test -- --runTestsByPath src/views/event/CreateEventView.test.tsx

npm test -- --runTestsByPath src/views/profile/ProfileView.test.tsx src/views/invitation/InvitationsView.test.tsx

npx tsc --noEmit

git diff --check
```

Expect:
- Focused Jest suites pass.
- TypeScript check passes.
- Diff whitespace check passes.