### PR TITLE
feat(mobile): allow editing event photo

### DIFF
--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -325,6 +325,19 @@
         "schedule": "Schedule",
         "participation": "Participation"
       },
+      "image": {
+        "label": "Cover image",
+        "add": "Add Cover Image",
+        "change": "Change Cover Image",
+        "discard": "Discard Selected Image",
+        "uploading": "Uploading...",
+        "uploadSuccess": "Cover image updated successfully.",
+        "permissionTitle": "Permission required",
+        "permissionRequired": "Please allow access to your photo library to update the event image.",
+        "readFailed": "We could not read the selected image. Please try a different one.",
+        "processFailed": "We could not process the selected image. Please try a different one.",
+        "openFailed": "We could not open your photo library. Please try again."
+      },
       "fields": {
         "titleLabel": "Title",
         "titlePlaceholder": "Event title",

--- a/mobile/src/i18n/locales/tr.json
+++ b/mobile/src/i18n/locales/tr.json
@@ -325,6 +325,19 @@
         "schedule": "Program",
         "participation": "Katılım"
       },
+      "image": {
+        "label": "Kapak görseli",
+        "add": "Kapak Görseli Ekle",
+        "change": "Kapak Görselini Değiştir",
+        "discard": "Seçili Görseli Vazgeç",
+        "uploading": "Yükleniyor...",
+        "uploadSuccess": "Kapak görseli başarıyla güncellendi.",
+        "permissionTitle": "İzin gerekli",
+        "permissionRequired": "Etkinlik görselini güncellemek için fotoğraf kitaplığına erişime izin vermelisin.",
+        "readFailed": "Seçilen görsel okunamadı. Lütfen başka bir görsel dene.",
+        "processFailed": "Seçilen görsel işlenemedi. Lütfen başka bir görsel dene.",
+        "openFailed": "Fotoğraf kitaplığı açılamadı. Lütfen tekrar dene."
+      },
       "fields": {
         "titleLabel": "Başlık",
         "titlePlaceholder": "Etkinlik başlığı",

--- a/mobile/src/viewmodels/event/useCreateEventViewModel.ts
+++ b/mobile/src/viewmodels/event/useCreateEventViewModel.ts
@@ -224,7 +224,7 @@ function getPickedImageUriCandidates(uri: string): string[] {
   return [...new Set([uri, decodeFileUriOnce(uri), normalizePickedImageUri(uri)])];
 }
 
-async function preparePickedImageUri(uri: string): Promise<string> {
+export async function preparePickedImageUri(uri: string): Promise<string> {
   let lastError: unknown = null;
 
   for (const candidateUri of getPickedImageUriCandidates(uri)) {

--- a/mobile/src/viewmodels/event/useEditEventViewModel.test.tsx
+++ b/mobile/src/viewmodels/event/useEditEventViewModel.test.tsx
@@ -17,6 +17,14 @@ jest.mock('@/contexts/AuthContext', () => ({
 
 const mockGetEventDetail = jest.mocked(eventService.getEventDetail);
 const mockUpdateEvent = jest.mocked(eventService.updateEvent);
+const mockGetEventImageUploadUrl = jest.mocked(eventService.getEventImageUploadUrl);
+const mockUploadFileToPresignedUrl = jest.mocked(eventService.uploadFileToPresignedUrl);
+const mockConfirmEventImageUpload = jest.mocked(eventService.confirmEventImageUpload);
+const ImagePicker = require('expo-image-picker');
+const ImageManipulator = require('expo-image-manipulator');
+const mockLaunchImageLibraryAsync =
+  ImagePicker.launchImageLibraryAsync as jest.MockedFunction<any>;
+const mockManipulateAsync = ImageManipulator.manipulateAsync as jest.MockedFunction<any>;
 
 function makeEvent(overrides: Partial<EventDetail> = {}): EventDetail {
   return {
@@ -89,11 +97,39 @@ const updateResponse: UpdateEventResponse = {
   updated_at: '2026-04-03T12:00:00+03:00',
 };
 
+const uploadInitFixture = {
+  base_url: 'https://cdn.example.com/events/event-1/cover/v1-upload',
+  version: 1,
+  confirm_token: 'confirm-token',
+  uploads: [
+    {
+      variant: 'ORIGINAL' as const,
+      method: 'PUT',
+      url: 'https://upload.example.com/original',
+      headers: { 'Content-Type': 'image/jpeg' },
+    },
+    {
+      variant: 'SMALL' as const,
+      method: 'PUT',
+      url: 'https://upload.example.com/small',
+      headers: { 'Content-Type': 'image/jpeg' },
+    },
+  ],
+};
+
 describe('useEditEventViewModel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetEventDetail.mockResolvedValue(makeEvent());
     mockUpdateEvent.mockResolvedValue(updateResponse);
+    mockGetEventImageUploadUrl.mockResolvedValue(uploadInitFixture);
+    mockUploadFileToPresignedUrl.mockResolvedValue(undefined);
+    mockConfirmEventImageUpload.mockResolvedValue(undefined);
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///selected-cover.jpg' }],
+    });
+    mockManipulateAsync.mockImplementation(async (uri: string) => ({ uri }));
   });
 
   it('prefills the edit form from the current event detail', async () => {
@@ -176,5 +212,51 @@ describe('useEditEventViewModel', () => {
       'Capacity cannot be below current approved plus pending participants',
     );
     expect(mockUpdateEvent).not.toHaveBeenCalled();
+  });
+
+  it('uploads a selected image without patching event fields', async () => {
+    const refreshed = makeEvent({
+      image_url: 'https://cdn.example.com/events/event-1/cover/v2-small.jpg',
+    });
+    mockGetEventDetail
+      .mockResolvedValueOnce(makeEvent())
+      .mockResolvedValueOnce(refreshed);
+
+    const { result } = renderHook(() => useEditEventViewModel('event-1'));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.pickImage();
+    });
+
+    expect(result.current.selectedImageUri).toBe('file:///selected-cover.jpg');
+
+    let preview: ReturnType<typeof result.current.previewChanges> = null;
+    act(() => {
+      preview = result.current.previewChanges();
+    });
+
+    expect(preview).toEqual({
+      request: {},
+      changedFields: ['image_url'],
+      criticalChangeLabels: [],
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit(preview?.request);
+    });
+
+    expect(mockUpdateEvent).not.toHaveBeenCalled();
+    expect(mockGetEventImageUploadUrl).toHaveBeenCalledWith('event-1', 'mock-token');
+    expect(mockUploadFileToPresignedUrl).toHaveBeenCalledTimes(2);
+    expect(mockConfirmEventImageUpload).toHaveBeenCalledWith(
+      'event-1',
+      'confirm-token',
+      'mock-token',
+    );
+    expect(result.current.event?.image_url).toBe(
+      'https://cdn.example.com/events/event-1/cover/v2-small.jpg',
+    );
+    expect(result.current.imageUploadSuccessMessage).toBe('Cover image updated successfully.');
   });
 });

--- a/mobile/src/viewmodels/event/useEditEventViewModel.ts
+++ b/mobile/src/viewmodels/event/useEditEventViewModel.ts
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import * as ImageManipulator from 'expo-image-manipulator';
 import { ApiError } from '@/services/api';
-import { getEventDetail, updateEvent } from '@/services/eventService';
+import {
+  confirmEventImageUpload,
+  getEventDetail,
+  getEventImageUploadUrl,
+  updateEvent,
+  uploadFileToPresignedUrl,
+} from '@/services/eventService';
 import { useAuth } from '@/contexts/AuthContext';
 import {
   EventConstraint,
@@ -25,10 +34,13 @@ import {
   deriveRouteAddress,
   formatDateForForm,
   parseDateTime,
+  preparePickedImageUri,
   validateLiveDateInput,
   validateLiveTimeInput,
 } from '@/viewmodels/event/useCreateEventViewModel';
 import i18n from '@/i18n';
+
+export type EditEventSubmitResult = UpdateEventResponse | { image_upload_only: true };
 
 export interface EditEventChangePreview {
   request: UpdateEventRequest;
@@ -42,9 +54,13 @@ export interface EditEventViewModel {
   errors: CreateEventFormErrors;
   isLoading: boolean;
   isSaving: boolean;
+  isUploadingImage: boolean;
   apiError: string | null;
+  imageError: string | null;
   successMessage: string | null;
+  imageUploadSuccessMessage: string | null;
   updateResult: UpdateEventResponse | null;
+  selectedImageUri: string | null;
   locationSuggestions: LocationSuggestion[];
   isSearchingLocation: boolean;
   categoriesExpanded: boolean;
@@ -52,7 +68,7 @@ export interface EditEventViewModel {
   constraintDraftType: string;
   constraintDraftInfo: string;
   previewChanges: () => EditEventChangePreview | null;
-  handleSubmit: (request?: UpdateEventRequest) => Promise<UpdateEventResponse | null>;
+  handleSubmit: (request?: UpdateEventRequest) => Promise<EditEventSubmitResult | null>;
   updateField: <K extends keyof CreateEventFormData>(
     field: K,
     value: CreateEventFormData[K],
@@ -68,6 +84,8 @@ export interface EditEventViewModel {
   moveRoutePoint: (index: number, direction: -1 | 1) => void;
   updateRoutePointLabel: (index: number, label: string) => void;
   toggleCategoriesExpanded: () => void;
+  pickImage: () => Promise<void>;
+  removeImage: () => void;
   updateConstraintDraftType: (value: string) => void;
   updateConstraintDraftInfo: (value: string) => void;
   addConstraint: () => void;
@@ -304,6 +322,34 @@ function mapApiValidationErrors(err: ApiError): CreateEventFormErrors {
   return fieldErrors;
 }
 
+function getEditImageUploadErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    if (error.message === 'Network request failed') {
+      return 'The event was updated, but uploading the image failed because the network request did not complete.';
+    }
+
+    if (error.message === 'Missing upload instructions from server') {
+      return 'The server returned incomplete image upload instructions.';
+    }
+
+    if (error.message.startsWith('Unsupported upload method')) {
+      return 'The server returned an unsupported image upload method.';
+    }
+
+    if (error.message.startsWith('Upload failed with status')) {
+      return 'The event was updated, but uploading the image to storage failed.';
+    }
+
+    return error.message;
+  }
+
+  return 'The event was updated, but the image upload failed.';
+}
+
 export function useEditEventViewModel(eventId: string): EditEventViewModel {
   const { token } = useAuth();
   const [event, setEvent] = useState<EventDetail | null>(null);
@@ -311,9 +357,13 @@ export function useEditEventViewModel(eventId: string): EditEventViewModel {
   const [errors, setErrors] = useState<CreateEventFormErrors>({});
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [imageUploadSuccessMessage, setImageUploadSuccessMessage] = useState<string | null>(null);
   const [updateResult, setUpdateResult] = useState<UpdateEventResponse | null>(null);
+  const [selectedImageUri, setSelectedImageUri] = useState<string | null>(null);
   const [locationSuggestions, setLocationSuggestions] = useState<LocationSuggestion[]>([]);
   const [isSearchingLocation, setIsSearchingLocation] = useState(false);
   const [categoriesExpanded, setCategoriesExpanded] = useState(false);
@@ -341,7 +391,10 @@ export function useEditEventViewModel(eventId: string): EditEventViewModel {
       setEvent(data);
       setFormData(formFromEvent(data));
       setErrors({});
+      setImageError(null);
+      setSelectedImageUri(null);
       setSuccessMessage(null);
+      setImageUploadSuccessMessage(null);
       setUpdateResult(null);
     } catch (err) {
       setEvent(null);
@@ -476,41 +529,120 @@ export function useEditEventViewModel(eventId: string): EditEventViewModel {
 
     const preview = buildUpdateRequest(formData, event);
     if (preview.changedFields.length === 0) {
-      setApiError(i18n.t('events.edit.errors.noChanges'));
-      return null;
+      if (!selectedImageUri) {
+        setApiError(i18n.t('events.edit.errors.noChanges'));
+        return null;
+      }
+      return {
+        request: {},
+        changedFields: ['image_url'],
+        criticalChangeLabels: [],
+      };
+    }
+    if (selectedImageUri && !preview.changedFields.includes('image_url')) {
+      preview.changedFields.push('image_url');
     }
 
     setErrors({});
     setApiError(null);
     return preview;
-  }, [canEdit, event, formData, validate]);
+  }, [canEdit, event, formData, selectedImageUri, validate]);
+
+  const uploadEventImage = useCallback(
+    async (eventIdToUpload: string, imageUri: string, authToken: string): Promise<void> => {
+      setIsUploadingImage(true);
+      try {
+        const original = await ImageManipulator.manipulateAsync(
+          imageUri,
+          [{ resize: { width: 1200 } }],
+          { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG },
+        );
+        const small = await ImageManipulator.manipulateAsync(
+          imageUri,
+          [{ resize: { width: 400 } }],
+          { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG },
+        );
+
+        const uploadInit = await getEventImageUploadUrl(eventIdToUpload, authToken);
+        const originalUpload = uploadInit.uploads.find((upload) => upload.variant === 'ORIGINAL');
+        const smallUpload = uploadInit.uploads.find((upload) => upload.variant === 'SMALL');
+        if (!originalUpload || !smallUpload) {
+          throw new Error('Missing upload instructions from server');
+        }
+
+        await Promise.all([
+          uploadFileToPresignedUrl(
+            originalUpload.method,
+            originalUpload.url,
+            originalUpload.headers,
+            original.uri,
+          ),
+          uploadFileToPresignedUrl(
+            smallUpload.method,
+            smallUpload.url,
+            smallUpload.headers,
+            small.uri,
+          ),
+        ]);
+
+        await confirmEventImageUpload(eventIdToUpload, uploadInit.confirm_token, authToken);
+      } finally {
+        setIsUploadingImage(false);
+      }
+    },
+    [],
+  );
 
   const handleSubmit = useCallback(async (request?: UpdateEventRequest) => {
     if (!token || !event) return null;
 
     const preparedRequest = request ?? previewChanges()?.request;
     if (!preparedRequest) return null;
+    const shouldUpdateEvent = Object.keys(preparedRequest).length > 0;
+    const imageUriToUpload = selectedImageUri;
 
     setIsSaving(true);
     setApiError(null);
+    setImageError(null);
     setSuccessMessage(null);
+    setImageUploadSuccessMessage(null);
     setUpdateResult(null);
 
     try {
-      const result = await updateEvent(event.id, preparedRequest, token);
+      const result = shouldUpdateEvent
+        ? await updateEvent(event.id, preparedRequest, token)
+        : null;
+
+      if (imageUriToUpload) {
+        try {
+          await uploadEventImage(event.id, imageUriToUpload, token);
+          setSelectedImageUri(null);
+          setImageUploadSuccessMessage(i18n.t('events.edit.image.uploadSuccess'));
+        } catch (err) {
+          setImageError(getEditImageUploadErrorMessage(err));
+          if (!result) {
+            return null;
+          }
+        }
+      }
+
       const refreshed = await getEventDetail(event.id, token);
       setEvent(refreshed);
       setFormData(formFromEvent(refreshed));
       setErrors({});
       setUpdateResult(result);
-      setSuccessMessage(
-        result.reconfirmation_required
-          ? i18n.t('events.edit.successWithReconfirmation', {
-              count: result.participants_marked_pending,
-            })
-          : i18n.t('events.edit.success'),
-      );
-      return result;
+      if (result) {
+        setSuccessMessage(
+          result.reconfirmation_required
+            ? i18n.t('events.edit.successWithReconfirmation', {
+                count: result.participants_marked_pending,
+              })
+            : i18n.t('events.edit.success'),
+        );
+        return result;
+      }
+
+      return { image_upload_only: true as const };
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.details) {
@@ -524,7 +656,7 @@ export function useEditEventViewModel(eventId: string): EditEventViewModel {
     } finally {
       setIsSaving(false);
     }
-  }, [event, previewChanges, token]);
+  }, [event, previewChanges, selectedImageUri, token, uploadEventImage]);
 
   const updateField = useCallback(
     <K extends keyof CreateEventFormData>(field: K, value: CreateEventFormData[K]) => {
@@ -536,11 +668,61 @@ export function useEditEventViewModel(eventId: string): EditEventViewModel {
       const errorKey = (errorKeyMap[field] ?? field) as keyof CreateEventFormErrors;
       setErrors((prev) => ({ ...prev, [errorKey]: null }));
       setApiError(null);
+      setImageError(null);
       setSuccessMessage(null);
+      setImageUploadSuccessMessage(null);
       setUpdateResult(null);
     },
     [],
   );
+
+  const pickImage = useCallback(async () => {
+    setImageError(null);
+
+    try {
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (status !== 'granted') {
+        const message = i18n.t('events.edit.image.permissionRequired');
+        setImageError(message);
+        Alert.alert(i18n.t('events.edit.image.permissionTitle'), message);
+        return;
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        allowsEditing: true,
+        aspect: [16, 9],
+        quality: 0.8,
+      });
+
+      if (result.canceled) return;
+
+      const asset = result.assets[0];
+      if (!asset?.uri) {
+        setImageError(i18n.t('events.edit.image.readFailed'));
+        return;
+      }
+
+      try {
+        setSelectedImageUri(await preparePickedImageUri(asset.uri));
+      } catch {
+        setImageError(i18n.t('events.edit.image.processFailed'));
+        return;
+      }
+
+      setApiError(null);
+      setSuccessMessage(null);
+      setImageUploadSuccessMessage(null);
+    } catch {
+      setImageError(i18n.t('events.edit.image.openFailed'));
+    }
+  }, []);
+
+  const removeImage = useCallback(() => {
+    setSelectedImageUri(null);
+    setImageError(null);
+    setImageUploadSuccessMessage(null);
+  }, []);
 
   const handleLocationSearch = useCallback((query: string) => {
     updateField('locationQuery', query);
@@ -692,9 +874,13 @@ export function useEditEventViewModel(eventId: string): EditEventViewModel {
     errors,
     isLoading,
     isSaving,
+    isUploadingImage,
     apiError,
+    imageError,
     successMessage,
+    imageUploadSuccessMessage,
     updateResult,
+    selectedImageUri,
     locationSuggestions,
     isSearchingLocation,
     categoriesExpanded,
@@ -715,6 +901,8 @@ export function useEditEventViewModel(eventId: string): EditEventViewModel {
     moveRoutePoint,
     updateRoutePointLabel,
     toggleCategoriesExpanded,
+    pickImage,
+    removeImage,
     updateConstraintDraftType: setConstraintDraftType,
     updateConstraintDraftInfo: setConstraintDraftInfo,
     addConstraint,

--- a/mobile/src/views/event/EditEventView.test.tsx
+++ b/mobile/src/views/event/EditEventView.test.tsx
@@ -10,11 +10,15 @@ import { useEditEventViewModel } from '@/viewmodels/event/useEditEventViewModel'
 
 const mockBack = jest.fn();
 const mockReplace = jest.fn();
+const mockDismissTo = jest.fn();
+const mockPush = jest.fn();
 
 jest.mock('expo-router', () => ({
   router: {
     back: (...args: unknown[]) => mockBack(...args),
     replace: (...args: unknown[]) => mockReplace(...args),
+    dismissTo: (...args: unknown[]) => mockDismissTo(...args),
+    push: (...args: unknown[]) => mockPush(...args),
   },
 }));
 
@@ -165,9 +169,13 @@ function buildViewModel(
     errors: {},
     isLoading: false,
     isSaving: false,
+    isUploadingImage: false,
     apiError: null,
+    imageError: null,
     successMessage: null,
+    imageUploadSuccessMessage: null,
     updateResult: null,
+    selectedImageUri: null,
     locationSuggestions: [],
     isSearchingLocation: false,
     categoriesExpanded: false,
@@ -188,6 +196,8 @@ function buildViewModel(
     moveRoutePoint: jest.fn(),
     updateRoutePointLabel: jest.fn(),
     toggleCategoriesExpanded: jest.fn(),
+    pickImage: jest.fn().mockResolvedValue(undefined),
+    removeImage: jest.fn(),
     updateConstraintDraftType: jest.fn(),
     updateConstraintDraftInfo: jest.fn(),
     addConstraint: jest.fn(),
@@ -216,13 +226,30 @@ describe('EditEventView', () => {
     expect(screen.getByDisplayValue('Belgrad Forest, Istanbul')).toBeTruthy();
     expect(screen.getByDisplayValue('12')).toBeTruthy();
     expect(screen.getByText('Bring water')).toBeTruthy();
+    expect(screen.getByText('Cover image')).toBeTruthy();
     expect(screen.queryByText('Privacy Level')).toBeNull();
+  });
+
+  it('lets hosts choose a cover image from the edit form', () => {
+    const pickImage = jest.fn().mockResolvedValue(undefined);
+    mockUseEditEventViewModel.mockReturnValue(
+      buildViewModel({
+        pickImage,
+        event: makeEvent({ image_url: 'https://example.com/current-cover.jpg' }),
+      }),
+    );
+
+    render(<EditEventView eventId="event-1" />);
+
+    fireEvent.click(screen.getByText('Change Cover Image'));
+
+    expect(pickImage).toHaveBeenCalledTimes(1);
   });
 
   it('shows confirmation for critical updates and navigates to refreshed detail on success', async () => {
     const previewChanges = jest.fn(() => ({
       request: { title: 'Updated Istanbul Trail Morning' },
-      changedFields: ['title'],
+      changedFields: ['title', 'image_url'],
       criticalChangeLabels: ['Title'],
     }));
     const handleSubmit = jest.fn().mockResolvedValue(updateResult);
@@ -241,12 +268,14 @@ describe('EditEventView', () => {
     expect(screen.getByTestId('edit-event-confirmation')).toBeTruthy();
     expect(screen.getByText('Review before saving')).toBeTruthy();
     expect(screen.getAllByText('Title').length).toBeGreaterThan(1);
+    expect(screen.getAllByText('Cover image').length).toBeGreaterThan(1);
 
     fireEvent.click(screen.getByText('Save Anyway'));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith({ title: 'Updated Istanbul Trail Morning' });
-      expect(mockReplace).toHaveBeenCalledWith('/event/event-1');
+      expect(mockDismissTo).toHaveBeenCalledWith('/(tabs)/home');
+      expect(mockPush).toHaveBeenCalledWith('/event/event-1');
     });
   });
 

--- a/mobile/src/views/event/EditEventView.tsx
+++ b/mobile/src/views/event/EditEventView.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Image,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -91,6 +92,7 @@ function getChangeFieldLabel(field: string, t: (key: string) => string): string 
     end_time: t('events.edit.fields.endTime'),
     capacity: t('events.edit.fields.capacity'),
     constraints: t('events.edit.fields.requirements'),
+    image_url: t('events.edit.image.label'),
   };
   return labels[field] ?? field.replace(/_/g, ' ');
 }
@@ -210,7 +212,8 @@ export default function EditEventView({ eventId }: EditEventViewProps) {
       setPendingPreview(null);
       const result = await vm.handleSubmit(preview.request);
       if (result) {
-        router.replace(`/event/${eventId}` as Href);
+        router.dismissTo('/(tabs)/home' as Href);
+        router.push(`/event/${eventId}` as Href);
       }
     },
     [eventId, vm],
@@ -227,7 +230,9 @@ export default function EditEventView({ eventId }: EditEventViewProps) {
   }, [submitPreview, vm]);
 
   const disabled = vm.isSaving || !vm.canEdit;
+  const imageDisabled = disabled || vm.isUploadingImage;
   const versionLabel = getEventVersionLabel(vm);
+  const displayedImageUri = vm.selectedImageUri ?? vm.event?.image_url ?? null;
 
   if (vm.isLoading) {
     return (
@@ -329,6 +334,13 @@ export default function EditEventView({ eventId }: EditEventViewProps) {
             </View>
           ) : null}
 
+          {vm.imageUploadSuccessMessage ? (
+            <View style={styles.successBanner}>
+              <Feather name="check-circle" size={16} color={theme.successText} />
+              <Text style={styles.successBannerText}>{vm.imageUploadSuccessMessage}</Text>
+            </View>
+          ) : null}
+
           <View style={styles.warningBanner}>
             <Feather name="alert-triangle" size={16} color={theme.warningText} />
             <Text style={styles.warningBannerText}>
@@ -338,6 +350,61 @@ export default function EditEventView({ eventId }: EditEventViewProps) {
 
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>{t('events.edit.sections.basics')}</Text>
+
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>{t('events.edit.image.label')}</Text>
+              <TouchableOpacity
+                style={styles.imagePicker}
+                onPress={vm.pickImage}
+                disabled={imageDisabled}
+                activeOpacity={0.85}
+                accessibilityLabel={t('events.edit.image.change')}
+              >
+                {displayedImageUri ? (
+                  <Image
+                    source={{ uri: displayedImageUri }}
+                    style={styles.imagePreview}
+                    resizeMode="cover"
+                  />
+                ) : (
+                  <View style={styles.imagePlaceholder}>
+                    <MaterialIcons name="add-photo-alternate" size={34} color={theme.textTertiary} />
+                    <Text style={styles.imagePlaceholderText}>{t('events.edit.image.add')}</Text>
+                  </View>
+                )}
+                {vm.isUploadingImage ? (
+                  <View style={styles.imageUploadOverlay}>
+                    <ActivityIndicator size="large" color="#FFFFFF" />
+                    <Text style={styles.imageUploadOverlayText}>
+                      {t('events.edit.image.uploading')}
+                    </Text>
+                  </View>
+                ) : null}
+              </TouchableOpacity>
+              <View style={styles.imageActions}>
+                <TouchableOpacity
+                  style={[styles.secondaryButton, imageDisabled && styles.buttonDisabled]}
+                  onPress={vm.pickImage}
+                  disabled={imageDisabled}
+                >
+                  <Feather name="image" size={16} color={theme.text} />
+                  <Text style={styles.secondaryButtonText}>
+                    {displayedImageUri ? t('events.edit.image.change') : t('events.edit.image.add')}
+                  </Text>
+                </TouchableOpacity>
+                {vm.selectedImageUri ? (
+                  <TouchableOpacity
+                    style={[styles.secondaryButton, imageDisabled && styles.buttonDisabled]}
+                    onPress={vm.removeImage}
+                    disabled={imageDisabled}
+                  >
+                    <Feather name="x" size={16} color={theme.text} />
+                    <Text style={styles.secondaryButtonText}>{t('events.edit.image.discard')}</Text>
+                  </TouchableOpacity>
+                ) : null}
+              </View>
+              {vm.imageError ? <Text style={styles.fieldError}>{vm.imageError}</Text> : null}
+            </View>
 
             <View style={styles.fieldGroup}>
               <Text style={styles.label}>{t('events.edit.fields.titleLabel')}</Text>
@@ -1075,6 +1142,69 @@ function makeStyles(t: Theme) {
       fontSize: 13,
       lineHeight: 18,
       fontWeight: '600',
+    },
+    imagePicker: {
+      height: 190,
+      borderRadius: 8,
+      overflow: 'hidden',
+      borderWidth: 1,
+      borderColor: t.border,
+      backgroundColor: t.surface,
+    },
+    imagePreview: {
+      width: '100%',
+      height: '100%',
+    },
+    imagePlaceholder: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      backgroundColor: t.imagePlaceholder,
+      borderWidth: 1,
+      borderStyle: 'dashed',
+      borderColor: t.border,
+    },
+    imagePlaceholderText: {
+      fontSize: 14,
+      lineHeight: 19,
+      color: t.textSecondary,
+      fontWeight: '800',
+    },
+    imageUploadOverlay: {
+      ...StyleSheet.absoluteFillObject,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      backgroundColor: 'rgba(0,0,0,0.48)',
+    },
+    imageUploadOverlayText: {
+      color: '#FFFFFF',
+      fontSize: 14,
+      fontWeight: '800',
+    },
+    imageActions: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 8,
+    },
+    secondaryButton: {
+      minHeight: 40,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 7,
+      paddingHorizontal: 12,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: t.border,
+      backgroundColor: t.surface,
+    },
+    secondaryButtonText: {
+      fontSize: 13,
+      lineHeight: 18,
+      color: t.text,
+      fontWeight: '800',
     },
     helperText: {
       fontSize: 12,

--- a/mobile/src/views/home/HomeView.test.tsx
+++ b/mobile/src/views/home/HomeView.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import type { HomeViewModel } from '@/viewmodels/home/useHomeViewModel';
+import HomeView from './HomeView';
+import { useHomeViewModel } from '@/viewmodels/home/useHomeViewModel';
+import { useUnreadNotificationCount } from '@/viewmodels/notifications/useUnreadNotificationCount';
+
+let latestFocusEffect: (() => void) | null = null;
+
+jest.mock('expo-router', () => {
+  const ReactLocal = require('react');
+  return {
+    router: {
+      push: jest.fn(),
+    },
+    useFocusEffect: (callback: () => void) => {
+      latestFocusEffect = callback;
+      ReactLocal.useEffect(callback, [callback]);
+    },
+  };
+});
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactLocal = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) =>
+      ReactLocal.createElement('div', null, children),
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const ReactLocal = require('react');
+  return {
+    Feather: ({ name }: { name: string }) =>
+      ReactLocal.createElement('span', { 'data-icon': name }),
+  };
+});
+
+jest.mock('@/components/common/SemLogo', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'SemLogo' });
+});
+
+jest.mock('@/components/home/HomeHeader', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'HomeHeader' });
+});
+
+jest.mock('@/components/home/SearchSection', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'SearchSection' });
+});
+
+jest.mock('@/components/home/EmptyState', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'EmptyState' });
+});
+
+jest.mock('@/components/home/LoadingState', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'LoadingState' });
+});
+
+jest.mock('@/components/events/EventCard', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'EventCard' });
+});
+
+jest.mock('@/components/home/FiltersBottomSheet', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'FiltersBottomSheet' });
+});
+
+jest.mock('@/components/home/EventMapView', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'EventMapView' });
+});
+
+jest.mock('@/components/home/CategoryChips', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'CategoryChips' });
+});
+
+jest.mock('@/components/home/LocationPickerPanel', () => {
+  const ReactLocal = require('react');
+  return () => ReactLocal.createElement('div', { 'data-testid': 'LocationPickerPanel' });
+});
+
+jest.mock('@/theme', () => ({
+  useTheme: () => ({
+    isDark: false,
+    setThemePreference: jest.fn().mockResolvedValue(undefined),
+    theme: {
+      background: '#FFFFFF',
+      text: '#111827',
+      textSecondary: '#4B5563',
+      textTertiary: '#6B7280',
+      textOnPrimary: '#FFFFFF',
+      placeholder: '#9CA3AF',
+      primary: '#2563EB',
+      surface: '#FFFFFF',
+      surfaceAlt: '#F3F4F6',
+      border: '#E5E7EB',
+      errorBg: '#FEF2F2',
+      errorText: '#B91C1C',
+      overlay: 'rgba(0,0,0,0.4)',
+    },
+  }),
+}));
+
+jest.mock('@/viewmodels/home/useHomeViewModel', () => ({
+  useHomeViewModel: jest.fn(),
+}));
+
+jest.mock('@/viewmodels/notifications/useUnreadNotificationCount', () => ({
+  useUnreadNotificationCount: jest.fn(),
+}));
+
+const mockUseHomeViewModel = jest.mocked(useHomeViewModel);
+const mockUseUnreadNotificationCount = jest.mocked(useUnreadNotificationCount);
+
+function buildViewModel(overrides: Partial<HomeViewModel> = {}): HomeViewModel {
+  return {
+    locationLabel: 'Besiktas, Istanbul',
+    locationQuery: '',
+    locationSuggestions: [],
+    isSearchingLocation: false,
+    isLocationModalOpen: false,
+    pendingLocation: null,
+    defaultLocationOption: {
+      title: 'Default location',
+      subtitle: 'Besiktas, Istanbul',
+      suggestion: null,
+      isLoading: false,
+    },
+    favoriteLocationOptions: [],
+    isLoadingFavoriteLocations: false,
+    favoriteLocationsError: null,
+    categories: [],
+    selectedCategoryIds: [],
+    searchText: '',
+    events: [],
+    isLoading: true,
+    isLoadingMore: false,
+    isRefreshing: false,
+    apiError: null,
+    hasMore: false,
+    isFilterModalOpen: false,
+    filterDraft: {
+      categoryIds: [],
+      privacyLevels: [],
+      startDate: '',
+      endDate: '',
+      radiusKm: 10,
+      sortBy: 'START_TIME',
+      childFriendly: false,
+      familyOriented: false,
+    },
+    filterError: null,
+    viewMode: 'LIST',
+    activeLocation: { lat: 41.0422, lon: 29.0083 },
+    currentLocation: null,
+    toggleViewMode: jest.fn(),
+    updateSearchText: jest.fn(),
+    submitSearch: jest.fn(),
+    toggleCategory: jest.fn(),
+    clearSelectedCategories: jest.fn(),
+    openFilterModal: jest.fn(),
+    closeFilterModal: jest.fn(),
+    resetFilterDraft: jest.fn(),
+    applyFilterDraft: jest.fn(),
+    toggleDraftCategory: jest.fn(),
+    toggleDraftPrivacy: jest.fn(),
+    updateDraftStartDate: jest.fn(),
+    updateDraftEndDate: jest.fn(),
+    updateDraftRadiusKm: jest.fn(),
+    updateDraftSortBy: jest.fn(),
+    toggleDraftChildFriendly: jest.fn(),
+    toggleDraftFamilyOriented: jest.fn(),
+    loadMoreEvents: jest.fn().mockResolvedValue(undefined),
+    refreshEvents: jest.fn().mockResolvedValue(undefined),
+    silentRefresh: jest.fn().mockResolvedValue(undefined),
+    openLocationModal: jest.fn(),
+    closeLocationModal: jest.fn(),
+    updateLocationQuery: jest.fn(),
+    selectSavedLocationOption: jest.fn(),
+    selectLocationSuggestion: jest.fn(),
+    applySelectedLocation: jest.fn(),
+    resetLocationDraft: jest.fn(),
+    retryFavoriteLocations: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('HomeView', () => {
+  beforeEach(() => {
+    latestFocusEffect = null;
+    jest.clearAllMocks();
+  });
+
+  it('silently refreshes events when Home regains focus after the initial mount', () => {
+    const silentRefresh = jest.fn().mockResolvedValue(undefined);
+    const refreshUnreadCount = jest.fn().mockResolvedValue(undefined);
+
+    mockUseHomeViewModel.mockReturnValue(buildViewModel({ silentRefresh }));
+    mockUseUnreadNotificationCount.mockReturnValue({
+      unreadCount: 0,
+      refresh: refreshUnreadCount,
+    });
+
+    render(<HomeView />);
+
+    expect(refreshUnreadCount).toHaveBeenCalledTimes(1);
+    expect(silentRefresh).not.toHaveBeenCalled();
+
+    act(() => {
+      latestFocusEffect?.();
+    });
+
+    expect(refreshUnreadCount).toHaveBeenCalledTimes(2);
+    expect(silentRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -38,11 +38,17 @@ export default function HomeView() {
   const styles = useMemo(() => makeStyles(theme, isDark), [theme, isDark]);
   const isMapMode = vm.viewMode === 'MAP';
   const insets = useSafeAreaInsets();
+  const hasFocusedOnceRef = useRef(false);
 
   useFocusEffect(
     useCallback(() => {
       void refreshUnreadCount();
-    }, [refreshUnreadCount]),
+      if (hasFocusedOnceRef.current) {
+        void vm.silentRefresh();
+      } else {
+        hasFocusedOnceRef.current = true;
+      }
+    }, [refreshUnreadCount, vm.silentRefresh]),
   );
 
   const locationButtonRef = useRef<any>(null);


### PR DESCRIPTION
## Summary
- add cover image selection and upload support to the event edit flow
- show cover image as a friendly changed-field label in the save review modal
- refresh Home on return so edited event cards update without manual pull-to-refresh

## Tests
- npm test -- --watchman=false --runTestsByPath src/views/home/HomeView.test.tsx src/views/event/EditEventView.test.tsx
- npm exec tsc -- --noEmit
- git diff --check