### PR TITLE
feat(mobile): add event map clustering and location overlays

### DIFF
--- a/mobile/src/components/home/EventMapView.test.tsx
+++ b/mobile/src/components/home/EventMapView.test.tsx
@@ -10,6 +10,7 @@ import type { EventSummary } from '@/models/event';
 var mockImagePrefetch: jest.Mock<Promise<boolean>, [string]>;
 var mockRedrawCallout: jest.Mock;
 var mockShowCallout: jest.Mock;
+var mockAnimateToRegion: jest.Mock;
 
 // ── react-native mock ──────────────────────────────────────────────────────────
 
@@ -124,33 +125,53 @@ jest.mock('react-native', () => {
   };
 });
 
+jest.mock('@expo/vector-icons', () => {
+  const ReactLocal = require('react');
+
+  return {
+    Feather: ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', { 'data-icon-name': name }),
+  };
+});
+
 // ── react-native-maps mock ─────────────────────────────────────────────────────
 
 jest.mock('react-native-maps', () => {
   const ReactLocal = require('react');
   mockRedrawCallout = jest.fn();
   mockShowCallout = jest.fn();
+  mockAnimateToRegion = jest.fn();
 
-  const MapView = ({
-    children,
-    testID,
-    mapPadding,
-    onPress,
-  }: {
-    children?: React.ReactNode;
-    testID?: string;
-    mapPadding?: unknown;
-    onPress?: () => void;
-  }) =>
-    ReactLocal.createElement(
-      'div',
+  const MapView = ReactLocal.forwardRef(
+    (
       {
-        'data-testid': testID ?? 'map-surface',
-        'data-map-padding': mapPadding ? JSON.stringify(mapPadding) : undefined,
-        onClick: onPress,
+        children,
+        testID,
+        mapPadding,
+        onPress,
+      }: {
+        children?: React.ReactNode;
+        testID?: string;
+        mapPadding?: unknown;
+        onPress?: () => void;
       },
-      children,
-    );
+      ref: React.Ref<unknown>,
+    ) => {
+      ReactLocal.useImperativeHandle(ref, () => ({
+        animateToRegion: mockAnimateToRegion,
+      }));
+
+      return ReactLocal.createElement(
+        'div',
+        {
+          'data-testid': testID ?? 'map-surface',
+          'data-map-padding': mapPadding ? JSON.stringify(mapPadding) : undefined,
+          onClick: onPress,
+        },
+        children,
+      );
+    },
+  );
 
   const Marker = ReactLocal.forwardRef(
     (
@@ -208,11 +229,27 @@ jest.mock('react-native-maps', () => {
       children,
     );
 
+  const Circle = ({
+    testID,
+    center,
+    radius,
+  }: {
+    testID?: string;
+    center?: { latitude: number; longitude: number };
+    radius?: number;
+  }) =>
+    ReactLocal.createElement('div', {
+      'data-testid': testID,
+      'data-center': center ? JSON.stringify(center) : undefined,
+      'data-radius': radius,
+    });
+
   return {
     __esModule: true,
     default: MapView,
     Marker,
     Callout,
+    Circle,
     PROVIDER_GOOGLE: 'google',
   };
 });
@@ -422,7 +459,7 @@ describe('EventMapView', () => {
       );
     });
 
-    it('offsets markers that are geographically very close', () => {
+    it('clusters events that are geographically very close at the current zoom', () => {
       render(
         <EventMapView
           events={[
@@ -436,16 +473,73 @@ describe('EventMapView', () => {
         />,
       );
 
-      const firstCoordinate = screen
-        .getByTestId('marker-evt-1')
-        .getAttribute('data-coordinate');
-      const secondCoordinate = screen
-        .getByTestId('marker-evt-2')
-        .getAttribute('data-coordinate');
+      expect(screen.getByTestId('cluster-marker-evt-1-evt-2')).toBeTruthy();
+      expect(screen.getByText('2')).toBeTruthy();
+      expect(screen.queryByText('events')).toBeNull();
+      expect(screen.queryByTestId('marker-evt-1')).toBeNull();
+      expect(screen.queryByTestId('marker-evt-2')).toBeNull();
+    });
 
-      expect(firstCoordinate).toBeTruthy();
-      expect(secondCoordinate).toBeTruthy();
-      expect(firstCoordinate).not.toEqual(secondCoordinate);
+    it('splits nearby clusters as the map zooms in', () => {
+      const closeEvents = [
+        makeEvent({ id: 'evt-1', location_lat: 41.0422, location_lon: 29.0083 }),
+        makeEvent({ id: 'evt-2', location_lat: 41.0432, location_lon: 29.0093 }),
+      ];
+
+      const { rerender } = render(
+        <EventMapView
+          events={closeEvents}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('cluster-marker-evt-1-evt-2')).toBeTruthy();
+
+      rerender(
+        <EventMapView
+          events={closeEvents}
+          isLoading={false}
+          apiError={null}
+          region={{
+            ...DEFAULT_REGION,
+            latitudeDelta: 0.006,
+            longitudeDelta: 0.006,
+          }}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('cluster-marker-evt-1-evt-2')).toBeNull();
+      expect(screen.getByTestId('marker-evt-1')).toBeTruthy();
+      expect(screen.getByTestId('marker-evt-2')).toBeTruthy();
+    });
+
+    it('zooms toward a cluster when the cluster marker is pressed', () => {
+      render(
+        <EventMapView
+          events={[
+            makeEvent({ id: 'evt-1', location_lat: 41.0422, location_lon: 29.0083 }),
+            makeEvent({ id: 'evt-2', location_lat: 41.0432, location_lon: 29.0093 }),
+          ]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('cluster-marker-evt-1-evt-2'));
+
+      const [nextRegion, duration] = mockAnimateToRegion.mock.calls.at(-1) ?? [];
+
+      expect(nextRegion.latitude).toBeCloseTo(41.0427);
+      expect(nextRegion.longitude).toBeCloseTo(29.0088);
+      expect(nextRegion.latitudeDelta).toBeCloseTo(DEFAULT_REGION.latitudeDelta * 0.45);
+      expect(nextRegion.longitudeDelta).toBeCloseTo(DEFAULT_REGION.longitudeDelta * 0.45);
+      expect(duration).toBe(250);
     });
 
     it('shows participant count and capacity when both are present', () => {
@@ -484,6 +578,71 @@ describe('EventMapView', () => {
 
       expect(screen.getByText(/5.*going/s)).toBeTruthy();
       expect(screen.queryByText(/\//)).toBeNull();
+    });
+  });
+
+  describe('location overlays', () => {
+    it('draws the active filter radius around the filter center', () => {
+      render(
+        <EventMapView
+          events={[makeEvent()]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          filterCenter={{ lat: 40.99, lon: 29.03 }}
+          filterRadiusMeters={15000}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      const circle = screen.getByTestId('filter-radius-circle');
+
+      expect(circle.getAttribute('data-radius')).toBe('15000');
+      expect(JSON.parse(circle.getAttribute('data-center') ?? '{}')).toEqual({
+        latitude: 40.99,
+        longitude: 29.03,
+      });
+    });
+
+    it('shows current location controls when live location is available', () => {
+      render(
+        <EventMapView
+          events={[makeEvent()]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          currentLocation={{ lat: 40.9869, lon: 29.0287 }}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('current-location-marker')).toBeTruthy();
+      expect(screen.getByTestId('current-location-button')).toBeTruthy();
+    });
+
+    it('centers the map on current location when the locate button is pressed', () => {
+      render(
+        <EventMapView
+          events={[makeEvent()]}
+          isLoading={false}
+          apiError={null}
+          region={DEFAULT_REGION}
+          currentLocation={{ lat: 40.9869, lon: 29.0287 }}
+          onMarkerPress={jest.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('current-location-button'));
+
+      expect(mockAnimateToRegion).toHaveBeenLastCalledWith(
+        {
+          latitude: 40.9869,
+          longitude: 29.0287,
+          latitudeDelta: DEFAULT_REGION.latitudeDelta,
+          longitudeDelta: DEFAULT_REGION.longitudeDelta,
+        },
+        250,
+      );
     });
   });
 

--- a/mobile/src/components/home/EventMapView.tsx
+++ b/mobile/src/components/home/EventMapView.tsx
@@ -5,10 +5,13 @@ import {
   Platform,
   StyleSheet,
   Text,
+  TouchableOpacity,
   View,
 } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import MapView, {
   Callout,
+  Circle,
   Marker,
   PROVIDER_GOOGLE,
   type MapMarker,
@@ -31,11 +34,19 @@ export interface MapRegion {
   longitudeDelta: number;
 }
 
+export interface MapCoordinate {
+  lat: number;
+  lon: number;
+}
+
 interface EventMapViewProps {
   events: EventSummary[];
   isLoading: boolean;
   apiError: string | null;
   region: MapRegion;
+  filterCenter?: MapCoordinate;
+  filterRadiusMeters?: number;
+  currentLocation?: MapCoordinate | null;
   onMarkerPress: (eventId: string) => void;
   /** Extra top pixels to add to map padding (e.g. safe-area inset when map is full-screen). */
   headerTopInset?: number;
@@ -47,9 +58,21 @@ interface MappableEvent {
     latitude: number;
     longitude: number;
   };
-  presentation: EventCategoryPresentation; 
-  groupSize: number;
+  presentation: EventCategoryPresentation;
 }
+
+interface MapCluster {
+  id: string;
+  coordinate: {
+    latitude: number;
+    longitude: number;
+  };
+  events: EventWithCoordinates[];
+}
+
+type MapItem =
+  | { type: 'EVENT'; item: MappableEvent }
+  | { type: 'CLUSTER'; cluster: MapCluster };
 
 type EventWithCoordinates = EventSummary & {
   location_lat: number;
@@ -63,6 +86,10 @@ const DISCOVERY_MAP_PADDING_BASE = {
   left: 20,
 };
 
+const CLUSTER_DISTANCE_RATIO = 0.08;
+const MIN_CLUSTER_DELTA = 0.0001;
+const MIN_CLUSTER_ZOOM_DELTA = 0.006;
+
 function hasMappableCoordinate(
   event: EventSummary,
 ): event is EventWithCoordinates {
@@ -74,65 +101,88 @@ function hasMappableCoordinate(
   );
 }
 
-function getDenseCoordinateKey(event: {
-  location_lat: number;
-  location_lon: number;
-}): string {
-  return `${event.location_lat.toFixed(4)}:${event.location_lon.toFixed(4)}`;
-}
-
-function getDenseMarkerOffset(
-  groupIndex: number,
-  groupSize: number,
+function getClusterDistanceRatio(
+  event: EventWithCoordinates,
+  cluster: MapCluster,
   region: MapRegion,
-): { latitude: number; longitude: number } {
-  if (groupSize <= 1) {
-    return { latitude: 0, longitude: 0 };
-  }
+): number {
+  const latitudeDelta = Math.max(Math.abs(region.latitudeDelta), MIN_CLUSTER_DELTA);
+  const longitudeDelta = Math.max(Math.abs(region.longitudeDelta), MIN_CLUSTER_DELTA);
+  const latitudeRatio = (event.location_lat - cluster.coordinate.latitude) / latitudeDelta;
+  const longitudeRatio = (event.location_lon - cluster.coordinate.longitude) / longitudeDelta;
 
-  const markersPerRing = 8;
-  const ring = Math.floor(groupIndex / markersPerRing) + 1;
-  const ringPosition = groupIndex % markersPerRing;
-  const visibleInRing = Math.min(groupSize, markersPerRing);
-  const angle = (Math.PI * 2 * ringPosition) / visibleInRing - Math.PI / 2;
-  const regionScale = Math.min(region.latitudeDelta, region.longitudeDelta);
-  const baseRadius = Math.min(Math.max(regionScale * 0.002, 0.00006), 0.00035);
-  const radius = baseRadius * Math.min(ring, 2.5);
-
-  return {
-    latitude: Math.sin(angle) * radius,
-    longitude: Math.cos(angle) * radius,
-  };
+  return Math.sqrt(latitudeRatio * latitudeRatio + longitudeRatio * longitudeRatio);
 }
 
-function buildMappableEvents(
+function addEventToCluster(cluster: MapCluster, event: EventWithCoordinates): void {
+  const nextSize = cluster.events.length + 1;
+
+  cluster.coordinate = {
+    latitude:
+      (cluster.coordinate.latitude * cluster.events.length + event.location_lat) /
+      nextSize,
+    longitude:
+      (cluster.coordinate.longitude * cluster.events.length + event.location_lon) /
+      nextSize,
+  };
+  cluster.events.push(event);
+}
+
+function buildMapItems(
   events: EventSummary[],
   region: MapRegion,
   isDark: boolean,
-): MappableEvent[] {
+): MapItem[] {
   const eventsWithCoordinates = events.filter(hasMappableCoordinate);
-  const denseGroups = new Map<string, EventWithCoordinates[]>();
+  const clusters: MapCluster[] = [];
 
   eventsWithCoordinates.forEach((event) => {
-    const key = getDenseCoordinateKey(event);
-    const group = denseGroups.get(key) ?? [];
-    group.push(event);
-    denseGroups.set(key, group);
+    const cluster = clusters.find(
+      (candidate) =>
+        getClusterDistanceRatio(event, candidate, region) <=
+        CLUSTER_DISTANCE_RATIO,
+    );
+
+    if (cluster) {
+      addEventToCluster(cluster, event);
+      return;
+    }
+
+    clusters.push({
+      id: event.id,
+      coordinate: {
+        latitude: event.location_lat,
+        longitude: event.location_lon,
+      },
+      events: [event],
+    });
   });
 
-  return eventsWithCoordinates.map((event) => {
-    const group = denseGroups.get(getDenseCoordinateKey(event)) ?? [event];
-    const groupIndex = group.indexOf(event);
-    const offset = getDenseMarkerOffset(groupIndex, group.length, region);
+  return clusters.map((cluster) => {
+    if (cluster.events.length > 1) {
+      const id = cluster.events.map((event) => event.id).sort().join('-');
+
+      return {
+        type: 'CLUSTER',
+        cluster: {
+          ...cluster,
+          id,
+        },
+      };
+    }
+
+    const event = cluster.events[0];
 
     return {
-      event,
-      coordinate: {
-        latitude: event.location_lat + offset.latitude,
-        longitude: event.location_lon + offset.longitude,
+      type: 'EVENT',
+      item: {
+        event,
+        coordinate: {
+          latitude: event.location_lat,
+          longitude: event.location_lon,
+        },
+        presentation: getEventCategoryPresentation(event.category_name, isDark),
       },
-      presentation: getEventCategoryPresentation(event.category_name, isDark),
-      groupSize: group.length,
     };
   });
 }
@@ -167,7 +217,7 @@ function EventMapMarker({
   const [hasImageRenderError, setHasImageRenderError] = useState(false);
   // Tracks whether the image inside the callout has finished loading.
   const [isImageLoaded, setIsImageLoaded] = useState(false);
-  const { event, coordinate, presentation, groupSize } = item;
+  const { event, coordinate, presentation } = item;
   const imageUrl = getImageUrl(event);
   // Hide the callout image if the render raised an error OR the prefetch
   // explicitly failed (resolved to false) — show the category placeholder instead.
@@ -245,11 +295,6 @@ function EventMapMarker({
           testID={`marker-bubble-${event.id}`}
         >
           <Text style={styles.markerEmoji}>{presentation.emoji}</Text>
-          {groupSize > 1 ? (
-            <View style={styles.markerCountBadge}>
-              <Text style={styles.markerCountText}>{groupSize}</Text>
-            </View>
-          ) : null}
         </View>
         <View
           style={[
@@ -359,11 +404,71 @@ function EventMapMarker({
   );
 }
 
+interface ClusterMapMarkerProps {
+  cluster: MapCluster;
+  styles: ReturnType<typeof makeStyles>;
+  onPress: (cluster: MapCluster) => void;
+}
+
+function ClusterMapMarker({
+  cluster,
+  styles,
+  onPress,
+}: ClusterMapMarkerProps) {
+  return (
+    <Marker
+      key={cluster.id}
+      identifier={`cluster-${cluster.id}`}
+      coordinate={cluster.coordinate}
+      anchor={{ x: 0.5, y: 0.5 }}
+      zIndex={500}
+      onPress={() => onPress(cluster)}
+      stopPropagation
+      testID={`cluster-marker-${cluster.id}`}
+    >
+      <View style={styles.clusterBubble}>
+        <Text style={styles.clusterCount}>{cluster.events.length}</Text>
+      </View>
+    </Marker>
+  );
+}
+
+interface CurrentLocationMarkerProps {
+  coordinate: MapCoordinate;
+  styles: ReturnType<typeof makeStyles>;
+}
+
+function CurrentLocationMarker({
+  coordinate,
+  styles,
+}: CurrentLocationMarkerProps) {
+  return (
+    <Marker
+      identifier="current-location"
+      coordinate={{
+        latitude: coordinate.lat,
+        longitude: coordinate.lon,
+      }}
+      anchor={{ x: 0.5, y: 0.5 }}
+      tracksViewChanges={false}
+      zIndex={1001}
+      testID="current-location-marker"
+    >
+      <View style={styles.currentLocationOuter}>
+        <View style={styles.currentLocationDot} />
+      </View>
+    </Marker>
+  );
+}
+
 export default function EventMapView({
   events,
   isLoading,
   apiError,
   region,
+  filterCenter,
+  filterRadiusMeters = 0,
+  currentLocation = null,
   onMarkerPress,
   headerTopInset = 0,
 }: EventMapViewProps) {
@@ -385,15 +490,26 @@ export default function EventMapView({
     mapRef.current?.animateToRegion(region, 250);
   }, [region]);
 
-  const mappableEvents = useMemo(
-    () => buildMappableEvents(events, visibleRegion, isDark),
+  const mapItems = useMemo(
+    () => buildMapItems(events, visibleRegion, isDark),
     [events, visibleRegion, isDark],
+  );
+  const eventItems = useMemo(
+    () =>
+      mapItems.flatMap((item) =>
+        item.type === 'EVENT' ? [item.item] : [],
+      ),
+    [mapItems],
+  );
+  const hasMappableEvents = useMemo(
+    () => events.some(hasMappableCoordinate),
+    [events],
   );
 
   const selectedEvent = useMemo(
     () =>
-      mappableEvents.find((item) => item.event.id === selectedEventId) ?? null,
-    [mappableEvents, selectedEventId],
+      eventItems.find((item) => item.event.id === selectedEventId) ?? null,
+    [eventItems, selectedEventId],
   );
 
   // Eagerly prefetch event images so the Android InfoWindow bitmap snapshot
@@ -401,7 +517,7 @@ export default function EventMapView({
   useEffect(() => {
     const urls = Array.from(
       new Set(
-        mappableEvents
+        eventItems
           .map((item) => getImageUrl(item.event))
           .filter((url): url is string => url !== null),
       ),
@@ -416,7 +532,7 @@ export default function EventMapView({
           setImageStatusByUrl((prev) => ({ ...prev, [url]: 'FAILED' }));
         });
     });
-  }, [imageStatusByUrl, mappableEvents]);
+  }, [eventItems, imageStatusByUrl]);
 
   useEffect(() => {
     if (selectedEventId && !selectedEvent) {
@@ -424,6 +540,56 @@ export default function EventMapView({
     }
   }, [selectedEvent, selectedEventId]);
 
+  const handleClusterPress = useCallback(
+    (cluster: MapCluster) => {
+      setSelectedEventId(null);
+
+      const nextRegion = {
+        latitude: cluster.coordinate.latitude,
+        longitude: cluster.coordinate.longitude,
+        latitudeDelta: Math.max(
+          visibleRegion.latitudeDelta * 0.45,
+          MIN_CLUSTER_ZOOM_DELTA,
+        ),
+        longitudeDelta: Math.max(
+          visibleRegion.longitudeDelta * 0.45,
+          MIN_CLUSTER_ZOOM_DELTA,
+        ),
+      };
+
+      setVisibleRegion(nextRegion);
+      mapRef.current?.animateToRegion(nextRegion, 250);
+    },
+    [visibleRegion],
+  );
+
+  const handleLocateCurrentLocation = useCallback(() => {
+    if (!currentLocation) return;
+
+    const nextRegion = {
+      latitude: currentLocation.lat,
+      longitude: currentLocation.lon,
+      latitudeDelta: visibleRegion.latitudeDelta,
+      longitudeDelta: visibleRegion.longitudeDelta,
+    };
+
+    setVisibleRegion(nextRegion);
+    mapRef.current?.animateToRegion(nextRegion, 250);
+  }, [currentLocation, visibleRegion]);
+
+  const filterCenterCoordinate = useMemo(
+    () => ({
+      latitude: filterCenter?.lat ?? region.latitude,
+      longitude: filterCenter?.lon ?? region.longitude,
+    }),
+    [filterCenter?.lat, filterCenter?.lon, region.latitude, region.longitude],
+  );
+  const radiusFillColor = isDark
+    ? 'rgba(96, 165, 250, 0.16)'
+    : 'rgba(37, 99, 235, 0.12)';
+  const radiusStrokeColor = isDark
+    ? 'rgba(147, 197, 253, 0.9)'
+    : 'rgba(37, 99, 235, 0.65)';
 
   if (isLoading) {
     return (
@@ -463,24 +629,72 @@ export default function EventMapView({
         onPress={() => setSelectedEventId(null)}
         testID="map-surface"
       >
-        {mappableEvents.map((item) => {
-          const imgUrl = getImageUrl(item.event);
+        {filterRadiusMeters > 0 ? (
+          <Circle
+            center={filterCenterCoordinate}
+            radius={filterRadiusMeters}
+            strokeWidth={2}
+            strokeColor={radiusStrokeColor}
+            fillColor={radiusFillColor}
+            testID="filter-radius-circle"
+          />
+        ) : null}
+
+        {mapItems.map((item) => {
+          if (item.type === 'CLUSTER') {
+            return (
+              <ClusterMapMarker
+                key={`cluster-${item.cluster.id}`}
+                cluster={item.cluster}
+                styles={styles}
+                onPress={handleClusterPress}
+              />
+            );
+          }
+
+          const imgUrl = getImageUrl(item.item.event);
           return (
             <EventMapMarker
-              key={item.event.id}
-              item={item}
+              key={item.item.event.id}
+              item={item.item}
               styles={styles}
-              isSelected={item.event.id === selectedEventId}
+              isSelected={item.item.event.id === selectedEventId}
               imageStatus={imgUrl ? imageStatusByUrl[imgUrl] : 'READY'}
               onSelect={(eventId) => setSelectedEventId(eventId || null)}
               onOpen={onMarkerPress}
             />
           );
         })}
+
+        {currentLocation ? (
+          <CurrentLocationMarker
+            coordinate={currentLocation}
+            styles={styles}
+          />
+        ) : null}
       </MapView>
 
-      {!isLoading && mappableEvents.length === 0 && (
-        <View style={styles.emptyOverlay} testID="map-empty">
+      {currentLocation ? (
+        <TouchableOpacity
+          style={styles.locateButton}
+          onPress={handleLocateCurrentLocation}
+          accessibilityRole="button"
+          accessibilityLabel="Go to current location"
+          activeOpacity={0.85}
+          testID="current-location-button"
+        >
+          <Feather name="navigation" size={20} color={theme.primary} />
+        </TouchableOpacity>
+      ) : null}
+
+      {!isLoading && !hasMappableEvents && (
+        <View
+          style={[
+            styles.emptyOverlay,
+            currentLocation && styles.emptyOverlayWithLocateButton,
+          ]}
+          testID="map-empty"
+        >
           <Text style={styles.emptyTitle}>No events on the map</Text>
           <Text style={styles.emptySubtitle}>
             Try panning the map or adjusting filters. Some events may be hidden due to age or gender restrictions.
@@ -527,6 +741,9 @@ function makeStyles(t: Theme) {
       shadowRadius: 8,
       elevation: 4,
     },
+    emptyOverlayWithLocateButton: {
+      bottom: 90,
+    },
     emptyTitle: {
       fontSize: 15,
       fontWeight: '700',
@@ -537,6 +754,24 @@ function makeStyles(t: Theme) {
       fontSize: 13,
       color: t.textSecondary,
       textAlign: 'center',
+    },
+    locateButton: {
+      position: 'absolute',
+      right: 18,
+      bottom: 28,
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+      backgroundColor: t.surface,
+      borderWidth: 1,
+      borderColor: t.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 3 },
+      shadowOpacity: 0.18,
+      shadowRadius: 8,
+      elevation: 6,
     },
     markerWrap: {
       alignItems: 'center',
@@ -578,24 +813,48 @@ function makeStyles(t: Theme) {
       borderLeftColor: 'transparent',
       borderRightColor: 'transparent',
     },
-    markerCountBadge: {
-      position: 'absolute',
-      top: -6,
-      right: -6,
-      minWidth: 19,
-      height: 19,
-      borderRadius: 10,
-      paddingHorizontal: 4,
-      backgroundColor: t.surface,
-      borderWidth: 1,
-      borderColor: t.border,
+    clusterBubble: {
+      minWidth: 54,
+      height: 54,
+      borderRadius: 27,
+      paddingHorizontal: 10,
+      backgroundColor: t.primary,
+      borderWidth: 3,
+      borderColor: t.surface,
       alignItems: 'center',
       justifyContent: 'center',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 5 },
+      shadowOpacity: 0.24,
+      shadowRadius: 8,
+      elevation: 7,
     },
-    markerCountText: {
-      fontSize: 10,
+    clusterCount: {
+      fontSize: 22,
+      lineHeight: 26,
       fontWeight: '800',
-      color: t.text,
+      color: t.textOnPrimary,
+    },
+    currentLocationOuter: {
+      width: 26,
+      height: 26,
+      borderRadius: 13,
+      backgroundColor: 'rgba(37, 99, 235, 0.18)',
+      borderWidth: 2,
+      borderColor: t.surface,
+      alignItems: 'center',
+      justifyContent: 'center',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.2,
+      shadowRadius: 4,
+      elevation: 5,
+    },
+    currentLocationDot: {
+      width: 12,
+      height: 12,
+      borderRadius: 6,
+      backgroundColor: '#2563EB',
     },
     callout: {
       width: 296,

--- a/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
+++ b/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
@@ -250,6 +250,10 @@ describe('useHomeViewModel', () => {
       'mock-token',
     );
     expect(result.current.locationLabel).toBe('Moda, Kadikoy');
+    expect(result.current.currentLocation).toEqual({
+      lat: 40.9869,
+      lon: 29.0287,
+    });
   });
 
   it('uses the profile default location when live location is unavailable', async () => {
@@ -293,6 +297,7 @@ describe('useHomeViewModel', () => {
       'mock-token',
     );
     expect(result.current.locationLabel).toContain('Kadikoy');
+    expect(result.current.currentLocation).toBeNull();
   });
 
   it('keeps showing the resolved default location after silent refresh', async () => {
@@ -360,6 +365,10 @@ describe('useHomeViewModel', () => {
       'mock-token',
     );
     expect(result.current.locationLabel).toBe('Moda, Kadikoy');
+    expect(result.current.currentLocation).toEqual({
+      lat: 40.9869,
+      lon: 29.0287,
+    });
     expect(result.current.defaultLocationOption.subtitle).toContain(
       'Current location:',
     );

--- a/mobile/src/viewmodels/home/useHomeViewModel.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.ts
@@ -351,6 +351,7 @@ export interface HomeViewModel {
   filterError: string | null;
   viewMode: HomeViewMode;
   activeLocation: { lat: number; lon: number };
+  currentLocation: { lat: number; lon: number } | null;
   toggleViewMode: () => void;
   updateSearchText: (value: string) => void;
   submitSearch: () => void;
@@ -400,6 +401,7 @@ export function useHomeViewModel(): HomeViewModel {
       : null,
   );
   const [defaultLocation, setDefaultLocation] = useState<LocationSuggestion | null>(null);
+  const [currentLocation, setCurrentLocation] = useState<LocationSuggestion | null>(null);
   const [defaultLocationSource, setDefaultLocationSource] =
     useState<DefaultLocationSource>('FALLBACK');
   const [pendingLocation, setPendingLocation] = useState<LocationSuggestion | null>(null);
@@ -479,6 +481,7 @@ export function useHomeViewModel(): HomeViewModel {
     setIsResolvingDefaultLocation(true);
 
     if (!token) {
+      setCurrentLocation(null);
       setDefaultLocation(FALLBACK_LOCATION);
       setDefaultLocationSource('FALLBACK');
       syncSelectedLocationWithDefault(FALLBACK_LOCATION);
@@ -491,6 +494,7 @@ export function useHomeViewModel(): HomeViewModel {
       const liveLocation = await getCurrentLocationSuggestion();
 
       if (liveLocation) {
+        setCurrentLocation(liveLocation);
         setDefaultLocation(liveLocation);
         setDefaultLocationSource('LIVE');
         syncSelectedLocationWithDefault(liveLocation);
@@ -499,6 +503,8 @@ export function useHomeViewModel(): HomeViewModel {
     } catch {
       // Fall through to profile and fallback location resolution.
     }
+
+    setCurrentLocation(null);
 
     try {
       const profile = await getMyProfile(token);
@@ -1040,6 +1046,12 @@ export function useHomeViewModel(): HomeViewModel {
       lat: Number(effectiveLocation.lat),
       lon: Number(effectiveLocation.lon),
     },
+    currentLocation: currentLocation
+      ? {
+        lat: Number(currentLocation.lat),
+        lon: Number(currentLocation.lon),
+      }
+      : null,
     toggleViewMode,
     defaultLocationOption: {
       title: 'Use Default Location',

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -88,6 +88,9 @@ export default function HomeView() {
             isLoading={vm.isLoading}
             apiError={vm.apiError}
             region={mapRegion}
+            filterCenter={vm.activeLocation}
+            filterRadiusMeters={vm.filterDraft.radiusKm * 1000}
+            currentLocation={vm.currentLocation}
             onMarkerPress={(id) => router.push(`/event/${id}` as Href)}
             headerTopInset={insets.top}
           />


### PR DESCRIPTION
## 📋 Summary

Improves the mobile event map with zoom-aware marker clustering, current-location visibility, and a filter radius overlay. Clusters dynamically split as users zoom in, the map can show the user’s live location when permission is granted, and a bottom-right locate button recenters the map on the current location. The filter radius is also drawn on the map so users can see the event discovery area.

## 🔄 Changes

### Event Map Clustering

- **Zoom-Aware Clusters:** Nearby event markers now combine into clusters based on the current map zoom level.
- **Dynamic Split:** Clusters split back into individual markers as users zoom in.
- **Cluster Tap:** Tapping a cluster zooms the map toward that cluster.
- **Compact Cluster Label:** Cluster markers show only the count, such as `2`, instead of `2 events`.

### Current Location

- **Location Marker:** Shows the user’s current location on the map when location access is granted.
- **Locate Button:** Added a bottom-right button that recenters the map on the current location.
- **Permission-Aware:** Current-location UI only appears when live location data is available.

### Filter Radius

- **Radius Circle:** Draws the active filter radius on the map.
- **Discovery Area:** Radius is centered around the active discovery location so users can see the event search area.

### Home ViewModel

- **Current Location State:** Exposes live current-location coordinates separately from the active discovery location.
- **Fallback Behavior:** Keeps existing profile/default/fallback location behavior when live location is unavailable.

### Tests

- Added coverage for map clustering.
- Added coverage for cluster zoom behavior.
- Added coverage for current-location marker/button rendering.
- Added coverage for filter radius rendering.
- Updated map mocks for `Circle` and `animateToRegion`.

## 🧪 Testing

### Automated

```bash
cd mobile
npm test -- EventMapView.test.tsx useHomeViewModel.test.tsx --runInBand
npx tsc --noEmit
```

### Manual

- Opened the Explore map view.
- Verified nearby markers are grouped into a cluster.
- Verified the cluster shows only the number count.
- Zoomed in and confirmed the cluster splits into individual event markers.
- Tapped a cluster and confirmed the map zooms toward it.
- Granted location access and confirmed the current-location marker appears.
- Tapped the bottom-right locate button and confirmed the map recenters on current location.
- Verified the filter radius circle is visible around the active discovery location.