### PR TITLE
docs: update README for final release setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,112 +1,251 @@
 # Social Event Mapper - Group 11
 
-A **CMPE354 Group 11** project for discovering and managing social events on a map.
+Social Event Mapper is the CMPE 354 Group 11 final milestone project for discovering, creating, joining, moderating, and checking in to social events on a map.
 
-## Tech stack
+The project ships three surfaces backed by one API:
+
+- **Web app:** event discovery, event creation/management, profile flows, and admin backoffice.
+- **Mobile app:** map-first discovery, event participation, invitations, tickets, QR check-in, and profile flows.
+- **Backend API:** auth, event lifecycle, participation, private invitations, protected join requests, QR tickets, notifications, reports, badges, and admin moderation.
+
+## Final Release
+
+| Item | Link |
+|---|---|
+| Live web app | [https://socialeventmapper.com/](https://socialeventmapper.com/) |
+| Live Swagger / OpenAPI docs | [https://socialeventmapper.com/api/docs/](https://socialeventmapper.com/api/docs/) |
+| Final release | [1.0.0 / `final-milestone`](https://github.com/bounswe/bounswe2026group11/releases/tag/final-milestone) |
+| Android APK | [social-event-mapper-final-milestone.apk](https://github.com/bounswe/bounswe2026group11/releases/download/final-milestone/social-event-mapper-final-milestone.apk) |
+| Final milestone wiki | [Final Milestone Deliverables](https://github.com/bounswe/bounswe2026group11/wiki/Final-Milestone-Deliverables) |
+
+## Tech Stack
 
 | Layer | Technology |
-|--------|------------|
-| **Backend** | Go 1.26.1, [Fiber](https://gofiber.io/), PostgreSQL + PostGIS, [golang-migrate](https://github.com/golang-migrate/migrate) |
-| **Frontend** | [React](https://react.dev/) - maps with [MapLibre GL JS](https://maplibre.org/). |
-| **Mobile** | React Native, [Expo](https://expo.dev) ~55, [Expo Router](https://docs.expo.dev/router/introduction/) |
+|---|---|
+| Backend | Go 1.26, Fiber, PostgreSQL 16 + PostGIS, golang-migrate, OpenAPI 3.1 |
+| Web | React 19, TypeScript, Vite, React Router, Google Maps |
+| Mobile | React Native, Expo SDK 55, Expo Router, React Native Maps |
+| Runtime | Docker Compose, NGINX reverse proxy, Swagger UI |
+| CI/CD | GitHub Actions, Docker Hub images, release APK workflow |
 
-## Repository layout
+## Repository Layout
 
 | Path | Role |
-|------|------|
-| [`backend/`](backend/) | Go API (`cmd/server`), domain/application layers, Postgres adapters, migrations |
-| [`frontend/`](frontend/) | Web client (React + MapLibre GL planned); Compose currently uses a placeholder static image |
-| [`mobile/`](mobile/) | React Native client (login, registration, API client) |
-| [`deploy/`](deploy/) | Docker Compose files and env templates (`IMAGE_TAG` selects the deployed app image tag on the dev server) |
-| [`nginx/`](nginx/) | Local and dev reverse proxy configuration |
-| [`docs/openapi/`](docs/openapi/) | OpenAPI 3.x specs consumed by Swagger UI and client teams |
-| [`docs/db/schema.sql`](docs/db/schema.sql) | Reference DDL (migrations under `backend/migrations/` are authoritative at runtime) |
+|---|---|
+| [`backend/`](backend/) | Go API, domain/application layers, adapters, migrations, backend tests |
+| [`frontend/`](frontend/) | React web app and admin backoffice |
+| [`mobile/`](mobile/) | Expo React Native app |
+| [`deploy/`](deploy/) | Local/dev Docker Compose files and environment template |
+| [`nginx/`](nginx/) | Local and deployed NGINX reverse proxy configs |
+| [`docs/openapi/`](docs/openapi/) | OpenAPI specs served by Swagger UI |
+| [`docs/backend/`](docs/backend/) | Backend architecture and business-flow documentation |
+| [`docs/db/`](docs/db/) | Database schema and persistence documentation |
 
-## Local development
+## Quick Start: Local Docker
 
-### Recommended: Docker Compose
+Use this path if you want to run the whole web stack locally. It builds the backend and frontend from source, starts PostgreSQL/PostGIS, and serves everything through local NGINX.
 
-You need [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/).
+### Prerequisites
 
-1. At the repository root, create the Compose env file and fill in the required secrets (`DB_PASSWORD`, `JWT_SECRET`, and `RESEND_CLIENT_API_KEY`):
+- Docker Desktop or Docker Engine with Compose
+- Git
+- A Google Maps Web API key if you want the web map to render normally
 
-   ```bash
-   cp deploy/.env.example deploy/.env
-   ```
+### 1. Create the local environment file
 
-2. Start the local stack from the repo root:
+```bash
+cp deploy/.env.example deploy/.env
+```
 
-   ```bash
-   docker compose -f deploy/docker-compose.local.yml up --build
-   ```
+For the minimum local boot, fill:
 
-3. Open:
-   - App: `http://localhost`
-   - API health: `http://localhost/api/health`
-   - Swagger UI: `http://localhost/api/docs/`
+```dotenv
+DB_PASSWORD=<local-postgres-password>
+JWT_SECRET=<local-jwt-secret>
+VITE_GOOGLE_MAPS_WEB_API_KEY=<google-maps-web-key>
+```
 
-The local compose stack includes:
+Optional feature credentials:
 
-- Backend API
-- Frontend
-- Postgres/PostGIS
-- Nginx
-- Local Swagger UI backed by [`docs/openapi/`](docs/openapi/)
+- `RESEND_CLIENT_API_KEY`: only needed if email delivery is changed from mock mode to Resend.
+- `SPACES_*`: needed for real direct image uploads.
+- `FIREBASE_SERVICE_ACCOUNT_JSON_BASE64` and `NEW_RELIC_LICENSE_KEY`: not needed for local compose; local push notifications use the mock provider.
+
+Do not commit `deploy/.env`.
+
+### 2. Start the local stack
+
+```bash
+docker compose -f deploy/docker-compose.local.yml up --build
+```
+
+Open:
+
+- Web app: [http://localhost](http://localhost)
+- Backend health: [http://localhost/api/health](http://localhost/api/health)
+- Swagger UI: [http://localhost/api/docs/](http://localhost/api/docs/)
 
 Useful local details:
 
-- Postgres is exposed at `127.0.0.1:5433` for local tools.
-- The dev-server compose file is different: [`deploy/docker-compose.dev.yml`](deploy/docker-compose.dev.yml) is for the remote droplet, not local development.
-- API docs are exposed by both local Compose and the shared dev deployment at `/api/docs/`.
+- The API base URL is `http://localhost/api`.
+- PostgreSQL is exposed to the host at `127.0.0.1:5433`.
+- Database name is `sem`, user is `postgres`, password is `DB_PASSWORD`.
+- Local backend config uses mock email and mock push providers.
+- Migrations seed the canonical event categories and badges. A fresh database does not need a separate category seed script.
 
-`deploy/docker-compose.dev.yml` is different: on the dev host, Postgres is published on **127.0.0.1:5432** for manual inspection and SSH tunneling, still with user `postgres`, database `sem`, and password from `deploy/.env`. That exposure is dev-only and loopback-bound, not a production pattern. If host `5432` is already in use on the dev machine, use a local Compose override file for that machine instead of changing the shared dev compose file; [`docs/deploy.md`](docs/deploy.md) shows the pattern.
-
-> Use [`deploy/docker-compose.local.yml`](deploy/docker-compose.local.yml) for local development. [`deploy/docker-compose.dev.yml`](deploy/docker-compose.dev.yml) is for a remote server with pre-built images; see [`docs/deploy.md`](docs/deploy.md) for details.
-
-## Remote dev deployment
-
-The shared development server is deployed by GitHub Actions workflow [`deploy-dev.yml`](.github/workflows/deploy-dev.yml).
-
-- **Automatic trigger:** pushes/merges to `main`
-- **Release trigger:** publishing a GitHub release also deploys to the same dev server for now
-- **Manual trigger:** `workflow_dispatch` from the GitHub Actions UI
-- **Image strategy:** backend and frontend images are pushed to Docker Hub with both `latest` and an immutable commit-SHA tag; the server deploys the exact `IMAGE_TAG` written into `deploy/.env`
-- **Safe update behavior:** the workflow pulls and recreates only the application services by default, waits for Postgres health before updating the backend, avoids unnecessary Postgres restarts, reloads nginx config when possible, and runs backend/frontend plus ingress smoke checks after deploy
-
-This is intentionally separate from the `dev` branch workflow. PRs still target `dev` for integration, but the shared dev droplet is updated from `main`. Until a separate production server exists, release-based deployments also target this same dev environment.
-
-## Releases and APKs
-
-GitHub Releases are currently used as milestone/pre-release checkpoints rather than production deployments.
-
-- Publishing a release keeps the current temporary behavior: deploy to the shared dev server.
-- [`mobile-apk.yml`](.github/workflows/mobile-apk.yml) builds an Android release APK when `mobile/**` changes are pushed to `main`, on manual dispatch, and when a GitHub release is published.
-- On matching pushes to `main`, the APK is stored as a workflow artifact.
-- On GitHub releases, the APK is also attached to the release as a downloadable asset.
-
-Current milestone convention:
-
-- **Release name:** `0.1.0-alpha`
-- **Tag:** `mvp-milestone`
-- **Type:** pre-release
-
-### Backend only (Go)
-
-This does not run in isolation: you need a reachable PostGIS database, runtime settings from `backend/config/application.local.yaml`, and secrets in the repository-root `.env` file (same keys as Compose: copy from [`deploy/.env.example`](deploy/.env.example); the Go server ignores `DOCKERHUB_NAMESPACE` if present).
+Stop the stack with:
 
 ```bash
-cp deploy/.env.example .env   # fill in with secrets at the repository root
+docker compose -f deploy/docker-compose.local.yml down
+```
+
+Remove local database state with:
+
+```bash
+docker compose -f deploy/docker-compose.local.yml down -v
+```
+
+## Local Review Accounts
+
+Default review credentials are distributed separately in the submitted credentials PDF. They are intentionally not stored in this repository.
+
+For a fresh local database, users can also be created through the registration flow. To test admin-only screens locally, create a user first, then promote it in the local database:
+
+```bash
+docker compose -f deploy/docker-compose.local.yml exec postgres \
+  psql -U postgres -d sem \
+  -c "UPDATE app_user SET role = 'ADMIN' WHERE email = '<admin-email@example.com>';"
+```
+
+Then log in again so the access token includes the updated `ADMIN` role.
+
+## Mobile App Against Local Docker
+
+The mobile app is developed from the `mobile/` directory.
+
+```bash
+cd mobile
+npm install
+cp .env.example .env
+npx expo start
+```
+
+API base URL behavior:
+
+| Runtime | API base |
+|---|---|
+| iOS Simulator | `http://localhost/api` |
+| Android Emulator | `http://10.0.2.2/api` |
+| Physical phone with Expo Go | Set `EXPO_PUBLIC_API_BASE_URL=http://<your-computer-LAN-IP>/api` in `mobile/.env` |
+
+For Android map rendering, set:
+
+```dotenv
+EXPO_PUBLIC_GOOGLE_MAPS_ANDROID_API_KEY=<google-maps-android-key>
+```
+
+Restart Metro after editing `mobile/.env`.
+
+## Web App Outside Docker
+
+The recommended local path is Docker Compose. If you need to run only the web app during development:
+
+```bash
+cd frontend
+npm install
+cp .env.example .env.local
+npm run dev
+```
+
+Set `VITE_GOOGLE_MAPS_WEB_API_KEY` in `frontend/.env.local`. The dev server expects a reachable backend API; the easiest option is to keep the Docker backend/nginx stack running.
+
+## Backend Outside Docker
+
+The recommended local path is Docker Compose. If you need to run only the backend:
+
+1. Start or provide a PostgreSQL/PostGIS database.
+2. Copy `deploy/.env.example` to `.env` at the repository root and fill local values.
+3. Run the server:
+
+```bash
 cd backend
 go run ./cmd/server
 ```
 
-By default the API listens on `http://localhost:8080`. Before finishing backend changes, run `./shipcheck.sh` from `backend/`.
+By default, the backend listens on `http://localhost:8080`. For full-stack review, prefer NGINX through Docker Compose so the public local API path remains `http://localhost/api`.
 
-## Further reading
+## API Documentation
 
-- [Deployment (local vs dev droplet)](docs/deploy.md)
+Swagger UI is served from the OpenAPI specs in [`docs/openapi/`](docs/openapi/).
+
+- Local Swagger UI: [http://localhost/api/docs/](http://localhost/api/docs/)
+- Live Swagger UI: [https://socialeventmapper.com/api/docs/](https://socialeventmapper.com/api/docs/)
+- Raw specs in the deployed environment: `https://socialeventmapper.com/api/docs/openapi/<spec>.yaml`
+
+The final release API includes domain specs for auth, events, tickets, profiles, notifications, badges, categories, favorite locations, and admin moderation.
+
+## Running Checks
+
+Backend:
+
+```bash
+cd backend
+./shipcheck.sh
+```
+
+Set `SKIP_INTEGRATION=1` only when Docker is unavailable:
+
+```bash
+SKIP_INTEGRATION=1 ./shipcheck.sh
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm install
+npm run build
+npm test
+```
+
+Mobile:
+
+```bash
+cd mobile
+npm install
+npm test
+```
+
+Mobile E2E scenarios use Maestro:
+
+```bash
+cd mobile
+npm run test:e2e
+```
+
+## Deployment Notes
+
+The shared server is updated by GitHub Actions workflow [`deploy-dev.yml`](.github/workflows/deploy-dev.yml). The workflow builds Docker images, pushes them to Docker Hub, deploys the selected image tag to the droplet, and runs smoke checks.
+
+Local development should use [`deploy/docker-compose.local.yml`](deploy/docker-compose.local.yml). The remote server uses [`deploy/docker-compose.dev.yml`](deploy/docker-compose.dev.yml), which expects pre-built images, TLS certificates, Firebase push credentials, New Relic credentials, and deployment secrets. See [`docs/deploy.md`](docs/deploy.md) for details.
+
+## Releases and APKs
+
+The final milestone release is [1.0.0](https://github.com/bounswe/bounswe2026group11/releases/tag/final-milestone) with tag `final-milestone`.
+
+The Android release APK is built by [`mobile-apk.yml`](.github/workflows/mobile-apk.yml). Release runs attach the APK to the GitHub Release page:
+
+- [social-event-mapper-final-milestone.apk](https://github.com/bounswe/bounswe2026group11/releases/download/final-milestone/social-event-mapper-final-milestone.apk)
+
+For local APK build details, see [`mobile/README.md`](mobile/README.md).
+
+## Further Reading
+
+- [Final Milestone Deliverables](https://github.com/bounswe/bounswe2026group11/wiki/Final-Milestone-Deliverables)
+- [Final API endpoint scenarios](https://github.com/bounswe/bounswe2026group11/wiki/Final-Milestone-API-Endpoints)
+- [Deployment guide](docs/deploy.md)
 - [Repository conventions](docs/conventions.md)
 - [Backend architecture](docs/backend/architecture.md)
-- [Backend database guide](docs/db/database.md)
+- [Backend business flows](docs/backend/business-flows/)
+- [Database guide](docs/db/database.md)
 - [OpenAPI specs](docs/openapi/)
-- [Database schema reference](docs/db/schema.sql)


### PR DESCRIPTION
## 📋 Summary
Updates the root README for the final milestone state of Social Event Mapper. The previous README still described MVP-era release details and incomplete setup notes; this version documents the current live release, local Docker setup, API docs, review-account handling, mobile/web/backend local workflows, checks, deployment notes, and APK release link.

## 🔄 Changes
- Replaces stale MVP release information with the final `1.0.0` / `final-milestone` release and APK links.
- Documents the current local Docker setup, required/optional environment variables, local URLs, database access, seeded categories/badges, and admin-user promotion flow.
- Adds current web, mobile, backend, API documentation, checks, deployment, and further-reading sections aligned with the final project structure.
- Removes outdated references such as MapLibre, placeholder frontend behavior, and the old `mvp-milestone` release convention.

## 🧪 Testing
- Ran `git diff --check -- README.md`.
- Reviewed the README for stale placeholder/MVP strings.
- No application tests were run because this PR changes documentation only.

## 🔗 Related
Related to final milestone release and setup documentation.
