### PR TITLE
fix(frontend): improve discover map card scrolling

### DIFF
--- a/frontend/src/styles/discover.css
+++ b/frontend/src/styles/discover.css
@@ -1732,7 +1732,7 @@
   right: 16px;
   top: 176px;
   width: clamp(300px, 23vw, 360px);
-  max-height: calc(100dvh - 192px);
+  max-height: calc(100% - 192px);
   background: #ffffff;
   border: 1px solid rgba(15, 23, 42, 0.06);
   border-radius: 18px;
@@ -1740,8 +1740,7 @@
   z-index: 20;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
   animation: dc-side-panel-enter 0.22s ease-out;
 }
 
@@ -1825,7 +1824,12 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .dc-side-panel-head {
@@ -1893,10 +1897,13 @@
 .dc-side-panel-cta {
   display: block;
   width: 100%;
+  position: sticky;
+  bottom: 0;
   padding: 10px 14px;
   background: #111827;
   color: #ffffff !important;
   border-radius: 12px;
+  box-shadow: 0 -8px 18px rgba(255, 255, 255, 0.9);
   text-align: center;
   font-size: 0.9rem;
   font-weight: 700;
@@ -2442,6 +2449,7 @@
 :root[data-theme='dark'] .dc-side-panel-cta {
   background: #f9fafb;
   color: #111827 !important;
+  box-shadow: 0 -8px 18px rgba(10, 10, 10, 0.9);
 }
 
 :root[data-theme='dark'] .dc-side-panel-cta:hover {


### PR DESCRIPTION
# fix(frontend): Improve Discover map event card scrolling

## 📋 Description
In Discover map view, selecting an event opens an event preview card on the right side of the map. For some events with longer content, the card does not fit properly within the visible viewport at 100% browser zoom. In these cases, the "View event details" button can be partially hidden below the screen, making the action difficult to access.

The map event preview card should stay bounded within the map viewport and allow its content to scroll properly while keeping the main action button fully reachable.

## ✅ Acceptance Criteria
- [ ] Discover map selected event card fits within the visible map viewport
- [ ] Long event card content scrolls inside the card without pushing actions off-screen
- [ ] "View event details" button remains fully visible/reachable at 100% browser zoom
- [ ] Behavior works in both light and dark mode
- [ ] Mobile and desktop layouts remain responsive
- [ ] Existing Discover map behavior is not regressed

## 🔗 References
- `frontend/src/views/discover/DiscoverEventSidePanel.tsx`
- `frontend/src/views/discover/DiscoverPage.tsx`
- `frontend/src/styles/discover.css`

## 🔗 Related
Related to #654 
