### PR TITLE
fix(frontend): Improve host event create and edit flows

### DIFF
--- a/frontend/src/components/PointLocationPicker.tsx
+++ b/frontend/src/components/PointLocationPicker.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AdvancedMarker,
+  Map as GoogleMap,
+  useMap,
+} from '@vis.gl/react-google-maps';
+import { useTheme } from '@/contexts/ThemeContext';
+import { GOOGLE_MAPS_MAP_ID, isGoogleMapsConfigured } from '@/components/GoogleMapsProvider';
+import type { LocationSuggestion } from '@/models/event';
+import { reverseGeocode } from '@/services/eventService';
+
+interface PointLocationPickerProps {
+  lat: number | null;
+  lon: number | null;
+  address?: string | null;
+  disabled?: boolean;
+  onSelect: (suggestion: LocationSuggestion) => void;
+}
+
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+function MapClickHandler({
+  disabled,
+  onMapClick,
+}: {
+  disabled?: boolean;
+  onMapClick: (lat: number, lng: number) => void;
+}) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map || disabled) return;
+    const listener = map.addListener('click', (event: google.maps.MapMouseEvent) => {
+      if (event.latLng) {
+        onMapClick(event.latLng.lat(), event.latLng.lng());
+      }
+    });
+    return () => listener.remove();
+  }, [disabled, map, onMapClick]);
+
+  return null;
+}
+
+function MapRecenter({ center }: { center: LatLng }) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+    map.panTo(center);
+  }, [center, map]);
+
+  return null;
+}
+
+function makeCoordinateSuggestion(lat: number, lon: number, displayName?: string | null): LocationSuggestion {
+  return {
+    display_name: displayName?.trim() || `${lat.toFixed(5)}, ${lon.toFixed(5)}`,
+    lat: String(lat),
+    lon: String(lon),
+  };
+}
+
+export default function PointLocationPicker({
+  lat,
+  lon,
+  address,
+  disabled,
+  onSelect,
+}: PointLocationPickerProps) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+  const configured = isGoogleMapsConfigured();
+  const [isResolving, setIsResolving] = useState(false);
+
+  const center = useMemo<LatLng>(() => {
+    if (lat != null && lon != null) return { lat, lng: lon };
+    return { lat: 41.0082, lng: 28.9784 };
+  }, [lat, lon]);
+
+  const handleMapClick = useCallback(
+    async (clickedLat: number, clickedLng: number) => {
+      if (disabled) return;
+      setIsResolving(true);
+      try {
+        const resolved = await reverseGeocode(clickedLat, clickedLng);
+        onSelect(makeCoordinateSuggestion(clickedLat, clickedLng, resolved?.display_name));
+      } catch {
+        onSelect(makeCoordinateSuggestion(clickedLat, clickedLng));
+      } finally {
+        setIsResolving(false);
+      }
+    },
+    [disabled, onSelect],
+  );
+
+  if (!configured) {
+    return (
+      <div className="ce-point-map-placeholder">
+        Set <code>VITE_GOOGLE_MAPS_WEB_API_KEY</code> to choose a point on the map.
+      </div>
+    );
+  }
+
+  return (
+    <div className="ce-point-map">
+      <GoogleMap
+        key={isDark ? 'dark' : 'light'}
+        mapId={GOOGLE_MAPS_MAP_ID}
+        defaultCenter={center}
+        defaultZoom={lat != null && lon != null ? 14 : 11}
+        colorScheme={isDark ? 'DARK' : 'LIGHT'}
+        gestureHandling="greedy"
+        disableDefaultUI={false}
+        mapTypeControl={false}
+        streetViewControl={false}
+        fullscreenControl={false}
+        clickableIcons={false}
+        className="ce-point-map-surface"
+      >
+        <MapClickHandler disabled={disabled} onMapClick={handleMapClick} />
+        <MapRecenter center={center} />
+        {lat != null && lon != null && (
+          <AdvancedMarker position={{ lat, lng: lon }}>
+            <div className="ce-point-marker" aria-label={address ?? 'Selected location'}>
+              <span />
+            </div>
+          </AdvancedMarker>
+        )}
+      </GoogleMap>
+      <div className="ce-point-map-footer">
+        {isResolving ? 'Resolving address...' : 'Click the map to choose the event point.'}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/models/profile.ts
+++ b/frontend/src/models/profile.ts
@@ -2,7 +2,7 @@ export interface EventSummary {
   id: string;
   title: string;
   start_time: string;
-  end_time?: string;
+  end_time?: string | null;
   status: string;
   category?: string;
   category_name?: string;

--- a/frontend/src/styles/create-event.css
+++ b/frontend/src/styles/create-event.css
@@ -930,6 +930,42 @@
   font-size: 14px;
 }
 
+.ce-point-map {
+  margin-top: 10px;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  background: #ffffff;
+}
+
+.ce-point-map-surface {
+  width: 100%;
+  height: 260px;
+}
+
+.ce-point-map-footer {
+  padding: 10px 12px;
+  border-top: 1px solid #e5e7eb;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.ce-point-map-placeholder {
+  margin-top: 10px;
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 24px;
+  color: #64748b;
+  background: #f1f5f9;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  font-size: 14px;
+}
+
 .ce-route-list-header {
   font-size: 12px;
   font-weight: 700;
@@ -1086,4 +1122,22 @@
   font-weight: 800;
   color: #ffffff;
   line-height: 1;
+}
+
+.ce-point-marker {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.15);
+}
+
+.ce-point-marker span {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 3px solid #ffffff;
+  background: #111827;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }

--- a/frontend/src/viewmodels/event/useCreateEventViewModel.ts
+++ b/frontend/src/viewmodels/event/useCreateEventViewModel.ts
@@ -395,6 +395,7 @@ export function useCreateEventViewModel() {
       lon: parseFloat(suggestion.lon),
     }));
     setLocationResults([]);
+    setErrors((prev) => ({ ...prev, location: undefined }));
   }, []);
 
   const addTag = useCallback(() => {

--- a/frontend/src/viewmodels/event/useEditEventViewModel.ts
+++ b/frontend/src/viewmodels/event/useEditEventViewModel.ts
@@ -463,6 +463,34 @@ export function useEditEventViewModel(eventId: string | undefined) {
       setEvent(refreshed);
       setForm(formFromEvent(refreshed));
       setUpdateResult(result);
+      if (typeof window !== 'undefined') {
+        const updatedEventSummary = {
+          eventId: refreshed.id,
+          title: refreshed.title,
+          status: refreshed.status,
+          category_name: refreshed.category?.name ?? null,
+          start_time: refreshed.start_time,
+          end_time: refreshed.end_time,
+          location_address: refreshed.location.address,
+          approved_participant_count: refreshed.approved_participant_count,
+          image_url: refreshed.image_url,
+          privacy_level: refreshed.privacy_level,
+          host_score: refreshed.host_score,
+        };
+        try {
+          window.sessionStorage.setItem(
+            'sem_recent_event_update',
+            JSON.stringify(updatedEventSummary),
+          );
+        } catch {
+          /* ignore */
+        }
+        window.dispatchEvent(
+          new CustomEvent('sem:event-updated', {
+            detail: updatedEventSummary,
+          }),
+        );
+      }
       const pendingReconfirmationCount = Math.max(
         refreshed.pending_participant_count,
         result.participants_marked_pending,

--- a/frontend/src/viewmodels/profile/useProfileViewModel.ts
+++ b/frontend/src/viewmodels/profile/useProfileViewModel.ts
@@ -19,6 +19,7 @@ import { formatEventLocation } from '@/utils/eventLocation';
 
 const SEARCH_DEBOUNCE_MS = 300;
 const MIN_PASSWORD_LENGTH = 8;
+const RECENT_EVENT_UPDATE_STORAGE_KEY = 'sem_recent_event_update';
 
 type ChangePasswordErrors = {
   currentPassword?: string;
@@ -33,6 +34,10 @@ type EquipmentDraft = {
   imageUrl: string;
 };
 
+type RecentEventUpdate = Partial<EventSummary> & {
+  eventId?: string;
+};
+
 function createEmptyEquipmentDraft(): EquipmentDraft {
   return {
     id: null,
@@ -45,6 +50,32 @@ function createEmptyEquipmentDraft(): EquipmentDraft {
 function getBackendValidationMessage(err: ApiError): string {
   const details = err.details ? Object.values(err.details).filter(Boolean) : [];
   return details.length > 0 ? details.join(' ') : err.message;
+}
+
+function readRecentEventUpdate(): RecentEventUpdate | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(RECENT_EVENT_UPDATE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as RecentEventUpdate;
+    return typeof parsed.eventId === 'string' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function applyRecentEventUpdate(events: EventSummary[], recent: RecentEventUpdate | null): EventSummary[] {
+  if (!recent?.eventId) return events;
+  return events.map((event) => {
+    if (event.id !== recent.eventId) return event;
+    return {
+      ...event,
+      ...recent,
+      id: event.id,
+      category: event.category,
+      category_name: recent.category_name ?? event.category_name,
+    };
+  });
 }
 
 export function useProfileViewModel(token: string | null) {
@@ -139,7 +170,11 @@ export function useProfileViewModel(token: string | null) {
       );
       setLocationQuery('');
       setLocationCleared(false);
-      const visibleHosted = hosted.filter((event) => shouldShowProfileEvent(event.status));
+      const recentUpdate = readRecentEventUpdate();
+      const visibleHosted = applyRecentEventUpdate(
+        hosted.filter((event) => shouldShowProfileEvent(event.status)),
+        recentUpdate,
+      );
       const hostedIds = new Set(hosted.map((event) => event.id));
       const mergedAttended = [...upcoming, ...completed, ...canceled]
         .filter((event, index, arr) => arr.findIndex((candidate) => candidate.id === event.id) === index)
@@ -187,6 +222,14 @@ export function useProfileViewModel(token: string | null) {
     void fetchProfile();
     void fetchBadges();
   }, [fetchBadges, fetchProfile]);
+
+  useEffect(() => {
+    const refreshAfterEventUpdate = () => {
+      void fetchProfile();
+    };
+    window.addEventListener('sem:event-updated', refreshAfterEventUpdate);
+    return () => window.removeEventListener('sem:event-updated', refreshAfterEventUpdate);
+  }, [fetchProfile]);
 
   useEffect(
     () => () => {

--- a/frontend/src/views/events/CreateEventPage.tsx
+++ b/frontend/src/views/events/CreateEventPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/viewmodels/event/useCreateEventViewModel';
 import type { PreferredGender, LocationType } from '@/models/event';
 import { getEventCategoryPresentation } from '@/utils/eventCategoryPresentation';
+import PointLocationPicker from '@/components/PointLocationPicker';
 import RoutePointsEditor from '@/components/RoutePointsEditor';
 import '@/styles/create-event.css';
 
@@ -429,6 +430,16 @@ function CreateEventForm() {
               {vm.form.address && (
                 <p className="ce-selected-location">{vm.form.address}</p>
               )}
+              <PointLocationPicker
+                lat={vm.form.lat}
+                lon={vm.form.lon}
+                address={vm.form.address}
+                disabled={busy}
+                onSelect={(suggestion) => {
+                  vm.touchField('location');
+                  vm.selectLocation(suggestion);
+                }}
+              />
             </>
           ) : (
             <RoutePointsEditor

--- a/frontend/src/views/events/EditEventPage.tsx
+++ b/frontend/src/views/events/EditEventPage.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import PointLocationPicker from '@/components/PointLocationPicker';
 import RoutePointsEditor from '@/components/RoutePointsEditor';
 import { getEventCategoryPresentation } from '@/utils/eventCategoryPresentation';
 import { MAX_CONSTRAINTS } from '@/viewmodels/event/useCreateEventViewModel';
@@ -61,12 +62,34 @@ function CriticalChangeModal({
   );
 }
 
+function EditSuccessModal({
+  message,
+  onGoToEvent,
+}: {
+  message: string;
+  onGoToEvent: () => void;
+}) {
+  return (
+    <div className="ce-popup-overlay" role="presentation">
+      <div className="ce-popup" role="dialog" aria-modal="true" aria-labelledby="edit-success-title">
+        <div className="ce-popup-icon">&#10003;</div>
+        <h2 id="edit-success-title" className="ce-popup-title">Event Updated</h2>
+        <p className="ce-popup-message">{message}</p>
+        <button type="button" className="btn-primary ce-popup-btn" onClick={onGoToEvent}>
+          Back to Event
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function EditEventPage() {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const vm = useEditEventViewModel(id);
   const [pendingPreview, setPendingPreview] = useState<EditEventChangePreview | null>(null);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
   const busy = vm.isLoading || vm.isSaving;
 
   const handleSubmit = (e: FormEvent) => {
@@ -79,7 +102,10 @@ export default function EditEventPage() {
   const confirmSubmit = async () => {
     if (!pendingPreview) return;
     const result = await vm.handleSubmit(pendingPreview.request);
-    if (result) setPendingPreview(null);
+    if (result) {
+      setPendingPreview(null);
+      setShowSuccessModal(true);
+    }
   };
 
   if (vm.isLoading) {
@@ -114,6 +140,12 @@ export default function EditEventPage() {
           onConfirm={confirmSubmit}
         />
       )}
+      {showSuccessModal && vm.successMessage && (
+        <EditSuccessModal
+          message={vm.successMessage}
+          onGoToEvent={() => navigate(`/events/${vm.event?.id}`, { replace: true })}
+        />
+      )}
 
       <Link className="ce-edit-back-link" to={`/events/${vm.event.id}`}>
         &larr; {t('edit_event.back_to_event')}
@@ -121,11 +153,6 @@ export default function EditEventPage() {
       <h1 className="create-event-title">{t('edit_event.title')}</h1>
       <p className="create-event-subtitle">{t('edit_event.subtitle')}</p>
 
-      {vm.successMessage && (
-        <div className="success-banner" role="status">
-          {vm.successMessage}
-        </div>
-      )}
       {vm.apiError && <div className="error-banner">{vm.apiError}</div>}
 
       {!vm.canEdit && (
@@ -238,6 +265,13 @@ export default function EditEventPage() {
                 {t('edit_event.selected_coordinates', { lat: vm.form.lat.toFixed(5), lon: vm.form.lon.toFixed(5) })}
               </p>
             )}
+            <PointLocationPicker
+              lat={vm.form.lat}
+              lon={vm.form.lon}
+              address={vm.form.address}
+              disabled={busy || !vm.canEdit}
+              onSelect={vm.selectLocation}
+            />
             {vm.errors.location && <p className="field-error">{vm.errors.location}</p>}
           </div>
         ) : (


### PR DESCRIPTION
## 📋 Summary
Fixes several web host event flow issues around event creation, event editing feedback, and stale hosted event data after edits.

## 🔄 Changes
- Added map-based point location selection to the Create Event form
- Reused the point map picker in the Edit Event form
- Added a success popup after editing an event with a clear action back to event details
- Broadcasts/stores recent event update metadata after edit success
- Refreshes/patches profile hosted events so edited event details do not appear stale
- Clears point location validation after selecting a location from search or map

## 🧪 Testing
- `npm run build`

## 🔗 Related
Related to #645 
