### PR TITLE
feat(frontend): Show rating counts in web UI

### DIFF
--- a/frontend/src/components/RatingWithCount.test.ts
+++ b/frontend/src/components/RatingWithCount.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { formatRatingWithCountText } from './RatingWithCount';
+
+describe('formatRatingWithCountText', () => {
+  it('shows the score with a defensive rating count when available', () => {
+    expect(formatRatingWithCountText({ score: 4.73, count: 12 })).toBe('★ 4.7 (12)');
+  });
+
+  it('keeps the score visible when the backend has not rolled out count yet', () => {
+    expect(formatRatingWithCountText({ score: 4.73 })).toBe('★ 4.7');
+  });
+
+  it('renders nothing for unrated items', () => {
+    expect(formatRatingWithCountText({ score: null, count: 0 })).toBe('');
+  });
+});

--- a/frontend/src/components/RatingWithCount.tsx
+++ b/frontend/src/components/RatingWithCount.tsx
@@ -1,0 +1,40 @@
+interface RatingWithCountProps {
+  score: number | null | undefined;
+  count?: number | null;
+  className?: string;
+  suffix?: string;
+}
+
+function normalizeCount(count: number | null | undefined): number | null {
+  return typeof count === 'number' && Number.isFinite(count) ? Math.max(0, count) : null;
+}
+
+export function formatRatingWithCountText({
+  score,
+  count,
+  suffix,
+}: RatingWithCountProps): string {
+  const normalizedCount = normalizeCount(count);
+
+  if (score == null || !Number.isFinite(score)) {
+    return '';
+  }
+
+  const countText = normalizedCount == null ? '' : ` (${normalizedCount})`;
+  const suffixText = suffix ? ` ${suffix}` : '';
+  return `★ ${score.toFixed(1)}${countText}${suffixText}`;
+}
+
+export function RatingWithCount(props: RatingWithCountProps) {
+  const text = formatRatingWithCountText(props);
+  if (!text) return null;
+
+  return (
+    <span
+      className={`rating-with-count ${props.className ?? ''}`.trim()}
+      aria-label={text.replace('★', 'Rating')}
+    >
+      {text}
+    </span>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -86,6 +86,10 @@ body {
   border: 0;
 }
 
+.rating-with-count {
+  white-space: nowrap;
+}
+
 :root[data-theme='dark'] input,
 :root[data-theme='dark'] textarea,
 :root[data-theme='dark'] select {

--- a/frontend/src/views/discover/DiscoverEventSidePanel.tsx
+++ b/frontend/src/views/discover/DiscoverEventSidePanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { EventCoverImage } from '@/components/EventCoverImage';
+import { RatingWithCount } from '@/components/RatingWithCount';
 import { UserAvatar } from '@/components/UserAvatar';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -117,6 +118,8 @@ export default function DiscoverEventSidePanel({
   const host = detail?.host ?? null;
   const hostName = host ? host.display_name ?? host.username : null;
   const hostScore = detail?.host_score?.final_score ?? event.host_score.final_score;
+  const hostScoreCount =
+    detail?.host_score?.hosted_event_rating_count ?? event.host_score.hosted_event_rating_count;
   const minAge = detail?.minimum_age ?? null;
   const preferredGender = formatGender(detail?.preferred_gender);
   const favoriteCount = detail?.favorite_count ?? null;
@@ -232,9 +235,12 @@ export default function DiscoverEventSidePanel({
             />
             <div className="dc-side-panel-host-info">
               <div className="dc-side-panel-host-name">{hostName}</div>
-              {hostScore != null && (
-                <div className="dc-side-panel-host-score">★ {hostScore.toFixed(1)} host score</div>
-              )}
+              <RatingWithCount
+                score={hostScore}
+                count={hostScoreCount}
+                className="dc-side-panel-host-score"
+                suffix="host score"
+              />
             </div>
           </div>
         )}

--- a/frontend/src/views/discover/DiscoverPage.tsx
+++ b/frontend/src/views/discover/DiscoverPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/viewmodels/discover/useDiscoverViewModel';
 import type { DiscoverEventItem, DiscoverSortBy } from '@/models/event';
 import { EventCoverImage } from '@/components/EventCoverImage';
+import { RatingWithCount } from '@/components/RatingWithCount';
 import { getEventLifecyclePresentation } from '@/utils/eventStatus';
 import { formatEventLocation } from '@/utils/eventLocation';
 import DiscoverMapView from './DiscoverMapView';
@@ -239,11 +240,11 @@ function EventCard({ event }: { event: DiscoverEventItem }) {
           <span className="dc-card-participants">
             {event.approved_participant_count} participant{event.approved_participant_count !== 1 ? 's' : ''}
           </span>
-          {event.host_score.final_score != null && (
-            <span className="dc-card-score">
-              {'★'} {event.host_score.final_score.toFixed(1)}
-            </span>
-          )}
+          <RatingWithCount
+            score={event.host_score.final_score}
+            count={event.host_score.hosted_event_rating_count}
+            className="dc-card-score"
+          />
         </div>
       </div>
     </Link>

--- a/frontend/src/views/events/EventDetailPage.tsx
+++ b/frontend/src/views/events/EventDetailPage.tsx
@@ -18,6 +18,7 @@ import type {
   InvitationFailureCode,
 } from '@/models/invitation';
 import { EventCoverImage } from '@/components/EventCoverImage';
+import { RatingWithCount } from '@/components/RatingWithCount';
 import { UserAvatar } from '@/components/UserAvatar';
 import { getEventLifecyclePresentation, getEventStatusPresentation } from '@/utils/eventStatus';
 import { getApproximateLocationText } from '@/utils/locationApproximation';
@@ -1572,7 +1573,11 @@ function HostParticipantRatingItem({
           <div className="ed-mgmt-user-topline">
             <span className="ed-mgmt-name">{getDisplayName(participant.user)}</span>
             {participant.user.final_score != null && (
-              <span className="ed-mgmt-user-score">{'★'} {participant.user.final_score.toFixed(1)} ({participant.user.rating_count})</span>
+              <RatingWithCount
+                score={participant.user.final_score}
+                count={participant.user.rating_count}
+                className="ed-mgmt-user-score"
+              />
             )}
           </div>
           <span className="ed-mgmt-username">@{participant.user.username}</span>
@@ -1861,9 +1866,11 @@ function HostPendingReconfirmationItem({ participant }: { participant: EventDeta
           <div className="ed-mgmt-user-topline">
             <span className="ed-mgmt-name">{getDisplayName(participant.user)}</span>
             {participant.user.final_score != null && (
-              <span className="ed-mgmt-user-score">
-                {'★'} {participant.user.final_score.toFixed(1)} ({participant.user.rating_count})
-              </span>
+              <RatingWithCount
+                score={participant.user.final_score}
+                count={participant.user.rating_count}
+                className="ed-mgmt-user-score"
+              />
             )}
           </div>
           <span className="ed-mgmt-username">@{participant.user.username}</span>
@@ -2275,12 +2282,6 @@ function EventContent({
           </div>
           <span className="ed-metric-label">Save{event.favorite_count !== 1 ? 's' : ''}</span>
         </div>
-        {event.host_score.final_score != null && (
-          <div className="ed-metric">
-            <span className="ed-metric-value">{'★'} {event.host_score.final_score.toFixed(1)}</span>
-            <span className="ed-metric-label">Host Score</span>
-          </div>
-        )}
       </div>
 
       {/* Expiry warning — shown in last 7 days before auto-completion */}
@@ -2375,12 +2376,11 @@ function EventContent({
                 <p className="ed-host-username">@{event.host.username}</p>
               </div>
             </Link>
-            {event.host_score.final_score != null && (
-              <span className="ed-host-score">
-                {'★'} {event.host_score.final_score.toFixed(1)}
-                <span className="ed-host-rating-count"> ({event.host_score.hosted_event_rating_count})</span>
-              </span>
-            )}
+            <RatingWithCount
+              score={event.host_score.final_score}
+              count={event.host_score.hosted_event_rating_count}
+              className="ed-host-score"
+            />
           </div>
         </div>
 
@@ -2624,7 +2624,11 @@ function EventContent({
                           </a>
                         )}
                         {r.user.final_score != null && (
-                          <span className="ed-mgmt-user-score">{'★'} {r.user.final_score.toFixed(1)} ({r.user.rating_count})</span>
+                          <RatingWithCount
+                            score={r.user.final_score}
+                            count={r.user.rating_count}
+                            className="ed-mgmt-user-score"
+                          />
                         )}
                       </div>
                       <div className="ed-mgmt-actions">

--- a/frontend/src/views/events/MyEventsPage.tsx
+++ b/frontend/src/views/events/MyEventsPage.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useMyEventsViewModel, type MyEventsTab } from '@/viewmodels/event/useMyEventsViewModel';
 import type { EventSummary } from '@/models/profile';
 import { EventCoverImage } from '@/components/EventCoverImage';
+import { RatingWithCount } from '@/components/RatingWithCount';
 import { getEventCardBadgePresentation } from '@/utils/eventStatus';
 import '@/styles/my-events.css';
 import '@/styles/discover.css';
@@ -75,10 +76,12 @@ function EventCard({ event }: { event: EventSummary }) {
           <span className="dc-card-participants">
             {participantCount} participant{participantCount === 1 ? '' : 's'}
           </span>
-          {event.host_score?.final_score != null && (
-            <span className="dc-card-score">
-              {'★'} {event.host_score.final_score.toFixed(1)}
-            </span>
+          {event.host_score && (
+            <RatingWithCount
+              score={event.host_score.final_score}
+              count={event.host_score.hosted_event_rating_count}
+              className="dc-card-score"
+            />
           )}
         </div>
       </div>

--- a/frontend/src/views/favorites/FavoritesPage.tsx
+++ b/frontend/src/views/favorites/FavoritesPage.tsx
@@ -5,6 +5,7 @@ import { useFavoritesViewModel } from '@/viewmodels/favorites/useFavoritesViewMo
 import FavoriteLocationsTab from './FavoriteLocationsTab';
 import type { FavoriteEventItem } from '@/models/event';
 import { EventCoverImage } from '@/components/EventCoverImage';
+import { RatingWithCount } from '@/components/RatingWithCount';
 import { getEventCardBadgePresentation } from '@/utils/eventStatus';
 import '@/styles/my-events.css';
 import '@/styles/discover.css';
@@ -79,10 +80,12 @@ function FavoriteCard({ item }: { item: FavoriteEventItem }) {
           <span className="dc-card-participants">
             {item.approved_participant_count ?? 0} participant{item.approved_participant_count === 1 ? '' : 's'}
           </span>
-          {item.host_score?.final_score != null && (
-            <span className="dc-card-score">
-              {'★'} {item.host_score.final_score.toFixed(1)}
-            </span>
+          {item.host_score && (
+            <RatingWithCount
+              score={item.host_score.final_score}
+              count={item.host_score.hosted_event_rating_count}
+              className="dc-card-score"
+            />
           )}
         </div>
       </div>

--- a/frontend/src/views/profile/ProfilePage.tsx
+++ b/frontend/src/views/profile/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { EventCoverImage } from '@/components/EventCoverImage';
+import { RatingWithCount } from '@/components/RatingWithCount';
 import { useProfileViewModel } from '../../viewmodels/profile/useProfileViewModel';
 import type { BadgeCategory, CatalogBadge, EarnedBadge, EventSummary } from '../../models/profile';
 import { getEventLifecyclePresentation } from '@/utils/eventStatus';
@@ -338,10 +339,12 @@ function ProfileHistoryCard({ event }: { event: EventSummary }) {
           <span className="dc-card-participants">
             {event.approved_participant_count ?? 0} participant{event.approved_participant_count === 1 ? '' : 's'}
           </span>
-          {event.host_score?.final_score != null && (
-            <span className="dc-card-score">
-              {'★'} {event.host_score.final_score.toFixed(1)}
-            </span>
+          {event.host_score && (
+            <RatingWithCount
+              score={event.host_score.final_score}
+              count={event.host_score.hosted_event_rating_count}
+              className="dc-card-score"
+            />
           )}
         </div>
       </div>

--- a/frontend/src/views/profile/ProfilePublicSections.tsx
+++ b/frontend/src/views/profile/ProfilePublicSections.tsx
@@ -1,3 +1,4 @@
+import { RatingWithCount } from '@/components/RatingWithCount';
 import type { ProfileEquipmentItem, PublicProfile, ShowcaseImageItem } from '@/models/profile';
 
 function getProfileInitial(profile: Pick<PublicProfile, 'display_name' | 'username'>): string {
@@ -21,6 +22,8 @@ export function ProfilePublicHero({
   >;
   eyebrow?: string;
 }) {
+  const totalRatings = profile.host_rating_count + profile.participant_rating_count;
+
   return (
     <section className="profile-public-hero">
       <div className="profile-public-avatar" aria-hidden={!profile.avatar_url}>
@@ -41,9 +44,11 @@ export function ProfilePublicHero({
       </div>
 
       <div className="profile-public-rating-card" aria-label="Profile rating">
-        <span className="profile-public-rating-value">
-          {profile.final_score != null ? `★ ${profile.final_score.toFixed(1)}` : 'New'}
-        </span>
+        <RatingWithCount
+          score={profile.final_score}
+          count={totalRatings}
+          className="profile-public-rating-value"
+        />
         <span className="profile-public-rating-summary">{formatRatingSummary(profile)}</span>
         <span className="profile-public-rating-breakdown">
           Host: {profile.host_rating_count} · Participant: {profile.participant_rating_count}


### PR DESCRIPTION
## 📋 Summary
Shows rating counts alongside rating scores across the web UI, while hiding rating text when no rating exists.

## 🔄 Changes
- Added a shared `RatingWithCount` component for consistent rating display
- Updated profile, event detail, Discover, My Events, and Favorites rating displays
- Shows ratings like `★ 4.7 (12)` when count is available
- Keeps score-only display if the count is missing during backend rollout
- Hides rating UI when there are no ratings
- Removed the duplicate Host Score metric from the event detail participants/saves row

## 🧪 Testing
- `npm test -- RatingWithCount.test.ts`
- `npm run build`

## 🔗 Related
Related to #499 
