### PR TITLE
Add mobile Maestro E2E flows and default home map view

### DIFF
--- a/mobile/.maestro/completed-event-feedback-rating-test.yaml
+++ b/mobile/.maestro/completed-event-feedback-rating-test.yaml
@@ -6,16 +6,7 @@ env:
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    id: "login-submit-button"
-- tapOn:
-    id: "login-username-input"
-- inputText: ${E2E_USERNAME}
-- tapOn:
-    id: "login-password-input"
-- inputText: ${E2E_PASSWORD}
-- tapOn:
-    id: "login-submit-button"
+- runFlow: login-flow.yaml
 - tapOn:
     text: "Don't allow"
     optional: true

--- a/mobile/.maestro/completed-event-feedback-rating-test.yaml
+++ b/mobile/.maestro/completed-event-feedback-rating-test.yaml
@@ -1,0 +1,71 @@
+appId: com.bounswe2026group11.socialeventmapper
+env:
+  E2E_USERNAME: "123"
+  E2E_PASSWORD: "ab123456"
+  E2E_EVENT_TITLE: "Film Night 2"
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- tapOn:
+    text: "Don't allow"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-events"
+    timeout: 30000
+- tapOn:
+    id: "tab-events"
+- extendedWaitUntil:
+    visible:
+      id: "my-events-tab-completed"
+    timeout: 30000
+- tapOn:
+    id: "my-events-tab-completed"
+- scrollUntilVisible:
+    element:
+      id: "my-event-card-${E2E_EVENT_TITLE}"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "my-event-card-${E2E_EVENT_TITLE}"
+- scrollUntilVisible:
+    element:
+      id: "event-actions-view-full-event-button"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "event-actions-view-full-event-button"
+- scrollUntilVisible:
+    element:
+      id: "discussion-qa-tab"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "discussion-qa-tab"
+- scrollUntilVisible:
+    element:
+      id: "event-feedback-edit-button"
+    direction: UP
+    timeout: 30000
+- tapOn:
+    id: "event-feedback-edit-button"
+- tapOn:
+    id: "event-feedback-star-3"
+- tapOn:
+    id: "event-feedback-submit-button"
+- extendedWaitUntil:
+    visible:
+      id: "event-feedback-edit-button"
+    timeout: 30000
+- assertVisible:
+    id: "event-feedback-edit-button"

--- a/mobile/.maestro/config.yaml
+++ b/mobile/.maestro/config.yaml
@@ -1,0 +1,2 @@
+appId: com.bounswe2026group11.socialeventmapper
+---

--- a/mobile/.maestro/dev-build-bootstrap.yaml
+++ b/mobile/.maestro/dev-build-bootstrap.yaml
@@ -1,0 +1,11 @@
+appId: com.bounswe2026group11.socialeventmapper
+---
+- tapOn:
+    text: "http://10.0.2.2:8081"
+    optional: true
+- tapOn:
+    point: "90%,74%"
+    optional: true
+- tapOn:
+    text: "Continue"
+    optional: true

--- a/mobile/.maestro/edit-event-title-test.yaml
+++ b/mobile/.maestro/edit-event-title-test.yaml
@@ -38,6 +38,7 @@ env:
     id: "edit-event-title-input"
 - eraseText
 - inputText: ${E2E_UPDATED_EVENT_TITLE}
+- hideKeyboard
 - scrollUntilVisible:
     element:
       id: "edit-event-save-button"

--- a/mobile/.maestro/edit-event-title-test.yaml
+++ b/mobile/.maestro/edit-event-title-test.yaml
@@ -7,16 +7,7 @@ env:
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    id: "login-submit-button"
-- tapOn:
-    id: "login-username-input"
-- inputText: ${E2E_USERNAME}
-- tapOn:
-    id: "login-password-input"
-- inputText: ${E2E_PASSWORD}
-- tapOn:
-    id: "login-submit-button"
+- runFlow: login-flow.yaml
 - tapOn:
     text: "Don't allow"
     optional: true

--- a/mobile/.maestro/edit-event-title-test.yaml
+++ b/mobile/.maestro/edit-event-title-test.yaml
@@ -1,0 +1,65 @@
+appId: com.bounswe2026group11.socialeventmapper
+env:
+  E2E_USERNAME: "123"
+  E2E_PASSWORD: "ab123456"
+  E2E_ORIGINAL_EVENT_TITLE: "Film Night"
+  E2E_UPDATED_EVENT_TITLE: "Movie Night for Film Lovers"
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- tapOn:
+    text: "Don't allow"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-events"
+    timeout: 30000
+- tapOn:
+    id: "tab-events"
+- assertVisible:
+    id: "my-events-tab-active"
+- tapOn:
+    id: "my-events-tab-active"
+- scrollUntilVisible:
+    element:
+      id: "my-event-card-${E2E_ORIGINAL_EVENT_TITLE}"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "my-event-card-${E2E_ORIGINAL_EVENT_TITLE}"
+- assertVisible: "Edit Event"
+- tapOn: "Edit Event"
+- extendedWaitUntil:
+    visible:
+      id: "edit-event-title-input"
+    timeout: 30000
+- tapOn:
+    id: "edit-event-title-input"
+- eraseText
+- inputText: ${E2E_UPDATED_EVENT_TITLE}
+- scrollUntilVisible:
+    element:
+      id: "edit-event-save-button"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "edit-event-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "edit-event-confirmation"
+    timeout: 30000
+- tapOn:
+    id: "edit-event-save-anyway-button"
+- extendedWaitUntil:
+    visible: ${E2E_UPDATED_EVENT_TITLE}
+    timeout: 30000

--- a/mobile/.maestro/favorite-event-discussion-post-test.yaml
+++ b/mobile/.maestro/favorite-event-discussion-post-test.yaml
@@ -30,6 +30,7 @@ env:
 - tapOn:
     id: "discussion-question-input"
 - inputText: ${E2E_DISCUSSION_MESSAGE}
+- hideKeyboard
 - scrollUntilVisible:
     element:
       id: "discussion-post-button"

--- a/mobile/.maestro/favorite-event-discussion-post-test.yaml
+++ b/mobile/.maestro/favorite-event-discussion-post-test.yaml
@@ -1,0 +1,51 @@
+appId: com.bounswe2026group11.socialeventmapper
+env:
+  E2E_USERNAME: "123"
+  E2E_PASSWORD: "ab123456"
+  E2E_EVENT_TITLE: "Vintage Vinyl Listening Night in Cihangir"
+  E2E_DISCUSSION_MESSAGE: "Hello, the event looks really enjoyable. What kinds of vinyl records will mostly be played?"
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- tapOn:
+    text: "Don't allow"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-favorites"
+    timeout: 30000
+- tapOn:
+    id: "tab-favorites"
+- extendedWaitUntil:
+    visible: ${E2E_EVENT_TITLE}
+    timeout: 30000
+- tapOn:
+    id: "profile-event-card-${E2E_EVENT_TITLE}"
+- scrollUntilVisible:
+    element:
+      id: "discussion-question-input"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "discussion-question-input"
+- inputText: ${E2E_DISCUSSION_MESSAGE}
+- scrollUntilVisible:
+    element:
+      id: "discussion-post-button"
+    direction: DOWN
+    timeout: 15000
+- tapOn:
+    id: "discussion-post-button"
+- extendedWaitUntil:
+    visible: ${E2E_DISCUSSION_MESSAGE}
+    timeout: 30000

--- a/mobile/.maestro/favorite-event-discussion-post-test.yaml
+++ b/mobile/.maestro/favorite-event-discussion-post-test.yaml
@@ -7,16 +7,7 @@ env:
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    id: "login-submit-button"
-- tapOn:
-    id: "login-username-input"
-- inputText: ${E2E_USERNAME}
-- tapOn:
-    id: "login-password-input"
-- inputText: ${E2E_PASSWORD}
-- tapOn:
-    id: "login-submit-button"
+- runFlow: login-flow.yaml
 - tapOn:
     text: "Don't allow"
     optional: true

--- a/mobile/.maestro/favorite-location-save-and-apply-test.yaml
+++ b/mobile/.maestro/favorite-location-save-and-apply-test.yaml
@@ -1,0 +1,80 @@
+appId: com.bounswe2026group11.socialeventmapper
+env:
+  E2E_USERNAME: "123"
+  E2E_PASSWORD: "ab123456"
+  E2E_LOCATION_NAME: "home"
+  E2E_LOCATION_QUERY: "denizli"
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- tapOn:
+    text: "Don't allow"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-favorites"
+    timeout: 30000
+- tapOn:
+    id: "tab-favorites"
+- extendedWaitUntil:
+    visible:
+      id: "favorites-tab-locations"
+    timeout: 30000
+- tapOn:
+    id: "favorites-tab-locations"
+- extendedWaitUntil:
+    visible:
+      id: "favorite-location-add-button"
+    timeout: 30000
+- tapOn:
+    id: "favorite-location-add-button"
+- extendedWaitUntil:
+    visible:
+      id: "favorite-location-name-input"
+    timeout: 30000
+- tapOn:
+    id: "favorite-location-name-input"
+- inputText: ${E2E_LOCATION_NAME}
+- tapOn:
+    id: "favorite-location-address-input"
+- inputText: ${E2E_LOCATION_QUERY}
+- extendedWaitUntil:
+    visible:
+      id: "favorite-location-suggestion-0"
+    timeout: 30000
+- tapOn:
+    id: "favorite-location-suggestion-0"
+- tapOn:
+    id: "favorite-location-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "favorite-location-name-${E2E_LOCATION_NAME}"
+    timeout: 30000
+- tapOn:
+    id: "tab-home"
+- extendedWaitUntil:
+    visible:
+      id: "home-location-picker-button"
+    timeout: 30000
+- tapOn:
+    id: "home-location-picker-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-location-favorite-option-${E2E_LOCATION_NAME}"
+    timeout: 30000
+- tapOn:
+    id: "home-location-favorite-option-${E2E_LOCATION_NAME}"
+- tapOn:
+    id: "home-location-apply-button"
+- assertNotVisible:
+    id: "home-location-apply-button"

--- a/mobile/.maestro/favorite-location-save-and-apply-test.yaml
+++ b/mobile/.maestro/favorite-location-save-and-apply-test.yaml
@@ -7,16 +7,7 @@ env:
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    id: "login-submit-button"
-- tapOn:
-    id: "login-username-input"
-- inputText: ${E2E_USERNAME}
-- tapOn:
-    id: "login-password-input"
-- inputText: ${E2E_PASSWORD}
-- tapOn:
-    id: "login-submit-button"
+- runFlow: login-flow.yaml
 - tapOn:
     text: "Don't allow"
     optional: true

--- a/mobile/.maestro/favorite-location-save-and-apply-test.yaml
+++ b/mobile/.maestro/favorite-location-save-and-apply-test.yaml
@@ -39,6 +39,7 @@ env:
 - tapOn:
     id: "favorite-location-address-input"
 - inputText: ${E2E_LOCATION_QUERY}
+- hideKeyboard
 - extendedWaitUntil:
     visible:
       id: "favorite-location-suggestion-0"

--- a/mobile/.maestro/host-approve-join-request-test.yaml
+++ b/mobile/.maestro/host-approve-join-request-test.yaml
@@ -1,0 +1,60 @@
+appId: com.bounswe2026group11.socialeventmapper
+env:
+  E2E_USERNAME: "123"
+  E2E_PASSWORD: "ab123456"
+  E2E_EVENT_TITLE: "Indie Film Discussion Night in Moda"
+  E2E_REQUEST_USERNAME: "sp123"
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- tapOn:
+    text: "Don't allow"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-events"
+    timeout: 30000
+- tapOn:
+    id: "tab-events"
+- assertVisible:
+    id: "my-events-tab-active"
+- tapOn:
+    id: "my-events-tab-active"
+- scrollUntilVisible:
+    element:
+      id: "my-event-card-${E2E_EVENT_TITLE}"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "my-event-card-${E2E_EVENT_TITLE}"
+- scrollUntilVisible:
+    element:
+      text: "View Full Event"
+    direction: DOWN
+    timeout: 30000
+- tapOn: "View Full Event"
+- scrollUntilVisible:
+    element:
+      id: "pending-requests-button"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "pending-requests-button"
+- extendedWaitUntil:
+    visible:
+      id: "join-request-row-${E2E_REQUEST_USERNAME}"
+    timeout: 30000
+- tapOn:
+    id: "join-request-approve-${E2E_REQUEST_USERNAME}"
+- assertNotVisible:
+    id: "join-request-row-${E2E_REQUEST_USERNAME}"

--- a/mobile/.maestro/host-approve-join-request-test.yaml
+++ b/mobile/.maestro/host-approve-join-request-test.yaml
@@ -3,20 +3,11 @@ env:
   E2E_USERNAME: "123"
   E2E_PASSWORD: "ab123456"
   E2E_EVENT_TITLE: "Indie Film Discussion Night in Moda"
-  E2E_REQUEST_USERNAME: "sp123"
+  E2E_REQUEST_USERNAME: "1234"
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    id: "login-submit-button"
-- tapOn:
-    id: "login-username-input"
-- inputText: ${E2E_USERNAME}
-- tapOn:
-    id: "login-password-input"
-- inputText: ${E2E_PASSWORD}
-- tapOn:
-    id: "login-submit-button"
+- runFlow: login-flow.yaml
 - tapOn:
     text: "Don't allow"
     optional: true

--- a/mobile/.maestro/host-approve-join-request-test.yaml
+++ b/mobile/.maestro/host-approve-join-request-test.yaml
@@ -3,7 +3,7 @@ env:
   E2E_USERNAME: "123"
   E2E_PASSWORD: "ab123456"
   E2E_EVENT_TITLE: "Indie Film Discussion Night in Moda"
-  E2E_REQUEST_USERNAME: "1234"
+  E2E_REQUEST_USERNAME: "12345"
 ---
 - launchApp:
     clearState: true

--- a/mobile/.maestro/invitation-accept-test.yaml
+++ b/mobile/.maestro/invitation-accept-test.yaml
@@ -1,0 +1,43 @@
+appId: com.bounswe2026group11.socialeventmapper
+env:
+  E2E_USERNAME: "123"
+  E2E_PASSWORD: "ab123456"
+  E2E_INVITATION_EVENT_TITLE: "Private Art Book Exchange and Discussion Night"
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- tapOn:
+    text: "Don't allow"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-profile"
+    timeout: 30000
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible: ${E2E_INVITATION_EVENT_TITLE}
+    timeout: 30000
+- tapOn: ${E2E_INVITATION_EVENT_TITLE}
+- extendedWaitUntil:
+    visible:
+      id: "invited-status-chip"
+    timeout: 30000
+- assertVisible:
+    id: "accept-invitation-button"
+- tapOn:
+    id: "accept-invitation-button"
+- extendedWaitUntil:
+    visible:
+      id: "joined-status-chip"
+    timeout: 30000

--- a/mobile/.maestro/invitation-accept-test.yaml
+++ b/mobile/.maestro/invitation-accept-test.yaml
@@ -6,16 +6,7 @@ env:
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    id: "login-submit-button"
-- tapOn:
-    id: "login-username-input"
-- inputText: ${E2E_USERNAME}
-- tapOn:
-    id: "login-password-input"
-- inputText: ${E2E_PASSWORD}
-- tapOn:
-    id: "login-submit-button"
+- runFlow: login-flow.yaml
 - tapOn:
     text: "Don't allow"
     optional: true

--- a/mobile/.maestro/login-flow.yaml
+++ b/mobile/.maestro/login-flow.yaml
@@ -1,0 +1,21 @@
+appId: com.bounswe2026group11.socialeventmapper
+---
+- runFlow: dev-build-bootstrap.yaml
+- extendedWaitUntil:
+    visible:
+      id: "login-username-input"
+    timeout: 60000
+- assertVisible:
+    id: "login-password-input"
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- eraseText
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- eraseText
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"

--- a/mobile/.maestro/login-flow.yaml
+++ b/mobile/.maestro/login-flow.yaml
@@ -17,5 +17,6 @@ appId: com.bounswe2026group11.socialeventmapper
     id: "login-password-input"
 - eraseText
 - inputText: ${E2E_PASSWORD}
+- hideKeyboard
 - tapOn:
     id: "login-submit-button"

--- a/mobile/.maestro/my-events-view-ticket-test.yaml
+++ b/mobile/.maestro/my-events-view-ticket-test.yaml
@@ -1,0 +1,54 @@
+appId: com.bounswe2026group11.socialeventmapper
+env:
+  E2E_USERNAME: "123"
+  E2E_PASSWORD: "ab123456"
+  E2E_EVENT_TITLE: "Private Rooftop Acoustic Session"
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- tapOn:
+    text: "Don't allow"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-events"
+    timeout: 30000
+- tapOn:
+    id: "tab-events"
+- assertVisible:
+    id: "my-events-tab-active"
+- tapOn:
+    id: "my-events-tab-active"
+- scrollUntilVisible:
+    element:
+      id: "my-event-card-${E2E_EVENT_TITLE}"
+    direction: DOWN
+    timeout: 30000
+- tapOn:
+    id: "my-event-card-${E2E_EVENT_TITLE}"
+- extendedWaitUntil:
+    visible:
+      id: "event-actions-primary-button"
+    timeout: 30000
+- tapOn:
+    id: "event-actions-primary-button"
+- extendedWaitUntil:
+    visible: "Ticket"
+    timeout: 30000
+- assertVisible: ${E2E_EVENT_TITLE}
+- scrollUntilVisible:
+    element:
+      text: "Refresh Code"
+    direction: DOWN
+    timeout: 30000
+- assertVisible: "Refresh Code"

--- a/mobile/.maestro/my-events-view-ticket-test.yaml
+++ b/mobile/.maestro/my-events-view-ticket-test.yaml
@@ -6,16 +6,7 @@ env:
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    id: "login-submit-button"
-- tapOn:
-    id: "login-username-input"
-- inputText: ${E2E_USERNAME}
-- tapOn:
-    id: "login-password-input"
-- inputText: ${E2E_PASSWORD}
-- tapOn:
-    id: "login-submit-button"
+- runFlow: login-flow.yaml
 - tapOn:
     text: "Don't allow"
     optional: true

--- a/mobile/.maestro/protected-event-join-request-test.yaml
+++ b/mobile/.maestro/protected-event-join-request-test.yaml
@@ -27,6 +27,7 @@ env:
 - eraseText
 - inputText: ${E2E_SEARCH_QUERY}
 - pressKey: Enter
+- hideKeyboard
 - extendedWaitUntil:
     visible: ${E2E_EVENT_TITLE}
     timeout: 60000
@@ -40,6 +41,7 @@ env:
 - tapOn:
     id: "join-request-message-input"
 - inputText: ${E2E_JOIN_MESSAGE}
+- hideKeyboard
 - tapOn:
     id: "join-request-send-button"
 - assertVisible:

--- a/mobile/.maestro/protected-event-join-request-test.yaml
+++ b/mobile/.maestro/protected-event-join-request-test.yaml
@@ -8,16 +8,7 @@ env:
 ---
 - launchApp:
     clearState: true
-- assertVisible:
-    id: "login-submit-button"
-- tapOn:
-    id: "login-username-input"
-- inputText: ${E2E_USERNAME}
-- tapOn:
-    id: "login-password-input"
-- inputText: ${E2E_PASSWORD}
-- tapOn:
-    id: "login-submit-button"
+- runFlow: login-flow.yaml
 - tapOn:
     text: "Don't allow"
     optional: true

--- a/mobile/.maestro/protected-event-join-request-test.yaml
+++ b/mobile/.maestro/protected-event-join-request-test.yaml
@@ -26,7 +26,6 @@ env:
     id: "home-search-input"
 - eraseText
 - inputText: ${E2E_SEARCH_QUERY}
-- pressKey: Enter
 - hideKeyboard
 - extendedWaitUntil:
     visible: ${E2E_EVENT_TITLE}

--- a/mobile/.maestro/protected-event-join-request-test.yaml
+++ b/mobile/.maestro/protected-event-join-request-test.yaml
@@ -1,0 +1,55 @@
+appId: com.bounswe2026group11.socialeventmapper
+env:
+  E2E_USERNAME: "123"
+  E2E_PASSWORD: "ab123456"
+  E2E_SEARCH_QUERY: "Vintage Vinyl"
+  E2E_EVENT_TITLE: "Vintage Vinyl Listening Night in Cihangir"
+  E2E_JOIN_MESSAGE: "I would like to participate"
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "login-submit-button"
+- tapOn:
+    id: "login-username-input"
+- inputText: ${E2E_USERNAME}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-button"
+- tapOn:
+    text: "Don't allow"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "toggle-list"
+    timeout: 30000
+- tapOn:
+    id: "toggle-list"
+- extendedWaitUntil:
+    visible:
+      id: "home-search-input"
+    timeout: 30000
+- tapOn:
+    id: "home-search-input"
+- eraseText
+- inputText: ${E2E_SEARCH_QUERY}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ${E2E_EVENT_TITLE}
+    timeout: 60000
+- tapOn: ${E2E_EVENT_TITLE}
+- assertVisible:
+    id: "request-to-join-button"
+- tapOn:
+    id: "request-to-join-button"
+- assertVisible:
+    id: "join-request-message-input"
+- tapOn:
+    id: "join-request-message-input"
+- inputText: ${E2E_JOIN_MESSAGE}
+- tapOn:
+    id: "join-request-send-button"
+- assertVisible:
+    id: "join-request-pending-chip"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -7,7 +7,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:e2e": "maestro test .maestro/"
   },
   "dependencies": {
     "@react-native-community/datetimepicker": "8.6.0",

--- a/mobile/src/components/common/BottomTabBar.tsx
+++ b/mobile/src/components/common/BottomTabBar.tsx
@@ -79,6 +79,7 @@ export default function BottomTabBar({ state, navigation }: BottomTabBarProps) {
         accessibilityRole="button"
         accessibilityState={{ selected: active }}
         accessibilityLabel={meta.label}
+        testID={`tab-${route.name}`}
         onPress={() => {
           if (!active) {
             navigation.navigate(route.name, route.params);

--- a/mobile/src/components/events/EventDiscussionSection.tsx
+++ b/mobile/src/components/events/EventDiscussionSection.tsx
@@ -300,6 +300,7 @@ export default function EventDiscussionSection({
         <TouchableOpacity
           style={[styles.tab, activeTab === 'qa' && styles.tabActive]}
           onPress={() => setActiveTab('qa')}
+          testID="discussion-qa-tab"
         >
           <Text style={[styles.tabText, activeTab === 'qa' && styles.tabTextActive]}>
             {t('events.detail.qaLabel', { count: vm.discussions.items.length })}
@@ -308,6 +309,7 @@ export default function EventDiscussionSection({
         <TouchableOpacity
           style={[styles.tab, activeTab === 'reviews' && styles.tabActive]}
           onPress={() => setActiveTab('reviews')}
+          testID="discussion-reviews-tab"
         >
           <Text style={[styles.tabText, activeTab === 'reviews' && styles.tabTextActive]}>
             {t('events.detail.reviewsLabel', { count: vm.reviews.items.length })}
@@ -328,6 +330,7 @@ export default function EventDiscussionSection({
                 multiline
                 maxLength={1000}
                 editable={!vm.discussionSubmitting}
+                testID="discussion-question-input"
               />
               <View style={styles.inputFooter}>
                 <Text style={styles.charCount}>{vm.newDiscussionMessage.length}/1000</Text>
@@ -339,6 +342,7 @@ export default function EventDiscussionSection({
                   ]}
                   onPress={() => void vm.submitDiscussionComment()}
                   disabled={!vm.newDiscussionMessage.trim() || vm.discussionSubmitting}
+                  testID="discussion-post-button"
                 >
                   {vm.discussionSubmitting ? (
                     <ActivityIndicator size="small" color="white" />

--- a/mobile/src/components/events/JoinRequestsModal.tsx
+++ b/mobile/src/components/events/JoinRequestsModal.tsx
@@ -114,7 +114,7 @@ export default function JoinRequestsModal({
             keyExtractor={(item) => item.join_request_id}
             contentContainerStyle={styles.list}
             renderItem={({ item }) => (
-              <View style={styles.requestRow}>
+              <View style={styles.requestRow} testID={`join-request-row-${item.user.username}`}>
                 <TouchableOpacity 
                   style={styles.userInfoTouchable}
                   onPress={() => {
@@ -162,6 +162,7 @@ export default function JoinRequestsModal({
                   <TouchableOpacity
                     style={[styles.actionBtn, styles.rejectBtn]}
                     onPress={() => onReject(item.join_request_id)}
+                    testID={`join-request-reject-${item.user.username}`}
                   >
                     <Feather name="x" size={20} color={theme.errorText} />
                   </TouchableOpacity>
@@ -169,6 +170,7 @@ export default function JoinRequestsModal({
                   <TouchableOpacity
                     style={[styles.actionBtn, styles.approveBtn]}
                     onPress={() => onApprove(item.join_request_id)}
+                    testID={`join-request-approve-${item.user.username}`}
                   >
                     <Feather name="check" size={20} color={theme.successText} />
                   </TouchableOpacity>

--- a/mobile/src/components/events/MyEventCard.tsx
+++ b/mobile/src/components/events/MyEventCard.tsx
@@ -103,6 +103,7 @@ export default function MyEventCard({ event, onPress }: MyEventCardProps) {
       activeOpacity={0.88}
       style={styles.card}
       onPress={() => onPress?.(event.id)}
+      testID={`my-event-card-${event.title}`}
     >
       <View style={styles.imageWrapper}>
         {event.image_url ? (

--- a/mobile/src/components/home/LocationPickerPanel.test.tsx
+++ b/mobile/src/components/home/LocationPickerPanel.test.tsx
@@ -21,6 +21,7 @@ jest.mock('react-native', () => {
     'transparent',
     'animationType',
     'onRequestClose',
+    'testID',
   ]);
 
   const stripReactNativeOnlyProps = (props: Record<string, unknown>) => {
@@ -35,19 +36,39 @@ jest.mock('react-native', () => {
 
   const createDiv =
     (displayName: string) =>
-      ({ children, ...props }: { children?: React.ReactNode }) =>
+      ({
+        children,
+        testID,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        testID?: string;
+      }) =>
         ReactLocal.createElement(
           'div',
-          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          {
+            ...stripReactNativeOnlyProps(props),
+            'data-testid': testID ?? displayName,
+          },
           children,
         );
 
   const createSpan =
     (displayName: string) =>
-      ({ children, ...props }: { children?: React.ReactNode }) =>
+      ({
+        children,
+        testID,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        testID?: string;
+      }) =>
         ReactLocal.createElement(
           'span',
-          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          {
+            ...stripReactNativeOnlyProps(props),
+            'data-testid': testID ?? displayName,
+          },
           children,
         );
 
@@ -57,17 +78,19 @@ jest.mock('react-native', () => {
         children,
         onPress,
         disabled,
+        testID,
         ...props
       }: {
         children?: React.ReactNode;
         onPress?: () => void;
         disabled?: boolean;
+        testID?: string;
       }) =>
         ReactLocal.createElement(
           'button',
           {
             ...stripReactNativeOnlyProps(props),
-            'data-testid': displayName,
+            'data-testid': testID ?? displayName,
             type: 'button',
             disabled,
             onClick: disabled ? undefined : onPress,
@@ -91,13 +114,16 @@ jest.mock('react-native', () => {
     TextInput: ({
       value,
       onChangeText,
+      testID,
       ...props
     }: {
       value?: string;
       onChangeText?: (value: string) => void;
+      testID?: string;
     }) =>
       ReactLocal.createElement('input', {
         ...stripReactNativeOnlyProps(props),
+        'data-testid': testID,
         value,
         onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
           onChangeText?.(event.target.value),

--- a/mobile/src/components/home/LocationPickerPanel.tsx
+++ b/mobile/src/components/home/LocationPickerPanel.tsx
@@ -69,6 +69,7 @@ function SavedLocationCard({
   iconName,
   isSelected,
   isDisabled = false,
+  testID,
   onPress,
   theme,
   styles,
@@ -78,6 +79,7 @@ function SavedLocationCard({
   iconName: React.ComponentProps<typeof Feather>['name'];
   isSelected: boolean;
   isDisabled?: boolean;
+  testID?: string;
   onPress: () => void;
   theme: Theme;
   styles: ReturnType<typeof makeStyles>;
@@ -92,6 +94,7 @@ function SavedLocationCard({
       onPress={onPress}
       disabled={isDisabled}
       activeOpacity={0.85}
+      testID={testID}
     >
       <Feather
         name={isSelected ? 'check-circle' : iconName}
@@ -184,6 +187,7 @@ export default function LocationPickerPanel({
               placeholderTextColor={theme.placeholder}
               style={styles.input}
               autoCorrect={false}
+              testID="home-location-picker-search-input"
             />
           </View>
 
@@ -246,6 +250,7 @@ export default function LocationPickerPanel({
                         onSelectSavedLocation(defaultOption.suggestion);
                       }
                     }}
+                    testID="home-location-default-option"
                     theme={theme}
                     styles={styles}
                   />
@@ -294,6 +299,7 @@ export default function LocationPickerPanel({
                           option.suggestion,
                         )}
                         onPress={() => onSelectSavedLocation(option.suggestion)}
+                        testID={`home-location-favorite-option-${option.title}`}
                         theme={theme}
                         styles={styles}
                       />
@@ -312,6 +318,7 @@ export default function LocationPickerPanel({
             onPress={onApply}
             activeOpacity={0.85}
             disabled={!canApply}
+            testID="home-location-apply-button"
           >
             <Text style={styles.applyButtonText}>{t('home.locationPicker.apply')}</Text>
           </TouchableOpacity>

--- a/mobile/src/components/home/SearchSection.tsx
+++ b/mobile/src/components/home/SearchSection.tsx
@@ -43,6 +43,7 @@ export default function SearchSection({
           autoCapitalize="none"
           autoCorrect={false}
           returnKeyType="search"
+          testID="home-search-input"
         />
       </View>
 

--- a/mobile/src/components/profile/ProfileEventCard.tsx
+++ b/mobile/src/components/profile/ProfileEventCard.tsx
@@ -75,6 +75,7 @@ export default function ProfileEventCard({
       activeOpacity={0.92}
       onPress={onPress}
       style={styles.card}
+      testID={`profile-event-card-${title}`}
     >
       <View style={styles.imageContainer}>
         {imageUrl ? (

--- a/mobile/src/viewmodels/home/useHomeViewModel.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.ts
@@ -440,7 +440,7 @@ export function useHomeViewModel(): HomeViewModel {
     useState<HomeFiltersDraft>(DEFAULT_FILTERS);
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
 
-  const [viewMode, setViewMode] = useState<HomeViewMode>('LIST');
+  const [viewMode, setViewMode] = useState<HomeViewMode>('MAP');
 
   const toggleViewMode = useCallback(() => {
     setViewMode((prev) => (prev === 'LIST' ? 'MAP' : 'LIST'));

--- a/mobile/src/viewmodels/home/useHomeViewModel.viewMode.test.ts
+++ b/mobile/src/viewmodels/home/useHomeViewModel.viewMode.test.ts
@@ -3,7 +3,7 @@
  *
  * Focused tests for the viewMode toggle introduced in useHomeViewModel.
  * The broader integration behaviour (events fetching, filters, location) is
- * covered by other tests; these tests pin only the new list/map toggle.
+ * covered by other tests; these tests pin only the default map/list toggle.
  */
 import { act, renderHook } from '@testing-library/react';
 
@@ -52,21 +52,39 @@ jest.mock('@/contexts/AuthContext', () => ({
 import { useHomeViewModel } from './useHomeViewModel';
 
 describe('useHomeViewModel – viewMode toggle', () => {
-  it('starts in LIST mode', async () => {
+  it('starts in MAP mode', async () => {
     const { result } = renderHook(() => useHomeViewModel());
 
     await act(async () => {
       await Promise.resolve();
     });
 
-    expect(result.current.viewMode).toBe('LIST');
+    expect(result.current.viewMode).toBe('MAP');
   });
 
-  it('switches to MAP mode when toggleViewMode is called once', async () => {
+  it('switches to LIST mode when toggleViewMode is called once', async () => {
     const { result } = renderHook(() => useHomeViewModel());
 
     await act(async () => {
       await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.toggleViewMode();
+    });
+
+    expect(result.current.viewMode).toBe('LIST');
+  });
+
+  it('switches back to MAP mode when toggleViewMode is called a second time', async () => {
+    const { result } = renderHook(() => useHomeViewModel());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.toggleViewMode();
     });
 
     act(() => {
@@ -74,24 +92,6 @@ describe('useHomeViewModel – viewMode toggle', () => {
     });
 
     expect(result.current.viewMode).toBe('MAP');
-  });
-
-  it('switches back to LIST mode when toggleViewMode is called a second time', async () => {
-    const { result } = renderHook(() => useHomeViewModel());
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    act(() => {
-      result.current.toggleViewMode();
-    });
-
-    act(() => {
-      result.current.toggleViewMode();
-    });
-
-    expect(result.current.viewMode).toBe('LIST');
   });
 
   it('exposes activeLocation as numeric lat/lon based on the resolved location', async () => {

--- a/mobile/src/views/auth/LoginView.tsx
+++ b/mobile/src/views/auth/LoginView.tsx
@@ -74,6 +74,7 @@ export default function LoginView() {
             editable={!vm.isLoading}
             accessibilityLabel="Username"
             accessibilityState={{ disabled: vm.isLoading }}
+            testID="login-username-input"
           />
           {vm.errors.username && (
             <Text style={styles.fieldError}>{vm.errors.username}</Text>
@@ -93,6 +94,7 @@ export default function LoginView() {
             editable={!vm.isLoading}
             accessibilityLabel="Password"
             accessibilityState={{ disabled: vm.isLoading }}
+            testID="login-password-input"
           />
           {vm.errors.password && (
             <Text style={styles.fieldError}>{vm.errors.password}</Text>
@@ -118,6 +120,7 @@ export default function LoginView() {
           accessibilityRole="button"
           accessibilityLabel={vm.isLoading ? 'Signing in' : 'Sign in'}
           accessibilityState={{ disabled: vm.isLoading, busy: vm.isLoading }}
+          testID="login-submit-button"
         >
           {vm.isLoading ? (
             <ActivityIndicator color={theme.textOnPrimary} />

--- a/mobile/src/views/auth/RegisterView.tsx
+++ b/mobile/src/views/auth/RegisterView.tsx
@@ -114,6 +114,7 @@ export default function RegisterView() {
                 editable={!vm.isLoading}
                 accessibilityLabel="Email"
                 accessibilityState={{ disabled: vm.isLoading }}
+                testID="register-email-input"
               />
               {vm.errors.email && (
                 <Text style={styles.fieldError}>{vm.errors.email}</Text>
@@ -133,6 +134,7 @@ export default function RegisterView() {
                 editable={!vm.isLoading}
                 accessibilityLabel="Username"
                 accessibilityState={{ disabled: vm.isLoading }}
+                testID="register-username-input"
               />
               {vm.errors.username && (
                 <Text style={styles.fieldError}>{vm.errors.username}</Text>
@@ -152,6 +154,7 @@ export default function RegisterView() {
                 editable={!vm.isLoading}
                 accessibilityLabel="Password"
                 accessibilityState={{ disabled: vm.isLoading }}
+                testID="register-password-input"
               />
               {vm.errors.password && (
                 <Text style={styles.fieldError}>{vm.errors.password}</Text>
@@ -276,6 +279,7 @@ export default function RegisterView() {
           accessibilityRole="button"
           accessibilityLabel={vm.isLoading ? `${buttonLabel} in progress` : buttonLabel}
           accessibilityState={{ disabled: vm.isLoading, busy: vm.isLoading }}
+          testID="register-submit-button"
         >
           {vm.isLoading ? (
             <ActivityIndicator color={theme.textOnPrimary} />

--- a/mobile/src/views/event/EditEventView.tsx
+++ b/mobile/src/views/event/EditEventView.tsx
@@ -416,6 +416,7 @@ export default function EditEventView({ eventId }: EditEventViewProps) {
                 placeholderTextColor={theme.placeholder}
                 maxLength={TITLE_MAX_LENGTH}
                 editable={!disabled}
+                testID="edit-event-title-input"
               />
               {vm.errors.title ? <Text style={styles.fieldError}>{vm.errors.title}</Text> : null}
             </View>
@@ -930,6 +931,7 @@ export default function EditEventView({ eventId }: EditEventViewProps) {
                 style={[styles.confirmSaveButton, vm.isSaving && styles.buttonDisabled]}
                 onPress={() => pendingPreview && void submitPreview(pendingPreview)}
                 disabled={vm.isSaving}
+                testID="edit-event-save-anyway-button"
               >
                 {vm.isSaving ? (
                   <ActivityIndicator size="small" color={theme.textOnPrimary} />

--- a/mobile/src/views/event/EventDetailView.tsx
+++ b/mobile/src/views/event/EventDetailView.tsx
@@ -482,6 +482,7 @@ function StarRatingInput({
             onPress={() => onChange(star)}
             activeOpacity={0.75}
             disabled={disabled}
+            testID={`event-feedback-star-${star}`}
           >
             <Text style={[styles.ratingStarIcon, active && styles.ratingStarIconActive]}>★</Text>
           </TouchableOpacity>
@@ -548,7 +549,7 @@ function ParticipantRatingSection({
     <>
       <View style={styles.divider} />
       <View style={styles.section}>
-        <View style={styles.ratingCard}>
+        <View style={styles.ratingCard} testID="event-feedback-section">
           <View style={styles.ratingCardHeader}>
             <View style={styles.ratingCardHeaderCopy}>
               <Text style={styles.ratingKicker}>{t('events.feedback.kicker')}</Text>
@@ -586,7 +587,7 @@ function ParticipantRatingSection({
 
           {isEligibleParticipant && existingRating && !isEditing ? (
             <View style={styles.ratingReadonly}>
-              <Text style={styles.ratingSummaryChip}>
+              <Text style={styles.ratingSummaryChip} testID="event-feedback-summary-chip">
                 {existingRating.rating}/5 · {renderStars(existingRating.rating)}
               </Text>
 
@@ -606,6 +607,7 @@ function ParticipantRatingSection({
                     onDismissError();
                     setIsEditing(true);
                   }}
+                  testID="event-feedback-edit-button"
                 >
                   <Text style={styles.ratingEditButtonText}>{t('events.feedback.editRating')}</Text>
                 </TouchableOpacity>
@@ -637,6 +639,7 @@ function ParticipantRatingSection({
                 textAlignVertical="top"
                 maxLength={FEEDBACK_MAX_LENGTH}
                 editable={!loading}
+                testID="event-feedback-message-input"
               />
 
               <View style={styles.ratingMeta}>
@@ -678,6 +681,7 @@ function ParticipantRatingSection({
                   disabled={loading || rating === 0 || Boolean(feedbackError)}
                   onPress={() => onSubmit(rating, message)}
                   activeOpacity={0.85}
+                  testID="event-feedback-submit-button"
                 >
                   {loading ? (
                     <ActivityIndicator size="small" color={theme.textOnPrimary} />
@@ -1017,7 +1021,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
 
       return (
         <View>
-          <View style={styles.statusChip}>
+          <View style={styles.statusChip} testID="joined-status-chip">
             <Ionicons name="checkmark-circle" size={16} color={theme.successText} />
             <Text style={styles.statusChipTextGreen}>{attendedLabel}</Text>
           </View>
@@ -1054,7 +1058,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
     if (status_ === 'PENDING' || vm.actionState === 'success_requested') {
       return (
         <View>
-          <View style={styles.statusChip}>
+          <View style={styles.statusChip} testID="join-request-pending-chip">
             <Feather name="clock" size={16} color={theme.warningText} />
             <Text style={styles.statusChipTextAmber}>{t('events.detail.requestPending')}</Text>
           </View>
@@ -1096,7 +1100,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
     if (status_ === 'INVITED') {
       return (
         <View>
-          <View style={styles.statusChip}>
+          <View style={styles.statusChip} testID="invited-status-chip">
             <Feather name="mail" size={16} color={theme.infoText} />
             <Text style={styles.statusChipTextBlue}>{t('events.detail.youAreInvited')}</Text>
           </View>
@@ -1139,6 +1143,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                 vm.actionState === 'declining_invitation'
               }
               activeOpacity={0.8}
+              testID="accept-invitation-button"
             >
               {vm.actionState === 'accepting_invitation' ? (
                 <ActivityIndicator color="#FFFFFF" size="small" />
@@ -1210,6 +1215,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
           style={[styles.actionButton, styles.actionButtonProtected]}
           onPress={vm.openJoinRequestModal}
           activeOpacity={0.8}
+          testID="request-to-join-button"
         >
           <Feather name="send" size={18} color={theme.textOnPrimary} />
           <Text style={styles.actionButtonText}>{t('events.detail.requestToJoin')}</Text>
@@ -1614,6 +1620,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                   <TouchableOpacity
                     style={[styles.hostActionBtn, styles.hostActionBtnPrimary]}
                     onPress={() => vm.setShowRequestsModal(true)}
+                    testID="pending-requests-button"
                   >
                     <Feather name="mail" size={18} color={theme.textOnPrimary} />
                     <Text style={styles.hostActionTextWhite}>
@@ -1833,6 +1840,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                 textAlignVertical="top"
                 maxLength={500}
                 editable={vm.actionState !== 'requesting'}
+                testID="join-request-message-input"
               />
               <Text style={styles.charCount}>{vm.joinRequestMessage.length}/500</Text>
 
@@ -1886,6 +1894,7 @@ export default function EventDetailView({ eventId }: EventDetailViewProps) {
                 onPress={vm.handleRequestJoin}
                 disabled={vm.actionState === 'requesting'}
                 activeOpacity={0.8}
+                testID="join-request-send-button"
               >
                 {vm.actionState === 'requesting' ? (
                   <ActivityIndicator color={theme.textOnPrimary} size="small" />

--- a/mobile/src/views/events/MyEventsView.tsx
+++ b/mobile/src/views/events/MyEventsView.tsx
@@ -97,6 +97,7 @@ export default function MyEventsView() {
                 activeOpacity={0.9}
                 onPress={() => vm.setActiveStatus(tab.value)}
                 style={[styles.tab, active && styles.tabActive]}
+                testID={`my-events-tab-${tab.value.toLowerCase()}`}
               >
                 <Text style={[styles.tabText, active && styles.tabTextActive]}>
                   {tab.label}

--- a/mobile/src/views/favorites/FavoriteLocationsTab.test.tsx
+++ b/mobile/src/views/favorites/FavoriteLocationsTab.test.tsx
@@ -17,6 +17,7 @@ jest.mock('react-native', () => {
     'keyboardShouldPersistTaps',
     'numberOfLines',
     'placeholderTextColor',
+    'testID',
   ]);
 
   const stripReactNativeOnlyProps = (props: Record<string, unknown>) => {
@@ -31,18 +32,38 @@ jest.mock('react-native', () => {
 
   const createDiv =
     (displayName: string) =>
-      ({ children, ...props }: { children?: React.ReactNode }) =>
+      ({
+        children,
+        testID,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        testID?: string;
+      }) =>
         ReactLocal.createElement(
           'div',
-          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          {
+            ...stripReactNativeOnlyProps(props),
+            'data-testid': testID ?? displayName,
+          },
           children,
         );
   const createSpan =
     (displayName: string) =>
-      ({ children, ...props }: { children?: React.ReactNode }) =>
+      ({
+        children,
+        testID,
+        ...props
+      }: {
+        children?: React.ReactNode;
+        testID?: string;
+      }) =>
         ReactLocal.createElement(
           'span',
-          { ...stripReactNativeOnlyProps(props), 'data-testid': displayName },
+          {
+            ...stripReactNativeOnlyProps(props),
+            'data-testid': testID ?? displayName,
+          },
           children,
         );
 
@@ -55,13 +76,16 @@ jest.mock('react-native', () => {
     TextInput: ({
       value,
       onChangeText,
+      testID,
       ...props
     }: {
       value?: string;
       onChangeText?: (value: string) => void;
+      testID?: string;
     }) =>
       ReactLocal.createElement('input', {
         ...stripReactNativeOnlyProps(props),
+        'data-testid': testID,
         value,
         onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
           onChangeText?.(event.target.value),
@@ -70,16 +94,19 @@ jest.mock('react-native', () => {
       children,
       onPress,
       disabled,
+      testID,
       ...props
     }: {
       children?: React.ReactNode;
       onPress?: () => void;
       disabled?: boolean;
+      testID?: string;
     }) =>
       ReactLocal.createElement(
         'button',
         {
           ...stripReactNativeOnlyProps(props),
+          'data-testid': testID,
           type: 'button',
           disabled,
           onClick: onPress,

--- a/mobile/src/views/favorites/FavoriteLocationsTab.tsx
+++ b/mobile/src/views/favorites/FavoriteLocationsTab.tsx
@@ -59,7 +59,12 @@ function LocationCard({
         <Ionicons name="location" size={22} color="#6366F1" />
       </View>
       <View style={styles.locationContent}>
-        <Text style={styles.locationName}>{location.name}</Text>
+        <Text
+          style={styles.locationName}
+          testID={`favorite-location-name-${location.name}`}
+        >
+          {location.name}
+        </Text>
         <Text style={styles.locationAddress} numberOfLines={2}>
           {formatEventLocation(location.address)}
         </Text>
@@ -146,6 +151,7 @@ function AddLocationModal({
               value={name}
               onChangeText={onChangeName}
               maxLength={50}
+              testID="favorite-location-name-input"
             />
 
             <Text style={[styles.fieldLabel, { marginTop: 20 }]}>
@@ -157,6 +163,7 @@ function AddLocationModal({
               placeholderTextColor={theme.placeholder}
               value={locationQuery}
               onChangeText={onChangeQuery}
+              testID="favorite-location-address-input"
             />
 
             {isSearching ? (
@@ -173,6 +180,7 @@ function AddLocationModal({
                     key={`${s.lat}-${s.lon}-${index}`}
                     style={styles.suggestionItem}
                     onPress={() => onSelectSuggestion(s)}
+                    testID={`favorite-location-suggestion-${index}`}
                   >
                     <Ionicons
                       name="location-outline"
@@ -214,6 +222,7 @@ function AddLocationModal({
               ]}
               onPress={onSubmit}
               disabled={isSubmitting}
+              testID="favorite-location-save-button"
             >
               {isSubmitting ? (
                 <ActivityIndicator size="small" color={theme.textOnPrimary} />
@@ -253,6 +262,7 @@ export default function FavoriteLocationsTab() {
           style={[styles.addButton, !vm.canAddMore && styles.addButtonDisabled]}
           onPress={vm.openAddModal}
           disabled={!vm.canAddMore}
+          testID="favorite-location-add-button"
         >
           <Feather
             name="plus"

--- a/mobile/src/views/favorites/FavoritesView.tsx
+++ b/mobile/src/views/favorites/FavoritesView.tsx
@@ -24,6 +24,7 @@ export default function FavoritesView() {
           <TouchableOpacity
             style={[styles.tab, activeTab === 'events' && styles.tabActive]}
             onPress={() => setActiveTab('events')}
+            testID="favorites-tab-events"
           >
             <Text
               style={[
@@ -38,6 +39,7 @@ export default function FavoritesView() {
           <TouchableOpacity
             style={[styles.tab, activeTab === 'locations' && styles.tabActive]}
             onPress={() => setActiveTab('locations')}
+            testID="favorites-tab-locations"
           >
             <Text
               style={[

--- a/mobile/src/views/home/HomeView.tsx
+++ b/mobile/src/views/home/HomeView.tsx
@@ -141,6 +141,7 @@ export default function HomeView() {
                 onPress={handleOpenLocationPicker}
                 accessibilityRole="button"
                 accessibilityLabel={t('home.locationPicker.selectAccessibility')}
+                testID="home-location-picker-button"
               >
                 <Feather name="map-pin" size={16} color={styles.mapLocationIconColor.color} />
                 <Text style={styles.mapLocationText} numberOfLines={1}>
@@ -169,6 +170,7 @@ export default function HomeView() {
                   autoCapitalize="none"
                   autoCorrect={false}
                   returnKeyType="search"
+                  testID="home-search-input"
                 />
               </View>
 
@@ -212,6 +214,7 @@ export default function HomeView() {
                 activeOpacity={0.85}
                 accessibilityRole="button"
                 accessibilityLabel={t('home.locationPicker.selectAccessibility')}
+                testID="home-location-picker-button"
               >
                 <Feather name="map-pin" size={18} color={isDark ? theme.text : theme.textOnPrimary} />
                 <Text style={styles.locationPillText} numberOfLines={1}>

--- a/mobile/src/views/ticket/EventActionsView.tsx
+++ b/mobile/src/views/ticket/EventActionsView.tsx
@@ -191,6 +191,7 @@ export default function EventActionsView({ eventId }: EventActionsViewProps) {
               activeOpacity={0.9}
               onPress={handlePrimaryAction}
               style={styles.primaryButton}
+              testID="event-actions-primary-button"
             >
               <Feather
                 name={vm.canScanTicket ? 'camera' : 'grid'}
@@ -218,6 +219,7 @@ export default function EventActionsView({ eventId }: EventActionsViewProps) {
             activeOpacity={0.9}
             onPress={() => router.push(`/event/${eventId}` as Href)}
             style={styles.secondaryButton}
+            testID="event-actions-view-full-event-button"
           >
             <Text style={styles.secondaryButtonText}>{t('tickets.actions.viewFullEvent')}</Text>
             <Ionicons name="chevron-forward" size={22} color={theme.text} />

--- a/reports/e2e/mobile/completed-event-feedback-rating.txt
+++ b/reports/e2e/mobile/completed-event-feedback-rating.txt
@@ -1,0 +1,29 @@
+Running on emulator-5554
+ > Flow completed-event-feedback-rating-test
+Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
+Assert that id: login-submit-button is visible... COMPLETED
+Tap on id: login-username-input... COMPLETED
+Input text ${E2E_USERNAME}... COMPLETED
+Tap on id: login-password-input... COMPLETED
+Input text ${E2E_PASSWORD}... COMPLETED
+Tap on id: login-submit-button... COMPLETED
+Tap on (Optional) "Don't allow"... WARNED
+
+
+ Warning: Element not found: Text matching regex: Don't allow
+Assert that id: tab-events is visible... COMPLETED
+Tap on id: tab-events... COMPLETED
+Assert that id: my-events-tab-completed is visible... COMPLETED
+Tap on id: my-events-tab-completed... COMPLETED
+Scrolling DOWN until id: my-event-card-${E2E_EVENT_TITLE} is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: my-event-card-${E2E_EVENT_TITLE}... COMPLETED
+Scrolling DOWN until id: event-actions-view-full-event-button is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: event-actions-view-full-event-button... COMPLETED
+Scrolling DOWN until id: discussion-qa-tab is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: discussion-qa-tab... COMPLETED
+Scrolling UP until id: event-feedback-edit-button is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: event-feedback-edit-button... COMPLETED
+Tap on id: event-feedback-star-3... COMPLETED
+Tap on id: event-feedback-submit-button... COMPLETED
+Assert that id: event-feedback-edit-button is visible... COMPLETED
+Assert that id: event-feedback-edit-button is visible... COMPLETED

--- a/reports/e2e/mobile/completed-event-feedback-rating.txt
+++ b/reports/e2e/mobile/completed-event-feedback-rating.txt
@@ -1,12 +1,23 @@
 Running on emulator-5554
  > Flow completed-event-feedback-rating-test
 Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
-Assert that id: login-submit-button is visible... COMPLETED
-Tap on id: login-username-input... COMPLETED
-Input text ${E2E_USERNAME}... COMPLETED
-Tap on id: login-password-input... COMPLETED
-Input text ${E2E_PASSWORD}... COMPLETED
-Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml...
+  Run dev-build-bootstrap.yaml...
+    Tap on (Optional) "http://10.0.2.2:8081"... COMPLETED
+    Tap on point (90%,74%)... COMPLETED
+    Tap on (Optional) "Continue"... WARNED
+  Run dev-build-bootstrap.yaml... COMPLETED
+  Assert that id: login-username-input is visible... COMPLETED
+  Assert that id: login-password-input is visible... COMPLETED
+  Assert that id: login-submit-button is visible... COMPLETED
+  Tap on id: login-username-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_USERNAME}... COMPLETED
+  Tap on id: login-password-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_PASSWORD}... COMPLETED
+  Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
 
 

--- a/reports/e2e/mobile/completed-event-feedback-rating.txt
+++ b/reports/e2e/mobile/completed-event-feedback-rating.txt
@@ -16,6 +16,7 @@ Run login-flow.yaml...
   Tap on id: login-password-input... COMPLETED
   Erase text... COMPLETED
   Input text ${E2E_PASSWORD}... COMPLETED
+  Hide Keyboard... COMPLETED
   Tap on id: login-submit-button... COMPLETED
 Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED

--- a/reports/e2e/mobile/edit-event-title.txt
+++ b/reports/e2e/mobile/edit-event-title.txt
@@ -16,6 +16,7 @@ Run login-flow.yaml...
   Tap on id: login-password-input... COMPLETED
   Erase text... COMPLETED
   Input text ${E2E_PASSWORD}... COMPLETED
+  Hide Keyboard... COMPLETED
   Tap on id: login-submit-button... COMPLETED
 Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
@@ -34,6 +35,7 @@ Assert that id: edit-event-title-input is visible... COMPLETED
 Tap on id: edit-event-title-input... COMPLETED
 Erase text... COMPLETED
 Input text ${E2E_UPDATED_EVENT_TITLE}... COMPLETED
+Hide Keyboard... COMPLETED
 Scrolling DOWN until id: edit-event-save-button is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
 Tap on id: edit-event-save-button... COMPLETED
 Assert that id: edit-event-confirmation is visible... COMPLETED

--- a/reports/e2e/mobile/edit-event-title.txt
+++ b/reports/e2e/mobile/edit-event-title.txt
@@ -1,12 +1,23 @@
 Running on emulator-5554
  > Flow edit-event-title-test
 Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
-Assert that id: login-submit-button is visible... COMPLETED
-Tap on id: login-username-input... COMPLETED
-Input text ${E2E_USERNAME}... COMPLETED
-Tap on id: login-password-input... COMPLETED
-Input text ${E2E_PASSWORD}... COMPLETED
-Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml...
+  Run dev-build-bootstrap.yaml...
+    Tap on (Optional) "http://10.0.2.2:8081"... COMPLETED
+    Tap on point (90%,74%)... COMPLETED
+    Tap on (Optional) "Continue"... WARNED
+  Run dev-build-bootstrap.yaml... COMPLETED
+  Assert that id: login-username-input is visible... COMPLETED
+  Assert that id: login-password-input is visible... COMPLETED
+  Assert that id: login-submit-button is visible... COMPLETED
+  Tap on id: login-username-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_USERNAME}... COMPLETED
+  Tap on id: login-password-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_PASSWORD}... COMPLETED
+  Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
 
 

--- a/reports/e2e/mobile/edit-event-title.txt
+++ b/reports/e2e/mobile/edit-event-title.txt
@@ -1,0 +1,30 @@
+Running on emulator-5554
+ > Flow edit-event-title-test
+Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
+Assert that id: login-submit-button is visible... COMPLETED
+Tap on id: login-username-input... COMPLETED
+Input text ${E2E_USERNAME}... COMPLETED
+Tap on id: login-password-input... COMPLETED
+Input text ${E2E_PASSWORD}... COMPLETED
+Tap on id: login-submit-button... COMPLETED
+Tap on (Optional) "Don't allow"... WARNED
+
+
+ Warning: Element not found: Text matching regex: Don't allow
+Assert that id: tab-events is visible... COMPLETED
+Tap on id: tab-events... COMPLETED
+Assert that id: my-events-tab-active is visible... COMPLETED
+Tap on id: my-events-tab-active... COMPLETED
+Scrolling DOWN until id: my-event-card-${E2E_ORIGINAL_EVENT_TITLE} is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: my-event-card-${E2E_ORIGINAL_EVENT_TITLE}... COMPLETED
+Assert that "Edit Event" is visible... COMPLETED
+Tap on "Edit Event"... COMPLETED
+Assert that id: edit-event-title-input is visible... COMPLETED
+Tap on id: edit-event-title-input... COMPLETED
+Erase text... COMPLETED
+Input text ${E2E_UPDATED_EVENT_TITLE}... COMPLETED
+Scrolling DOWN until id: edit-event-save-button is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: edit-event-save-button... COMPLETED
+Assert that id: edit-event-confirmation is visible... COMPLETED
+Tap on id: edit-event-save-anyway-button... COMPLETED
+Assert that "${E2E_UPDATED_EVENT_TITLE}" is visible... COMPLETED

--- a/reports/e2e/mobile/favorite-event-discussion-post.txt
+++ b/reports/e2e/mobile/favorite-event-discussion-post.txt
@@ -16,6 +16,7 @@ Run login-flow.yaml...
   Tap on id: login-password-input... COMPLETED
   Erase text... COMPLETED
   Input text ${E2E_PASSWORD}... COMPLETED
+  Hide Keyboard... COMPLETED
   Tap on id: login-submit-button... COMPLETED
 Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
@@ -29,6 +30,7 @@ Tap on id: profile-event-card-${E2E_EVENT_TITLE}... COMPLETED
 Scrolling DOWN until id: discussion-question-input is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
 Tap on id: discussion-question-input... COMPLETED
 Input text ${E2E_DISCUSSION_MESSAGE}... COMPLETED
+Hide Keyboard... COMPLETED
 Scrolling DOWN until id: discussion-post-button is visible with speed 40, visibility percentage 100%, timeout 15000 ms, with centering disabled... COMPLETED
 Tap on id: discussion-post-button... COMPLETED
 Assert that "${E2E_DISCUSSION_MESSAGE}" is visible... COMPLETED

--- a/reports/e2e/mobile/favorite-event-discussion-post.txt
+++ b/reports/e2e/mobile/favorite-event-discussion-post.txt
@@ -1,0 +1,23 @@
+Running on emulator-5554
+ > Flow favorite-event-discussion-post-test
+Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
+Assert that id: login-submit-button is visible... COMPLETED
+Tap on id: login-username-input... COMPLETED
+Input text ${E2E_USERNAME}... COMPLETED
+Tap on id: login-password-input... COMPLETED
+Input text ${E2E_PASSWORD}... COMPLETED
+Tap on id: login-submit-button... COMPLETED
+Tap on (Optional) "Don't allow"... WARNED
+
+
+ Warning: Element not found: Text matching regex: Don't allow
+Assert that id: tab-favorites is visible... COMPLETED
+Tap on id: tab-favorites... COMPLETED
+Assert that "${E2E_EVENT_TITLE}" is visible... COMPLETED
+Tap on id: profile-event-card-${E2E_EVENT_TITLE}... COMPLETED
+Scrolling DOWN until id: discussion-question-input is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: discussion-question-input... COMPLETED
+Input text ${E2E_DISCUSSION_MESSAGE}... COMPLETED
+Scrolling DOWN until id: discussion-post-button is visible with speed 40, visibility percentage 100%, timeout 15000 ms, with centering disabled... COMPLETED
+Tap on id: discussion-post-button... COMPLETED
+Assert that "${E2E_DISCUSSION_MESSAGE}" is visible... COMPLETED

--- a/reports/e2e/mobile/favorite-event-discussion-post.txt
+++ b/reports/e2e/mobile/favorite-event-discussion-post.txt
@@ -1,12 +1,23 @@
 Running on emulator-5554
  > Flow favorite-event-discussion-post-test
 Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
-Assert that id: login-submit-button is visible... COMPLETED
-Tap on id: login-username-input... COMPLETED
-Input text ${E2E_USERNAME}... COMPLETED
-Tap on id: login-password-input... COMPLETED
-Input text ${E2E_PASSWORD}... COMPLETED
-Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml...
+  Run dev-build-bootstrap.yaml...
+    Tap on (Optional) "http://10.0.2.2:8081"... COMPLETED
+    Tap on point (90%,74%)... COMPLETED
+    Tap on (Optional) "Continue"... WARNED
+  Run dev-build-bootstrap.yaml... COMPLETED
+  Assert that id: login-username-input is visible... COMPLETED
+  Assert that id: login-password-input is visible... COMPLETED
+  Assert that id: login-submit-button is visible... COMPLETED
+  Tap on id: login-username-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_USERNAME}... COMPLETED
+  Tap on id: login-password-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_PASSWORD}... COMPLETED
+  Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
 
 

--- a/reports/e2e/mobile/favorite-location-save-and-apply.txt
+++ b/reports/e2e/mobile/favorite-location-save-and-apply.txt
@@ -1,0 +1,35 @@
+Running on emulator-5554
+ > Flow favorite-location-save-and-apply-test
+Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
+Assert that id: login-submit-button is visible... COMPLETED
+Tap on id: login-username-input... COMPLETED
+Input text ${E2E_USERNAME}... COMPLETED
+Tap on id: login-password-input... COMPLETED
+Input text ${E2E_PASSWORD}... COMPLETED
+Tap on id: login-submit-button... COMPLETED
+Tap on (Optional) "Don't allow"... WARNED
+
+
+ Warning: Element not found: Text matching regex: Don't allow
+Assert that id: tab-favorites is visible... COMPLETED
+Tap on id: tab-favorites... COMPLETED
+Assert that id: favorites-tab-locations is visible... COMPLETED
+Tap on id: favorites-tab-locations... COMPLETED
+Assert that id: favorite-location-add-button is visible... COMPLETED
+Tap on id: favorite-location-add-button... COMPLETED
+Assert that id: favorite-location-name-input is visible... COMPLETED
+Tap on id: favorite-location-name-input... COMPLETED
+Input text ${E2E_LOCATION_NAME}... COMPLETED
+Tap on id: favorite-location-address-input... COMPLETED
+Input text ${E2E_LOCATION_QUERY}... COMPLETED
+Assert that id: favorite-location-suggestion-0 is visible... COMPLETED
+Tap on id: favorite-location-suggestion-0... COMPLETED
+Tap on id: favorite-location-save-button... COMPLETED
+Assert that id: favorite-location-name-${E2E_LOCATION_NAME} is visible... COMPLETED
+Tap on id: tab-home... COMPLETED
+Assert that id: home-location-picker-button is visible... COMPLETED
+Tap on id: home-location-picker-button... COMPLETED
+Assert that id: home-location-favorite-option-${E2E_LOCATION_NAME} is visible... COMPLETED
+Tap on id: home-location-favorite-option-${E2E_LOCATION_NAME}... COMPLETED
+Tap on id: home-location-apply-button... COMPLETED
+Assert that id: home-location-apply-button is not visible... COMPLETED

--- a/reports/e2e/mobile/favorite-location-save-and-apply.txt
+++ b/reports/e2e/mobile/favorite-location-save-and-apply.txt
@@ -16,6 +16,7 @@ Run login-flow.yaml...
   Tap on id: login-password-input... COMPLETED
   Erase text... COMPLETED
   Input text ${E2E_PASSWORD}... COMPLETED
+  Hide Keyboard... COMPLETED
   Tap on id: login-submit-button... COMPLETED
 Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
@@ -33,6 +34,7 @@ Tap on id: favorite-location-name-input... COMPLETED
 Input text ${E2E_LOCATION_NAME}... COMPLETED
 Tap on id: favorite-location-address-input... COMPLETED
 Input text ${E2E_LOCATION_QUERY}... COMPLETED
+Hide Keyboard... COMPLETED
 Assert that id: favorite-location-suggestion-0 is visible... COMPLETED
 Tap on id: favorite-location-suggestion-0... COMPLETED
 Tap on id: favorite-location-save-button... COMPLETED

--- a/reports/e2e/mobile/favorite-location-save-and-apply.txt
+++ b/reports/e2e/mobile/favorite-location-save-and-apply.txt
@@ -1,12 +1,23 @@
 Running on emulator-5554
  > Flow favorite-location-save-and-apply-test
 Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
-Assert that id: login-submit-button is visible... COMPLETED
-Tap on id: login-username-input... COMPLETED
-Input text ${E2E_USERNAME}... COMPLETED
-Tap on id: login-password-input... COMPLETED
-Input text ${E2E_PASSWORD}... COMPLETED
-Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml...
+  Run dev-build-bootstrap.yaml...
+    Tap on (Optional) "http://10.0.2.2:8081"... COMPLETED
+    Tap on point (90%,74%)... COMPLETED
+    Tap on (Optional) "Continue"... WARNED
+  Run dev-build-bootstrap.yaml... COMPLETED
+  Assert that id: login-username-input is visible... COMPLETED
+  Assert that id: login-password-input is visible... COMPLETED
+  Assert that id: login-submit-button is visible... COMPLETED
+  Tap on id: login-username-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_USERNAME}... COMPLETED
+  Tap on id: login-password-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_PASSWORD}... COMPLETED
+  Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
 
 

--- a/reports/e2e/mobile/host-approve-join-request.txt
+++ b/reports/e2e/mobile/host-approve-join-request.txt
@@ -1,12 +1,23 @@
 Running on emulator-5554
  > Flow host-approve-join-request-test
 Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
-Assert that id: login-submit-button is visible... COMPLETED
-Tap on id: login-username-input... COMPLETED
-Input text ${E2E_USERNAME}... COMPLETED
-Tap on id: login-password-input... COMPLETED
-Input text ${E2E_PASSWORD}... COMPLETED
-Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml...
+  Run dev-build-bootstrap.yaml...
+    Tap on (Optional) "http://10.0.2.2:8081"... COMPLETED
+    Tap on point (90%,74%)... COMPLETED
+    Tap on (Optional) "Continue"... WARNED
+  Run dev-build-bootstrap.yaml... COMPLETED
+  Assert that id: login-username-input is visible... COMPLETED
+  Assert that id: login-password-input is visible... COMPLETED
+  Assert that id: login-submit-button is visible... COMPLETED
+  Tap on id: login-username-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_USERNAME}... COMPLETED
+  Tap on id: login-password-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_PASSWORD}... COMPLETED
+  Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
 
 

--- a/reports/e2e/mobile/host-approve-join-request.txt
+++ b/reports/e2e/mobile/host-approve-join-request.txt
@@ -16,6 +16,7 @@ Run login-flow.yaml...
   Tap on id: login-password-input... COMPLETED
   Erase text... COMPLETED
   Input text ${E2E_PASSWORD}... COMPLETED
+  Hide Keyboard... COMPLETED
   Tap on id: login-submit-button... COMPLETED
 Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED

--- a/reports/e2e/mobile/host-approve-join-request.txt
+++ b/reports/e2e/mobile/host-approve-join-request.txt
@@ -1,0 +1,26 @@
+Running on emulator-5554
+ > Flow host-approve-join-request-test
+Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
+Assert that id: login-submit-button is visible... COMPLETED
+Tap on id: login-username-input... COMPLETED
+Input text ${E2E_USERNAME}... COMPLETED
+Tap on id: login-password-input... COMPLETED
+Input text ${E2E_PASSWORD}... COMPLETED
+Tap on id: login-submit-button... COMPLETED
+Tap on (Optional) "Don't allow"... WARNED
+
+
+ Warning: Element not found: Text matching regex: Don't allow
+Assert that id: tab-events is visible... COMPLETED
+Tap on id: tab-events... COMPLETED
+Assert that id: my-events-tab-active is visible... COMPLETED
+Tap on id: my-events-tab-active... COMPLETED
+Scrolling DOWN until id: my-event-card-${E2E_EVENT_TITLE} is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: my-event-card-${E2E_EVENT_TITLE}... COMPLETED
+Scrolling DOWN until "View Full Event" is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on "View Full Event"... COMPLETED
+Scrolling DOWN until id: pending-requests-button is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: pending-requests-button... COMPLETED
+Assert that id: join-request-row-${E2E_REQUEST_USERNAME} is visible... COMPLETED
+Tap on id: join-request-approve-${E2E_REQUEST_USERNAME}... COMPLETED
+Assert that id: join-request-row-${E2E_REQUEST_USERNAME} is not visible... COMPLETED

--- a/reports/e2e/mobile/invitation-accept.txt
+++ b/reports/e2e/mobile/invitation-accept.txt
@@ -1,12 +1,23 @@
 Running on emulator-5554
  > Flow invitation-accept-test
 Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
-Assert that id: login-submit-button is visible... COMPLETED
-Tap on id: login-username-input... COMPLETED
-Input text ${E2E_USERNAME}... COMPLETED
-Tap on id: login-password-input... COMPLETED
-Input text ${E2E_PASSWORD}... COMPLETED
-Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml...
+  Run dev-build-bootstrap.yaml...
+    Tap on (Optional) "http://10.0.2.2:8081"... COMPLETED
+    Tap on point (90%,74%)... COMPLETED
+    Tap on (Optional) "Continue"... WARNED
+  Run dev-build-bootstrap.yaml... COMPLETED
+  Assert that id: login-username-input is visible... COMPLETED
+  Assert that id: login-password-input is visible... COMPLETED
+  Assert that id: login-submit-button is visible... COMPLETED
+  Tap on id: login-username-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_USERNAME}... COMPLETED
+  Tap on id: login-password-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_PASSWORD}... COMPLETED
+  Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
 
 

--- a/reports/e2e/mobile/invitation-accept.txt
+++ b/reports/e2e/mobile/invitation-accept.txt
@@ -1,0 +1,21 @@
+Running on emulator-5554
+ > Flow invitation-accept-test
+Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
+Assert that id: login-submit-button is visible... COMPLETED
+Tap on id: login-username-input... COMPLETED
+Input text ${E2E_USERNAME}... COMPLETED
+Tap on id: login-password-input... COMPLETED
+Input text ${E2E_PASSWORD}... COMPLETED
+Tap on id: login-submit-button... COMPLETED
+Tap on (Optional) "Don't allow"... WARNED
+
+
+ Warning: Element not found: Text matching regex: Don't allow
+Assert that id: tab-profile is visible... COMPLETED
+Tap on id: tab-profile... COMPLETED
+Assert that "${E2E_INVITATION_EVENT_TITLE}" is visible... COMPLETED
+Tap on "${E2E_INVITATION_EVENT_TITLE}"... COMPLETED
+Assert that id: invited-status-chip is visible... COMPLETED
+Assert that id: accept-invitation-button is visible... COMPLETED
+Tap on id: accept-invitation-button... COMPLETED
+Assert that id: joined-status-chip is visible... COMPLETED

--- a/reports/e2e/mobile/invitation-accept.txt
+++ b/reports/e2e/mobile/invitation-accept.txt
@@ -16,6 +16,7 @@ Run login-flow.yaml...
   Tap on id: login-password-input... COMPLETED
   Erase text... COMPLETED
   Input text ${E2E_PASSWORD}... COMPLETED
+  Hide Keyboard... COMPLETED
   Tap on id: login-submit-button... COMPLETED
 Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED

--- a/reports/e2e/mobile/my-events-view-ticket.txt
+++ b/reports/e2e/mobile/my-events-view-ticket.txt
@@ -1,12 +1,23 @@
 Running on emulator-5554
  > Flow my-events-view-ticket-test
 Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
-Assert that id: login-submit-button is visible... COMPLETED
-Tap on id: login-username-input... COMPLETED
-Input text ${E2E_USERNAME}... COMPLETED
-Tap on id: login-password-input... COMPLETED
-Input text ${E2E_PASSWORD}... COMPLETED
-Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml...
+  Run dev-build-bootstrap.yaml...
+    Tap on (Optional) "http://10.0.2.2:8081"... COMPLETED
+    Tap on point (90%,74%)... COMPLETED
+    Tap on (Optional) "Continue"... WARNED
+  Run dev-build-bootstrap.yaml... COMPLETED
+  Assert that id: login-username-input is visible... COMPLETED
+  Assert that id: login-password-input is visible... COMPLETED
+  Assert that id: login-submit-button is visible... COMPLETED
+  Tap on id: login-username-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_USERNAME}... COMPLETED
+  Tap on id: login-password-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_PASSWORD}... COMPLETED
+  Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
 
 

--- a/reports/e2e/mobile/my-events-view-ticket.txt
+++ b/reports/e2e/mobile/my-events-view-ticket.txt
@@ -16,6 +16,7 @@ Run login-flow.yaml...
   Tap on id: login-password-input... COMPLETED
   Erase text... COMPLETED
   Input text ${E2E_PASSWORD}... COMPLETED
+  Hide Keyboard... COMPLETED
   Tap on id: login-submit-button... COMPLETED
 Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED

--- a/reports/e2e/mobile/my-events-view-ticket.txt
+++ b/reports/e2e/mobile/my-events-view-ticket.txt
@@ -1,0 +1,25 @@
+Running on emulator-5554
+ > Flow my-events-view-ticket-test
+Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
+Assert that id: login-submit-button is visible... COMPLETED
+Tap on id: login-username-input... COMPLETED
+Input text ${E2E_USERNAME}... COMPLETED
+Tap on id: login-password-input... COMPLETED
+Input text ${E2E_PASSWORD}... COMPLETED
+Tap on id: login-submit-button... COMPLETED
+Tap on (Optional) "Don't allow"... WARNED
+
+
+ Warning: Element not found: Text matching regex: Don't allow
+Assert that id: tab-events is visible... COMPLETED
+Tap on id: tab-events... COMPLETED
+Assert that id: my-events-tab-active is visible... COMPLETED
+Tap on id: my-events-tab-active... COMPLETED
+Scrolling DOWN until id: my-event-card-${E2E_EVENT_TITLE} is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Tap on id: my-event-card-${E2E_EVENT_TITLE}... COMPLETED
+Assert that id: event-actions-primary-button is visible... COMPLETED
+Tap on id: event-actions-primary-button... COMPLETED
+Assert that "Ticket" is visible... COMPLETED
+Assert that "${E2E_EVENT_TITLE}" is visible... COMPLETED
+Scrolling DOWN until "Refresh Code" is visible with speed 40, visibility percentage 100%, timeout 30000 ms, with centering disabled... COMPLETED
+Assert that "Refresh Code" is visible... COMPLETED

--- a/reports/e2e/mobile/protected-event-join-request.txt
+++ b/reports/e2e/mobile/protected-event-join-request.txt
@@ -1,0 +1,29 @@
+Running on emulator-5554
+ > Flow protected-event-join-request-test
+Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
+Assert that id: login-submit-button is visible... COMPLETED
+Tap on id: login-username-input... COMPLETED
+Input text ${E2E_USERNAME}... COMPLETED
+Tap on id: login-password-input... COMPLETED
+Input text ${E2E_PASSWORD}... COMPLETED
+Tap on id: login-submit-button... COMPLETED
+Tap on (Optional) "Don't allow"... WARNED
+
+
+ Warning: Element not found: Text matching regex: Don't allow
+Assert that id: toggle-list is visible... COMPLETED
+Tap on id: toggle-list... COMPLETED
+Assert that id: home-search-input is visible... COMPLETED
+Tap on id: home-search-input... COMPLETED
+Erase text... COMPLETED
+Input text ${E2E_SEARCH_QUERY}... COMPLETED
+Press Enter key... COMPLETED
+Assert that "${E2E_EVENT_TITLE}" is visible... COMPLETED
+Tap on "${E2E_EVENT_TITLE}"... COMPLETED
+Assert that id: request-to-join-button is visible... COMPLETED
+Tap on id: request-to-join-button... COMPLETED
+Assert that id: join-request-message-input is visible... COMPLETED
+Tap on id: join-request-message-input... COMPLETED
+Input text ${E2E_JOIN_MESSAGE}... COMPLETED
+Tap on id: join-request-send-button... COMPLETED
+Assert that id: join-request-pending-chip is visible... COMPLETED

--- a/reports/e2e/mobile/protected-event-join-request.txt
+++ b/reports/e2e/mobile/protected-event-join-request.txt
@@ -1,12 +1,23 @@
 Running on emulator-5554
  > Flow protected-event-join-request-test
 Launch app "com.bounswe2026group11.socialeventmapper" with clear state... COMPLETED
-Assert that id: login-submit-button is visible... COMPLETED
-Tap on id: login-username-input... COMPLETED
-Input text ${E2E_USERNAME}... COMPLETED
-Tap on id: login-password-input... COMPLETED
-Input text ${E2E_PASSWORD}... COMPLETED
-Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml...
+  Run dev-build-bootstrap.yaml...
+    Tap on (Optional) "http://10.0.2.2:8081"... COMPLETED
+    Tap on point (90%,74%)... COMPLETED
+    Tap on (Optional) "Continue"... WARNED
+  Run dev-build-bootstrap.yaml... COMPLETED
+  Assert that id: login-username-input is visible... COMPLETED
+  Assert that id: login-password-input is visible... COMPLETED
+  Assert that id: login-submit-button is visible... COMPLETED
+  Tap on id: login-username-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_USERNAME}... COMPLETED
+  Tap on id: login-password-input... COMPLETED
+  Erase text... COMPLETED
+  Input text ${E2E_PASSWORD}... COMPLETED
+  Tap on id: login-submit-button... COMPLETED
+Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
 
 

--- a/reports/e2e/mobile/protected-event-join-request.txt
+++ b/reports/e2e/mobile/protected-event-join-request.txt
@@ -16,6 +16,7 @@ Run login-flow.yaml...
   Tap on id: login-password-input... COMPLETED
   Erase text... COMPLETED
   Input text ${E2E_PASSWORD}... COMPLETED
+  Hide Keyboard... COMPLETED
   Tap on id: login-submit-button... COMPLETED
 Run login-flow.yaml... COMPLETED
 Tap on (Optional) "Don't allow"... WARNED
@@ -28,7 +29,7 @@ Assert that id: home-search-input is visible... COMPLETED
 Tap on id: home-search-input... COMPLETED
 Erase text... COMPLETED
 Input text ${E2E_SEARCH_QUERY}... COMPLETED
-Press Enter key... COMPLETED
+Hide Keyboard... COMPLETED
 Assert that "${E2E_EVENT_TITLE}" is visible... COMPLETED
 Tap on "${E2E_EVENT_TITLE}"... COMPLETED
 Assert that id: request-to-join-button is visible... COMPLETED
@@ -36,5 +37,6 @@ Tap on id: request-to-join-button... COMPLETED
 Assert that id: join-request-message-input is visible... COMPLETED
 Tap on id: join-request-message-input... COMPLETED
 Input text ${E2E_JOIN_MESSAGE}... COMPLETED
+Hide Keyboard... COMPLETED
 Tap on id: join-request-send-button... COMPLETED
 Assert that id: join-request-pending-chip is visible... COMPLETED


### PR DESCRIPTION
## Summary

This PR adds mobile end-to-end (E2E) coverage with Maestro for key final user workflows and introduces the required mobile `testID` hooks to make those flows stable and repeatable.

It also updates the default Discover/Home experience to open in map view instead of list view.

## Included E2E Flows

- Protected event join request flow
- Private invitation accept flow
- Favorite event discussion post flow
- My Events -> View Ticket flow
- Favorite location save and apply flow
- Host approves pending join request flow
- Edit event title flow
- Completed event feedback/rating update flow

## Supporting Mobile Changes

Stable `testID` hooks were added for Maestro on:

- login inputs and submit button
- bottom tab navigation
- home location picker
- favorites tabs and favorite location modal
- my events cards and status tabs
- event actions and event detail actions
- feedback/rating controls
- discussion tabs
- join request and invitation related controls

Relevant mobile updates also include:
- default Discover/Home view mode changed from list to map
- mobile view-mode tests updated to match the new default
- local RN web test mocks updated so newly added `testID` props do not produce DOM warnings in Jest

## Validation

The flows were executed locally on the Android emulator using Maestro.

Example commands:

```bash
cd mobile
maestro test .maestro/protected-event-join-request-test.yaml
maestro test .maestro/invitation-accept-test.yaml
maestro test .maestro/favorite-event-discussion-post-test.yaml
maestro test .maestro/my-events-view-ticket-test.yaml
maestro test .maestro/favorite-location-save-and-apply-test.yaml
maestro test .maestro/host-approve-join-request-test.yaml
maestro test .maestro/edit-event-title-test.yaml
maestro test .maestro/completed-event-feedback-rating-test.yaml
```

## Test Data Notes

These Maestro flows depend on specific local/test data.

Please make sure the referenced users and events exist in your local environment, or update the usernames, passwords, event titles, and related test data in the Maestro files before running the flows.

In particular, the tests currently reference the users and events defined directly inside the `.maestro/*.yaml` files.

