### PR TITLE
feat(mobile): allow multi-select category filter in discovery

### DIFF
--- a/mobile/src/components/home/CategoryChips.test.tsx
+++ b/mobile/src/components/home/CategoryChips.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import CategoryChips from './CategoryChips';
+
+jest.mock('react-native', () => {
+  const ReactLocal = require('react');
+  const rnProps = new Set([
+    'accessibilityLabel',
+    'accessibilityRole',
+    'activeOpacity',
+    'contentContainerStyle',
+    'horizontal',
+    'numberOfLines',
+    'showsHorizontalScrollIndicator',
+    'testID',
+  ]);
+
+  const strip = (props: any) => {
+    const out = { ...props };
+    if (out.accessibilityLabel) out['aria-label'] = out.accessibilityLabel;
+    if (out.accessibilityRole) out.role = out.accessibilityRole;
+    if (out.testID) out['data-testid'] = out.testID;
+    rnProps.forEach((p) => delete out[p]);
+    return out;
+  };
+
+  const mergeStyle = (style: any) => {
+    if (Array.isArray(style)) return Object.assign({}, ...style);
+    return style;
+  };
+
+  return {
+    ScrollView: ({ children, style, contentContainerStyle, ...props }: any) =>
+      ReactLocal.createElement(
+        'div',
+        { style: mergeStyle([style, contentContainerStyle]), ...strip(props) },
+        children,
+      ),
+    StyleSheet: { create: (s: any) => s },
+    Text: ({ children, style, ...props }: any) =>
+      ReactLocal.createElement('span', { style: mergeStyle(style), ...strip(props) }, children),
+    TouchableOpacity: ({ children, style, onPress, ...props }: any) =>
+      ReactLocal.createElement(
+        'button',
+        { type: 'button', onClick: onPress, style: mergeStyle(style), ...strip(props) },
+        children,
+      ),
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const ReactLocal = require('react');
+
+  return {
+    Feather: ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', {
+        'data-icon-library': 'feather',
+        'data-icon': name,
+      }),
+  };
+});
+
+jest.mock('@/theme', () => ({
+  useTheme: () => ({
+    theme: {
+      surface: '#FFFFFF',
+      border: '#D1D5DB',
+      primary: '#6366F1',
+      text: '#111827',
+      textOnPrimary: '#FFFFFF',
+    },
+  }),
+}));
+
+const categories = [
+  { id: 1, name: 'Sports' },
+  { id: 2, name: 'Music' },
+];
+
+describe('CategoryChips', () => {
+  it('renders selected category chips with remove affordances', () => {
+    const { container } = render(
+      <CategoryChips
+        categories={categories}
+        selectedCategoryIds={[1, 2]}
+        onToggleCategory={jest.fn()}
+        onClearCategories={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Remove Sports category filter')).toBeTruthy();
+    expect(screen.getByLabelText('Remove Music category filter')).toBeTruthy();
+    expect(container.querySelectorAll('[data-icon="x"]').length).toBe(2);
+  });
+
+  it('toggles categories and clears all selected categories', () => {
+    const onToggleCategory = jest.fn();
+    const onClearCategories = jest.fn();
+
+    render(
+      <CategoryChips
+        categories={categories}
+        selectedCategoryIds={[1]}
+        onToggleCategory={onToggleCategory}
+        onClearCategories={onClearCategories}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Remove Sports category filter'));
+    fireEvent.click(screen.getByLabelText('Add Music category filter'));
+    fireEvent.click(screen.getByLabelText('Clear selected categories'));
+
+    expect(onToggleCategory).toHaveBeenNthCalledWith(1, 1);
+    expect(onToggleCategory).toHaveBeenNthCalledWith(2, 2);
+    expect(onClearCategories).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/components/home/CategoryChips.tsx
+++ b/mobile/src/components/home/CategoryChips.tsx
@@ -1,22 +1,26 @@
 import React, { useMemo } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import { EventCategory } from '@/models/event';
 import { useTheme } from '@/theme';
 import type { Theme } from '@/theme';
 
 interface CategoryChipsProps {
   categories: readonly EventCategory[];
-  selectedCategoryId: number | null;
-  onSelectCategory: (categoryId: number | null) => void;
+  selectedCategoryIds: readonly number[];
+  onToggleCategory: (categoryId: number) => void;
+  onClearCategories: () => void;
 }
 
 export default function CategoryChips({
   categories,
-  selectedCategoryId,
-  onSelectCategory,
+  selectedCategoryIds,
+  onToggleCategory,
+  onClearCategories,
 }: CategoryChipsProps) {
   const { theme } = useTheme();
   const styles = useMemo(() => makeStyles(theme), [theme]);
+  const hasSelection = selectedCategoryIds.length > 0;
 
   return (
     <ScrollView
@@ -25,14 +29,17 @@ export default function CategoryChips({
       contentContainerStyle={styles.container}
     >
       <TouchableOpacity
-        style={[styles.chip, selectedCategoryId === null && styles.chipSelected]}
-        onPress={() => onSelectCategory(null)}
+        style={[styles.chip, !hasSelection && styles.chipSelected]}
+        onPress={onClearCategories}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Clear selected categories"
+        testID="category-chip-clear-all"
       >
         <Text
           style={[
             styles.chipText,
-            selectedCategoryId === null && styles.chipTextSelected,
+            !hasSelection && styles.chipTextSelected,
           ]}
           numberOfLines={1}
         >
@@ -41,14 +48,21 @@ export default function CategoryChips({
       </TouchableOpacity>
 
       {categories.map((category) => {
-        const isSelected = selectedCategoryId === category.id;
+        const isSelected = selectedCategoryIds.includes(category.id);
 
         return (
           <TouchableOpacity
             key={category.id}
             style={[styles.chip, isSelected && styles.chipSelected]}
-            onPress={() => onSelectCategory(category.id)}
+            onPress={() => onToggleCategory(category.id)}
             activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel={
+              isSelected
+                ? `Remove ${category.name} category filter`
+                : `Add ${category.name} category filter`
+            }
+            testID={`category-chip-${category.id}`}
           >
             <Text
               style={[styles.chipText, isSelected && styles.chipTextSelected]}
@@ -56,6 +70,9 @@ export default function CategoryChips({
             >
               {category.name}
             </Text>
+            {isSelected ? (
+              <Feather name="x" size={14} color={theme.textOnPrimary} />
+            ) : null}
           </TouchableOpacity>
         );
       })}
@@ -79,6 +96,8 @@ function makeStyles(t: Theme) {
       borderColor: t.border,
       alignItems: 'center',
       justifyContent: 'center',
+      flexDirection: 'row',
+      gap: 6,
     },
     chipSelected: {
       backgroundColor: t.primary,

--- a/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
+++ b/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
@@ -699,6 +699,8 @@ describe('useHomeViewModel', () => {
         result.current.applyFilterDraft();
       });
 
+      expect(result.current.selectedCategoryIds).toEqual([2]);
+
       await waitFor(() => {
         expect(mockListEvents).toHaveBeenLastCalledWith(
           expect.objectContaining({
@@ -734,12 +736,14 @@ describe('useHomeViewModel', () => {
         result.current.openFilterModal();
       });
 
+      expect(result.current.filterDraft.categoryIds).toEqual([1, 4]);
+
       act(() => {
         result.current.toggleDraftCategory(2);
       });
 
       await waitFor(() => {
-        expect(result.current.filterDraft.categoryIds).toEqual([2]);
+        expect(result.current.filterDraft.categoryIds).toEqual([1, 4, 2]);
       });
 
       act(() => {
@@ -749,7 +753,7 @@ describe('useHomeViewModel', () => {
       await waitFor(() => {
         expect(mockListEvents).toHaveBeenLastCalledWith(
           expect.objectContaining({
-            category_ids: expect.arrayContaining([1, 2, 4]),
+            category_ids: [1, 4, 2],
           }),
           'mock-token',
         );

--- a/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
+++ b/mobile/src/viewmodels/home/useHomeViewModel.test.tsx
@@ -431,14 +431,38 @@ describe('useHomeViewModel', () => {
     expect(result.current.searchText).toBe('music');
   });
 
-  it('updates selected category id', async () => {
+  it('toggles selected category ids', async () => {
     const { result } = renderHook(() => useHomeViewModel());
 
     await act(async () => {
-      result.current.selectCategory(2);
+      result.current.toggleCategory(2);
+      result.current.toggleCategory(4);
     });
 
-    expect(result.current.selectedCategoryId).toBe(2);
+    expect(result.current.selectedCategoryIds).toEqual([2, 4]);
+
+    await act(async () => {
+      result.current.toggleCategory(2);
+    });
+
+    expect(result.current.selectedCategoryIds).toEqual([4]);
+  });
+
+  it('clears selected category ids', async () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await act(async () => {
+      result.current.toggleCategory(2);
+      result.current.toggleCategory(4);
+    });
+
+    expect(result.current.selectedCategoryIds).toEqual([2, 4]);
+
+    await act(async () => {
+      result.current.clearSelectedCategories();
+    });
+
+    expect(result.current.selectedCategoryIds).toEqual([]);
   });
 
   it('refreshes events from the first page', async () => {
@@ -685,7 +709,7 @@ describe('useHomeViewModel', () => {
       });
     });
 
-    it('keeps selected chip category together with modal categories', async () => {
+    it('keeps selected chip categories together with modal categories', async () => {
       const { result } = renderHook(() => useHomeViewModel());
 
       await waitFor(() => {
@@ -693,13 +717,14 @@ describe('useHomeViewModel', () => {
       });
 
       act(() => {
-        result.current.selectCategory(1);
+        result.current.toggleCategory(1);
+        result.current.toggleCategory(4);
       });
 
       await waitFor(() => {
         expect(mockListEvents).toHaveBeenLastCalledWith(
           expect.objectContaining({
-            category_ids: [1],
+            category_ids: [1, 4],
           }),
           'mock-token',
         );
@@ -724,7 +749,42 @@ describe('useHomeViewModel', () => {
       await waitFor(() => {
         expect(mockListEvents).toHaveBeenLastCalledWith(
           expect.objectContaining({
-            category_ids: expect.arrayContaining([1, 2]),
+            category_ids: expect.arrayContaining([1, 2, 4]),
+          }),
+          'mock-token',
+        );
+      });
+    });
+
+    it('clears chip category filters from the discovery request', async () => {
+      const { result } = renderHook(() => useHomeViewModel());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      act(() => {
+        result.current.toggleCategory(1);
+        result.current.toggleCategory(4);
+      });
+
+      await waitFor(() => {
+        expect(mockListEvents).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            category_ids: [1, 4],
+          }),
+          'mock-token',
+        );
+      });
+
+      act(() => {
+        result.current.clearSelectedCategories();
+      });
+
+      await waitFor(() => {
+        expect(mockListEvents).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            category_ids: undefined,
           }),
           'mock-token',
         );

--- a/mobile/src/viewmodels/home/useHomeViewModel.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.ts
@@ -433,7 +433,6 @@ export function useHomeViewModel(): HomeViewModel {
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [filterError, setFilterError] = useState<string | null>(null);
   const [appliedSearchText, setAppliedSearchText] = useState('');
-  const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
 
   const [appliedFilters, setAppliedFilters] =
     useState<HomeFiltersDraft>(DEFAULT_FILTERS);
@@ -609,10 +608,6 @@ export function useHomeViewModel(): HomeViewModel {
 
         setApiError(null);
 
-        const combinedCategoryIds = Array.from(
-          new Set([...selectedCategoryIds, ...appliedFilters.categoryIds]),
-        );
-
         const response = await listEvents(
           {
             lat: Number(activeLocation.lat),
@@ -620,7 +615,9 @@ export function useHomeViewModel(): HomeViewModel {
             radius_meters: appliedFilters.radiusKm * 1000,
             q: appliedSearchText || undefined,
             category_ids:
-              combinedCategoryIds.length > 0 ? combinedCategoryIds : undefined,
+              appliedFilters.categoryIds.length > 0
+                ? appliedFilters.categoryIds
+                : undefined,
             privacy_levels:
               appliedFilters.privacyLevels.length > 0
                 ? appliedFilters.privacyLevels
@@ -659,7 +656,6 @@ export function useHomeViewModel(): HomeViewModel {
       selectedLocation,
       defaultLocation,
       appliedSearchText,
-      selectedCategoryIds,
       appliedFilters,
     ],
   );
@@ -729,15 +725,19 @@ export function useHomeViewModel(): HomeViewModel {
   }, [searchText]);
 
   const toggleCategory = useCallback((categoryId: number) => {
-    setSelectedCategoryIds((prev) => (
-      prev.includes(categoryId)
-        ? prev.filter((id) => id !== categoryId)
-        : [...prev, categoryId]
-    ));
+    setAppliedFilters((prev) => ({
+      ...prev,
+      categoryIds: prev.categoryIds.includes(categoryId)
+        ? prev.categoryIds.filter((id) => id !== categoryId)
+        : [...prev.categoryIds, categoryId],
+    }));
   }, []);
 
   const clearSelectedCategories = useCallback(() => {
-    setSelectedCategoryIds([]);
+    setAppliedFilters((prev) => ({
+      ...prev,
+      categoryIds: [],
+    }));
   }, []);
 
   const openLocationModal = useCallback(() => {
@@ -996,10 +996,6 @@ export function useHomeViewModel(): HomeViewModel {
           ? persistedSelection.location
           : refreshedDefaultLocation;
 
-      const combinedCategoryIds = Array.from(
-        new Set([...selectedCategoryIds, ...appliedFilters.categoryIds]),
-      );
-
       const response = await listEvents(
         {
           lat: Number(activeLocation.lat),
@@ -1007,7 +1003,9 @@ export function useHomeViewModel(): HomeViewModel {
           radius_meters: appliedFilters.radiusKm * 1000,
           q: appliedSearchText || undefined,
           category_ids:
-            combinedCategoryIds.length > 0 ? combinedCategoryIds : undefined,
+            appliedFilters.categoryIds.length > 0
+              ? appliedFilters.categoryIds
+              : undefined,
           privacy_levels:
             appliedFilters.privacyLevels.length > 0
               ? appliedFilters.privacyLevels
@@ -1034,7 +1032,6 @@ export function useHomeViewModel(): HomeViewModel {
     resolveDefaultLocation,
     locationSelectionScope,
     appliedSearchText,
-    selectedCategoryIds,
     appliedFilters,
   ]);
 
@@ -1055,7 +1052,7 @@ export function useHomeViewModel(): HomeViewModel {
         : DEFAULT_LOCATION_LABEL,
     locationQuery,
     categories,
-    selectedCategoryIds,
+    selectedCategoryIds: appliedFilters.categoryIds,
     searchText,
     events,
     isLoading,

--- a/mobile/src/viewmodels/home/useHomeViewModel.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.ts
@@ -355,7 +355,7 @@ export interface HomeViewModel {
   isLoadingFavoriteLocations: boolean;
   favoriteLocationsError: string | null;
   categories: readonly EventCategory[];
-  selectedCategoryId: number | null;
+  selectedCategoryIds: readonly number[];
   searchText: string;
   events: EventSummary[];
   isLoading: boolean;
@@ -372,7 +372,8 @@ export interface HomeViewModel {
   toggleViewMode: () => void;
   updateSearchText: (value: string) => void;
   submitSearch: () => void;
-  selectCategory: (categoryId: number | null) => void;
+  toggleCategory: (categoryId: number) => void;
+  clearSelectedCategories: () => void;
   openFilterModal: () => void;
   closeFilterModal: () => void;
   resetFilterDraft: () => void;
@@ -432,7 +433,7 @@ export function useHomeViewModel(): HomeViewModel {
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [filterError, setFilterError] = useState<string | null>(null);
   const [appliedSearchText, setAppliedSearchText] = useState('');
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
 
   const [appliedFilters, setAppliedFilters] =
     useState<HomeFiltersDraft>(DEFAULT_FILTERS);
@@ -608,12 +609,9 @@ export function useHomeViewModel(): HomeViewModel {
 
         setApiError(null);
 
-        const combinedCategoryIds =
-          selectedCategoryId != null
-            ? Array.from(
-              new Set([selectedCategoryId, ...appliedFilters.categoryIds]),
-            )
-            : appliedFilters.categoryIds;
+        const combinedCategoryIds = Array.from(
+          new Set([...selectedCategoryIds, ...appliedFilters.categoryIds]),
+        );
 
         const response = await listEvents(
           {
@@ -656,7 +654,14 @@ export function useHomeViewModel(): HomeViewModel {
         if (mode === 'loadMore') setIsLoadingMore(false);
       }
     },
-    [token, selectedLocation, defaultLocation, appliedSearchText, selectedCategoryId, appliedFilters],
+    [
+      token,
+      selectedLocation,
+      defaultLocation,
+      appliedSearchText,
+      selectedCategoryIds,
+      appliedFilters,
+    ],
   );
 
   useEffect(() => {
@@ -723,8 +728,16 @@ export function useHomeViewModel(): HomeViewModel {
     setAppliedSearchText(searchText.trim());
   }, [searchText]);
 
-  const selectCategory = useCallback((categoryId: number | null) => {
-    setSelectedCategoryId(categoryId);
+  const toggleCategory = useCallback((categoryId: number) => {
+    setSelectedCategoryIds((prev) => (
+      prev.includes(categoryId)
+        ? prev.filter((id) => id !== categoryId)
+        : [...prev, categoryId]
+    ));
+  }, []);
+
+  const clearSelectedCategories = useCallback(() => {
+    setSelectedCategoryIds([]);
   }, []);
 
   const openLocationModal = useCallback(() => {
@@ -983,12 +996,9 @@ export function useHomeViewModel(): HomeViewModel {
           ? persistedSelection.location
           : refreshedDefaultLocation;
 
-      const combinedCategoryIds =
-        selectedCategoryId != null
-          ? Array.from(
-            new Set([selectedCategoryId, ...appliedFilters.categoryIds]),
-          )
-          : appliedFilters.categoryIds;
+      const combinedCategoryIds = Array.from(
+        new Set([...selectedCategoryIds, ...appliedFilters.categoryIds]),
+      );
 
       const response = await listEvents(
         {
@@ -1024,7 +1034,7 @@ export function useHomeViewModel(): HomeViewModel {
     resolveDefaultLocation,
     locationSelectionScope,
     appliedSearchText,
-    selectedCategoryId,
+    selectedCategoryIds,
     appliedFilters,
   ]);
 
@@ -1045,7 +1055,7 @@ export function useHomeViewModel(): HomeViewModel {
         : DEFAULT_LOCATION_LABEL,
     locationQuery,
     categories,
-    selectedCategoryId,
+    selectedCategoryIds,
     searchText,
     events,
     isLoading,
@@ -1087,7 +1097,8 @@ export function useHomeViewModel(): HomeViewModel {
     favoriteLocationsError,
     updateSearchText,
     submitSearch,
-    selectCategory,
+    toggleCategory,
+    clearSelectedCategories,
     openFilterModal,
     closeFilterModal,
     resetFilterDraft,

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -19,6 +19,7 @@ import LoadingState from '@/components/home/LoadingState';
 import EventCard from '@/components/events/EventCard';
 import FiltersBottomSheet from '@/components/home/FiltersBottomSheet';
 import EventMapView from '@/components/home/EventMapView';
+import CategoryChips from '@/components/home/CategoryChips';
 import { useHomeViewModel } from '@/viewmodels/home/useHomeViewModel';
 import LocationPickerPanel from '@/components/home/LocationPickerPanel';
 import { useUnreadNotificationCount } from '@/viewmodels/notifications/useUnreadNotificationCount';
@@ -222,6 +223,13 @@ export default function HomeView() {
               onPressMapView={() => {
                 if (vm.viewMode !== 'MAP') vm.toggleViewMode();
               }}
+            />
+
+            <CategoryChips
+              categories={vm.categories}
+              selectedCategoryIds={vm.selectedCategoryIds}
+              onToggleCategory={vm.toggleCategory}
+              onClearCategories={vm.clearSelectedCategories}
             />
 
             {vm.apiError ? (


### PR DESCRIPTION
## Summary
- Add multi-select behavior to the discovery category chips
- Send selected discovery chip IDs together with filter sheet IDs as category_ids
- Show selected chips with remove affordances and clear-all behavior via All
- Fix EventCard accessibility label crash from missing privacy formatter

Closes #485

## Testing
- Added/updated unit tests for discovery category chip selection and request serialization
- Manually tested on Android: selected multiple discovery categories, removed active chips, cleared selection with All, and confirmed the discovery screen no longer crashes on event cards